### PR TITLE
OSAC-3519: Add bare-metal-fulfillment-operator to e2e-vmaas/e2e-caas components arrays

### DIFF
--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -56,13 +56,21 @@ jobs:
               - '!**/*.md'
               - '!**/docs/**'
 
-  # Builds both fulfillment-service and osac-operator from this PR's current
-  # code and installs them together in one cluster -- not one "component
-  # under test" plus a stale pinned image for the other. Runs for any change
-  # touching either component (see `changes` above) rather than being
-  # path-scoped per component; splitting this by component to avoid running
-  # both suites when only one changed is deferred to the future full
-  # path-based CI matrix, once its skip-logic pattern is verified.
+  # Builds fulfillment-service, osac-operator, and bare-metal-fulfillment-operator
+  # from this PR's current code and installs them together in one cluster --
+  # not one "component under test" plus a stale pinned image for the others.
+  # Runs for any change touching any component (see `changes` above) rather
+  # than being path-scoped per component; splitting this by component to
+  # avoid running both suites when only one changed is deferred to the
+  # future full path-based CI matrix, once its skip-logic pattern is
+  # verified. (osac-aap is not built here -- that's a pre-existing scope
+  # decision for this flow, unrelated to BMF, not changed by this entry.)
+  #
+  # bare-metal-fulfillment-operator's image override (bmf.image.repository)
+  # is currently a no-op in this flow specifically: values/caas-ci/values.yaml
+  # sets bmf.enabled: false, so the chart isn't deployed here at all. Still
+  # built from source for consistency with the other components -- revisit
+  # if caas ever needs BMF enabled.
   e2e-caas-full-install:
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
@@ -70,8 +78,8 @@ jobs:
     with:
       test-suite: ${{ inputs.test-suite || 'caas' }}
       test-filter: ${{ inputs.test-filter || '' }}
-      # Build both component images from the PR's fork/branch (same monorepo checkout)
-      components: '[{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"}]'
+      # Build all component images from the PR's fork/branch (same monorepo checkout)
+      components: '[{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}]'
       # Pass author_association for fork PR authorization (empty for non-fork PRs)
       fork-pr-author-association: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association || '' }}
       fork-pr-author: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.user.login || '' }}

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -56,14 +56,21 @@ jobs:
               - '!**/*.md'
               - '!**/docs/**'
 
-  # Builds fulfillment-service, osac-operator, and osac-aap's execution
-  # environment from this PR's current code and installs them together in
-  # one cluster -- not one "component under test" plus stale pinned images
-  # for the others. Runs for any change touching any component (see
-  # `changes` above) rather than being path-scoped per component;
-  # splitting this by component to avoid running both suites when only one
-  # changed is deferred to the future full path-based CI matrix, once its
-  # skip-logic pattern is verified.
+  # Builds fulfillment-service, osac-operator, osac-aap's execution
+  # environment, and bare-metal-fulfillment-operator from this PR's current
+  # code and installs them together in one cluster -- not one "component
+  # under test" plus stale pinned images for the others. Runs for any
+  # change touching any component (see `changes` above) rather than being
+  # path-scoped per component; splitting this by component to avoid
+  # running both suites when only one changed is deferred to the future
+  # full path-based CI matrix, once its skip-logic pattern is verified.
+  #
+  # bare-metal-fulfillment-operator's image override (bmf.image.repository)
+  # is currently a no-op in this flow specifically: values/vmaas-ci/values.yaml
+  # sets bmf.enabled: false, so the chart isn't deployed here at all. Still
+  # built from source for consistency with the other 3 components (all 4
+  # should build from the PR in every e2e flow, even where one isn't
+  # currently deployed) -- revisit if vmaas ever needs BMF enabled.
   e2e-vmaas-full-install:
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
@@ -72,7 +79,7 @@ jobs:
       test-suite: ${{ inputs.test-suite || 'vmaas' }}
       test-filter: ${{ inputs.test-filter || '' }}
       # Build all component images from the PR's fork/branch (same monorepo checkout)
-      components: '[{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"}]'
+      components: '[{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}]'
       # Pass author_association for fork PR authorization (empty for non-fork PRs)
       fork-pr-author-association: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association || '' }}
       fork-pr-author: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.user.login || '' }}


### PR DESCRIPTION
## Summary
Final slice of [OSAC-3519](https://redhat.atlassian.net/browse/OSAC-3519) -- extends PR #51's bmaas fix (merged) to the other two e2e flows. Same change, same imageKey, same containerfile path:

- `e2e-vmaas-full-install.yml`: added bare-metal-fulfillment-operator (BMF) as a 4th `components` entry (alongside fulfillment-service, osac-operator, osac-aap).
- `e2e-caas-full-install.yml`: added BMF as a 3rd `components` entry. Note this file's own components array only has 2 entries today (no osac-aap) -- that's a pre-existing scope decision for this flow unrelated to BMF, left untouched.

Both use `containerfile: "bare-metal-fulfillment-operator/Containerfile"`, `imageKey: "bmf.image.repository"` (no `buildType`, same as fulfillment-service/osac-operator's entries), matching what was verified end-to-end in PR #51.

## Important: this is currently a no-op for both of these flows specifically
Re-confirmed against osac-installer's actual current values files before writing anything:
- `values/vmaas-ci/values.yaml`: `bmf.enabled: false`
- `values/caas-ci/values.yaml`: `bmf.enabled: false`

BMF's chart isn't deployed at all in either flow (unlike `values/bmaas-ci/values.yaml`, where it's `true`), so the `bmf.image.repository` override has nothing to apply to -- no running BMF pod exists in these clusters for the freshly-built image to reach. This is **not a bug in this change**, just a real, currently-inert side effect worth being explicit about rather than silent.

Added anyway, for the same reason the other 3 components are built from source in every flow regardless of what each flow exercises: consistency (all 4 mono-repo components build from the PR everywhere), and it costs nothing beyond one extra image build per run. If vmaas/caas ever need BMF enabled, this wiring is already in place and will start actually mattering with no further change needed here.

## Validation
YAML parse + `yamllint -c .yamllint.yaml --strict` clean on both files. Also parsed the embedded `components` JSON strings directly to confirm 4 entries (vmaas) / 3 entries (caas) with the expected keys.

## Verification plan
Will trigger real e2e-vmaas and e2e-caas runs and confirm from the logs that BMF builds from source (same evidence standard as PR #51 -- component build log entry, submodule replacement, image load), even though the override itself won't be exercised by a running BMF pod in either flow. Will report back with run links before this is ready to merge.

Not merging this myself. Once this merges, [OSAC-3519](https://redhat.atlassian.net/browse/OSAC-3519) is fully done (all 3 e2e flows) and I'll close the ticket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated end-to-end installation workflows to build the bare-metal fulfillment operator alongside existing components.
  * Added the operator’s image configuration to both full-install workflows.
  * Documented that operator deployment remains disabled in the CAAS workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->