### PR TITLE
OSAC-3519: Add bare-metal-fulfillment-operator to e2e-bmaas components array

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -56,14 +56,14 @@ jobs:
               - '!*.md'
               - '!docs/**'
 
-  # Builds fulfillment-service, osac-operator, and osac-aap's execution
-  # environment from this PR's current code and installs them together in
-  # one cluster -- not one "component under test" plus stale pinned images
-  # for the others. Runs for any change touching any component (see
-  # `changes` above) rather than being path-scoped per component;
-  # splitting this by component to avoid running both suites when only one
-  # changed is deferred to the future full path-based CI matrix, once its
-  # skip-logic pattern is verified.
+  # Builds fulfillment-service, osac-operator, osac-aap's execution
+  # environment, and bare-metal-fulfillment-operator from this PR's current
+  # code and installs them together in one cluster -- not one "component
+  # under test" plus stale pinned images for the others. Runs for any
+  # change touching any component (see `changes` above) rather than being
+  # path-scoped per component; splitting this by component to avoid
+  # running both suites when only one changed is deferred to the future
+  # full path-based CI matrix, once its skip-logic pattern is verified.
   e2e-bmaas-full-install:
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
@@ -73,7 +73,7 @@ jobs:
       test-suite: ${{ inputs.test-suite || 'bmaas' }}
       test-filter: ${{ inputs.test-filter || '' }}
       # Build all component images from the PR's fork/branch (same monorepo checkout)
-      components: '[{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"}]'
+      components: '[{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}]'
       # Pass author_association for fork PR authorization (empty for non-fork PRs)
       fork-pr-author-association: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association || '' }}
       fork-pr-author: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.user.login || '' }}


### PR DESCRIPTION
## Summary
`e2e-bmaas-full-install.yml`'s `components` array builds fulfillment-service, osac-operator, and osac-aap from the PR's own mono-repo source, but bare-metal-fulfillment-operator (BMF) was missing -- since [OSAC-3395](https://redhat.atlassian.net/browse/OSAC-3395) merged it in, e2e-bmaas has been exercising whatever stale/default BMF image `osac-installer`'s values pin, not the PR's actual BMF code. Same "testing old code, not the PR" gap already solved for the other 3 components.

This is the bmaas-only change, prioritized first per explicit instruction since it's the e2e suite that actually exercises BMF's own functionality (bare-metal-as-a-service). vmaas/caas follow-up covered separately below.

## Verified against actual current state, not guessed
- `bare-metal-fulfillment-operator/Containerfile` exists at the repo root -- confirmed directly.
- **imageKey**: cloned `osac-installer` and read `charts/osac/Chart.yaml` + `charts/osac/values.yaml` + `values/bmaas-ci/values.yaml` directly. BMF is wired into the umbrella chart as dependency alias `bmf` (`repository: file://../../base/bare-metal-fulfillment-operator/charts/operator`, `condition: bmf.enabled`), with its image at `bmf.image.repository` -- confirmed exact key path, not assumed from the osac-operator analogy alone.
- **Conditional wiring is not a blocker for bmaas**: `bmf.enabled: true` in both the umbrella chart's own defaults and `values/bmaas-ci/values.yaml` (the values file this e2e flow actually deploys with) -- BMF's chart is enabled, so the image override will actually apply to a running deployment.
- **`replace-installer-submodule.sh`'s `SUBMODULE_MAP`**: already has a `[bare-metal-fulfillment-operator]="bare-metal-fulfillment-operator"` entry (added ahead of this, presumably during [OSAC-3395](https://redhat.atlassian.net/browse/OSAC-3395)'s own merge prep) -- confirmed the mapped submodule directory (`base/bare-metal-fulfillment-operator`) also exists in `osac-installer`. No change needed in osac-test-infra for the bmaas case.
- Confirmed osac-test-infra's reusable `e2e-bmaas-full-install.yml` loops over the `components` array generically ("so any number of components") -- no hardcoded component count to work around.

## Change
Added a 4th `components` entry: `containerfile: "bare-metal-fulfillment-operator/Containerfile"`, `imageKey: "bmf.image.repository"` (no `buildType`, defaults to `containerfile`, matching fulfillment-service/osac-operator's entries -- only osac-aap uses `ansible-builder`). Updated the job's explanatory comment to mention BMF.

## Validation
YAML parse + `yamllint -c .yamllint.yaml --strict` clean. Also parsed the embedded `components` JSON string directly to confirm it's valid JSON with exactly 4 entries and the expected keys.

## Verification plan (not yet done)
Will trigger a real e2e-bmaas run (workflow_dispatch or a test PR) once this is up for review, and confirm from the actual logs that BMF's image is being built from this PR's source rather than pulled pre-built -- same standard used for the other 3 components' onboarding. Will report back with the run link.

## Follow-up (separate, not in this PR)
The ticket covers all 3 e2e workflows (vmaas/bmaas/caas) for consistency; bmaas is first per priority. One nuance worth flagging before I extend to the other two: `bmf.enabled: false` in both `values/vmaas-ci/values.yaml` and `values/caas-ci/values.yaml` -- BMF's chart isn't deployed at all in those flows today, so adding the same components entry there would be harmless but a functional no-op (no running BMF pod for the image override to ever reach). Will call this out explicitly when I get to those two rather than silently adding a no-op.

Not merging this myself.