### PR TITLE
OSAC-3512: Increase periodic CI frequency for e2e and unit/integration tests

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -8,8 +8,14 @@ on:
   pull_request:
     branches: [main]
   merge_group:
+  # 3x/day (every 8h). Offset 23 minutes past the hour, not on the hour --
+  # GitHub Actions' shared cron scheduler queues everyone's on-the-hour
+  # schedules together and can delay/drop them under load (see
+  # osac-test-infra's e2e-caas-netris-caller.yml for the same reasoning).
+  # Staggered from the other periodic workflows in this repo too, so they
+  # don't all land on the same offset simultaneously.
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "23 */8 * * *"
   workflow_dispatch:
     inputs:
       test-suite:

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -8,8 +8,14 @@ on:
   pull_request:
     branches: [main]
   merge_group:
+  # 3x/day (every 8h). Offset 38 minutes past the hour, not on the hour --
+  # GitHub Actions' shared cron scheduler queues everyone's on-the-hour
+  # schedules together and can delay/drop them under load (see
+  # osac-test-infra's e2e-caas-netris-caller.yml for the same reasoning).
+  # Staggered from the other periodic workflows in this repo too, so they
+  # don't all land on the same offset simultaneously.
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "38 */8 * * *"
   workflow_dispatch:
     inputs:
       test-suite:

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -8,8 +8,14 @@ on:
   pull_request:
     branches: [main]
   merge_group:
+  # 3x/day (every 8h). Offset 7 minutes past the hour, not on the hour --
+  # GitHub Actions' shared cron scheduler queues everyone's on-the-hour
+  # schedules together and can delay/drop them under load (see
+  # osac-test-infra's e2e-caas-netris-caller.yml for the same reasoning).
+  # Staggered from the other periodic workflows in this repo too, so they
+  # don't all land on the same offset simultaneously.
   schedule:
-    - cron: "0 */12 * * *"
+    - cron: "7 */8 * * *"
   workflow_dispatch:
     inputs:
       test-suite:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -21,8 +21,14 @@ on:
       - '!osac-aap/**/*.md'
       - '!osac-aap/docs/**'
   workflow_dispatch:
+  # 2x/day (every 12h). Offset 47 minutes past the hour, not on the hour --
+  # GitHub Actions' shared cron scheduler queues everyone's on-the-hour
+  # schedules together and can delay/drop them under load (see
+  # osac-test-infra's e2e-caas-netris-caller.yml for the same reasoning).
+  # Staggered from the other periodic workflows in this repo too, so they
+  # don't all land on the same offset simultaneously.
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '47 */12 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,8 +25,14 @@ on:
       - '!fulfillment-service/**/*.md'
       - '!fulfillment-service/docs/**'
   workflow_dispatch:
+  # 2x/day (every 12h). Offset 13 minutes past the hour, not on the hour --
+  # GitHub Actions' shared cron scheduler queues everyone's on-the-hour
+  # schedules together and can delay/drop them under load (see
+  # osac-test-infra's e2e-caas-netris-caller.yml for the same reasoning).
+  # Staggered from the other periodic workflows in this repo too, so they
+  # don't all land on the same offset simultaneously.
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '13 */12 * * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Increases periodic (schedule-triggered) run frequency:

| Workflow | Before | After |
|---|---|---|
| `e2e-vmaas-full-install.yml` | `0 */12 * * *` (2x/day) | `7 */8 * * *` (3x/day) |
| `e2e-bmaas-full-install.yml` | `0 */12 * * *` (2x/day) | `23 */8 * * *` (3x/day) |
| `e2e-caas-full-install.yml` | `0 */12 * * *` (2x/day) | `38 */8 * * *` (3x/day) |
| `unit-tests.yml` | `0 0 * * *` (1x/day) | `13 */12 * * *` (2x/day) |
| `integration-tests.yml` | `0 0 * * *` (1x/day) | `47 */12 * * *` (2x/day) |

## Why non-zero, staggered minute offsets

Rather than a bare `0 */N * * *` pattern, each workflow uses a distinct, non-round minute offset (7, 23, 38, 13, 47) — GitHub Actions' shared cron scheduler queues everyone's on-the-hour schedules together and can delay or silently drop them under load. This follows the precedent already established in `osac-test-infra`'s `e2e-caas-netris-caller.yml` (`cron: "17 */3 * * *"`), which has the same reasoning documented in its own comment.

## Verification

- Computed actual daily fire times for each new cron expression to confirm the target frequency:
  - vmaas: 00:07, 08:07, 16:07 (3x/day)
  - bmaas: 00:23, 08:23, 16:23 (3x/day)
  - caas: 00:38, 08:38, 16:38 (3x/day)
  - unit-tests: 00:13, 12:13 (2x/day)
  - integration-tests: 00:47, 12:47 (2x/day)
- All 5 minute offsets are distinct, so no two workflows fire at the same moment.
- `actionlint` reports no issues on all 5 changed files.
- `pre-commit run` (yamllint, etc.) passes.