### PR TITLE
NO-ISSUE: Fix stale fulfillment-service doc links

### DIFF
--- a/fulfillment-service/docs/AUTH.md
+++ b/fulfillment-service/docs/AUTH.md
@@ -38,7 +38,7 @@ Before installing Keycloak, ensure you have:
 The fulfillment service includes a Helm chart for deploying Keycloak. The chart is published with
 each release as an OCI image at [ghcr.io/osac/charts/keycloak][keycloak-chart].
 
-[keycloak-chart]: https://github.com/osac-project/fulfillment-service/pkgs/container/charts%2Fkeycloak
+[keycloak-chart]: https://github.com/osac-project/osac/pkgs/container/charts%2Fkeycloak
 
 ### Installation Steps
 

--- a/fulfillment-service/docs/INSTALL.md
+++ b/fulfillment-service/docs/INSTALL.md
@@ -29,7 +29,7 @@ You will also need the following command-line tools installed:
 - `osac` - To interact with the OSAC system from the command line.
 
 The `osac` CLI can be downloaded from the [releases
-page](https://github.com/osac-project/fulfillment-service/releases) of the project.
+page](https://github.com/osac-project/osac/releases) of the project.
 
 Before starting, set the `DOMAIN` environment variable to the OpenShift applications domain of your
 cluster. This is the domain suffix used by OpenShift routes to construct hostnames. You can find it
@@ -1060,7 +1060,7 @@ helm upgrade fulfillment-service oci://ghcr.io/osac-project/charts/fulfillment-s
 ```
 
 You can add `--version <version>` to pin a specific chart version if needed. See the
-[releases page](https://github.com/osac-project/fulfillment-service/releases) for available
+[releases page](https://github.com/osac-project/osac/releases) for available
 versions.
 
 ## Verify the installation


### PR DESCRIPTION
## Summary
- Update two release-page links in `fulfillment-service/docs/INSTALL.md` from `osac-project/fulfillment-service` to `osac-project/osac`
- Update keycloak container-package link in `fulfillment-service/docs/AUTH.md` from `osac-project/fulfillment-service` to `osac-project/osac`

These URLs pointed at the now-locked standalone repo and should reference the monorepo.

## Test plan
- [x] Links syntactically correct (markdown renders, URL paths valid)
- [ ] Verify new release/package URLs resolve after first monorepo release