### PR TITLE
NO-ISSUE: Fix AGENTS.md pre-commit descriptions after root consolidation

### DIFF
--- a/fulfillment-service/AGENTS.md
+++ b/fulfillment-service/AGENTS.md
@@ -22,7 +22,7 @@ This file contains only frequently-needed commands and non-obvious rules. For de
 - **Linter configuration**:
   - Go: `.golangci.yml`
   - Python: `pyproject.toml`
-  - YAML: `.yamllint.yaml`
+  - YAML: root-level `.yamllint.yaml` (no component-local copy anymore)
 
 **Before planning or implementing any change, read every document listed above that is
 relevant to the area you are working in.** Do not rely solely on existing source code as a
@@ -198,7 +198,7 @@ The following automated checks are configured and should be run at the appropria
 
 - **After proto changes**: See [Linting and Code Generation](#linting-and-code-generation).
 - **After Go module changes**: When `go.mod` is edited, run `go mod tidy`.
-- **Before committing**: `buf lint` (via `uv run dev.py lint proto`) and the Go linter (via `uv run dev.py lint go`) run automatically as pre-commit hooks — see `.pre-commit-config.yaml` — so there is no need to remember to run them manually, though you still can with `uv run dev.py lint`.
+- **Before committing**: `buf lint` (via `uv run dev.py lint proto`) and the Go linter (via `uv run dev.py lint go`) run automatically as pre-commit hooks — see the `fulfillment-service-*` hooks in the root-level `.pre-commit-config.yaml` (there is no component-local `.pre-commit-config.yaml` anymore) — so there is no need to remember to run them manually, though you still can with `uv run dev.py lint`.
 - **Before creating a PR**: Run `gofmt -s -w .` (auto-formats, then fails if any files changed — commit the fixes first), `uv run dev.py lint proto`, and `ginkgo run -r internal`.
 
 `buf lint` includes a custom plugin rule, `OSAC_OBJECT_SHAPE` (implemented in `cmd/buf-plugin-osac-lint/`), which checks that the base message of every resource — the message returned by `Get` and accepted by `Create` — has the standard `id`/`metadata`/`spec`/`status` shape described above. Messages that intentionally deviate from this shape must be marked with a `// buf:lint:ignore OSAC_OBJECT_SHAPE` comment directly above the message declaration.
@@ -283,4 +283,4 @@ See [Linting and Code Generation](#linting-and-code-generation) for the required
 - `charts/` and `it/charts/` - maintained Helm chart sources, not generated; call out the change explicitly in the PR description so a reviewer from [OWNERS](OWNERS) can confirm it's intentional
 - `proto/**/*.proto` - changes cascade to generated code (see [Linting and Code Generation](#linting-and-code-generation))
 - `internal/database/migrations/*.up.sql` - existing migrations must never be modified; only add new numbered files
-- `.pre-commit-config.yaml`, `.goreleaser.yaml`, `buf.yaml`, `buf.gen.yaml` - infrastructure config; call out the change explicitly in the PR description so a reviewer from [OWNERS](OWNERS) can confirm it's intentional
+- `.goreleaser.yaml`, `buf.yaml`, `buf.gen.yaml` - infrastructure config; call out the change explicitly in the PR description so a reviewer from [OWNERS](OWNERS) can confirm it's intentional (pre-commit/yamllint config now lives in the root-level `.pre-commit-config.yaml`/`.yamllint.yaml`, not here)

--- a/osac-operator/AGENTS.md
+++ b/osac-operator/AGENTS.md
@@ -134,8 +134,8 @@ hack/sync-helm-crds.py     # Script invoked by `make helm-crds` to sync CRDs to 
 
 - **golangci-lint** (see `Makefile` for pinned version) configured in `.golangci.yml`: dupl, errcheck, ginkgolinter, goconst, gocyclo, govet, ineffassign, lll, misspell, prealloc, revive, staticcheck, unconvert, unused
 - Formatters: gofmt, goimports
-- Pre-commit hooks (trailing-whitespace, check-merge-conflict, end-of-file-fixer, yamllint --strict excluding `config/`, detect-private-key, plus a local `golangci-lint` hook) are defined in `.pre-commit-config.yaml`, used for local development. CI runs the equivalent repo-wide hooks via the root-level `pre-commit.yaml` workflow (against the root `.pre-commit-config.yaml`) and lints Go separately via `make lint` — it does not invoke this file directly.
-- Run manually: `pre-commit run --all-files`
+- Pre-commit hooks (trailing-whitespace, check-merge-conflict, end-of-file-fixer, yamllint --strict, detect-private-key, plus an `osac-operator-golangci-lint` hook scoped to this component's `.go` files) are defined in the root-level `.pre-commit-config.yaml` — there is no `osac-operator`-local pre-commit/yamllint config anymore.
+- Run manually from the repo root: `pre-commit run --all-files`
 - **CRITICAL**: Always run `make lint` before committing — CI enforces strict linting
 
 ## Automation Hooks


### PR DESCRIPTION
## Summary

Follow-up to #18. `OSAC-3485` (consolidating the remaining per-component `.yamllint.yaml`/`.pre-commit-config.yaml` files into the root config) landed concurrently with #18, and #18 ended up merging afterward without accounting for it -- so `fulfillment-service/AGENTS.md` and `osac-operator/AGENTS.md` are currently describing component-local `.pre-commit-config.yaml`/`.yamllint.yaml` files that no longer exist (they were deleted by OSAC-3485; all pre-commit/yamllint config now lives in the root-level `.pre-commit-config.yaml`, with per-component hooks scoped via an anchored `files:` regex).

- `fulfillment-service/AGENTS.md`: linter-configuration list, the "before committing" pre-commit-hooks note, and the "verify before changing" infra-config list all still pointed at a component-local `.pre-commit-config.yaml`/`.yamllint.yaml`.
- `osac-operator/AGENTS.md`: same issue -- described `.pre-commit-config.yaml` as a local file "used for local development", which no longer exists.

Both now correctly point at the root-level `.pre-commit-config.yaml`/`.yamllint.yaml` and name the actual per-component hook IDs (`fulfillment-service-golangci-lint`, `fulfillment-service-buf-lint`, `osac-operator-golangci-lint`).

## Test plan
- [x] `pre-commit run --files fulfillment-service/AGENTS.md osac-operator/AGENTS.md` passes
- [x] Diff verified clean against current `main` (no unrelated files touched)