### PR TITLE
OSAC-3482: Add true per-component path-based skip logic to merged CI jobs

### DIFF
--- a/.github/workflows/check-floating-tags.yaml
+++ b/.github/workflows/check-floating-tags.yaml
@@ -18,13 +18,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      changes: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            fulfillment-service:
+              - 'fulfillment-service/charts/**/values.yaml'
+              - '.github/scripts/check-floating-tags.sh'
+              - '.github/workflows/check-floating-tags.yaml'
+            osac-operator:
+              - 'osac-operator/charts/**/values.yaml'
+              - '.github/scripts/check-floating-tags.sh'
+              - '.github/workflows/check-floating-tags.yaml'
+            bare-metal-fulfillment-operator:
+              - 'bare-metal-fulfillment-operator/charts/**/values.yaml'
+              - '.github/scripts/check-floating-tags.sh'
+              - '.github/workflows/check-floating-tags.yaml'
+            osac-installer:
+              - 'osac-installer/charts/**/values.yaml'
+              - '.github/scripts/check-floating-tags.sh'
+              - '.github/workflows/check-floating-tags.yaml'
+
   check-floating-tags:
     name: Reject unmarked floating tags (${{ matrix.component }})
+    needs: changes
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         component: [fulfillment-service, osac-operator, bare-metal-fulfillment-operator, osac-installer]
+    if: github.event_name != 'pull_request' || contains(fromJSON(needs.changes.outputs.changes), matrix.component)
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/check-generated-code.yaml
+++ b/.github/workflows/check-generated-code.yaml
@@ -14,15 +14,46 @@ on:
       - '!osac-operator/**/*.md'
       - '!osac-operator/docs/**'
 
+permissions:
+  contents: read
+
 jobs:
+
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      changes: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            fulfillment-service:
+              - 'fulfillment-service/**'
+              - '!fulfillment-service/OWNERS'
+              - '!fulfillment-service/LICENSE'
+              - '!fulfillment-service/**/*.md'
+              - '!fulfillment-service/docs/**'
+            osac-operator:
+              - 'osac-operator/**'
+              - '!osac-operator/OWNERS'
+              - '!osac-operator/LICENSE'
+              - '!osac-operator/**/*.md'
+              - '!osac-operator/docs/**'
 
   check-generated-code:
     name: Check generated code (${{ matrix.component }})
+    needs: changes
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         component: [fulfillment-service, osac-operator]
+    if: github.event_name != 'pull_request' || contains(fromJSON(needs.changes.outputs.changes), matrix.component)
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -25,17 +25,60 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      changes: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            osac-operator:
+              - 'osac-operator/api/**'
+              - 'osac-operator/charts/**'
+              - 'osac-operator/config/crd/bases/**'
+              - 'osac-operator/hack/sync-helm-crds.py'
+              - 'osac-operator/Makefile'
+              - '.github/workflows/helm-lint.yaml'
+            bare-metal-fulfillment-operator:
+              - 'bare-metal-fulfillment-operator/api/**'
+              - 'bare-metal-fulfillment-operator/charts/**'
+              - 'bare-metal-fulfillment-operator/config/crd/bases/**'
+              - 'bare-metal-fulfillment-operator/hack/sync-helm-crds.py'
+              - 'bare-metal-fulfillment-operator/Makefile'
+              - '.github/workflows/helm-lint.yaml'
+            fulfillment-service:
+              - 'fulfillment-service/charts/**'
+              - '.github/workflows/helm-lint.yaml'
+            osac-aap:
+              - 'osac-aap/charts/**'
+              - '.github/workflows/helm-lint.yaml'
+            osac-csi-driver:
+              - 'osac-csi-driver/charts/**'
+              - '.github/workflows/helm-lint.yaml'
+            osac-installer:
+              - 'osac-installer/charts/**'
+              - 'osac-installer/values/**'
+              - 'osac-installer/ct.yaml'
+              - '.github/workflows/helm-lint.yaml'
+
   # Matrixed over every component that generates Helm CRD templates from a
   # kubebuilder config/crd/bases/ source of truth via hack/sync-helm-crds.py
   # + make check-helm-crds (osac-operator and bare-metal-fulfillment-operator
   # share the identical mechanism; fulfillment-service/osac-aap don't have one).
   helm-crds-sync:
     name: Check Helm CRD sync (${{ matrix.component }})
+    needs: changes
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         component: [osac-operator, bare-metal-fulfillment-operator]
+    if: github.event_name != 'pull_request' || contains(fromJSON(needs.changes.outputs.changes), matrix.component)
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
@@ -57,6 +100,7 @@ jobs:
   # charts have no such guards and lint fine bare.
   helm-lint:
     name: Lint Helm chart (${{ matrix.component }}/${{ matrix.chart }})
