### PR TITLE
OSAC-3490: Use explicit per-component IMAGE_NAME to fix ghcr.io collision

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -22,8 +22,12 @@ concurrency:
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
+  # Hardcoded rather than github.repository: that now resolves to
+  # osac-project/osac for every component's build workflow post-merge,
+  # colliding on mutable tags with fulfillment-service's image. Keeping
+  # this component's pre-merge image identity stable instead, same as
+  # osac-aap's execution-environment.yml does.
+  IMAGE_NAME: osac-project/osac-operator
 
 
 jobs:

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -103,7 +103,14 @@ jobs:
         VERSION: ${{ needs.guard.outputs.version }}
         REGISTRY_USERNAME: ${{ github.actor }}
         REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        REPO: ${{ github.repository }}
+        # Hardcoded rather than github.repository: that now resolves to
+        # osac-project/osac post-merge, which would inject a reference to an
+        # image that doesn't exist there -- the real image only ever gets
+        # published to osac-project/fulfillment-service (see build-image.yaml/
+        # publish-image.yaml's own IMAGE_NAME). Only used below to build the
+        # image reference written into the chart, nothing else in this job
+        # needs it to be the actual triggering repo.
+        REPO: osac-project/fulfillment-service
       run: |
         # Login to the registry:
         export registry="ghcr.io"

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -25,8 +25,12 @@ permissions:
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
+  # Hardcoded rather than github.repository: that now resolves to
+  # osac-project/osac for every component's build workflow post-merge,
+  # colliding on mutable tags with osac-operator's image. Keeping this
+  # component's pre-merge image identity stable instead, same as
+  # osac-aap's execution-environment.yml does.
+  IMAGE_NAME: osac-project/fulfillment-service
 
 jobs:
   image:


### PR DESCRIPTION
## Summary
Fixes a currently-live bug: `osac-operator`'s `build-image.yaml` and `fulfillment-service`'s `publish-image.yaml` both set `IMAGE_NAME: ${{ github.repository }}`. Before the mono-repo merge that resolved to two different values; now both resolve to `osac-project/osac` for both workflows, so both components push to `ghcr.io/osac-project/osac` and stomp each other's mutable `:latest`/`:main` tags -- last-write-wins between two entirely different binaries. `sha-<commit>` tags don't collide since they're unique per commit; only the mutable tags do.

## Fix
Gave each workflow an explicit, component-specific `IMAGE_NAME` literal instead of deriving it from `github.repository`, restoring the original per-component image names:
- `build-image.yaml` (osac-operator): `IMAGE_NAME: osac-project/osac-operator`
- `publish-image.yaml` (fulfillment-service): `IMAGE_NAME: osac-project/fulfillment-service`

## Verification
Read both files' full current content fresh rather than trusting the ticket's line numbers (they'd shifted by one from the ticket's snapshot). Traced every `IMAGE_NAME`/`REGISTRY`/`github.repository` usage in both files, not just the env line:
- `build-image.yaml` has **two** `images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}` references (the main manager image and the manifest-container image) -- both correctly inherit from the same corrected env var, so the manifest image also lands under the right per-component path.
- `publish-image.yaml` has exactly one such reference.
- No other `IMAGE_NAME`/`REGISTRY` derivation exists in either file, and no other `github.repository` usage in either file relates to image naming.

Also grepped every workflow in the repo for `github.repository` to make sure no other file has the same unfixed anti-pattern: everything else (e2e-*.yml, publish-charts.yaml, scan-workflow-logs.yml) uses it for benign repo-identification purposes (checkout source, `gh api`/release calls), never as part of an image name. **Found one directly relevant precedent while doing this**: `osac-aap`'s own `execution-environment.yml` already hardcodes `images: ghcr.io/osac-project/osac-aap` with a comment explicitly calling out this exact collision class -- confirming someone already applied the same fix pattern proactively for that component. This PR brings the other two components in line with that established pattern.

Also searched the mono-repo and org-wide for any file (Helm values, kustomize, docs) hardcoding the currently-broken shared `ghcr.io/osac-project/osac` path expecting it to mean a specific component -- found none. (The only other `ghcr.io/osac-project/osac`-prefixed hits found were `osac-csi-driver`'s own image name in a different repo, unrelated.)

Validated with a YAML parse check and `yamllint -c .yamllint.yaml --strict` on both files -- clean.

## Follow-up fix: same collision leaking into the service chart (via CodeRabbit review)
`publish-charts.yaml`'s `publish-service-chart` job (fulfillment-service) independently derived `REPO: ${{ github.repository }}` and used it to build `app_image="${registry}/${REPO}:${app_version}"`, written into `charts/service/values.yaml`'s `images.service` field at release time. Same root cause, a second leak point: once the `IMAGE_NAME` fix above lands, fulfillment-service's real image only exists at `ghcr.io/osac-project/fulfillment-service`, so this job would have injected a reference to an image that no longer exists at `ghcr.io/osac-project/osac` -- breaking every real fulfillment-service chart release.

Fixed by hardcoding that job's `REPO` env var to `osac-project/fulfillment-service`, matching the `IMAGE_NAME` set in `publish-image.yaml`.

Re-read the full file to confirm scope: `REPO` in `publish-service-chart` is used exactly once, only for the image-reference construction above -- nothing else in that job needs it. The other four `REPO: ${{ github.repository }}` occurrences in this file (osac-operator's `publish-operator-crds-chart`/`publish-operator-chart`/`create-operator-release` jobs) all use it correctly for real `gh api`/`gh release create` calls against the actual triggering repo and are untouched -- confirmed osac-operator's own chart (`charts/operator/values.yaml`) already hardcodes its `repository:` field statically and this file's operator job only ever sed-replaces the tag, never the repository, so osac-operator was never affected by this particular leak.

Validated with a YAML parse check and `yamllint -c .yamllint.yaml --strict` -- clean.

## Unblocks
[OSAC-3368](https://redhat.atlassian.net/browse/OSAC-3368) (updating the enclave repo's hardcoded image references) was blocked on this -- there was no correct, stable image name to point at for either component. This restores `ghcr.io/osac-project/osac-operator` and `ghcr.io/osac-project/fulfillment-service` as the correct stable names, matching what [OSAC-3368](https://redhat.atlassian.net/browse/OSAC-3368) already expects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized container image references used during builds and publishing.
  * Updated service chart publishing to use the correct image repository.
  * Improved consistency of image tags across deployment artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->