### PR TITLE
OSAC-3528: Convert osac-ui from git submodule to OCI chart + image reference

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "osac-installer/base/osac-ui"]
-	path = osac-installer/base/osac-ui
-	url = https://github.com/osac-project/osac-ui.git
 [submodule "osac-installer/base/osac-csi-driver"]
 	path = osac-installer/base/osac-csi-driver
 	url = https://github.com/osac-project/osac-csi-driver.git

--- a/osac-installer/.github/workflows/bump-submodules.yaml
+++ b/osac-installer/.github/workflows/bump-submodules.yaml
@@ -1,4 +1,4 @@
-name: Bump submodules and pinned refs
+name: Bump pinned refs
 
 on:
   schedule:
@@ -13,96 +13,19 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.0
         with:
-          submodules: true
           fetch-depth: 0
           token: ${{ secrets.OSAC_BOT_PAT }}
 
-      - name: Check latest commits have published images
-        id: find
-        env:
-          GH_TOKEN: ${{ secrets.OSAC_BOT_PAT }}
-        run: |
-          set -euo pipefail
-
-          # osac-operator, fulfillment-service, osac-aap, and
-          # bare-metal-fulfillment-operator are now part of this mono-repo
-          # and share its commit history with osac-installer itself --
-          # there's no independent submodule pin to bump toward for them
-          # anymore. Only osac-ui remains a genuinely separate repo with
-          # its own commit lineage to track.
-          #
-          # A repo becoming unreachable (renamed, archived, or deleted as
-          # part of a future mono-repo cutover) must only skip that
-          # component's bump, not abort the whole job -- this used to be a
-          # bare, unguarded call under `set -e`, so one 404 here killed the
-          # bump every 3 hours, until someone noticed. `|| return 1` on the
-          # repo lookup plus `|| VAR=""` at the call site keeps set -e from
-          # propagating past a single component's failure.
-          check_image() {
-            local repo=$1
-            local image=$2
-            local sha
-            sha=$(gh api "repos/osac-project/${repo}/commits?sha=main&per_page=1" --jq '.[0].sha') || {
-              echo "::warning::${repo}: could not resolve latest main commit (repo missing/renamed/archived?) -- skipping this component's bump" >&2
-              return 1
-            }
-            local tag="sha-${sha:0:7}"
-            local token
-            token=$(curl -sf "https://ghcr.io/token?scope=repository:osac-project/${image}:pull" | jq -r .token)
-            local code
-            code=$(curl -s -o /dev/null -w "%{http_code}" \
-              -H "Authorization: Bearer ${token}" \
-              -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json" \
-              "https://ghcr.io/v2/osac-project/${image}/manifests/${tag}")
-            if [[ "${code}" != "200" ]]; then
-              echo "::warning::${repo} latest main commit ${sha:0:7} has no published image (tag ${tag}) -- skipping this component's bump" >&2
-              return 1
-            fi
-            echo "${sha}"
-          }
-
-          UI=$(check_image osac-ui osac-ui) || UI=""
-
-          echo "ui=${UI}" >> "$GITHUB_OUTPUT"
-
-      - name: Update submodules
-        id: update
-        run: |
-          changed=false
-          summary=""
-
-          update_submodule() {
-            local path=$1
-            local name=$2
-            local target=$3
-            if [[ -z "${target}" ]]; then
-              echo "${name}: skipping (no eligible commit found this run -- see check_image warning above)"
-              return
-            fi
-            local current
-            current=$(git -C "${path}" rev-parse HEAD)
-            if [[ "${current}" == "${target}" ]]; then
-              echo "${name}: already at ${target:0:7}"
-              return
-            fi
-            git -C "${path}" fetch origin
-            git -C "${path}" checkout "${target}"
-            changed=true
-            local count
-            count=$(git -C "${path}" rev-list --count "${current}..${target}" 2>/dev/null || echo "?")
-            summary="${summary}- **${name}**: ${current:0:7} → ${target:0:7} (${count} commits)\n"
-            echo "${name}: ${current:0:7} -> ${target:0:7}"
-          }
-
-          update_submodule base/osac-ui osac-ui "${{ steps.find.outputs.ui }}"
-
-          echo "changed=${changed}" >> "$GITHUB_OUTPUT"
-          echo -e "${summary}" > /tmp/bump-summary.txt
-
-      - name: Sync image tags
-        if: steps.update.outputs.changed == 'true'
-        run: ./scripts/sync-image-tags.sh --fix
-
+      # osac-operator, fulfillment-service, osac-aap,
+      # bare-metal-fulfillment-operator, and osac-ui are all either part
+      # of this mono-repo's own commit history or a real released OCI
+      # chart/image dependency now -- there is no submodule left under
+      # base/ to bump a commit pin toward (only osac-csi-driver remains a
+      # submodule, and it isn't bumped by this workflow). The "check
+      # published images, checkout submodule, sync-image-tags --fix"
+      # steps that used to live here were removed for that reason, not
+      # just trimmed -- there's nothing left for them to do. Only the
+      # osac-test-infra pin bump below still applies.
       - name: Bump pinned osac-test-infra reusable-workflow SHA(s)
         id: pins
         env:
@@ -143,11 +66,11 @@ jobs:
           echo -e "${summary}" >> /tmp/bump-summary.txt
 
       - name: Create or update PR
-        if: steps.update.outputs.changed == 'true' || steps.pins.outputs.changed == 'true'
+        if: steps.pins.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.OSAC_BOT_PAT }}
         run: |
