### PR TITLE
OSAC-3227: Add reference implementation for always-trigger path-skip CI pattern

### DIFF
--- a/.github/workflows/verify-path-skip-poc.yml
+++ b/.github/workflows/verify-path-skip-poc.yml
@@ -1,0 +1,68 @@
+---
+name: PoC Path Skip Check
+
+# Reference implementation for the "always-triggering workflow with internal
+# dorny/paths-filter skip logic" pattern, extracted from the e2e-*-full-install.yml
+# workflows (see their `changes` + `if: always()` aggregator jobs) so it can be
+# validated on its own, without the cost of a full e2e run, before OSAC-1734
+# builds a full path-based CI matrix on top of it.
+#
+# The key property under test: the `poc-path-skip-check` job must always reach a
+# terminal conclusion (success or failure), never `skipped`, regardless of whether
+# `check` ran, passed, failed, or was skipped. A required status check that can end
+# up `skipped` is the exact failure mode this pattern exists to avoid (GitHub then
+# treats it as perpetually pending and the PR can never merge).
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: poc-path-skip-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      hit: ${{ steps.filter.outputs.hit }}
+    steps:
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        id: filter
+        with:
+          filters: |
+            hit:
+              - '.github/ci-poc/**'
+
+  # Stands in for an expensive build/test step. Skipped entirely when the
+  # filtered path isn't touched; fails only when a `FAIL_ME` sentinel file is
+  # present, so its pass/fail behavior can be exercised on demand.
+  check:
+    needs: changes
+    if: needs.changes.outputs.hit == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "Filtered path was touched -- running the real check."
+          test ! -f .github/ci-poc/FAIL_ME
+
+  # This is the job a required status check should point at -- never `check`
+  # directly. `if: always()` keeps this job from inheriting a skip when `check`
+  # is skipped; the step below then maps a failed or cancelled dependency onto
+  # an explicit exit 1, so `skipped` never leaks through as this job's own
+  # conclusion.
+  poc-path-skip-check:
+    if: always()
+    needs: [changes, check]
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "changes: ${{ needs.changes.result }}"
+          echo "check:   ${{ needs.check.result }}"
+          echo ""
+          echo "One or more upstream jobs failed or were cancelled."
+          exit 1


### PR DESCRIPTION
## Summary
This is Phase 0 of OSAC-3227: a minimal, self-contained reference implementation of the "always-triggering workflow with internal `dorny/paths-filter` skip logic" pattern that OSAC-1734 plans to rely on for its full path-based CI matrix.

The pattern itself already exists in this repo (see `e2e-vmaas-full-install.yml`, `e2e-bmaas-full-install.yml`, `e2e-caas-full-install.yml`), but only embedded inside expensive, slow e2e workflows. This adds a cheap, isolated copy of the same shape so the mechanism can be exercised and verified in seconds instead of tens of minutes, before OSAC-1734 scales it up.

### The pattern
- `changes`: runs `dorny/paths-filter` to detect whether `.github/ci-poc/**` was touched.
- `check`: stands in for an expensive build/test step; skipped when the path isn't touched, and fails only when a `.github/ci-poc/FAIL_ME` sentinel is present (so its pass/fail behavior can be exercised on demand).
- `poc-path-skip-check`: the job a required status check should point at (never `check` directly). Uses `if: always()` so it never inherits a skip from its dependency, then explicitly maps a failed/cancelled dependency to `exit 1` in its one step. This keeps its own conclusion always terminal (success or failure) — never `skipped` — which is the property this whole pattern depends on: a required check stuck at `skipped` is treated by GitHub as perpetually pending and blocks merging forever.

### Next steps (not in this PR)
Two throwaway test PRs will follow to empirically verify both branches of this behavior:
- One that touches `.github/ci-poc/**` (including the `FAIL_ME` sentinel, then a follow-up commit removing it) — proving `poc-path-skip-check` runs `check` for real and can both fail and pass.
- One that doesn't touch `.github/ci-poc/**` — proving `check` is skipped but `poc-path-skip-check` still concludes `success` rather than `skipped`.

Those will be closed without merging once their `gh pr checks` output is captured as evidence on OSAC-3227. No branch protection changes are proposed as part of this work.

## Test plan
- [x] Workflow mirrors the already-in-use, working `e2e-*-full-install.yml` structure (pinned `dorny/paths-filter` SHA, `if: always()` aggregator, explicit `needs.*.result` failure mapping).
- [ ] Verified empirically via the two follow-up test PRs described above (tracked in OSAC-3227).