### PR TITLE
OSAC-3227: Add reference implementation for always-trigger path-skip CI pattern

### DIFF
--- a/.github/workflows/verify-path-skip-poc.yml
+++ b/.github/workflows/verify-path-skip-poc.yml
@@ -1,0 +1,75 @@
+#
+# Reference implementation for the always-trigger path-skip CI pattern.
+#
+# The failure mode this guards against: a required status check gated
+# directly behind a `paths:` filter never runs at all on PRs that don't
+# touch that path, and GitHub treats an unrun required check as blocking
+# forever rather than as a pass. The fix is to never point branch
+# protection at the path-filtered job itself. Instead, an aggregator job
+# depends on it, sets `if: always()` so it isn't skipped when its
+# dependency is skipped, and only fails when it explicitly detects a
+# real failure among its dependencies. A skipped dependency does not
+# match that condition, so the aggregator reaches a real success
+# conclusion -- never "skipped" -- regardless of whether the path-gated
+# job ran, passed, failed, or was skipped.
+#
+# This workflow is a minimal, disposable proof of the mechanism, scoped
+# to its own path so it can't collide with real CI. See OSAC-1734 for
+# the real path-based CI matrix this pattern will be applied to.
+#
+name: Verify path-skip CI pattern (PoC)
+
+on:
+  pull_request:
+    paths:
+      - '.github/ci-poc/**'
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Detect ci-poc path changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      ci-poc: ${{ steps.filter.outputs.ci-poc }}
+    steps:
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        id: filter
+        with:
+          filters: |
+            ci-poc:
+              - '.github/ci-poc/**'
+
+  check:
+    name: Run ci-poc check
+    needs: changes
+    if: needs.changes.outputs.ci-poc == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Fail if the sentinel file is present
+        run: |
+          if [ -f .github/ci-poc/FAIL_ME ]; then
+            echo "::error::.github/ci-poc/FAIL_ME is present -- failing on purpose"
+            exit 1
+          fi
+          echo "No FAIL_ME sentinel found -- check passes"
+
+  poc-path-skip-check:
+    name: PoC path-skip check
+    needs: [changes, check]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any dependency failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "::error::A required dependency failed or was cancelled: ${{ toJSON(needs) }}"
+          exit 1
+      - name: Report success
+        run: echo "All dependencies concluded without failure or cancellation."


### PR DESCRIPTION
## Summary

Required GitHub status checks combined with a `paths:` filter on the same workflow leave PRs that don't touch the filtered path stuck forever: the check never runs, and GitHub treats a required check that never ran as permanently blocking rather than as a pass. OSAC-1734's plan for a full path-based CI matrix depends on avoiding this, so this ticket verifies the pattern with a minimal, disposable reference workflow before scaling it up.

## The pattern

- `changes` — a `dorny/paths-filter` job, filtered on `.github/ci-poc/**`.
- `check` — the inner, path-gated job. Only runs if the filter hit. Fails on purpose if `.github/ci-poc/FAIL_ME` exists (a sentinel used for testing). This job is legitimately allowed to show `skipped` — it's never what branch protection would point at.
- `poc-path-skip-check` — the aggregator, and the job branch protection would actually require. `needs: [changes, check]`, `if: always()` at the job level (without this, the job's implicit default is `if: success()`, meaning a skipped `needs:` dependency would skip the aggregator too — the exact bug this exists to prevent, one level removed). A step inside explicitly checks `contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')` and only then exits 1. A skipped inner check doesn't match that condition, so the aggregator reaches a real `success` conclusion instead of `skipped`.

Net effect: the aggregator always reaches a terminal conclusion (success or failure), never `skipped`, regardless of whether the inner path-gated check ran, passed, failed, or was skipped.

Scoped to `.github/ci-poc/**`, a path that doesn't overlap any existing filter, so it can't collide with or add latency to real CI.

## Next steps (tracked on OSAC-3227, not in this PR)

Once this merges: a Phase A test PR (touches `.github/ci-poc/**`, expects filter hit + failure then success) and a Phase B test PR (touches something unrelated, expects filter skip + aggregator still succeeds) will be opened to verify the behavior end-to-end, then both closed without merging. Results will be posted on OSAC-3227.

## Test plan

- [x] Workflow YAML validated (`yaml.safe_load`)
- [x] `pre-commit run` passes on the new file
- [x] `actionlint` reports no issues
- [ ] End-to-end behavior verified via Phase A/B test PRs (tracked separately, this PR just adds the reference implementation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a proof-of-concept automated workflow that detects changes in specific paths and conditionally runs validation checks.
  * Added consolidated workflow status reporting for passed, skipped, failed, or cancelled checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->