-          BRANCH="auto/bump-submodules"
+          BRANCH="auto/bump-pinned-refs"
           git config user.name "osac-dev-bot"
           git config user.email "osac-dev-bot@users.noreply.github.com"
           git add -A
@@ -161,18 +84,17 @@ jobs:
             exit 0
           fi
 
-          git commit -m "bump submodules and pinned osac-test-infra refs"
+          git commit -m "bump pinned osac-test-infra refs"
           git push origin "HEAD:${BRANCH}" --force
 
           BODY=$(cat <<BODY_EOF
-          ## Automated submodule and pinned-ref bump
+          ## Automated pinned-ref bump
 
           $(cat /tmp/bump-summary.txt)
 
-          Submodule bumps only move to commits that have a published container
-          image in GHCR. \`osac-test-infra\` pin bumps track its \`main\` branch
-          directly, since that repo publishes no tags for Dependabot to track.
-          Runs every 3 hours via [bump-submodules workflow](../actions/workflows/bump-submodules.yaml).
+          \`osac-test-infra\` pin bumps track its \`main\` branch directly,
+          since that repo publishes no tags for Dependabot to track.
+          Runs every 3 hours via [bump-pinned-refs workflow](../actions/workflows/bump-submodules.yaml).
           BODY_EOF
           )
 
@@ -182,7 +104,7 @@ jobs:
             echo "Updated existing PR #${EXISTING}"
           else
             gh pr create \
-              --title "bump submodules and pinned refs" \
+              --title "bump pinned refs" \
               --body "${BODY}" \
               --base main \
               --head "${BRANCH}"

--- a/osac-installer/.github/workflows/nightly-build.yaml
+++ b/osac-installer/.github/workflows/nightly-build.yaml
@@ -17,16 +17,29 @@ env:
   CHARTS_REPO: ${{ github.repository_owner }}/charts
   VALUES_FILE: values/development/values.yaml
   # Single source of truth for submodule components: repo, image, path, tag-mode (tag|inline), chart-path
+  #
+  # Deliberately empty now -- every component that used to be listed here
+  # is gone, for two different reasons:
+  #   - osac-ui: no longer a submodule at all. Converted to a real released
+  #     OCI chart + image reference, consumed directly via a version pin in
+  #     charts/osac/Chart.yaml, and it already publishes its own chart/image
+  #     independently via its own publish-image.yaml/publish-charts.yaml --
+  #     there's nothing left for this pipeline's submodule-bump/republish
+  #     loops to do for it.
+  #   - osac-operator, fulfillment-service, osac-aap, and
+  #     bare-metal-fulfillment-operator: NOT independently published --
+  #     they're now mono-repo-resident directories sharing this repo's own
+  #     commit history with osac-installer itself, with no submodule under
+  #     base/ at all (removed). There's no separate repo/commit/image
+  #     lineage left for this pipeline to bump a pin toward or republish a
+  #     chart from; they build and version alongside the mono-repo directly.
+  # Once this workflow is wired into root-level CI (a separate, deeper
+  # redesign of what "nightly build" even means when there's nothing left
+  # to bump), these lists -- and the loops that consume them -- likely need
+  # to be replaced entirely rather than repopulated.
   COMPONENTS: >-
-    osac-operator:osac-operator:base/osac-operator:tag:base/osac-operator/charts/operator
-    fulfillment-service:fulfillment-service:base/osac-fulfillment-service:inline:base/osac-fulfillment-service/charts/service
-    osac-aap:osac-aap:base/osac-aap:inline:base/osac-aap/charts/aap
-    bare-metal-fulfillment-operator:bare-metal-fulfillment-operator:base/bare-metal-fulfillment-operator:tag:base/bare-metal-fulfillment-operator/charts/operator
-    osac-ui:osac-ui:base/osac-ui:inline:base/osac-ui/charts/ui
   # CRD charts: name, submodule path, chart path (no image, so no tag-mode field)
   CRD_CHARTS: >-
-    osac-operator-crds:base/osac-operator:base/osac-operator/charts/operator-crds
-    bare-metal-fulfillment-operator-crds:base/bare-metal-fulfillment-operator:base/bare-metal-fulfillment-operator/charts/operator-crds
 
 jobs:
   # -------------------------------------------------------------------

--- a/osac-installer/charts/osac/Chart.yaml
+++ b/osac-installer/charts/osac/Chart.yaml
@@ -31,8 +31,8 @@ dependencies:
     alias: bmf
     condition: bmf.enabled
   - name: osac-ui
-    version: ">=0.0.0"
-    repository: "file://../../base/osac-ui/charts/ui"
+    version: "0.0.5"
+    repository: "oci://ghcr.io/osac-project/charts"
     alias: ui
     condition: ui.enabled
   - name: csi-driver

--- a/osac-installer/scripts/sync-image-tags.sh
+++ b/osac-installer/scripts/sync-image-tags.sh
@@ -4,8 +4,11 @@
 # bare-metal-fulfillment-operator now live in the same mono-repo as
 # osac-installer itself and publish SHA-tagged images off that mono-repo's
 # own commits -- there's one shared commit for all of them, not four
-# independent submodule pins. osac-ui remains a genuinely separate
-# repo/submodule and keeps its own commit lookup.
+# independent submodule pins. osac-ui is a real released dependency now
+# (an OCI chart + image pinned to a version tag, e.g. v0.0.5) rather than
+# a submodule commit this script derives a tag from -- its version is
+# bumped manually/deliberately like any other external chart dependency,
+# not auto-synced here.
 
 set -euo pipefail
 
@@ -20,7 +23,6 @@ operator_tag="${osac_tag}"
 fulfillment_tag="${osac_tag}"
 aap_tag="${osac_tag}"
 bmf_tag="${osac_tag}"
-ui_tag="sha-$(git -C "${REPO_ROOT}" submodule status base/osac-ui | awk '{print $1}' | tr -d ' +-' | cut -c1-7)"
 
 for values_file in "${REPO_ROOT}"/values/*/values.yaml; do
   [[ ! -f "${values_file}" ]] && continue
@@ -31,8 +33,7 @@ for values_file in "${REPO_ROOT}"/values/*/values.yaml; do
     "osac-operator:tag ${operator_tag}" \
     "fulfillment-service:inline ${fulfillment_tag}" \
     "osac-aap:inline ${aap_tag}" \
-    "bare-metal-fulfillment-operator:tag ${bmf_tag}" \
-    "osac-ui:inline ${ui_tag}"; do
+    "bare-metal-fulfillment-operator:tag ${bmf_tag}"; do
     component="${pair%%:*}"
     rest="${pair#*:}"
     mode="${rest%% *}"

--- a/osac-installer/values/bmaas-ci/values.yaml
+++ b/osac-installer/values/bmaas-ci/values.yaml
@@ -110,7 +110,7 @@ service:
 ui:
   enabled: true
   images:
-    ui: ghcr.io/osac-project/osac-ui:sha-d74aaaf
+    ui: ghcr.io/osac-project/osac-ui:v0.0.5
   api:
     fulfillment:
       certs:

--- a/osac-installer/values/vmaas-ci/values.yaml
+++ b/osac-installer/values/vmaas-ci/values.yaml
@@ -112,7 +112,7 @@ service:
 ui:
   enabled: true
   images:
-    ui: ghcr.io/osac-project/osac-ui:sha-d74aaaf
+    ui: ghcr.io/osac-project/osac-ui:v0.0.5
   api:
     fulfillment:
       certs:


### PR DESCRIPTION
## Summary

Converts osac-ui from a git submodule in osac-installer to a plain OCI Helm chart dependency + image-tag reference, following OSAC-3524's submodule-removal work for the mono-repo-merged components.

osac-ui already publishes real, versioned chart + image artifacts on every tag via its own `publish-image.yaml`/`publish-charts.yaml` (structurally identical to every merged component's own release pipeline). The submodule bought osac-installer nothing that a published OCI artifact reference doesn't already buy it. Unlike the 4 components merged under OSAC-3524, osac-ui has no full-install e2e workflow of its own and is never referenced in any `e2e-*-full-install.yml` `components[]` array -- the PR-source-substitution justification that legitimately keeps those 4 on a local-source pattern (tracked separately in [OSAC-3523](https://redhat.atlassian.net/browse/OSAC-3523)) doesn't apply here in practice.

## Sanity check performed before implementing (per the ticket's explicit ask)

- Latest osac-ui release: `v0.0.5`, published 2026-07-17 (94 commits behind current `main` -- flagging the drift, not fixing osac-ui's own release cadence here).
- **`ghcr.io/osac-project/osac-ui:v0.0.5`**: confirmed via a real registry token + manifest fetch (`HTTP 200`), not just a Packages API listing.
- **`ghcr.io/osac-project/charts/osac-ui:0.0.5`**: confirmed via a real `helm pull`, producing a genuine 2.5KB tarball with `name: osac-ui`, `version: 0.0.5` inside.
- osac-test-infra's netris-lab dev-refresh role has a `# Disable osac-ui (image not published yet)` switch that's now stale given the above -- flagged, not fixed here (different repo/concern, would need someone who owns that lab flow to confirm it's safe to remove).

## Changes

- **`charts/osac/Chart.yaml`**: `file://../../base/osac-ui/charts/ui` → `oci://ghcr.io/osac-project/charts`, pinned to `version: "0.0.5"`.
- **`values/bmaas-ci` and `vmaas-ci`**: `ghcr.io/osac-project/osac-ui:sha-d74aaaf` → `ghcr.io/osac-project/osac-ui:v0.0.5`. `values/development` keeps its floating `:latest` tag, unchanged.
- **`.gitmodules`**: removed `base/osac-ui` + its gitlink. Only `osac-installer/base/osac-csi-driver` remains a real submodule (hasn't merged into the mono-repo).
- **`scripts/sync-image-tags.sh`**: dropped osac-ui's submodule-status-based tag derivation entirely -- its version is a real release now, bumped deliberately like any other external chart dependency, not auto-synced by this script.
- **`.github/workflows/bump-submodules.yaml`** (still nested, not yet wired into root CI -- separate, already-tracked concern, [OSAC-3526](https://redhat.atlassian.net/browse/OSAC-3526)): removed the "check published images"/"update submodules" steps entirely, not just osac-ui's entry -- it was the last one, so those steps had nothing left to do. Renamed the workflow `Bump submodules and pinned refs` → `Bump pinned refs`, dropped the now-inaccurate "submodule" language from its PR title/body/branch name.
- **osac-test-infra companion PR**: [osac-test-infra#292](https://github.com/osac-project/osac-test-infra/pull/292) drops the now-dead `osac-ui` entry from `replace-installer-submodule.sh`'s `SUBMODULE_MAP`.

## Verification

- `helm dependency build charts/osac/` succeeds -- log shows a genuine OCI pull: `Downloading osac-ui from repo oci://ghcr.io/osac-project/charts` / `Pulled: ghcr.io/osac-project/charts/osac-ui:0.0.5`.
- `helm template` succeeds against **every** values file (`development`, `vmaas-ci`, `bmaas-ci`, `caas-ci`).
- Confirmed the rendered UI deployment (`vmaas-ci` values) uses `image: ghcr.io/osac-project/osac-ui:v0.0.5` as expected.
- `helm lint charts/osac/` reports the same pre-existing, unrelated schema error as OSAC-3524's PR (hostname `minLength`) -- not introduced here.
- `actionlint` and `pre-commit run` pass on all changed files.

Part of OSAC-1732. Implements [OSAC-3528](https://redhat.atlassian.net/browse/OSAC-3528).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated the UI deployment to use the released `v0.0.5` image and Helm chart.
  * Improved release automation to manage pinned workflow references more reliably.
  * Aligned component image versioning with shared repository releases.

* **Maintenance**
  * Removed the UI’s source submodule integration in favor of the published chart and image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->