### PR TITLE
OSAC-3481: Add CI dummy-values file for fulfillment-service chart

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -8,6 +8,7 @@ on:
       - 'osac-operator/config/crd/bases/**'
       - 'osac-operator/hack/sync-helm-crds.py'
       - 'osac-operator/Makefile'
+      - 'fulfillment-service/charts/**'
       - '.github/workflows/helm-lint.yaml'
 
 permissions:
@@ -35,17 +36,24 @@ jobs:
       working-directory: osac-operator
       run: make check-helm-crds
 
-  # fulfillment-service's chart isn't included here: it guards most values
-  # with `required "..." .Values.X` (auth/certs/idp config), so it can't be
-  # helm-lint'd with bare values.yaml the way osac-operator's charts can.
-  # Needs a CI-only dummy-values file before it can join this matrix.
+  # fulfillment-service's chart guards most values with `required "..." .Values.X`
+  # (auth/certs/idp config), so it needs its CI-only charts/service/ci-values.yaml
+  # passed via -f to lint/template cleanly -- osac-operator's charts have no such
+  # guards and lint fine bare.
   helm-lint:
-    name: Lint Helm chart (osac-operator/${{ matrix.chart }})
+    name: Lint Helm chart (${{ matrix.component }}/${{ matrix.chart }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        chart: [operator-crds, operator]
+        include:
+          - component: osac-operator
+            chart: operator-crds
+          - component: osac-operator
+            chart: operator
+          - component: fulfillment-service
+            chart: service
+            values-file: ci-values.yaml
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
@@ -58,9 +66,19 @@ jobs:
         version: v3.17.0
 
     - name: Lint chart
-      working-directory: osac-operator
-      run: helm lint charts/${{ matrix.chart }}/
+      working-directory: ${{ matrix.component }}
+      run: |
+        if [ -n "${{ matrix.values-file }}" ]; then
+          helm lint "charts/${{ matrix.chart }}/" -f "charts/${{ matrix.chart }}/${{ matrix.values-file }}"
+        else
+          helm lint "charts/${{ matrix.chart }}/"
+        fi
 
     - name: Template chart
-      working-directory: osac-operator
-      run: helm template test charts/${{ matrix.chart }}/ > /dev/null
+      working-directory: ${{ matrix.component }}
+      run: |
+        if [ -n "${{ matrix.values-file }}" ]; then
+          helm template test "charts/${{ matrix.chart }}/" -f "charts/${{ matrix.chart }}/${{ matrix.values-file }}" > /dev/null
+        else
+          helm template test "charts/${{ matrix.chart }}/" > /dev/null
+        fi

--- a/fulfillment-service/charts/service/ci-values.yaml
+++ b/fulfillment-service/charts/service/ci-values.yaml
@@ -1,0 +1,58 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+# CI-only dummy values, used solely to satisfy this chart's `required "..."` guards so that
+# `helm lint`/`helm template` can exercise every template. Not used for real deploys -- see
+# values.yaml for the real, documented defaults and the actual deploy-time overrides.
+
+certs:
+  issuerRef:
+    name: ci-selfsigned-issuer
+  caBundle:
+    configMap: ci-ca-bundle
+
+externalHostname: fulfillment-api.ci.example.com
+internalHostname: fulfillment-internal-api.ci.example.com
+
+auth:
+  issuerUrl: https://issuer.ci.example.com
+  controllerCredentials:
+  - secret:
+      name: ci-controller-credentials
+      items:
+      - key: client-id
+        param: client-id
+      - key: client-secret
+        param: client-secret
+
+idp:
+  url: https://idp.ci.example.com
+  credentials:
+  - secret:
+      name: ci-idp-credentials
+      items:
+      - key: client-id
+        param: client-id
+      - key: client-secret
+        param: client-secret
+
+# Non-empty so grpc-server's deployment template takes its `range` branch instead of its
+# `database.connection` empty-list branch (rendering the latter is a separate, pre-existing bug
+# unrelated to the required-value guards this file otherwise exists to satisfy).
+database:
+  connection:
+  - secret:
+      name: ci-db-credentials
+      items:
+      - key: uri
+        param: url


### PR DESCRIPTION
## Summary

`fulfillment-service`'s Helm chart (`charts/service`) guards most values with `required "..." .Values.X` (`auth.controllerCredentials`, `auth.issuerUrl`, `certs.caBundle.configMap`, `idp.url`, `idp.credentials`, etc.), so `helm lint`/`helm template` fail immediately against its bare `values.yaml`. That's why `helm-lint.yaml`'s matrix currently only covers `osac-operator`'s charts, which have no such guards.

- Added `fulfillment-service/charts/service/ci-values.yaml`: CI-only placeholder values satisfying every `required` guard in the chart's templates. Not used for real deploys -- `values.yaml` remains the source of documented defaults/overrides.
- Also set a non-empty `database.connection` in that file: leaving it at its default empty list hits a separate, pre-existing bug in `grpc-server/deployment.yaml`'s `{{ else }} [] {{ end }}` branch (bad indentation under a block-sequence context breaks YAML parsing) -- unrelated to the `required`-value guards, but it blocks `helm template` all the same. Left the template itself untouched since fixing that bug is out of scope for this ticket; the dummy value routes around it.
- Extended `helm-lint.yaml`'s matrix from a flat `chart: [...]` list to a `component`+`chart` `include` list, and added `fulfillment-service`/`service` with `values-file: ci-values.yaml` passed via `-f` (only for that entry). Also added `fulfillment-service/charts/**` to the workflow's path trigger.

Part of OSAC-1732 (mono-repo consolidation) / OSAC-1733.

## Test plan
- [x] `helm lint charts/service/ -f charts/service/ci-values.yaml` passes (both default `variant: kind` and `--set variant=openshift`)
- [x] `helm template test charts/service/ -f charts/service/ci-values.yaml` renders successfully for both variants
- [x] Re-ran the two existing `osac-operator` matrix entries (`operator-crds`, `operator`) locally with the updated workflow's exact commands -- still pass unchanged
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on both touched files
- [x] `pre-commit run --files fulfillment-service/charts/service/ci-values.yaml .github/workflows/helm-lint.yaml` passes