### PR TITLE
OSAC-1733: Split e2e-full-install.yml into 3 independently-runnable workflows

### DIFF
--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -1,5 +1,5 @@
 ---
-name: E2E BMaaS Full Install
+name: E2E CaaS Full Install
 
 permissions:
   contents: read
@@ -13,9 +13,9 @@ on:
   workflow_dispatch:
     inputs:
       test-suite:
-        description: "Test suite (bmaas, or empty for all)"
+        description: "Test suite (caas, or empty for all)"
         required: false
-        default: "bmaas"
+        default: "caas"
       test-filter:
         description: "pytest -k filter"
         required: false
@@ -26,7 +26,7 @@ on:
         default: "main"
 
 concurrency:
-  group: e2e-bmaas-full-install-${{ github.event.pull_request.number || github.run_id }}
+  group: e2e-caas-full-install-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -57,12 +57,12 @@ jobs:
   # path-scoped per component; splitting this by component to avoid running
   # both suites when only one changed is deferred to the future full
   # path-based CI matrix, once its skip-logic pattern is verified.
-  e2e-bmaas-full-install:
+  e2e-caas-full-install:
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
-    uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-full-install.yml@main
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-caas-full-install.yml@main
     with:
-      test-suite: ${{ inputs.test-suite || 'bmaas' }}
+      test-suite: ${{ inputs.test-suite || 'caas' }}
       test-filter: ${{ inputs.test-filter || '' }}
       # Build both component images from the PR's fork/branch (same monorepo checkout)
       components: '[{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"}]'
@@ -73,17 +73,21 @@ jobs:
       # Checkout osac-test-infra for tests/Containerfile (not the caller repo)
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+      # CaaS-specific inputs (cluster-template, caas-domain, flavor-image,
+      # flavor-name, namespace, installer-repo/ref, etc.) are left at the
+      # reusable workflow's own defaults -- none are required and this
+      # caller has no need to override them today.
 
   e2e:
     if: always()
-    needs: [changes, e2e-bmaas-full-install]
+    needs: [changes, e2e-caas-full-install]
     runs-on: ubuntu-latest
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "Upstream job results:"
           echo "  changes: ${{ needs.changes.result }}"
-          echo "  e2e-bmaas-full-install: ${{ needs.e2e-bmaas-full-install.result }}"
+          echo "  e2e-caas-full-install: ${{ needs.e2e-caas-full-install.result }}"
           echo ""
           echo "One or more upstream jobs failed or were cancelled."
           exit 1

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -65,14 +65,7 @@ jobs:
       test-suite: ${{ inputs.test-suite || 'vmaas' }}
       test-filter: ${{ inputs.test-filter || '' }}
       # Build both component images from the PR's fork/branch (same monorepo checkout)
-      component-repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-      component-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
-      component-containerfile: fulfillment-service/Containerfile
-      component-image-key: service.images.service
-      component2-repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-      component2-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
-      component2-containerfile: osac-operator/Containerfile
-      component2-image-key: operator.image.repository
+      components: '[{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"}]'
       # Pass author_association for fork PR authorization (empty for non-fork PRs)
       fork-pr-author-association: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association || '' }}
       fork-pr-author: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.user.login || '' }}

--- a/.github/workflows/scan-workflow-logs.yml
+++ b/.github/workflows/scan-workflow-logs.yml
@@ -19,8 +19,9 @@ name: Scan workflow logs
 on:
   workflow_run:  # zizmor: ignore[dangerous-triggers] -- no PR-head checkout; only trusted SHA-pinned/local composite actions; untrusted event data via env:, never interpolated into run: bodies.
     workflows:
-      - E2E VMaaS Full Install
       - E2E BMaaS Full Install
+      - E2E VMaaS Full Install
+      - E2E CaaS Full Install
     types: [completed]
 
 concurrency:


### PR DESCRIPTION
## Summary

Splits e2e testing into three separate workflow files -- `e2e-bmaas-full-install.yml`, `e2e-vmaas-full-install.yml`, and a new `e2e-caas-full-install.yml` -- instead of one merged file with multiple jobs. Separate files can be independently re-triggered/re-run in the GitHub Actions UI, which matters because each e2e run reprovisions a whole cluster: with jobs sharing one file there's no way to retest just one failed suite without also re-running the others.

- Added the twice-daily `schedule: cron: '0 */12 * * *'` trigger to all three files (previously only VMaaS had it).
- Added the new `e2e-caas-full-install.yml`, calling `osac-project/osac-test-infra/.github/workflows/e2e-caas-full-install.yml@main`. CaaS-specific inputs (`cluster-template`, `caas-domain`, `flavor-image`/`flavor-name`, `namespace`, `installer-repo`/`installer-ref`, etc.) are left at the reusable workflow's own defaults since none are required.
- Switched all three callers from the old `component-repo`/`component-ref`/`component-containerfile`/`component-image-key`/`component2-*` inputs to the new `components` JSON-array input shape.
- Updated `scan-workflow-logs.yml`'s `workflow_run.workflows` list to the three workflow names.

**This PR depends on [osac-project/osac-test-infra#283](https://github.com/osac-project/osac-test-infra/pull/283) merging first** (adds the `components` input this PR uses) -- do not merge before that lands.

## Test plan
- [ ] `osac-test-infra#283` merges, adding the `components` input to the reusable e2e workflows
- [x] YAML syntax validated (`yaml.safe_load`) for all four touched/new files
- [ ] CI runs green for all three e2e workflows on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated end-to-end coverage for full CaaS installations across pull requests, merge queues, scheduled runs, and manual launches.
  * Improved full-install testing for BMaaS and VMaaS by consolidating component configuration.
  * Added clearer workflow status reporting so failed or cancelled test runs are surfaced reliably.

* **Chores**
  * Expanded automated log monitoring to include CaaS full-install test results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->