### PR TITLE
OSAC-3511: Wire osac-aap into the tag-scoped release pipeline

### DIFF
--- a/.github/workflows/execution-environment.yml
+++ b/.github/workflows/execution-environment.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - main
     tags:
-      - 'v*'
+      - 'osac-aap/v*'
   pull_request:
     branches:
       - main
@@ -50,6 +50,29 @@ jobs:
                                             --tag "osac-ee"         \
                                             -f "./execution-environment/execution-environment.yaml"
 
+      # Component-scoped tags (see the `tags:` trigger above) can't be used verbatim
+      # as image tags -- Docker/OCI tags can't contain the '/' the git tag does --
+      # so strip the prefix here to recover the bare vX.Y.Z for the actual image tags.
+      - name: Compute release version
+        if: startsWith(github.ref, 'refs/tags/osac-aap/')
+        run: |
+          version="${GITHUB_REF_NAME#osac-aap/}"
+          # Same SemVer rule as publish-charts.yaml's guard job -- rejects build
+          # metadata (+...) and validates the core/prerelease shape before it's
+          # trusted as an image tag.
+          semver_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?$'
+          if ! [[ "${version}" =~ ${semver_re} ]]; then
+            echo "::error::Tag '${GITHUB_REF_NAME}' is not a valid semver release tag"
+            exit 1
+          fi
+          # Prerelease identifiers can themselves contain dots (e.g. v1.2.3-beta.1),
+          # so derive major/minor from the prerelease-stripped core version --
+          # otherwise a dotted prerelease would corrupt the major.minor alias.
+          core="${version%%-*}"
+          echo "RELEASE_VERSION=${version}" >> "$GITHUB_ENV"
+          echo "RELEASE_MAJOR_MINOR=${core%.*}" >> "$GITHUB_ENV"
+          echo "RELEASE_MAJOR=${core%%.*}" >> "$GITHUB_ENV"
+
       - name: Extract metadata (tags, labels)
         if: github.event_name != 'pull_request'
         id: meta
@@ -60,11 +83,15 @@ jobs:
           # workflow post-merge (see OSAC-3490), colliding on mutable tags.
           # Keeping this component's pre-merge image identity stable instead.
           images: ghcr.io/osac-project/osac-aap
+          # No `type=ref,event=tag` here: the `tags:` trigger above only ever
+          # matches this component's own scoped prefix, so the tag-triggered
+          # case is always covered by the three raw entries below already --
+          # keeping it would just add a redundant, slash-sanitized duplicate
+          # tag (e.g. "osac-aap-v1.2.3").
           tags: |
-            type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
-            type=semver,pattern=v{{major}}
-            type=ref,event=tag
+            type=raw,value=${{ env.RELEASE_VERSION }},enable=${{ env.RELEASE_VERSION != '' }}
+            type=raw,value=${{ env.RELEASE_MAJOR_MINOR }},enable=${{ env.RELEASE_VERSION != '' }}
+            type=raw,value=${{ env.RELEASE_MAJOR }},enable=${{ env.RELEASE_VERSION != '' }}
             type=sha
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -29,16 +29,9 @@ jobs:
   # component's image-build workflow fired. Each publish job below then
   # gates on github.event.workflow_run.name to only publish its own
   # component's chart -- the image-build workflows themselves stay separate
-  # per component (see build-image.yaml/publish-image.yaml), so this is the
-  # one place their otherwise-independent tag-triggered releases converge.
-  #
-  # osac-aap's execution-environment.yml is NOT wired in here yet: PR #29
-  # (OSAC-3467) is reworking this guard job to use component-scoped tags
-  # (<component>/vX.Y.Z) and a shared `version` output instead of the bare
-  # `v*` matching below, and is still open/under review. Wiring osac-aap in
-  # against the current unscoped shape would conflict with that PR and need
-  # rework regardless of merge order. Deferred to a follow-up once PR #29's
-  # final shape lands -- see OSAC-3491.
+  # per component (see build-image.yaml/publish-image.yaml/execution-environment.yml),
+  # so this is the one place their otherwise-independent tag-triggered
+  # releases converge.
   guard:
     name: Verify image build succeeded
     runs-on: ubuntu-latest
@@ -47,7 +40,8 @@ jobs:
     if: >
       github.event.workflow_run.event == 'push' &&
       (startsWith(github.event.workflow_run.head_branch, 'fulfillment-service/v') ||
-       startsWith(github.event.workflow_run.head_branch, 'osac-operator/v'))
+       startsWith(github.event.workflow_run.head_branch, 'osac-operator/v') ||
+       startsWith(github.event.workflow_run.head_branch, 'osac-aap/v'))
     outputs:
       tag: ${{ github.event.workflow_run.head_branch }}
       version: ${{ steps.check.outputs.version }}
@@ -59,12 +53,14 @@ jobs:
         CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
       run: |
