### PR TITLE
OSAC-3518: Wire bare-metal-fulfillment-operator into the tag-scoped release pipeline

### DIFF
--- a/.github/scripts/bare-metal-fulfillment-operator-verify-tag-matches-sha.sh
+++ b/.github/scripts/bare-metal-fulfillment-operator-verify-tag-matches-sha.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Verifies that a git tag still resolves to the guarded commit SHA that was
+# validated by this workflow's guard job, protecting against a force-push/
+# retag race between the image build and any subsequent chart-publish or
+# release step.
+#
+# Required env vars: GH_TOKEN, REPO, TAG, GUARDED_SHA
+set -euo pipefail
+
+ref_json="$(gh api "repos/${REPO}/git/ref/tags/${TAG}" --jq '[.object.type, .object.sha] | @tsv')"
+read -r current_type current_sha <<< "$ref_json"
+if [[ "$current_type" == "tag" ]]; then
+  # Annotated tag: the ref's object.sha is the tag object, not the commit - peel it.
+  current_sha="$(gh api "repos/${REPO}/git/tags/${current_sha}" --jq .object.sha)"
+fi
+
+if [[ "$current_sha" != "$GUARDED_SHA" ]]; then
+  echo "::error::Tag '${TAG}' now points at ${current_sha}, not the guarded commit ${GUARDED_SHA} (force-pushed?). Refusing to proceed."
+  exit 1
+fi
+
+echo "Tag '${TAG}' still points at the guarded commit ${GUARDED_SHA}."

