### PR TITLE
OSAC-3227: Phase A verification -- ci-poc path touched, FAIL_ME sentinel present

### DIFF
--- a/.github/ci-poc/FAIL_ME
+++ b/.github/ci-poc/FAIL_ME
@@ -1,0 +1,2 @@
+This sentinel file's mere presence makes the PoC workflow's inner
+check job fail on purpose. Removing it lets the check pass.

--- a/.github/ci-poc/marker.txt
+++ b/.github/ci-poc/marker.txt
@@ -1,0 +1,3 @@
+This file exists solely to trigger the path-skip-check PoC workflow's
+dorny/paths-filter for manual verification. Safe to remove once
+verification is complete.


### PR DESCRIPTION
## Purpose

Throwaway test PR for OSAC-3227 Phase A: verifies the `poc-path-skip-check` reference workflow (merged in #20) when its filtered path IS touched.

**Expected:** the `dorny/paths-filter` hits, the inner `check` job runs and fails (because `.github/ci-poc/FAIL_ME` is present), and the `poc-path-skip-check` aggregator concludes `failure`.

A follow-up commit will remove `FAIL_ME` to verify the same jobs then conclude `success`.

**This PR will be closed without merging once evidence is captured.**