-        # Each component owns a scoped tag prefix (see publish-image.yaml/build-image.yaml's
-        # own `tags:` triggers) so a single tag push can't fire every component's release
-        # chain at once; strip it here to recover the bare vX.Y.Z used for artifact versions.
+        # Each component owns a scoped tag prefix (see publish-image.yaml/build-image.yaml/
+        # execution-environment.yml's own `tags:` triggers) so a single tag push can't fire
+        # every component's release chain at once; strip it here to recover the bare vX.Y.Z
+        # used for artifact versions.
         case "$HEAD_BRANCH" in
           fulfillment-service/v*) VERSION="${HEAD_BRANCH#fulfillment-service/}" ;;
           osac-operator/v*) VERSION="${HEAD_BRANCH#osac-operator/}" ;;
+          osac-aap/v*) VERSION="${HEAD_BRANCH#osac-aap/}" ;;
           *) echo "::error::Tag '$HEAD_BRANCH' does not match a known component prefix"; exit 1 ;;
         esac
 
@@ -277,6 +273,115 @@ jobs:
         || gh release edit "${TAG}" \
           --repo "${REPO}" \
           --title "osac-operator ${VERSION}"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ needs.guard.outputs.tag }}
+        VERSION: ${{ needs.guard.outputs.version }}
+        REPO: ${{ github.repository }}
+
+  # Single job, unlike osac-operator's chart-publish/release split: osac-aap
+  # has only one chart, so there's no multi-chart parallelism to justify
+  # separating release creation into its own job -- this mirrors the old
+  # standalone osac-aap repo's own publish-aap-chart job, including its
+  # double tag-race check (once before packaging, again right before the
+  # release, since real wall-clock time passes between the two).
+  publish-osac-aap-chart:
+    name: Publish osac-aap chart
+    needs: guard
+    if: success() && github.event.workflow_run.name == 'Build execution environment'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      with:
+        ref: ${{ needs.guard.outputs.sha }}
+        persist-credentials: false
+
+    - name: Verify tag still points at the guarded commit
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ needs.guard.outputs.tag }}
+        GUARDED_SHA: ${{ needs.guard.outputs.sha }}
+        REPO: ${{ github.repository }}
+      run: .github/scripts/osac-aap-verify-tag-matches-sha.sh
+
+    - name: Set up Helm
+      uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
+      with:
+        version: v3.17.0
+
+    - name: Log in to GHCR
+      env:
+        REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        REGISTRY_USERNAME: ${{ github.actor }}
+      run: echo "${REGISTRY_PASSWORD}" | helm registry login "${REGISTRY}" -u "${REGISTRY_USERNAME}" --password-stdin
+
+    - name: Extract version from tag
+      id: version
+      run: echo "version=${VERSION#v}" >> "$GITHUB_OUTPUT"
+      env:
+        VERSION: ${{ needs.guard.outputs.version }}
+
+    - name: Update image tag in values.yaml
+      working-directory: osac-aap
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
+      run: |
+        if [[ ! "$VERSION" =~ ^[0-9A-Za-z._-]+$ ]]; then
+          echo "Invalid release version: $VERSION" >&2
+          exit 1
+        fi
+
+        # sed exits 0 even when a pattern matches zero lines, so a future values.yaml
+        # format change could silently leave a placeholder unpinned. Verify the expected
+        # replacement actually landed and fail the release instead of packaging stale values.
+        replace_and_verify() {
+          local old="$1" new="$2"
+          sed -i "s|${old}|${new}|" charts/aap/values.yaml
+          if ! grep -qF -- "${new}" charts/aap/values.yaml; then
+            echo "::error::Expected '${new}' not found in charts/aap/values.yaml after substitution (placeholder '${old}' may be missing or already changed)" >&2
+            exit 1
+          fi
+        }
+
+        replace_and_verify "image: ghcr.io/osac-project/osac-aap:latest" "image: ghcr.io/osac-project/osac-aap:v${VERSION}"
+        replace_and_verify "eeImage: \"\"" "eeImage: \"ghcr.io/osac-project/osac-aap:v${VERSION}\""
+        replace_and_verify "projectGitBranch: \"\"" "projectGitBranch: \"v${VERSION}\""
+
+    - name: Package chart
+      working-directory: osac-aap
+      run: |
+        helm package charts/aap/ \
+          --version "${{ steps.version.outputs.version }}" \
+          --app-version "${{ steps.version.outputs.version }}"
+
+    - name: Push chart to GHCR
+      working-directory: osac-aap
+      run: |
+        helm push osac-aap-${{ steps.version.outputs.version }}.tgz \
+          oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
+
+    - name: Verify tag still points at the guarded commit
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ needs.guard.outputs.tag }}
+        GUARDED_SHA: ${{ needs.guard.outputs.sha }}
+        REPO: ${{ github.repository }}
+      run: .github/scripts/osac-aap-verify-tag-matches-sha.sh
+
+    - name: Create GitHub Release
+      run: |
+        gh release create "${TAG}" \
+          --repo "${REPO}" \
+          --title "osac-aap ${VERSION}" \
+          --generate-notes \
+          --verify-tag \
+        || gh release edit "${TAG}" \
+          --repo "${REPO}" \
+          --title "osac-aap ${VERSION}"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ needs.guard.outputs.tag }}


