### PR TITLE
OSAC-3520: Fix dorny/paths-filter exclude globs to match nested docs paths

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -51,10 +51,10 @@ jobs:
           filters: |
             code:
               - '**'
-              - '!OWNERS'
-              - '!LICENSE'
-              - '!*.md'
-              - '!docs/**'
+              - '!**/OWNERS'
+              - '!**/LICENSE'
+              - '!**/*.md'
+              - '!**/docs/**'
 
   # Builds fulfillment-service, osac-operator, and osac-aap's execution
   # environment from this PR's current code and installs them together in

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -51,10 +51,10 @@ jobs:
           filters: |
             code:
               - '**'
-              - '!OWNERS'
-              - '!LICENSE'
-              - '!*.md'
-              - '!docs/**'
+              - '!**/OWNERS'
+              - '!**/LICENSE'
+              - '!**/*.md'
+              - '!**/docs/**'
 
   # Builds both fulfillment-service and osac-operator from this PR's current
   # code and installs them together in one cluster -- not one "component

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -51,10 +51,10 @@ jobs:
           filters: |
             code:
               - '**'
-              - '!OWNERS'
-              - '!LICENSE'
-              - '!*.md'
-              - '!docs/**'
+              - '!**/OWNERS'
+              - '!**/LICENSE'
+              - '!**/*.md'
+              - '!**/docs/**'
 
   # Builds fulfillment-service, osac-operator, and osac-aap's execution
   # environment from this PR's current code and installs them together in


### PR DESCRIPTION
## Bug

The shared `dorny/paths-filter` exclude list (`'!OWNERS'`, `'!LICENSE'`, `'!*.md'`, `'!docs/**'`) used by the 3 e2e workflows only matches files/directories sitting directly at the **repo root** — these are unanchored, non-`**`-prefixed globs, so they never match nested per-component paths like `fulfillment-service/docs/AUTH.md`, which is how virtually all real documentation actually lives in this mono-repo.

**Live-proven, not theoretical:** #46 touched only `fulfillment-service/docs/AUTH.md` and `fulfillment-service/docs/INSTALL.md` (pure documentation), yet `e2e-vmaas-full-install`, `e2e-bmaas-full-install`, and `e2e-caas-full-install` all ran in full (43m-1h1m each, real cluster provisioning) because the filter's negation patterns never matched those changed paths.

## Verified against the actual tree, not assumed

Checked whether `OWNERS`/`LICENSE` genuinely only exist at repo root today: they don't. Confirmed real files at multiple depths:
- Root: `OWNERS`, `LICENSE`
- Per-component (1 level): `fulfillment-service/OWNERS`, `osac-operator/OWNERS`, `osac-aap/OWNERS`, `bare-metal-fulfillment-operator/OWNERS` + `LICENSE`
- Vendored, several levels deep: `osac-aap/vendor/ansible_collections/*/LICENSE`, `osac-aap/collections/ansible_collections/osac/templates/LICENSE`

So the `**/` prefix isn't just future-proofing — it's necessary right now for paths that already exist in the tree.

## Fix

Prefixed each exclude pattern with `**/` in all 3 e2e workflows (`e2e-vmaas-full-install.yml`, `e2e-bmaas-full-install.yml`, `e2e-caas-full-install.yml`):

```diff
 code:
   - '**'
-  - '!OWNERS'
-  - '!LICENSE'
-  - '!*.md'
-  - '!docs/**'
+  - '!**/OWNERS'
+  - '!**/LICENSE'
+  - '!**/*.md'
+  - '!**/docs/**'
```

`**/` matches zero-or-more path segments, so this still correctly excludes the root-level case these patterns already handled, while now also matching any nested depth.

## unit-tests.yml / integration-tests.yml

These two inherited the identical bug via #50 ([OSAC-3517](https://redhat.atlassian.net/browse/OSAC-3517)), which is still open/unmerged. Since their buggy content only exists on that PR's branch (not yet on `main`), I pushed a corresponding fix commit directly onto that PR rather than duplicating the change here against non-existent base content — see #50's latest commit.

## Verification

- `actionlint` reports no issues on all 3 changed files.
- `pre-commit run` (yamllint, etc.) passes.
- Confirmed the OWNERS/LICENSE tree depths above directly (`find . -name OWNERS -o -name LICENSE`), rather than assuming.
- **On live-testing the "after" behavior**: cleanly isolating a nested-docs-only diff against this fix specifically isn't possible within a single PR here, since this PR's own diff necessarily includes real code (the workflow YAML changes themselves), which alone makes the filter's `code` output `true` regardless of any docs file also present — the two effects can't be cleanly separated in one diff against a base that doesn't yet have the fix. Once this merges, I'll open a follow-up docs-only test PR (touching e.g. `fulfillment-service/docs/**`) against the now-fixed `main`, the same way #46 exposed the original bug, to close the loop with a genuine live "after" proof -- and close that test PR without merging once confirmed.