### PR TITLE
OSAC-3511: Add Build execution environment to publish-charts.yaml's workflow_run trigger

### DIFF
--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -16,7 +16,11 @@ name: Publish charts
 
 on:
   workflow_run:
-    workflows: ["Container image", "Build container image"]
+    # OSAC-3511 added osac-aap's guard condition and publish-osac-aap-chart
+    # job, but missed adding its actual build workflow's name here --
+    # workflow_run only fires for workflows explicitly listed, so without
+    # this the osac-aap chart-publish path silently never triggers at all.
+    workflows: ["Container image", "Build container image", "Build execution environment"]
     types: [completed]
 
 env:

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -16,10 +16,10 @@ name: Publish charts
 
 on:
   workflow_run:
-    # OSAC-3511 added osac-aap's guard condition and publish-osac-aap-chart
-    # job, but missed adding its actual build workflow's name here --
-    # workflow_run only fires for workflows explicitly listed, so without
-    # this the osac-aap chart-publish path silently never triggers at all.
+    # workflow_run only fires for workflows explicitly listed here -- the
+    # guard condition and publish-osac-aap-chart job alone aren't enough
+    # to trigger this workflow at all without osac-aap's build workflow
+    # name also present in this list.
     workflows: ["Container image", "Build container image", "Build execution environment"]
     types: [completed]
 


### PR DESCRIPTION
## Summary
Found while live-testing PR #44's osac-aap wiring: pushing `osac-aap/v0.0.12` built and pushed the image successfully, but never triggered a `Publish charts` run at all.

## Root cause
PR #44 correctly added osac-aap's guard condition (`startsWith(head_branch, 'osac-aap/v')`) and the `publish-osac-aap-chart` job, but never added `Build execution environment` (osac-aap's actual image-build workflow name) to `publish-charts.yaml`'s top-level `on: workflow_run: workflows: [...]` list. `workflow_run` only fires for workflows explicitly named there -- without this, the entire osac-aap chart-publish path was dead code regardless of the job-level guard being correct.

## Fix
Added `"Build execution environment"` to the `workflows:` list. One line.

## Test plan
- [ ] Push a fresh `osac-aap/vX.Y.Z` tag against this fix and confirm a `Publish charts` run actually fires and completes the `publish-osac-aap-chart`/guard jobs this time.