### PR DESCRIPTION
## Summary
Wires osac-aap into the now-proven [OSAC-3467](https://redhat.atlassian.net/browse/OSAC-3467)/OSAC-3490 tag-scoped release pattern already verified end-to-end on fulfillment-service and osac-operator. This was deliberately deferred, not forgotten -- per `publish-charts.yaml`'s own prior comment, wiring osac-aap in before PR #29 ([OSAC-3467](https://redhat.atlassian.net/browse/OSAC-3467)) settled its final shape would have needed rework regardless of merge order. PR #29 is merged and both other components have real tags fully verified through image build -> GHCR push -> chart publish -> GitHub Release.

## Changes

**`execution-environment.yml`**: trigger changed from unscoped `tags: - 'v*'` to `osac-aap/v*`, matching `build-image.yaml`/`publish-image.yaml`'s established convention. Added the same tag-prefix-stripping + SemVer-validation step (including the prerelease-safe major/minor derivation) and swapped `docker/metadata-action`'s `type=semver,pattern=...` entries for the same `type=raw,value=...,enable=...` pattern those two files use, for the same reason: a scoped tag with a literal `/` in it can't be matched by `type=semver`'s anchored pattern. Also dropped the now-redundant `type=ref,event=tag` entry, matching the reasoning already applied to the other two workflows.

**`publish-charts.yaml`**: added `osac-aap/v` to the shared `guard` job's `startsWith` condition and its tag-prefix-stripping `case` statement. Added a new `publish-osac-aap-chart` job, ported from the old standalone `osac-project/osac-aap` repo's own `publish-aap-chart` job (read in full, not guessed), adapted to this file's current conventions:
- `if: success() && github.event.workflow_run.name == 'Build execution environment'` (the actual name of this repo's build workflow), matching how the fulfillment-service/osac-operator jobs gate on their own workflow names.
- Sources the version from `needs.guard.outputs.version` (already prefix-stripped) instead of re-deriving it from the raw tag.
- Uses `.github/scripts/osac-aap-verify-tag-matches-sha.sh` (the script [OSAC-3491](https://redhat.atlassian.net/browse/OSAC-3491) already moved/renamed to root in preparation for this, previously unused).
- Kept as a **single job**, unlike osac-operator's chart-publish/release split -- osac-aap has only one chart, so there's no multi-chart parallelism to justify separating release creation into its own job. This also preserves the old job's double tag-race check (once before packaging, again immediately before the release), which is a real race guard given real wall-clock time passes between the two, not incidental duplication.

## Verification
Read all four current files fresh (`execution-environment.yml`, `build-image.yaml`, `publish-image.yaml`, `publish-charts.yaml`) rather than assuming their shape, and the old standalone repo's `publish-charts.yaml` in full before porting anything. YAML parse check + `yamllint -c .yamllint.yaml --strict` on both changed files -- clean.

## GHCR "Manage Actions access" gap -- checked proactively, looks like it's needed
Per the same class of gap that hit fulfillment-service/osac-operator twice already (container images, then chart packages): checked `osac-aap`'s and `charts/osac-aap`'s package linkage via the GitHub Packages API before attempting any real tag push.

Both packages currently show `repository: osac-project/osac-aap` (the old standalone repo) as their origin. Note this field doesn't reliably indicate whether a "Manage Actions access" grant for `osac-project/osac` already exists or not -- it reflects historical package origin, not the current grant list, and there's no REST API to read the actual grant list (this is UI-only). Given osac-operator/fulfillment-service needed this grant added manually before their real-tag tests could push successfully, and nobody would have had reason to add it for osac-aap before this ticket wired it into the pipeline, I'm flagging this now rather than discovering a 403 mid-test: **`osac-aap` (container) and `charts/osac-aap` likely both need `osac-project/osac` added under Package Settings -> Manage Actions access -> Add repository, with Write role**, same as was needed for the other two components.

## Testing plan (not yet done -- pending the access grant above)
Once merged to main (workflow file content is pinned to the tag's target commit, so testing against a stale/unmerged tag wouldn't exercise this fix) and the GHCR grant is confirmed, will push a real `osac-aap/vX.Y.Z` tag (next in sequence: `osac-aap/v0.0.12`, following the old repo's last release `v0.0.11`) and confirm the image builds and pushes to `ghcr.io/osac-project/osac-aap`, the chart publishes to `ghcr.io/osac-project/charts/osac-aap`, and a GitHub Release is created -- then report back and close [OSAC-3511](https://redhat.atlassian.net/browse/OSAC-3511).

Not merging this myself.