### PR TITLE
OSAC-3467: Scope fulfillment-service/osac-operator release-trigger tags

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -13,7 +13,7 @@ on:
     branches:
     - main
     tags:
-    - 'v*'
+    - 'osac-operator/v*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -80,6 +80,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Component-scoped tags (see the `tags:` trigger above) can't be used verbatim
+      # as image tags -- Docker/OCI tags can't contain the '/' the git tag does --
+      # so strip the prefix here to recover the bare vX.Y.Z for the actual image tags.
+      - name: Compute release version
+        if: startsWith(github.ref, 'refs/tags/osac-operator/')
+        run: |
+          version="${GITHUB_REF_NAME#osac-operator/}"
+          echo "RELEASE_VERSION=${version}" >> "$GITHUB_ENV"
+          echo "RELEASE_MAJOR_MINOR=${version%.*}" >> "$GITHUB_ENV"
+          echo "RELEASE_MAJOR=${version%%.*}" >> "$GITHUB_ENV"
+
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
@@ -88,9 +99,9 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
-            type=semver,pattern=v{{major}}
+            type=raw,value=${{ env.RELEASE_VERSION }},enable=${{ env.RELEASE_VERSION != '' }}
+            type=raw,value=${{ env.RELEASE_MAJOR_MINOR }},enable=${{ env.RELEASE_VERSION != '' }}
+            type=raw,value=${{ env.RELEASE_MAJOR }},enable=${{ env.RELEASE_VERSION != '' }}
             type=ref,event=branch
             type=ref,event=pr
             type=ref,event=tag

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -98,13 +98,17 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # No `type=ref,event=tag` here: the `tags:` trigger above only ever
+          # matches this component's own scoped prefix, so the tag-triggered
+          # case is always covered by the three raw entries below already --
+          # keeping it would just add a redundant, slash-sanitized duplicate
+          # tag (e.g. "osac-operator-v1.2.3").
           tags: |
             type=raw,value=${{ env.RELEASE_VERSION }},enable=${{ env.RELEASE_VERSION != '' }}
             type=raw,value=${{ env.RELEASE_MAJOR_MINOR }},enable=${{ env.RELEASE_VERSION != '' }}
             type=raw,value=${{ env.RELEASE_MAJOR }},enable=${{ env.RELEASE_VERSION != '' }}
             type=ref,event=branch
             type=ref,event=pr
-            type=ref,event=tag
             type=sha
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -87,9 +87,21 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/osac-operator/')
         run: |
           version="${GITHUB_REF_NAME#osac-operator/}"
+          # Same SemVer rule as publish-charts.yaml's guard job -- rejects build
+          # metadata (+...) and validates the core/prerelease shape before it's
+          # trusted as an image tag.
+          semver_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?$'
+          if ! [[ "${version}" =~ ${semver_re} ]]; then
+            echo "::error::Tag '${GITHUB_REF_NAME}' is not a valid semver release tag"
+            exit 1
+          fi
+          # Prerelease identifiers can themselves contain dots (e.g. v1.2.3-beta.1),
+          # so derive major/minor from the prerelease-stripped core version --
+          # otherwise a dotted prerelease would corrupt the major.minor alias.
+          core="${version%%-*}"
           echo "RELEASE_VERSION=${version}" >> "$GITHUB_ENV"
-          echo "RELEASE_MAJOR_MINOR=${version%.*}" >> "$GITHUB_ENV"
-          echo "RELEASE_MAJOR=${version%%.*}" >> "$GITHUB_ENV"
+          echo "RELEASE_MAJOR_MINOR=${core%.*}" >> "$GITHUB_ENV"
+          echo "RELEASE_MAJOR=${core%%.*}" >> "$GITHUB_ENV"
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action

--- a/.github/workflows/publish-binaries.yaml
+++ b/.github/workflows/publish-binaries.yaml
@@ -41,6 +41,7 @@ jobs:
     - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7
       with:
         workdir: fulfillment-service
-        args: release --clean --current-tag ${{ env.RELEASE_VERSION }}
+        args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GORELEASER_CURRENT_TAG: ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/publish-binaries.yaml
+++ b/.github/workflows/publish-binaries.yaml
@@ -17,7 +17,7 @@ name: Publish binaries
 on:
   push:
     tags:
-    - 'v*'
+    - 'fulfillment-service/v*'
 
 jobs:
 
@@ -34,9 +34,13 @@ jobs:
     - uses: ./.github/actions/setup-go
       with:
         working-directory: fulfillment-service