--- a/.github/workflows/build-bmf-image.yaml
+++ b/.github/workflows/build-bmf-image.yaml
@@ -1,0 +1,211 @@
+name: Build bare-metal-fulfillment-operator image
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'bare-metal-fulfillment-operator/**'
+      - '!bare-metal-fulfillment-operator/OWNERS'
+      - '!bare-metal-fulfillment-operator/LICENSE'
+      - '!bare-metal-fulfillment-operator/**/*.md'
+      - '!bare-metal-fulfillment-operator/docs/**'
+  push:
+    branches:
+    - main
+    tags:
+    - 'bare-metal-fulfillment-operator/v*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # Hardcoded rather than github.repository: that now resolves to
+  # osac-project/osac for every component's build workflow post-merge,
+  # colliding on mutable tags with other components' images. Keeping this
+  # component's pre-merge image identity stable instead, same as
+  # osac-operator's build-image.yaml and osac-aap's execution-environment.yml do.
+  IMAGE_NAME: osac-project/bare-metal-fulfillment-operator
+
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'bare-metal-fulfillment-operator/go.mod'
+
+      - name: Install kind
+        uses: helm/kind-action@v1
+        with:
+          install_only: true
+
+      - name: Run unit tests
+        working-directory: bare-metal-fulfillment-operator
+        run: make test
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Component-scoped tags (see the `tags:` trigger above) can't be used verbatim
+      # as image tags -- Docker/OCI tags can't contain the '/' the git tag does --
+      # so strip the prefix here to recover the bare vX.Y.Z for the actual image tags.
+      - name: Compute release version
+        if: startsWith(github.ref, 'refs/tags/bare-metal-fulfillment-operator/')
+        run: |
+          version="${GITHUB_REF_NAME#bare-metal-fulfillment-operator/}"
+          # Same SemVer rule as publish-charts.yaml's guard job -- rejects build
+          # metadata (+...) and validates the core/prerelease shape before it's
+          # trusted as an image tag.
+          semver_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?$'
+          if ! [[ "${version}" =~ ${semver_re} ]]; then
+            echo "::error::Tag '${GITHUB_REF_NAME}' is not a valid semver release tag"
+            exit 1
+          fi
+          # Prerelease identifiers can themselves contain dots (e.g. v1.2.3-beta.1),
+          # so derive major/minor from the prerelease-stripped core version --
+          # otherwise a dotted prerelease would corrupt the major.minor alias.
+          core="${version%%-*}"
+          echo "RELEASE_VERSION=${version}" >> "$GITHUB_ENV"
+          echo "RELEASE_MAJOR_MINOR=${core%.*}" >> "$GITHUB_ENV"
+          echo "RELEASE_MAJOR=${core%%.*}" >> "$GITHUB_ENV"
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # No `type=ref,event=tag` here: the `tags:` trigger above only ever
+          # matches this component's own scoped prefix, so the tag-triggered
+          # case is always covered by the three raw entries below already --
+          # keeping it would just add a redundant, slash-sanitized duplicate
+          # tag (e.g. "bare-metal-fulfillment-operator-v1.2.3").
+          tags: |
+            type=raw,value=${{ env.RELEASE_VERSION }},enable=${{ env.RELEASE_VERSION != '' }}
+            type=raw,value=${{ env.RELEASE_MAJOR_MINOR }},enable=${{ env.RELEASE_VERSION != '' }}
+            type=raw,value=${{ env.RELEASE_MAJOR }},enable=${{ env.RELEASE_VERSION != '' }}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-operator
+        uses: docker/build-push-action@v7
+        with:
+          context: bare-metal-fulfillment-operator
+          file: bare-metal-fulfillment-operator/Containerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # Extract the commit SHA tag for manifest generation
+      - name: Extract commit SHA tag
+        id: sha-tag
+        if: github.event_name != 'pull_request'
+        run: |
+          # Extract the sha tag from the metadata output
+          FULL_SHA_TAG=$(echo "${{ steps.meta.outputs.tags }}" | grep -E "sha-[0-9a-f]{7}" | head -n1)
+          SHA_TAG=$(echo "$FULL_SHA_TAG" | sed "s/.*://")
+          echo "sha-tag=$SHA_TAG" >> $GITHUB_OUTPUT
+          echo "full-sha-tag=$FULL_SHA_TAG" >> $GITHUB_OUTPUT
+          echo "manifest-tag=$SHA_TAG-manifests" >> $GITHUB_OUTPUT
+          echo "Using SHA tag: $SHA_TAG"
+          echo "Full SHA tag: $FULL_SHA_TAG"
+          echo "Manifest tag: $SHA_TAG-manifests"
+
+      # Set up Go for kustomize operations
+      - name: Set up Go for manifest generation
+        if: github.event_name != 'pull_request'
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'bare-metal-fulfillment-operator/go.mod'
+
+      # Generate manifests with kustomize pointing to the SHA-tagged image
+      - name: Generate manifests with kustomize
+        if: github.event_name != 'pull_request'
+        working-directory: bare-metal-fulfillment-operator
+        run: |
+          # Install kustomize
+          make kustomize
+
+          # Create dist directory
+          mkdir -p dist
+
+          # Set the manager image to the SHA-tagged version
+          cd config/manager && ../../bin/kustomize edit set image controller=${{ steps.sha-tag.outputs.full-sha-tag }}
+
+          # Generate the complete manifest
+          cd ../..
+          ./bin/kustomize build config/default > dist/install.yaml
+
+          echo "Generated manifest with image: ${{ steps.sha-tag.outputs.full-sha-tag }}"
+          echo "Manifest content preview:"
+          head -20 dist/install.yaml
+
+      # Create Dockerfile for manifest container
+      - name: Create manifest container Dockerfile
+        if: github.event_name != 'pull_request'
+        working-directory: bare-metal-fulfillment-operator
+        run: |
+          cat > Dockerfile.manifests << 'EOF'
+          FROM scratch
+          COPY dist/install.yaml /manifests/install.yaml
+          EOF
+
+          echo "Created Dockerfile.manifests:"
+          cat Dockerfile.manifests
+
+      # Extract metadata for manifest container
+      - name: Extract manifest container metadata
+        id: meta-manifests
+        if: github.event_name != 'pull_request'
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.sha-tag.outputs.manifest-tag }}
+
+      # Build and push manifest container
+      - name: Build and push manifest container
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v7
+        with:
+          context: bare-metal-fulfillment-operator
+          file: bare-metal-fulfillment-operator/Dockerfile.manifests
+          push: true
+          tags: ${{ steps.meta-manifests.outputs.tags }}
+          labels: ${{ steps.meta-manifests.outputs.labels }}

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -17,10 +17,11 @@ name: Publish charts
 on:
   workflow_run:
     # workflow_run only fires for workflows explicitly listed here -- the
