### PR TITLE
OSAC-3483: Fix osac-operator Makefile tag-api target broken by monorepo move

### DIFF
--- a/osac-operator/Makefile
+++ b/osac-operator/Makefile
@@ -196,16 +196,16 @@ API_VERSION ?= $(error API_VERSION is required (e.g. make tag-api API_VERSION=v0
 tag-api: ## Tag a new release of the api/ Go module (e.g. make tag-api API_VERSION=v0.0.2).
 	@echo "$(API_VERSION)" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$$' || \
 		{ echo "Error: API_VERSION must match vX.Y.Z (got '$(API_VERSION)')"; exit 1; }
-	@REMOTE=$$(git remote -v | grep 'osac-project/osac-operator' | grep '(push)' | awk '{print $$1}' | head -1); \
+	@REMOTE=$$(git remote -v | grep 'osac-project/osac' | grep '(push)' | awk '{print $$1}' | head -1); \
 	if [ -z "$$REMOTE" ]; then \
-		echo "Error: no remote found pointing to osac-project/osac-operator"; \
+		echo "Error: no remote found pointing to osac-project/osac"; \
 		exit 1; \
 	fi; \
 	if [ -z "$$(git status --porcelain)" ]; then \
-		echo "Tagging api/$(API_VERSION) and pushing to $$REMOTE..." ; \
-		git tag "api/$(API_VERSION)" ; \
-		git push "$$REMOTE" "api/$(API_VERSION)" ; \
-		echo "Tagged and pushed api/$(API_VERSION) to $$REMOTE" ; \
+		echo "Tagging osac-operator/api/$(API_VERSION) and pushing to $$REMOTE..." ; \
+		git tag "osac-operator/api/$(API_VERSION)" ; \
+		git push "$$REMOTE" "osac-operator/api/$(API_VERSION)" ; \
+		echo "Tagged and pushed osac-operator/api/$(API_VERSION) to $$REMOTE" ; \
 	else \
 		echo "Error: working tree is dirty — commit or stash changes first" ; \
 		exit 1 ; \


### PR DESCRIPTION
## Summary
- \`osac-operator/Makefile\`'s \`tag-api\` target detected the push remote via a grep for \`osac-project/osac-operator\`, which no longer matches since this repo's remote is \`osac-project/osac\` (the monorepo). The target always hard-failed with "no remote found" even though a valid remote existed. Fixed the grep to match \`osac-project/osac\` generically.
- Even with the remote check fixed, the target tagged \`api/\$(API_VERSION)\`, which was only correct when \`osac-operator/api\` was its own repo root. Go's module-in-subdirectory versioning convention requires the tag be prefixed with the module's path from the current repo root, so both the \`git tag\` and \`git push\` lines now use \`osac-operator/api/\$(API_VERSION)\`.

Fixes OSAC-3483.

## Caveat
There's no way to fully exercise this target without actually pushing a real tag to a real remote, which this PR intentionally avoids. The fix was verified by careful inline inspection of the grep pattern and tag string. **Please do a manual dry-run of \`make tag-api API_VERSION=vX.Y.Z\` before the next real osac-operator/api release** to confirm end-to-end behavior.

## Test plan
- [ ] Manual dry-run: run \`make tag-api API_VERSION=vX.Y.Z\` against a real clone/remote before the next osac-operator/api release, confirm remote detection succeeds and the tag pushed is \`osac-operator/api/vX.Y.Z\`.