+    - name: Compute release version
+      # Strip this component's tag prefix (see the `tags:` trigger above) --
+      # goreleaser expects a bare vX.Y.Z, not the scoped git tag.
+      run: echo "RELEASE_VERSION=${GITHUB_REF_NAME#fulfillment-service/}" >> "$GITHUB_ENV"
     - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7
       with:
         workdir: fulfillment-service
-        args: release --clean
+        args: release --clean --current-tag ${{ env.RELEASE_VERSION }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -46,20 +46,32 @@ jobs:
     permissions: {}
     if: >
       github.event.workflow_run.event == 'push' &&
-      startsWith(github.event.workflow_run.head_branch, 'v')
+      (startsWith(github.event.workflow_run.head_branch, 'fulfillment-service/v') ||
+       startsWith(github.event.workflow_run.head_branch, 'osac-operator/v'))
     outputs:
       tag: ${{ github.event.workflow_run.head_branch }}
+      version: ${{ steps.check.outputs.version }}
       sha: ${{ github.event.workflow_run.head_sha }}
     steps:
     - name: Check image build result
+      id: check
       env:
         CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
       run: |
-        # No build-metadata (+...) suffix allowed: this tag is used verbatim as a
+        # Each component owns a scoped tag prefix (see publish-image.yaml/build-image.yaml's
+        # own `tags:` triggers) so a single tag push can't fire every component's release
+        # chain at once; strip it here to recover the bare vX.Y.Z used for artifact versions.
+        case "$HEAD_BRANCH" in
+          fulfillment-service/v*) VERSION="${HEAD_BRANCH#fulfillment-service/}" ;;
+          osac-operator/v*) VERSION="${HEAD_BRANCH#osac-operator/}" ;;
+          *) echo "::error::Tag '$HEAD_BRANCH' does not match a known component prefix"; exit 1 ;;
+        esac
+
+        # No build-metadata (+...) suffix allowed: this version is used verbatim as a
         # container image tag downstream, and Docker/OCI tags cannot contain '+'.
         semver_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?$'
-        if ! [[ "$HEAD_BRANCH" =~ $semver_re ]]; then
+        if ! [[ "$VERSION" =~ $semver_re ]]; then
           echo "::error::Tag '$HEAD_BRANCH' is not a valid semver release tag"
           exit 1
         fi
@@ -67,6 +79,7 @@ jobs:
           echo "::error::Image build for tag $HEAD_BRANCH did not succeed (conclusion: $CONCLUSION). Refusing to publish chart."
           exit 1
         fi
+        echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
         echo "Image build succeeded for tag $HEAD_BRANCH"
 
   publish-service-chart:
@@ -87,7 +100,7 @@ jobs:
     - id: run
       working-directory: fulfillment-service
       env:
-        TAG: ${{ needs.guard.outputs.tag }}
+        VERSION: ${{ needs.guard.outputs.version }}
         REGISTRY_USERNAME: ${{ github.actor }}
         REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         REPO: ${{ github.repository }}
@@ -96,8 +109,9 @@ jobs:
         export registry="ghcr.io"
         echo "${REGISTRY_PASSWORD}" | helm registry login --username "${REGISTRY_USERNAME}" --password-stdin "${registry}"
 
-        # Get the git version from the tag that triggered the image build:
-        export git_version="${TAG}"
+        # Get the bare version from the tag that triggered the image build (the
+        # component-scoped prefix was already stripped by the guard job):
+        export git_version="${VERSION}"
 
         # Update the image reference in the chart:
         export app_version="${git_version}"
@@ -149,9 +163,9 @@ jobs:
 
     - name: Extract version from tag
       id: version
-      run: echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+      run: echo "version=${VERSION#v}" >> "$GITHUB_OUTPUT"
       env:
-        TAG: ${{ needs.guard.outputs.tag }}
+        VERSION: ${{ needs.guard.outputs.version }}
 
     - name: Package chart
       working-directory: osac-operator
@@ -202,9 +216,9 @@ jobs:
 
     - name: Extract version from tag
       id: version
-      run: echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+      run: echo "version=${VERSION#v}" >> "$GITHUB_OUTPUT"
       env:
-        TAG: ${{ needs.guard.outputs.tag }}
+        VERSION: ${{ needs.guard.outputs.version }}
 
     - name: Update image tag in values.yaml
       working-directory: osac-operator
@@ -250,13 +264,14 @@ jobs:
       run: |
         gh release create "${TAG}" \
           --repo "${REPO}" \
-          --title "osac-operator ${TAG}" \
+          --title "osac-operator ${VERSION}" \
           --generate-notes \
           --verify-tag \
         || gh release edit "${TAG}" \
           --repo "${REPO}" \
