### PR TITLE
OSAC-3467/OSAC-3507: Fix goreleaser release failure on scoped release tags

### DIFF
--- a/.github/workflows/publish-binaries.yaml
+++ b/.github/workflows/publish-binaries.yaml
@@ -41,7 +41,13 @@ jobs:
     - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7
       with:
         workdir: fulfillment-service
-        args: release --clean
+        # goreleaser's own git-state pipe additionally requires a real git tag
+        # literally named GORELEASER_CURRENT_TAG to exist at HEAD, separate from
+        # (and not satisfied by) the env var override above -- our actual pushed
+        # tag is scoped (fulfillment-service/vX.Y.Z), so that check always fails.
+        # --skip=validate disables just that check (plus an irrelevant-in-CI
+        # dirty-worktree check); it doesn't affect anything else in the release.
+        args: release --clean --skip=validate
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GORELEASER_CURRENT_TAG: ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/publish-binaries.yaml
+++ b/.github/workflows/publish-binaries.yaml
@@ -42,8 +42,8 @@ jobs:
       with:
         workdir: fulfillment-service
         # goreleaser's own git-state pipe additionally requires a real git tag
-        # literally named GORELEASER_CURRENT_TAG to exist at HEAD, separate from
-        # (and not satisfied by) the env var override above -- our actual pushed
+        # named by the value of GORELEASER_CURRENT_TAG to exist at HEAD, separate
+        # from (and not satisfied by) the env var override above -- our actual pushed
         # tag is scoped (fulfillment-service/vX.Y.Z), so that check always fails.
         # --skip=validate disables just that check (plus an irrelevant-in-CI
         # dirty-worktree check); it doesn't affect anything else in the release.


### PR DESCRIPTION
## Summary

Fixes the "Publish binaries" workflow failure that hit on the first real tag pushed after [OSAC-3467](https://redhat.atlassian.net/browse/OSAC-3467) scoped release-trigger tags to `<component>/vX.Y.Z`:

```
release failed after 0s error=git tag v0.0.80 was not made against commit e19901c79c9d1405b61d8bcce5c5cd91065799b6
```

Run: https://github.com/osac-project/osac/actions/runs/30654772655

## Root cause (verified against goreleaser v2.17.1's actual source, not assumption)

`GORELEASER_CURRENT_TAG` fully overrides the tag *string* goreleaser uses (`internal/pipe/git/git.go:getTag`, which checks this env var first, before any git lookup). But goreleaser's git-state pipe runs a second, independent check afterward (`internal/pipe/git/git.go:validate`) that does:

```go
git describe --exact-match --tags --match <CurrentTag>
```

against HEAD, regardless of where `CurrentTag` came from. Since the actually-pushed tag is `fulfillment-service/v0.0.80`, not a bare `v0.0.80`, no ref matches and this always fails -- the env var satisfies the version string, but not this separate existence check.

## Investigated options (per the ticket, all checked against goreleaser's real source/docs before picking one)

1. **`--skip=validate`** -- a real, current, documented CLI flag on `release` (`cmd/release.go`; `skips.Validate` is in the `skips.Release` allowed list). It disables exactly the pipe containing both this tag-exact-match check and an unrelated dirty-worktree check -- nothing else in the release pipeline is affected. ✅ **This is the fix used here.**
2. Native monorepo tag-prefix support (`monorepo.tag_prefix` in `.goreleaser.yaml`) -- this exists and is exactly designed for `subproject/vX.Y.Z`-style tags, but confirmed via source (`grep -rn monorepo internal/ pkg/` finds nothing) and docs (`{{< g_featpro >}}` shortcode on `www/content/customization/monorepo.md`) that it's a **GoReleaser Pro** (paid) feature, not present at all in the OSS binary this workflow uses. Not usable.
3. Creating a local, unpushed lightweight tag aliasing the scoped tag to the bare version before invoking goreleaser -- would also satisfy the check (confirmed: `git describe --exact-match` only cares about local refs), but is a more roundabout workaround for something goreleaser already has a first-class, documented escape hatch for. Not used.

## Verification

Reproduced the exact failure locally by building goreleaser from source at v2.17.1 and running it against a minimal repo with a scoped tag + `GORELEASER_CURRENT_TAG` set the same way this workflow sets it -- got the identical error message. Re-ran with `--skip=validate` added: the git-state pipe now logs `pipe skipped or partially skipped reason=validation is disabled` and the release proceeds past it into the build stage (which then hits an unrelated local Go toolchain mismatch in my sandbox, not a goreleaser or workflow issue).

Part of [OSAC-1732](https://redhat.atlassian.net/browse/OSAC-1732) / [OSAC-3467](https://redhat.atlassian.net/browse/OSAC-3467) (original tag-scoping change). [OSAC-3507](https://redhat.atlassian.net/browse/OSAC-3507) tracks this specific regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the binary release process to bypass validation checks while preserving clean release behavior.
  * Added documentation explaining the scoped-tag mismatch and skipped checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->