-    # guard condition and publish-osac-aap-chart job alone aren't enough
-    # to trigger this workflow at all without osac-aap's build workflow
-    # name also present in this list.
-    workflows: ["Container image", "Build container image", "Build execution environment"]
+    # guard condition and publish-*-chart jobs alone aren't enough to trigger
+    # this workflow at all without each component's build workflow name also
+    # present in this list (missed once for osac-aap, see OSAC-3511/#49 --
+    # don't repeat that).
+    workflows: ["Container image", "Build container image", "Build execution environment", "Build bare-metal-fulfillment-operator image"]
     types: [completed]
 
 env:
@@ -45,7 +46,8 @@ jobs:
       github.event.workflow_run.event == 'push' &&
       (startsWith(github.event.workflow_run.head_branch, 'fulfillment-service/v') ||
        startsWith(github.event.workflow_run.head_branch, 'osac-operator/v') ||
-       startsWith(github.event.workflow_run.head_branch, 'osac-aap/v'))
+       startsWith(github.event.workflow_run.head_branch, 'osac-aap/v') ||
+       startsWith(github.event.workflow_run.head_branch, 'bare-metal-fulfillment-operator/v'))
     outputs:
       tag: ${{ github.event.workflow_run.head_branch }}
       version: ${{ steps.check.outputs.version }}
@@ -65,6 +67,7 @@ jobs:
           fulfillment-service/v*) VERSION="${HEAD_BRANCH#fulfillment-service/}" ;;
           osac-operator/v*) VERSION="${HEAD_BRANCH#osac-operator/}" ;;
           osac-aap/v*) VERSION="${HEAD_BRANCH#osac-aap/}" ;;
+          bare-metal-fulfillment-operator/v*) VERSION="${HEAD_BRANCH#bare-metal-fulfillment-operator/}" ;;
           *) echo "::error::Tag '$HEAD_BRANCH' does not match a known component prefix"; exit 1 ;;
         esac
 
@@ -386,6 +389,155 @@ jobs:
         || gh release edit "${TAG}" \
           --repo "${REPO}" \
           --title "osac-aap ${VERSION}"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ needs.guard.outputs.tag }}
