### PR TITLE
OSAC-3227: Phase B verification -- unrelated path, filter should skip

### DIFF
--- a/PHASE_B_UNRELATED_MARKER.md
+++ b/PHASE_B_UNRELATED_MARKER.md
@@ -1,0 +1,4 @@
+Throwaway marker file for manual CI verification. Touches something
+outside .github/ci-poc/** on purpose, to confirm a path-filtered check
+is correctly skipped while its aggregator still reaches a real
+conclusion. Safe to delete; this change is not intended to be merged.


### PR DESCRIPTION
## Purpose

Throwaway test PR for OSAC-3227 Phase B: verifies the `poc-path-skip-check` reference workflow when its filtered path is NOT touched.

**Expected:** the `dorny/paths-filter` does not hit, the inner `check` job shows `skipped`, and the `poc-path-skip-check` aggregator still runs (never itself skipped) and concludes `success`. This is the case a misconfigured filter could get wrong — proving it explicitly is the whole point of the ticket.

**This PR will be closed without merging once evidence is captured.**