### PR TITLE
OSAC-3225: Add root OWNERS file for osac mono-repo

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,40 @@
+filters:
+  "[^.]":
+    approvers:
+    - jhernand
+    - adriengentil
+    - tzvatot
+    - larsks
+    - tzumainn
+    - akshaynadkarni
+    - trewest
+    - omer-vishlitzky
+    - eranco74
+    - rgolangh
+    - ygalblum
+    - eliorerz
+    - sk-ilya
+    - vladikr
+    - rccrdpccl
+    - ori-amizur
+    - danmanor
+    - CrystalChun
+    reviewers:
+    - jhernand
+    - adriengentil
+    - tzvatot
+    - larsks
+    - tzumainn
+    - akshaynadkarni
+    - trewest
+    - omer-vishlitzky
+    - eranco74
+    - rgolangh
+    - ygalblum
+    - eliorerz
+    - sk-ilya
+    - vladikr
+    - rccrdpccl
+    - ori-amizur
+    - danmanor
+    - CrystalChun


### PR DESCRIPTION
## Summary
- Adds a root-level `OWNERS` file, the fallback Prow needs for anything not under `fulfillment-service/` or `osac-operator/` (root `Makefile`, `go.work`, `.github/`, `README.md`, `docs/`, `enhancement-proposals/`, etc.), which currently have no owners at all.
- `approvers`/`reviewers` are the union of `fulfillment-service/OWNERS` and `osac-operator/OWNERS`'s existing lists — anyone who can approve changes in either currently-merged component is a reasonable owner of shared root-level files today.
- Does not modify `fulfillment-service/OWNERS` or `osac-operator/OWNERS` — those already correctly scope approvals for their own subdirectories via Prow's upward directory walk.

## Test plan
- [x] Validated YAML with `python3 -c "import yaml; yaml.safe_load(open('OWNERS'))"`
- [x] Ran `pre-commit run --files OWNERS` (all checks pass)
- [x] Confirmed `fulfillment-service/OWNERS` and `osac-operator/OWNERS` are unchanged