### PR TITLE
OSAC-3529: Point fulfillment-service's goreleaser release at its scoped tag

### DIFF
--- a/.github/workflows/publish-binaries.yaml
+++ b/.github/workflows/publish-binaries.yaml
@@ -51,3 +51,23 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GORELEASER_CURRENT_TAG: ${{ env.RELEASE_VERSION }}
+    - name: Point release at the scoped trigger tag
+      # GORELEASER_CURRENT_TAG must be a bare, semver-parseable value (see
+      # above), so the release -- and an accompanying lightweight git tag --
+      # that goreleaser's own `gh release create` produces is necessarily
+      # named after that bare version, not the scoped tag that actually
+      # triggered this workflow (decoupling the two is a goreleaser Pro-only
+      # feature, confirmed via https://goreleaser.com/customization/monorepo/).
+      # Re-point the release at the real scoped tag for consistency with the
+      # other 3 components' releases (OSAC-3467) -- verified this works
+      # correctly for slash-containing tags (GitHub's own generated
+      # browser_download_url uses the literal, non-percent-encoded tag) --
+      # then remove the now-orphaned bare tag goreleaser left behind.
+      run: |
+        gh release edit "${RELEASE_VERSION}" \
+          --tag "${GITHUB_REF_NAME}" \
+          --title "fulfillment-service ${RELEASE_VERSION}" \
+          --verify-tag
+        gh api -X DELETE "repos/${{ github.repository }}/git/refs/tags/${RELEASE_VERSION}"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

fulfillment-service's release publishes under a bare `vX.Y.Z` tag (e.g. `v0.0.81`), while osac-operator/osac-aap/bare-metal-fulfillment-operator all publish under a component-prefixed tag (e.g. `osac-operator/v0.0.12`) per OSAC-3467's tag-scoping design.

**Root cause**: fulfillment-service's release is created via goreleaser, which requires `GORELEASER_CURRENT_TAG` to be a bare, semver-parseable value -- so its own `gh release create` necessarily names the release (and creates an accompanying lightweight git tag) after that bare version, not the scoped tag that triggered the workflow. The other 3 components instead create their release via a plain `gh release create "${TAG}"` using the scoped git tag verbatim, so scoping survives for them but not for goreleaser's output.

Decoupling the release tag from goreleaser's internal version template (which is what would be needed to fix this natively) is a **goreleaser Pro-only feature** -- confirmed against the [monorepo customization docs](https://goreleaser.com/customization/monorepo/).

**Fix**: add a step after the goreleaser-action to re-point the release at the real scoped trigger tag (`gh release edit --tag`) with a matching title, then delete the now-orphaned bare tag goreleaser leaves behind. This also fixes a standing (if minor) bug: every past release has left a stray duplicate tag pointing at the same commit as the real one -- confirmed live (`v0.0.81` and `fulfillment-service/v0.0.81` both point at the same SHA today).

Verified GitHub's release download URLs work correctly with a literal, non-percent-encoded slash embedded in the tag path -- GitHub's own generated `browser_download_url` uses exactly this form for a real-world example (`cloudquery/cloudquery`'s per-plugin releases), and a live request against it resolves with a 302 to the real asset.

The automated tag-deletion step was explicitly confirmed with the repo owner before being added, since it's a recurring destructive git operation (deletes a remote tag on every future release).

## Downstream impact -- sequencing matters

`osac-test-infra`'s `Containerfile`/`machine-init.sh` filter `osac-project/osac`'s release list for fulfillment-service's **bare** `vX.Y.Z` tag ([OSAC-3365](https://redhat.atlassian.net/browse/OSAC-3365), needed because this repo now hosts multiple components' releases). That filter needs to switch to matching the **prefixed** `fulfillment-service/vX.Y.Z` pattern once this change is live -- companion PR ready, opened as a draft.

**This PR must merge, and a new fulfillment-service release must actually be cut under the new tag scheme, before the companion osac-test-infra PR merges.** Merging the test-infra filter update first would break every e2e job org-wide (no `fulfillment-service/vX.Y.Z`-tagged release would exist yet to match against) -- the same class of outage [OSAC-3365](https://redhat.atlassian.net/browse/OSAC-3365) already fixed once, in reverse.

Tracked in [OSAC-3529](https://redhat.atlassian.net/browse/OSAC-3529) (part of epic [OSAC-1732](https://redhat.atlassian.net/browse/OSAC-1732)).

## Test plan

- [x] `yamllint --strict` / `pre-commit run` clean on the touched workflow
- [x] Live tag inspection confirms today's state: `v0.0.81` and `fulfillment-service/v0.0.81` both point at the same commit (the exact clutter this fixes)
- [x] Live HTTP request against a real-world slash-tagged release asset (`cloudquery/cloudquery`) confirms GitHub's download URLs work correctly with unescaped slashes in the tag path
- [ ] Verify end-to-end on the next real fulfillment-service release: confirm the release ends up tagged `fulfillment-service/vX.Y.Z` with a matching title, and the stray bare tag is gone afterward