+    needs: changes
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -79,6 +123,7 @@ jobs:
             chart: csi-driver
           - component: osac-csi-driver
             chart: csi-backends
+    if: github.event_name != 'pull_request' || contains(fromJSON(needs.changes.outputs.changes), matrix.component)
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
@@ -113,9 +158,23 @@ jobs:
   # dependency -- a different thing from linting any one component's chart in
   # isolation above, so this stays a separate job rather than another matrix
   # entry.
+  #
+  # Skip condition intentionally isn't scoped to osac-installer's own filter
+  # alone: charts/osac/ pulls in every other component's chart as a local
+  # file:// dependency, so a change to any of them changes what this job
+  # actually builds and lints, not just a change under osac-installer/ itself.
   helm-lint-installer:
     name: Lint Helm charts (osac-installer)
+    needs: changes
     runs-on: ubuntu-latest
+    if: >
+      github.event_name != 'pull_request' ||
+      contains(fromJSON(needs.changes.outputs.changes), 'osac-installer') ||
+      contains(fromJSON(needs.changes.outputs.changes), 'osac-operator') ||
+      contains(fromJSON(needs.changes.outputs.changes), 'bare-metal-fulfillment-operator') ||
+      contains(fromJSON(needs.changes.outputs.changes), 'fulfillment-service') ||
+      contains(fromJSON(needs.changes.outputs.changes), 'osac-aap') ||
+      contains(fromJSON(needs.changes.outputs.changes), 'osac-csi-driver')
     steps:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6


### PR DESCRIPTION
## Summary

`check-floating-tags.yaml`, `check-generated-code.yaml`, and `helm-lint.yaml` each merge several components' same-concept jobs into one matrixed workflow. Each is gated at the workflow level by a single combined `paths:` filter (any component's paths, OR'd together) — but once triggered, every matrix entry runs regardless of which single component actually changed. A PR touching only `osac-installer/charts/` still runs `helm-lint`'s `fulfillment-service`, `osac-aap`, `osac-csi-driver`, etc. entries too.

This is distinct from the already-closed OSAC-3517, which added one coarse doc-only-PR exclusion to `unit-tests.yml`/`integration-tests.yml` (single "did any real code change" filter, not per-component).

## Approach

Added a `changes` job to each file using `dorny/paths-filter`, with one **named filter per component** (reusing each workflow's own existing trigger paths verbatim, so no scope drift). Each matrix entry then gates on:

```yaml
if: github.event_name != 'pull_request' || contains(fromJSON(needs.changes.outputs.changes), matrix.component)
```

This is `dorny/paths-filter`'s own documented pattern for skipping individual matrix jobs (`outputs.changes` is a JSON array of every filter name that matched). Verified the semantics before using them: `predicate-quantifier` only affects how multiple patterns combine *per file* within one filter, not whether the aggregate filter requires every changed file in a PR to match (it doesn't — any single matching file triggers the filter). Used:
- Default `some` for filters that are pure path alternatives (`check-floating-tags.yaml`, `helm-lint.yaml`) — any one of several paths indicating that component is relevant.
- `every` only for `check-generated-code.yaml`, which mirrors the existing positive-path-minus-doc-exclusions shape (`'fulfillment-service/**'` + `'!fulfillment-service/**/*.md'` etc.) — `every` is what makes the negation patterns actually exclude, per file.

`helm-lint-installer` (osac-installer's umbrella chart) is gated on its own filter **OR** any dependency component's filter, since `charts/osac/` pulls in every other component's chart as a local `file://` dependency — scoping it to `osac-installer`'s own paths alone would silently skip it when a dependency chart changes.

**`publish-charts.yaml` was reviewed and intentionally left out of scope**: it's triggered by `workflow_run` (post-merge, after each component's own separate image-build workflow completes), not `pull_request`. There's no PR diff to filter on, and each publish job already self-scopes via `if: ... workflow_run.name == '<component's build workflow>'` with no measurable waste — non-matching jobs are skipped instantly at zero cost. A `dorny/paths-filter` "changes" job doesn't apply to that trigger model.

## Test plan

- [x] `yaml.safe_load` clean on all 3 changed files
- [x] `yamllint -c .yamllint.yaml` clean
- [x] Manually traced each new skip condition against the existing top-level path lists to confirm no scope drift
- [x] `dorny/paths-filter`'s `predicate-quantifier`/`changes`-output semantics verified against upstream docs before use, not assumed
- Not verified: no `act`/`actionlint` available locally to dry-run the workflow YAML itself — recommend watching the first few PRs against this branch (or a scratch PR) to confirm the skip logic behaves as expected live before treating these as required checks