### PR TITLE
TEMP: e2e verification for OSAC-3509 (do not merge)

### DIFF
--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -76,7 +76,7 @@ jobs:
   e2e-vmaas-full-install:
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
-    uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main
+    uses: eliorerz/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@osac-3509-e2e-readiness-check-hardening
     with:
       test-suite: ${{ inputs.test-suite || 'vmaas' }}
       test-filter: ${{ inputs.test-filter || '' }}


### PR DESCRIPTION
Throwaway PR to exercise osac-project/osac-test-infra#295's gRPC readiness-check hardening (checksum-verified grpcurl download, public endpoint + bearer auth, JSON status parsing) against a real e2e-vmaas run that actually builds components (unlike osac-test-infra's own dogfood callers, which skip the MERGED_OVERRIDES-guarded readiness-check block entirely when no components/overrides are passed). Points the vmaas caller's `uses:` at eliorerz/osac-test-infra@osac-3509-e2e-readiness-check-hardening. Will be closed (not merged) once verified. See osac-project/osac-test-infra#295 for the real PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the end-to-end full-install validation workflow to use the latest readiness-check configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->