### PR TITLE
OSAC-3517: Add path-filter skip logic to unit-tests.yml and integration-tests.yml

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,22 +4,6 @@ on:
   pull_request:
     branches:
     - main
-    paths:
-      - 'fulfillment-service/**'
-      - '!fulfillment-service/OWNERS'
-      - '!fulfillment-service/LICENSE'
-      - '!fulfillment-service/**/*.md'
-      - '!fulfillment-service/docs/**'
-      - 'osac-operator/**'
-      - '!osac-operator/OWNERS'
-      - '!osac-operator/LICENSE'
-      - '!osac-operator/**/*.md'
-      - '!osac-operator/docs/**'
-      - 'osac-aap/**'
-      - '!osac-aap/OWNERS'
-      - '!osac-aap/LICENSE'
-      - '!osac-aap/**/*.md'
-      - '!osac-aap/docs/**'
   workflow_dispatch:
   # 2x/day (every 12h). Offset 47 minutes past the hour, not on the hour --
   # GitHub Actions' shared cron scheduler queues everyone's on-the-hour
@@ -39,6 +23,26 @@ permissions:
 
 jobs:
 
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      should-run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+    steps:
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '**'
+              - '!OWNERS'
+              - '!LICENSE'
+              - '!*.md'
+              - '!docs/**'
+
   # fulfillment-service, osac-operator, and osac-aap use genuinely different
   # integration test mechanisms (ginkgo directly, a Kind cluster + Makefile
   # target, and a Kind cluster + uv/pytest respectively), so these stay
@@ -46,6 +50,8 @@ jobs:
   # parameterize, only the workflow-level trigger/name were duplicated before.
   fulfillment-service:
     name: Run integration test (fulfillment-service)
+    needs: changes
+    if: needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -69,6 +75,8 @@ jobs:
 
   osac-operator:
     name: Run integration test (osac-operator)
+    needs: changes
+    if: needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -95,6 +103,8 @@ jobs:
 
   osac-aap:
     name: Run integration test (osac-aap)
+    needs: changes
+    if: needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,10 +38,10 @@ jobs:
           filters: |
             code:
               - '**'
-              - '!OWNERS'
-              - '!LICENSE'
-              - '!*.md'
-              - '!docs/**'
+              - '!**/OWNERS'
+              - '!**/LICENSE'
+              - '!**/*.md'
+              - '!**/docs/**'
 
   # fulfillment-service, osac-operator, and osac-aap use genuinely different
   # integration test mechanisms (ginkgo directly, a Kind cluster + Makefile

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -48,10 +48,10 @@ jobs:
           filters: |
             code:
               - '**'
-              - '!OWNERS'
-              - '!LICENSE'
-              - '!*.md'
-              - '!docs/**'
+              - '!**/OWNERS'
+              - '!**/LICENSE'
+              - '!**/*.md'
+              - '!**/docs/**'
 
   run-unit-tests:
     name: Run unit tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,12 +18,6 @@ on:
   pull_request:
     branches:
     - main
-    paths:
-      - 'fulfillment-service/**'
-      - '!fulfillment-service/OWNERS'
-      - '!fulfillment-service/LICENSE'
-      - '!fulfillment-service/**/*.md'
-      - '!fulfillment-service/docs/**'
   workflow_dispatch:
   # 2x/day (every 12h). Offset 13 minutes past the hour, not on the hour --
   # GitHub Actions' shared cron scheduler queues everyone's on-the-hour
@@ -39,8 +33,30 @@ permissions:
 
 jobs:
 
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      should-run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+    steps:
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '**'
+              - '!OWNERS'
+              - '!LICENSE'
+              - '!*.md'
+              - '!docs/**'
+
   run-unit-tests:
     name: Run unit tests
+    needs: changes
+    if: needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1


### PR DESCRIPTION
## Summary

`unit-tests.yml` and `integration-tests.yml` used a component-scoped `paths:` filter at the workflow-trigger level (e.g. `fulfillment-service/**` with OWNERS/LICENSE/*.md/docs/** exclusions). That's the exact anti-pattern [OSAC-3227](https://redhat.atlassian.net/browse/OSAC-3227) verified against: when a `paths:` filter lives on the trigger itself, a PR whose changed files never match means the whole workflow never gets a run registered at all — which permanently blocks merge if either job is ever made a required status check (the check just sits at "Expected" forever).

Replaced it with the same pattern already used (and already verified) by the 3 e2e workflows: an internal `changes` job running `dorny/paths-filter`, gating the actual test job(s) via `needs.changes.outputs.should-run` instead of gating the workflow trigger itself. Copied verbatim from `e2e-vmaas-full-install.yml`:

- Same pinned SHA: `dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706` (v4.0.2)
- Same `predicate-quantifier: 'every'`
- Same exclude list: `OWNERS`, `LICENSE`, `*.md`, `docs/**`
- Same `should-run` expression: `github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'`

## Behavior note

This does change trigger scope slightly: previously these two workflows only ran for PRs touching their specific component directories (`fulfillment-service/`, or `fulfillment-service`+`osac-operator`+`osac-aap`). The ported filter (matching e2e's own filter exactly, per e2e's own comment about deferring true per-component scoping to the future path-based CI matrix in [OSAC-1734](https://redhat.atlassian.net/browse/OSAC-1734)) now runs them for any PR touching any non-doc file repo-wide, skipping only on doc-only changes (OWNERS/LICENSE/*.md/docs/**). This trades some unnecessary cross-component runs for closing the required-status-check risk class — consistent with how the e2e workflows already work.

push/schedule/workflow_dispatch triggers are unaffected — the `dorny/paths-filter` step only runs `if: github.event_name == 'pull_request'`, and `should-run` short-circuits to `true` otherwise, exactly as before.

## Verification

- Read both files' full current job structure directly (not assumed identical to the e2e workflows — `unit-tests.yml` has one job, `integration-tests.yml` has three independent per-component jobs since they use genuinely different test mechanisms).
- Traced the gating logic by hand for all three cases:
  - Doc-only PR (e.g. touches only `README.md`): fails the `!*.md` predicate under `every` → `code` output is `false` → `should-run` is `false` → job skipped.
  - Code-touching PR: passes all AND-conditions → `code` is `true` → `should-run` is `true` → job runs.
  - Non-`pull_request` trigger (schedule/workflow_dispatch): filter step doesn't run at all → `should-run` short-circuits to `true` via the `github.event_name != 'pull_request'` clause → job always runs.
- `actionlint` reports no issues on both files.
- `pre-commit run` (yamllint, etc.) passes.
- This PR's own diff (workflow files, not docs) should itself exercise the "should-run == true" path when its checks run.