### PR TITLE
OSAC-2190: Cover osac-aap in floating-tag CI guard

### DIFF
--- a/.github/workflows/check-floating-tags.yaml
+++ b/.github/workflows/check-floating-tags.yaml
@@ -7,6 +7,7 @@ on:
       - 'osac-operator/charts/**/values.yaml'
       - 'bare-metal-fulfillment-operator/charts/**/values.yaml'
       - 'osac-installer/charts/**/values.yaml'
+      - 'osac-aap/charts/**/values.yaml'
       - '.github/scripts/check-floating-tags.sh'
       - '.github/workflows/check-floating-tags.yaml'
 
@@ -44,6 +45,10 @@ jobs:
               - '.github/workflows/check-floating-tags.yaml'
             osac-installer:
               - 'osac-installer/charts/**/values.yaml'
+              - '.github/scripts/check-floating-tags.sh'
+              - '.github/workflows/check-floating-tags.yaml'
+            osac-aap:
+              - 'osac-aap/charts/**/values.yaml'
               - '.github/scripts/check-floating-tags.sh'
               - '.github/workflows/check-floating-tags.yaml'
 

--- a/osac-aap/charts/aap/values.yaml
+++ b/osac-aap/charts/aap/values.yaml
@@ -16,7 +16,7 @@ aap:
 
 bootstrap:
   enabled: true
-  image: ghcr.io/osac-project/osac-aap:latest
+  image: ghcr.io/osac-project/osac-aap:latest  # PLACEHOLDER -- overwritten at release time by publish-charts.yaml
   cliImage: quay.io/openshift/origin-cli:4.20.0
   backoffLimit: 15
 


### PR DESCRIPTION
## Summary
- Migrate [osac-aap#440](https://github.com/osac-project/osac-aap/pull/440) into the monorepo `osac-aap/` tree
- Mark `osac-aap/charts/aap/values.yaml` bootstrap image `:latest` with `# PLACEHOLDER -- overwritten at release time by publish-charts.yaml`
- Add `osac-aap` to `.github/workflows/check-floating-tags.yaml` path filters and matrix (shared root script already present from FS/operator merge)

No change to release-publish behavior. Note: `publish-charts.yaml` still does not wire osac-aap chart publish yet (deferred per [OSAC-3491](https://redhat.atlassian.net/browse/OSAC-3491) / after [OSAC-3467](https://redhat.atlassian.net/browse/OSAC-3467)).

Ref: [OSAC-2190](https://redhat.atlassian.net/browse/OSAC-2190)

## Test plan
- [x] `bash .github/scripts/check-floating-tags.sh` passes under `fulfillment-service`, `osac-operator`, and `osac-aap`
- [ ] CI `Check Floating Image Tags` job runs for osac-aap matrix entry on this PR
- [ ] Confirm unmarked `:latest` without PLACEHOLDER would fail (already verified pre-change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded automated image-tag validation to include osac-aap updates.
  * Improved release checks for osac-aap chart changes.
  * Added documentation clarifying that the bootstrap image value is updated during release preparation.
  * Clarified release-time image handling for more consistent chart updates and deployment preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->