### PR TITLE
OSAC-3531: Increase e2e full-install periodic CI frequency to 10x/day

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -8,14 +8,16 @@ on:
   pull_request:
     branches: [main]
   merge_group:
-  # 3x/day (every 8h). Offset 23 minutes past the hour, not on the hour --
-  # GitHub Actions' shared cron scheduler queues everyone's on-the-hour
+  # 10x/day. Offset 23 minutes past the hour, not on the hour -- GitHub
+  # Actions' shared cron scheduler queues everyone's on-the-hour
   # schedules together and can delay/drop them under load (see
   # osac-test-infra's e2e-caas-netris-caller.yml for the same reasoning).
   # Staggered from the other periodic workflows in this repo too, so they
-  # don't all land on the same offset simultaneously.
+  # don't all land on the same offset simultaneously. 24 doesn't divide
+  # evenly by 10, so this lists 10 explicit hours (roughly every 2-3h)
+  # instead of a bare */N pattern.
   schedule:
-    - cron: "23 */8 * * *"
+    - cron: "23 0,2,5,7,10,12,14,17,19,22 * * *"
   workflow_dispatch:
     inputs:
       test-suite:

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -8,14 +8,16 @@ on:
   pull_request:
     branches: [main]
   merge_group:
-  # 3x/day (every 8h). Offset 38 minutes past the hour, not on the hour --
-  # GitHub Actions' shared cron scheduler queues everyone's on-the-hour
+  # 10x/day. Offset 38 minutes past the hour, not on the hour -- GitHub
+  # Actions' shared cron scheduler queues everyone's on-the-hour
   # schedules together and can delay/drop them under load (see
   # osac-test-infra's e2e-caas-netris-caller.yml for the same reasoning).
   # Staggered from the other periodic workflows in this repo too, so they
-  # don't all land on the same offset simultaneously.
+  # don't all land on the same offset simultaneously. 24 doesn't divide
+  # evenly by 10, so this lists 10 explicit hours (roughly every 2-3h)
+  # instead of a bare */N pattern.
   schedule:
-    - cron: "38 */8 * * *"
+    - cron: "38 0,2,5,7,10,12,14,17,19,22 * * *"
   workflow_dispatch:
     inputs:
       test-suite:

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -8,14 +8,16 @@ on:
   pull_request:
     branches: [main]
   merge_group:
-  # 3x/day (every 8h). Offset 7 minutes past the hour, not on the hour --
-  # GitHub Actions' shared cron scheduler queues everyone's on-the-hour
+  # 10x/day. Offset 7 minutes past the hour, not on the hour -- GitHub
+  # Actions' shared cron scheduler queues everyone's on-the-hour
   # schedules together and can delay/drop them under load (see
   # osac-test-infra's e2e-caas-netris-caller.yml for the same reasoning).
   # Staggered from the other periodic workflows in this repo too, so they
-  # don't all land on the same offset simultaneously.
+  # don't all land on the same offset simultaneously. 24 doesn't divide
+  # evenly by 10, so this lists 10 explicit hours (roughly every 2-3h)
+  # instead of a bare */N pattern.
   schedule:
-    - cron: "7 */8 * * *"
+    - cron: "7 0,2,5,7,10,12,14,17,19,22 * * *"
   workflow_dispatch:
     inputs:
       test-suite:


### PR DESCRIPTION
## Summary

- Bumps the periodic (schedule-triggered) frequency of the 3 e2e full-install workflows from 3x/day to 10x/day: `e2e-vmaas-full-install.yml`, `e2e-bmaas-full-install.yml`, `e2e-caas-full-install.yml`.
- Follow-up to [OSAC-3512](https://redhat.atlassian.net/browse/OSAC-3512) (which set these to 3x/day), scoped separately since this is a new ask beyond that ticket's closed scope.

## Approach

24 doesn't divide evenly by 10, so a bare `*/N` hour-field pattern can't produce exactly 10 evenly-spaced runs/day (`*/N` only yields counts that evenly divide 24). Instead, each workflow's cron now lists 10 explicit hours: `0,2,5,7,10,12,14,17,19,22` — alternating 2h/3h gaps, never more than 0.6h off a perfect 2.4h spacing.

Each workflow keeps its existing non-zero minute offset (`:07` / `:23` / `:38`) so all three stay staggered from each other and off the `:00`/`:30` marks, per the same GitHub Actions shared-scheduler contention reasoning already documented in these files (and in osac-test-infra's `e2e-caas-netris-caller.yml`).

## Verification

Simulated a 24h window for each new cron expression with `croniter` and confirmed:
- Exactly 10 matches/day for all 3.
- Gaps: `[2, 3, 2, 3, 2, 2, 3, 2, 3, 2]` hours (sums to 24).
- None land on `:00` or `:30`.
- The 3 workflows remain staggered from each other by their distinct minute offsets.

```
vmaas: 7 0,2,5,7,10,12,14,17,19,22 * * *  -> 00:07 02:07 05:07 07:07 10:07 12:07 14:07 17:07 19:07 22:07
bmaas: 23 0,2,5,7,10,12,14,17,19,22 * * * -> 00:23 02:23 05:23 07:23 10:23 12:23 14:23 17:23 19:23 22:23
caas:  38 0,2,5,7,10,12,14,17,19,22 * * * -> 00:38 02:38 05:38 07:38 10:38 12:38 14:38 17:38 19:38 22:38
```

## Test plan

- [x] `yaml.safe_load` clean on all 3 changed files
- [x] `yamllint -c .yamllint.yaml` clean
- [x] Cron correctness verified programmatically with `croniter` (see above), not eyeballed