### PR TITLE
OSAC-3484: Scope fulfillment-service's SRPM archive to its own subtree

### DIFF
--- a/fulfillment-service/.copr/srpm.sh
+++ b/fulfillment-service/.copr/srpm.sh
@@ -12,13 +12,17 @@
 # language governing permissions and limitations under the License.
 #
 
-set -e
+set -eo pipefail
 
 # Name of the project:
 name="osac-cli"
 
 # Directory containing this script:
 here="$(dirname "$(readlink -f "$0")")"
+
+# This component's own directory, and the mono-repo root above it:
+component_dir="$(readlink -f "${here}/..")"
+repo_root="$(readlink -f "${here}/../..")"
 
 # Output directory:
 outdir="${outdir:-$here}"
@@ -28,24 +32,36 @@ if ! command -v git >/dev/null 2>&1; then
   dnf install -y git
 fi
 
-# Calculate the version from git. This uses git describe to get a version string based on the most recent tag. If there
-# are commits after the tag, the version will include the commit count and short hash. Any leading 'v' is stripped and
-# the format is converted to use RPM's caret notation for post-release versions (e.g., 0.0.20^29.gfa27fa8).
+# Calculate the version from git. This uses git describe to get a version string based on the most recent tag matching
+# this component's own scoped tag prefix -- since the mono-repo's tags aren't namespaced per directory, an unscoped
+# `git describe --tags` would happily describe against the nearest tag from *any* component (e.g. osac-operator/vX.Y.Z),
+# giving fulfillment-service a nonsensical version. If there are commits after the tag, the version will include the
+# commit count and short hash. The component prefix and any leading 'v' are stripped, and the format is converted to
+# use RPM's caret notation for post-release versions (e.g., 0.0.20^29.gfa27fa8).
 version=$(
-  git describe --tags --always 2>/dev/null |
+  git -C "${component_dir}" describe --tags --always --match 'fulfillment-service/v*' 2>/dev/null |
   sed \
-    -e 's/^v//' \
+    -e 's#^fulfillment-service/v##' \
     -e 's/-\([0-9]*\)-g/^\1.g/'
 )
 
 # Calculate the date for the changelog entry in the format required by RPM:
 date=$(date +'%a %b %d %Y')
 
-# Create the tarball:
-git -C "${here}/.." archive \
-  --prefix="${name}-${version}/" \
-  --output="${outdir}/${name}-${version}.tar.gz" \
-  HEAD
+# Create the tarball. `git archive` has no pathspec-based way to scope to a subdirectory *and* flatten it to the
+# archive root in one step -- `HEAD:fulfillment-service` (a subtree, not a full-tree pathspec) gives the scoping,
+# archiving fulfillment-service/ as if it were the repo root, so %build/%install's bare `cmd/osac`, `go.mod` etc.
+# paths resolve correctly instead of everything (including every other component) landing in the tarball. But
+# fulfillment-service/LICENSE was deleted as a redundant duplicate when its root files were consolidated into the
+# mono-repo's own LICENSE (see OSAC-1733), so that subtree archive alone would be missing the %license file the spec
+# requires -- assemble the tarball in a scratch directory instead, adding the root LICENSE back in.
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+extract_dir="${workdir}/${name}-${version}"
+mkdir -p "${extract_dir}"
+git -C "${repo_root}" archive "HEAD:fulfillment-service" | tar -x -C "${extract_dir}"
+cp "${repo_root}/LICENSE" "${extract_dir}/LICENSE"
+tar -czf "${outdir}/${name}-${version}.tar.gz" -C "${workdir}" "${name}-${version}"
 
 # Create the spec file:
 sed \


### PR DESCRIPTION
## Summary

`fulfillment-service/.copr/srpm.sh` builds the SRPM's source tarball with:

```
git -C "${here}/.." archive --prefix="${name}-${version}/" --output=... HEAD
```

This worked pre-merge because `${here}/..` (fulfillment-service's own root) *was* the repo root, so an unscoped `archive HEAD` correctly meant "the whole (small) repo." Post-merge, `${here}/..` is just a subdirectory of the mono-repo — the same command now archives the **entire mono-repo tree**, so the "fulfillment-service" SRPM's source tarball ends up containing every other component's full source too.

## Fix

- Archives `HEAD:fulfillment-service` (a subtree pathspec) instead of `HEAD`, so fulfillment-service's own directory becomes the archive root — matching what `%build`/`%install` in `osac-cli.spec.in` expect (bare `cmd/osac`, `go.mod`, etc.).
- `fulfillment-service/LICENSE` was itself deleted as a redundant duplicate when its root files were consolidated into the mono-repo's own `LICENSE` ([OSAC-1733](https://redhat.atlassian.net/browse/OSAC-1733)) — so the subtree archive alone is missing the `%license` file the spec requires. The tarball is now assembled in a scratch directory instead, with the root `LICENSE` copied back in before packing.
- Also scopes the version's `git describe` to `fulfillment-service/v*`: the mono-repo's tags aren't namespaced per directory, so an unscoped `git describe --tags` can just as easily resolve against the nearest tag from an unrelated component.

## Test plan

Verified end-to-end in a clean Fedora container (matching the real COPR builder environment):
- [x] `make -f .copr/Makefile srpm` produces a valid SRPM
- [x] Version resolves to fulfillment-service's own tag (`0.0.82`), not another component's
- [x] Tarball contains only fulfillment-service's own tree plus `LICENSE` (2.8M vs. 93M for the whole repo) — no other component directories present
- [x] `rpmbuild --rebuild` on the produced SRPM succeeds end-to-end (`go build ./cmd/osac`, `%license LICENSE`, `%doc README.md` all resolve)
- [x] The resulting `osac` binary runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved fulfillment-service source archive generation.
  * Version detection now uses fulfillment-service-specific tags.
  * Archives contain only the relevant service files and include the repository license.
  * Added safer staging and error handling during package creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->