+        VERSION: ${{ needs.guard.outputs.version }}
+        REPO: ${{ github.repository }}
+
+  publish-bmf-crds-chart:
+    name: Publish bare-metal-fulfillment-operator-crds chart
+    needs: guard
+    if: success() && github.event.workflow_run.name == 'Build bare-metal-fulfillment-operator image'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      with:
+        ref: ${{ needs.guard.outputs.sha }}
+        persist-credentials: false
+
+    - name: Verify tag still points at the guarded commit
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ needs.guard.outputs.tag }}
+        GUARDED_SHA: ${{ needs.guard.outputs.sha }}
+        REPO: ${{ github.repository }}
+      run: .github/scripts/bare-metal-fulfillment-operator-verify-tag-matches-sha.sh
+
+    - name: Set up Helm
+      uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
+      with:
+        version: v3.17.0
+
+    - name: Log in to GHCR
+      env:
+        REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        REGISTRY_USERNAME: ${{ github.actor }}
+      run: echo "${REGISTRY_PASSWORD}" | helm registry login "${REGISTRY}" -u "${REGISTRY_USERNAME}" --password-stdin
+
+    - name: Extract version from tag
+      id: version
+      run: echo "version=${VERSION#v}" >> "$GITHUB_OUTPUT"
+      env:
+        VERSION: ${{ needs.guard.outputs.version }}
+
+    - name: Package chart
+      working-directory: bare-metal-fulfillment-operator
+      run: |
+        helm package charts/operator-crds/ \
+          --version "${{ steps.version.outputs.version }}" \
+          --app-version "${{ steps.version.outputs.version }}"
+
+    - name: Push chart to GHCR
+      working-directory: bare-metal-fulfillment-operator
+      run: |
+        helm push bare-metal-fulfillment-operator-crds-${{ steps.version.outputs.version }}.tgz \
+          oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
+
+  publish-bmf-chart:
+    name: Publish bare-metal-fulfillment-operator chart
+    needs: guard
+    if: success() && github.event.workflow_run.name == 'Build bare-metal-fulfillment-operator image'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      with:
+        ref: ${{ needs.guard.outputs.sha }}
+        persist-credentials: false
+
+    - name: Verify tag still points at the guarded commit
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ needs.guard.outputs.tag }}
+        GUARDED_SHA: ${{ needs.guard.outputs.sha }}
+        REPO: ${{ github.repository }}
+      run: .github/scripts/bare-metal-fulfillment-operator-verify-tag-matches-sha.sh
+
+    - name: Set up Helm
+      uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
+      with:
+        version: v3.17.0
+
+    - name: Log in to GHCR
+      env:
+        REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        REGISTRY_USERNAME: ${{ github.actor }}
+      run: echo "${REGISTRY_PASSWORD}" | helm registry login "${REGISTRY}" -u "${REGISTRY_USERNAME}" --password-stdin
+
+    - name: Extract version from tag
+      id: version
+      run: echo "version=${VERSION#v}" >> "$GITHUB_OUTPUT"
+      env:
+        VERSION: ${{ needs.guard.outputs.version }}
+
+    - name: Update image tag in values.yaml
+      working-directory: bare-metal-fulfillment-operator
+      run: |
+        sed -i "s/tag: latest/tag: v${{ steps.version.outputs.version }}/" charts/operator/values.yaml
+
+    - name: Package chart
+      working-directory: bare-metal-fulfillment-operator
+      run: |
+        helm package charts/operator/ \
+          --version "${{ steps.version.outputs.version }}" \
+          --app-version "${{ steps.version.outputs.version }}"
+
+    - name: Push chart to GHCR
+      working-directory: bare-metal-fulfillment-operator
+      run: |
+        helm push bare-metal-fulfillment-operator-${{ steps.version.outputs.version }}.tgz \
+          oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
+
+  create-bmf-release:
+    name: Create GitHub Release (bare-metal-fulfillment-operator)
+    runs-on: ubuntu-latest
+    needs: [guard, publish-bmf-crds-chart, publish-bmf-chart]
+    if: success() && github.event.workflow_run.name == 'Build bare-metal-fulfillment-operator image'
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      with:
+        ref: ${{ needs.guard.outputs.sha }}
+        persist-credentials: false
+
+    - name: Verify tag still points at the guarded commit
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ needs.guard.outputs.tag }}
+        GUARDED_SHA: ${{ needs.guard.outputs.sha }}
+        REPO: ${{ github.repository }}
+      run: .github/scripts/bare-metal-fulfillment-operator-verify-tag-matches-sha.sh
+
+    - name: Create GitHub Release
+      run: |
+        gh release create "${TAG}" \
+          --repo "${REPO}" \
+          --title "bare-metal-fulfillment-operator ${VERSION}" \
+          --generate-notes \
+          --verify-tag \
+        || gh release edit "${TAG}" \
+          --repo "${REPO}" \
+          --title "bare-metal-fulfillment-operator ${VERSION}"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ needs.guard.outputs.tag }}


### PR DESCRIPTION
## Summary

bare-metal-fulfillment-operator (BMF) merged via #48 with minimal CI wiring only (build/lint checks) -- the actual tag-scoped release pipeline (image build, chart publish, GitHub Release) was deliberately deferred. This wires it in, mirroring [OSAC-3511](https://redhat.atlassian.net/browse/OSAC-3511)'s exact playbook for osac-aap (#44 + the #49 fix).

## build-bmf-image.yaml (new)