-          --title "osac-operator ${TAG}"
+          --title "osac-operator ${VERSION}"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ needs.guard.outputs.tag }}
+        VERSION: ${{ needs.guard.outputs.version }}
         REPO: ${{ github.repository }}

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -54,9 +54,21 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/fulfillment-service/')
         run: |
           version="${GITHUB_REF_NAME#fulfillment-service/}"
+          # Same SemVer rule as publish-charts.yaml's guard job -- rejects build
+          # metadata (+...) and validates the core/prerelease shape before it's
+          # trusted as an image tag.
+          semver_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?$'
+          if ! [[ "${version}" =~ ${semver_re} ]]; then
+            echo "::error::Tag '${GITHUB_REF_NAME}' is not a valid semver release tag"
+            exit 1
+          fi
+          # Prerelease identifiers can themselves contain dots (e.g. v1.2.3-beta.1),
+          # so derive major/minor from the prerelease-stripped core version --
+          # otherwise a dotted prerelease would corrupt the major.minor alias.
+          core="${version%%-*}"
           echo "RELEASE_VERSION=${version}" >> "$GITHUB_ENV"
-          echo "RELEASE_MAJOR_MINOR=${version%.*}" >> "$GITHUB_ENV"
-          echo "RELEASE_MAJOR=${version%%.*}" >> "$GITHUB_ENV"
+          echo "RELEASE_MAJOR_MINOR=${core%.*}" >> "$GITHUB_ENV"
+          echo "RELEASE_MAJOR=${core%%.*}" >> "$GITHUB_ENV"
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -66,13 +66,17 @@ jobs:
         with:
           context: git
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # No `type=ref,event=tag` here: the `tags:` trigger above only ever
+          # matches this component's own scoped prefix, so the tag-triggered
+          # case is always covered by the three raw entries below already --
+          # keeping it would just add a redundant, slash-sanitized duplicate
+          # tag (e.g. "fulfillment-service-v1.2.3").
           tags: |
             type=raw,value=${{ env.RELEASE_VERSION }},enable=${{ env.RELEASE_VERSION != '' }}
             type=raw,value=${{ env.RELEASE_MAJOR_MINOR }},enable=${{ env.RELEASE_VERSION != '' }}
             type=raw,value=${{ env.RELEASE_MAJOR }},enable=${{ env.RELEASE_VERSION != '' }}
             type=ref,event=branch
             type=ref,event=pr
-            type=ref,event=tag
             type=sha
           # type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -12,7 +12,7 @@ on:
     branches:
       - main
     tags:
-      - 'v*'
+      - 'fulfillment-service/v*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-image
@@ -47,6 +47,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Component-scoped tags (see the `tags:` trigger above) can't be used verbatim
+      # as image tags -- Docker/OCI tags can't contain the '/' the git tag does --
+      # so strip the prefix here to recover the bare vX.Y.Z for the actual image tags.
+      - name: Compute release version
+        if: startsWith(github.ref, 'refs/tags/fulfillment-service/')
+        run: |
+          version="${GITHUB_REF_NAME#fulfillment-service/}"
+          echo "RELEASE_VERSION=${version}" >> "$GITHUB_ENV"
+          echo "RELEASE_MAJOR_MINOR=${version%.*}" >> "$GITHUB_ENV"
+          echo "RELEASE_MAJOR=${version%%.*}" >> "$GITHUB_ENV"
+
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
@@ -56,9 +67,9 @@ jobs:
           context: git
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
-            type=semver,pattern=v{{major}}
+            type=raw,value=${{ env.RELEASE_VERSION }},enable=${{ env.RELEASE_VERSION != '' }}
+            type=raw,value=${{ env.RELEASE_MAJOR_MINOR }},enable=${{ env.RELEASE_VERSION != '' }}
+            type=raw,value=${{ env.RELEASE_MAJOR }},enable=${{ env.RELEASE_VERSION != '' }}
             type=ref,event=branch
             type=ref,event=pr
             type=ref,event=tag

--- a/.github/workflows/publish-proto.yaml
+++ b/.github/workflows/publish-proto.yaml
@@ -19,7 +19,7 @@ name: Publish proto
 on:
   push:
     tags:
-    - 'v*'
+    - 'fulfillment-service/v*'
 
 jobs:
 
@@ -37,4 +37,6 @@ jobs:
         version: 1.71.0
     - working-directory: fulfillment-service
       run: |
-        buf push --label "${{ github.ref_name }}"
+        # Strip this component's tag prefix (see the `tags:` trigger above) so the
+        # label reads as a plain version, not the full scoped git tag.
+        buf push --label "${GITHUB_REF_NAME#fulfillment-service/}"


