### PR TITLE
Verify: nested docs-only PR skips e2e/unit/integration checks (OSAC-3520 live proof)

### DIFF
--- a/fulfillment-service/docs/verify-nested-docs-filter.md
+++ b/fulfillment-service/docs/verify-nested-docs-filter.md
@@ -1,0 +1,5 @@
+# Nested docs path-filter verification
+
+This file exists only to verify that a nested docs-only change (under
+fulfillment-service/docs/) is correctly excluded by the paths-filter's
+any-depth exclude patterns. Safe to delete once verified.


### PR DESCRIPTION
## Purpose

Live "after" verification for [OSAC-3520](https://redhat.atlassian.net/browse/OSAC-3520), now that both fix PRs (#54, #50) are merged. This PR's only change is `fulfillment-service/docs/verify-nested-docs-filter.md` -- a nested docs path, the exact case PR #46 proved was broken before the fix.

**Expected:** the `dorny/paths-filter` does not hit (its `code` output is `false`), and all of `unit-tests`, `integration-tests`, `e2e-vmaas-full-install`, `e2e-bmaas-full-install`, `e2e-caas-full-install` show their real test job as `skipped` rather than running in full.

**This PR will be closed without merging once evidence is captured.**