Ported from the old standalone repo's `build-image.yaml`, adapted to this repo's established per-component pattern (same shape as `build-image.yaml`/osac-operator and `publish-image.yaml`/fulfillment-service):
- Path-filtered PR trigger on `bare-metal-fulfillment-operator/**`.
- Tag trigger scoped to `bare-metal-fulfillment-operator/vX.Y.Z`, with the same tag-prefix-strip + SemVer-validation logic already proven on the other 3 components.
- `IMAGE_NAME` hardcoded to `osac-project/bare-metal-fulfillment-operator` (not `github.repository`) -- same [OSAC-3490](https://redhat.atlassian.net/browse/OSAC-3490) collision-avoidance pattern osac-operator/osac-aap already use.
- Test job runs `make test` only (BMF has no `test-kustomize`/`test-smoke` Makefile targets like osac-operator does, so this matches BMF's own old workflow rather than osac-operator's exact 3-step test job).
- Kustomize manifest-container generation/push, same as osac-operator's build-image.yaml.

**Important naming note:** BMF's *old standalone* build-image.yaml was named `"Build container image"` -- identical to osac-operator's existing mono-repo workflow name. Porting it verbatim would have made `publish-charts.yaml`'s `workflow_run.name == 'Build container image'` guard incorrectly also match BMF's builds, misrouting BMF's successful builds into osac-operator's chart-publish job. Renamed to `"Build bare-metal-fulfillment-operator image"` to avoid the collision.

## publish-charts.yaml

- Added `bare-metal-fulfillment-operator/v` to the guard job's `startsWith` condition and its tag-prefix-stripping `case` statement.
- Added `bare-metal-fulfillment-operator-verify-tag-matches-sha.sh` (identical content to the existing per-component scripts, matching the established convention of a dedicated script file per component rather than a shared one).
- Added three new jobs mirroring osac-operator's split (BMF has two charts -- `operator` and `operator-crds` -- same shape as osac-operator, unlike osac-aap's single-chart case): `publish-bmf-crds-chart`, `publish-bmf-chart` (includes the `sed` image-tag update in `charts/operator/values.yaml`, same placeholder pattern as osac-operator's chart), and `create-bmf-release`.
- **The critical thing explicitly called out in the ticket, verified rather than assumed:** added `"Build bare-metal-fulfillment-operator image"` to the top-level `on: workflow_run: workflows: [...]` list -- this exact list is what was missed for osac-aap in #44 (the job-level `if:` conditions alone don't make `workflow_run` fire at all) and had to be fixed live in #49 after osac-aap's chart-publish silently never ran. Confirmed by grep that the workflow's own `name:` field and all 4 references to it in `publish-charts.yaml` (the trigger list plus 3 job conditions) match byte-for-byte.

## Validation

- YAML parses clean, `yamllint --strict` clean on both changed workflow files.
- `pre-commit run` clean on all changed files (golangci-lint/buf-lint hooks skipped -- no matching files changed).
- Confirmed BMF's chart names (`bare-metal-fulfillment-operator`, `bare-metal-fulfillment-operator-crds`) and the `tag: latest` placeholder in `charts/operator/values.yaml` match what the new jobs assume.

## Not yet done: real end-to-end tag test

Per the same constraint hit during [OSAC-3511](https://redhat.atlassian.net/browse/OSAC-3511): GitHub Actions resolves tag-triggered workflow files from the tagged commit's own tree, not the default branch -- so a real `bare-metal-fulfillment-operator/vX.Y.Z` tag can only exercise this new pipeline once it's actually on `main`. I don't have direct push access to `osac-project/osac` (everything in this session has gone through fork+PR), so I can't push a test tag against an unmerged commit. Once this merges, I'll push a real tag (next version per `gh api repos/osac-project/bare-metal-fulfillment-operator/releases/latest`) and confirm the full chain: image build -> GHCR push -> chart publish -> GitHub Release.

Part of OSAC-1732, follow-on to OSAC-3395, mirrors [OSAC-3511](https://redhat.atlassian.net/browse/OSAC-3511).

## Test plan
- [ ] Merge (same `required_linear_history` toggle dance as every prior component merge/wiring PR, if needed -- this one has no merge commits of its own so may not need it, but worth checking)
- [ ] Push a real `bare-metal-fulfillment-operator/vX.Y.Z` tag once merged and confirm: image build succeeds and pushes to `ghcr.io/osac-project/bare-metal-fulfillment-operator`, both charts publish to GHCR, a GitHub Release is created