### PR DESCRIPTION
## Summary

Fixes the tag-collision gap identified in OSAC-3467's comments after the OSAC-1733 merge: fulfillment-service's 4 tag-triggered workflows and osac-operator's 2 still trigger on a bare `v*`, so a single tag push right now would fire every one of them at once.

Convention adopted (already precedented by osac-operator's own `api/vX.Y.Z` submodule tags): `<component>/vX.Y.Z`, e.g. `fulfillment-service/v1.2.3`, `osac-operator/v1.2.3`.

**Trigger scoping** (`on.push.tags`):
- `publish-image.yaml`, `publish-binaries.yaml`, `publish-proto.yaml` -> `fulfillment-service/v*`
- `build-image.yaml` -> `osac-operator/v*`

**Downstream version handling** -- scoping the trigger alone isn't sufficient: several steps assumed a bare `vX.Y.Z` tag and would have silently broken (invalid Docker tags containing `/`, goreleaser/semver parsing failing on the prefix, `publish-charts.yaml`'s guard regex rejecting anything not starting with `v`). Updated all of these to strip the known prefix before using the value as a version:
- `publish-image.yaml`/`build-image.yaml`: replaced `docker/metadata-action`'s `type=semver,pattern=...` lines (which match the raw ref and would no longer match a prefixed tag) with a preceding step that strips the prefix and emits `RELEASE_VERSION`/`RELEASE_MAJOR_MINOR`/`RELEASE_MAJOR`, fed in via `type=raw,value=...,enable=...`.
- `publish-binaries.yaml`: strips the prefix and passes the bare version to goreleaser explicitly via `--current-tag` (goreleaser's own tag auto-detection would otherwise try to parse the full scoped tag as semver and fail).
- `publish-proto.yaml`: strips the prefix before using it as the buf push label (cosmetic, buf labels have no semver requirement, but keeps it clean).
- `publish-charts.yaml` (triggered via `workflow_run` from the two image-build workflows, not directly by the tag push): the shared `guard` job now recognizes either component's prefix, strips it to a `version` output (bare `vX.Y.Z`), and validates *that* against the semver regex. All three chart-publishing jobs and `create-operator-release` now derive chart/app versions from `needs.guard.outputs.version` instead of mis-stripping a literal `v` off the front of the full scoped tag (which was a no-op on a tag starting with a component name, not `v`). The full scoped tag is still used wherever the actual git ref matters (`gh release create`, the force-push/retag guard script).

**Stale tags from the subtree merge** -- verified directly against the live repo (`git tag -l` on this clone): **zero tags exist**. This matches what's already recorded in OSAC-3467's comments (subtree-add's internal fetch did not carry tag refs into either the fulfillment-service or osac-operator merge). Nothing to strip for this PR.

## Not included (flagging, not fixing here)
OSAC-3467's third sub-item -- dropping now-unnecessary go.mod version-pin tags now that `go.work` resolves cross-component imports locally -- is a real, separate finding: both `fulfillment-service/go.mod` and `osac-operator/go.mod` still `require github.com/osac-project/osac-operator/api v0.0.7` even though `go.work`'s `use` directive already makes that resolve to the local `./osac-operator/api` in this repo. Left untouched here since it's a Go-module-correctness change (needs `go mod tidy`/build verification, not YAML) rather than CI tag-trigger scoping -- recommend a separate follow-up.

## Validation
- [x] `yamllint -c .yamllint.yaml --strict` on all 5 changed files -- clean.
- [x] `python3 -c "yaml.safe_load(...)"` on all 5 files -- parses.
- [x] Full diff reviewed end-to-end for internal consistency (which value feeds which downstream step).
- [ ] Not able to exercise this live end-to-end (no tag has been pushed to this repo yet, and I didn't want to push a real component-scoped tag myself since that would trigger real image builds/chart publishes/GitHub releases). Recommend a real dry run with a test tag before relying on this for an actual release -- flagging the specific third-party-tool assumptions this makes: `docker/metadata-action`'s `type=raw`/`enable=` combination (well-established, low risk) and goreleaser's `--current-tag` flag overriding its own git-tag auto-detection (a real, documented goreleaser flag, but not exercised here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Automation**
  * Release workflows now support component-specific version tags for service and operator releases.
  * Docker images, binaries, charts, and protocol packages are published with clean, consistent version labels.
  * Chart releases validate version formats and use the extracted component version for packaging and release titles.
  * Builds and publishing are restricted to the appropriate component tags, reducing accidental cross-component releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->