### PR TITLE
OSAC-3505: Track osac-test-infra's main instead of pinning a SHA

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -68,7 +68,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
     # bump this SHA when osac-test-infra reusable workflows change
-    uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-full-install.yml@5347598040856b07c61afed01b5b1e6f428c81d7
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-full-install.yml@56af8a0690f855dd7ebf6378372bdb1f9ad9fdfa
     with:
       test-suite: ${{ inputs.test-suite || 'bmaas' }}
       test-filter: ${{ inputs.test-filter || '' }}

--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -67,8 +67,7 @@ jobs:
   e2e-bmaas-full-install:
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
-    # bump this SHA when osac-test-infra reusable workflows change
-    uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-full-install.yml@56af8a0690f855dd7ebf6378372bdb1f9ad9fdfa
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-full-install.yml@main
     with:
       test-suite: ${{ inputs.test-suite || 'bmaas' }}
       test-filter: ${{ inputs.test-filter || '' }}

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -66,8 +66,7 @@ jobs:
   e2e-caas-full-install:
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
-    # bump this SHA when osac-test-infra reusable workflows change
-    uses: osac-project/osac-test-infra/.github/workflows/e2e-caas-full-install.yml@56af8a0690f855dd7ebf6378372bdb1f9ad9fdfa
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-caas-full-install.yml@main
     with:
       test-suite: ${{ inputs.test-suite || 'caas' }}
       test-filter: ${{ inputs.test-filter || '' }}

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -67,7 +67,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
     # bump this SHA when osac-test-infra reusable workflows change
-    uses: osac-project/osac-test-infra/.github/workflows/e2e-caas-full-install.yml@5347598040856b07c61afed01b5b1e6f428c81d7
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-caas-full-install.yml@56af8a0690f855dd7ebf6378372bdb1f9ad9fdfa
     with:
       test-suite: ${{ inputs.test-suite || 'caas' }}
       test-filter: ${{ inputs.test-filter || '' }}

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -68,7 +68,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
     # bump this SHA when osac-test-infra reusable workflows change
-    uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@5347598040856b07c61afed01b5b1e6f428c81d7
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@56af8a0690f855dd7ebf6378372bdb1f9ad9fdfa
     with:
       test-suite: ${{ inputs.test-suite || 'vmaas' }}
       test-filter: ${{ inputs.test-filter || '' }}

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -67,8 +67,7 @@ jobs:
   e2e-vmaas-full-install:
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
-    # bump this SHA when osac-test-infra reusable workflows change
-    uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@56af8a0690f855dd7ebf6378372bdb1f9ad9fdfa
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main
     with:
       test-suite: ${{ inputs.test-suite || 'vmaas' }}
       test-filter: ${{ inputs.test-filter || '' }}


### PR DESCRIPTION
## Summary
All 3 e2e workflows (`e2e-vmaas-full-install.yml`, `e2e-bmaas-full-install.yml`, `e2e-caas-full-install.yml`) pin `osac-test-infra`'s reusable workflow at a specific SHA (`5347598`, per each file's own comment: "bump this SHA when osac-test-infra reusable workflows change"). That SHA predates [OSAC-3505](https://redhat.atlassian.net/browse/OSAC-3505)'s caas readiness fix (merged into `osac-test-infra` as `56af8a06`), so `osac` never actually picked it up.

Confirmed live: run https://github.com/osac-project/osac/actions/runs/30668446511/job/91280789323 hit the identical `ERROR: Failed to create host type (HTTP 503)` signature [OSAC-3505](https://redhat.atlassian.net/browse/OSAC-3505) was filed to fix.

## Change
Bumped all 3 pins to `osac-test-infra`'s current `main` (`56af8a06`). Diffed the full 13-commit range: besides the target fix, it carries the already-known/verified [OSAC-3496](https://redhat.atlassian.net/browse/OSAC-3496) submodule-path fixes (reviewed earlier this session), one small real change to `e2e-bmaas-full-install.yml` itself (OSAC-3217, removes an always-empty placeholder secret -- confirmed benign, doesn't touch anything the bmaas flow depends on), and otherwise-unrelated fleet/infra commits (runner provisioning, monitoring) that don't touch any workflow file. No surprises.

## Test plan
- [ ] Confirm a subsequent `e2e-caas-full-install` run no longer hits the HTTP 503 race.