### PR TITLE
OSAC-3227: Fix missing checkout step in path-skip-check PoC's inner check job

### DIFF
--- a/.github/workflows/verify-path-skip-poc.yml
+++ b/.github/workflows/verify-path-skip-poc.yml
@@ -45,6 +45,9 @@ jobs:
     if: needs.changes.outputs.hit == 'true'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
       - run: |
           echo "Filtered path was touched -- running the real check."
           test ! -f .github/ci-poc/FAIL_ME


### PR DESCRIPTION
## Bug

The reference workflow merged in #20 has a real correctness bug: the inner `check` job runs `test ! -f .github/ci-poc/FAIL_ME` without ever checking out the repository first. GitHub Actions runners start with an empty workspace, so `.github/ci-poc/FAIL_ME` never existed there regardless of whether it was actually present in the PR — the test always evaluated true and the job always concluded `success`.

Caught live during Phase A verification (#33): a PR that added `.github/ci-poc/FAIL_ME` still showed `check` and the `poc-path-skip-check` aggregator both passing, when the expected/correct behavior is for both to fail.

## Fix

Adds `actions/checkout`, pinned to the same SHA already used across this repo's other workflows (`3d3c42e5aac5ba805825da76410c181273ba90b1` / v7.0.1), as the first step of the `check` job, before the sentinel-file test runs.

## Test plan

- [x] YAML validated (`yaml.safe_load`)
- [x] `actionlint` reports no issues
- [x] `pre-commit run` passes
- [ ] Re-verified end-to-end via a fresh Phase A test PR once this merges (tracked on OSAC-3227)