### PR TITLE
OSAC-3546: Build osac-aap's execution environment for every image field it fills

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -59,12 +59,13 @@ jobs:
               - '!**/docs/**'
 
   # Builds fulfillment-service, osac-operator, osac-aap's execution
-  # environment, and bare-metal-fulfillment-operator from this PR's current
-  # code and installs them together in one cluster -- not one "component
-  # under test" plus stale pinned images for the others. Runs for any
-  # change touching any component (see `changes` above) rather than being
-  # path-scoped per component; splitting this by component to avoid
-  # running both suites when only one changed is deferred to the future
+  # environment (twice -- once each for aap.bootstrap.image and
+  # aap.configAsCode.eeImage, see OSAC-3546), and bare-metal-fulfillment-operator
+  # from this PR's current code and installs them together in one cluster --
+  # not one "component under test" plus stale pinned images for the others.
+  # Runs for any change touching any component (see `changes` above) rather
+  # than being path-scoped per component; splitting this by component to
+  # avoid running both suites when only one changed is deferred to the future
   # full path-based CI matrix, once its skip-logic pattern is verified.
   e2e-bmaas-full-install:
     needs: changes
@@ -80,8 +81,13 @@ jobs:
       # standalone-repo default.
       installer-repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       installer-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
-      # Build all component images from the PR's fork/branch (same monorepo checkout)
-      components: '[{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}]'
+      # Build all component images from the PR's fork/branch (same monorepo checkout).
+      # osac-aap's execution-environment is built twice (aap.bootstrap.image and
+      # aap.configAsCode.eeImage): the two are logically the same image but the
+      # override mechanism keys strictly off imageKey, one build per key, so this
+      # is the only way to get both fields covered without changing that mechanism
+      # (which lives in osac-test-infra, not here). See OSAC-3546.
+      components: '[{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}]'
       # Pass author_association for fork PR authorization (empty for non-fork PRs)
       fork-pr-author-association: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association || '' }}
       fork-pr-author: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.user.login || '' }}

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -58,15 +58,20 @@ jobs:
               - '!**/*.md'
               - '!**/docs/**'
 
-  # Builds fulfillment-service, osac-operator, and bare-metal-fulfillment-operator
+  # Builds fulfillment-service, osac-operator, osac-aap's execution
+  # environment (twice -- once each for aap.bootstrap.image and
+  # aap.configAsCode.eeImage, see OSAC-3546), and bare-metal-fulfillment-operator
   # from this PR's current code and installs them together in one cluster --
   # not one "component under test" plus a stale pinned image for the others.
   # Runs for any change touching any component (see `changes` above) rather
   # than being path-scoped per component; splitting this by component to
   # avoid running both suites when only one changed is deferred to the
   # future full path-based CI matrix, once its skip-logic pattern is
-  # verified. (osac-aap is not built here -- that's a pre-existing scope
-  # decision for this flow, unrelated to BMF, not changed by this entry.)
+  # verified. osac-aap *is* built here (added by OSAC-3546): caas's own
+  # values/caas-ci/values.yaml sets provisioning.provider: "aap" and
+  # controllers.clusterOrder: true, so CaaS's core cluster-provisioning path
+  # runs through AAP just as much as vmaas/bmaas's does -- the prior
+  # exclusion was deferred scope, not a real technical constraint.
   #
   # bare-metal-fulfillment-operator's image override (bmf.image.repository)
   # is currently a no-op in this flow specifically: values/caas-ci/values.yaml
@@ -87,8 +92,13 @@ jobs:
       # standalone-repo default.
       installer-repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       installer-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
-      # Build all component images from the PR's fork/branch (same monorepo checkout)
-      components: '[{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}]'
+      # Build all component images from the PR's fork/branch (same monorepo checkout).
+      # osac-aap's execution-environment is built twice (aap.bootstrap.image and
+      # aap.configAsCode.eeImage): the two are logically the same image but the
+      # override mechanism keys strictly off imageKey, one build per key, so this
+      # is the only way to get both fields covered without changing that mechanism
+      # (which lives in osac-test-infra, not here). See OSAC-3546.
+      components: '[{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}]'
       # Pass author_association for fork PR authorization (empty for non-fork PRs)
       fork-pr-author-association: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association || '' }}
       fork-pr-author: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.user.login || '' }}

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -59,12 +59,13 @@ jobs:
               - '!**/docs/**'
 
   # Builds fulfillment-service, osac-operator, osac-aap's execution
-  # environment, and bare-metal-fulfillment-operator from this PR's current
-  # code and installs them together in one cluster -- not one "component
-  # under test" plus stale pinned images for the others. Runs for any
-  # change touching any component (see `changes` above) rather than being
-  # path-scoped per component; splitting this by component to avoid
-  # running both suites when only one changed is deferred to the future
+  # environment (twice -- once each for aap.bootstrap.image and
+  # aap.configAsCode.eeImage, see OSAC-3546), and bare-metal-fulfillment-operator
+  # from this PR's current code and installs them together in one cluster --
+  # not one "component under test" plus stale pinned images for the others.
+  # Runs for any change touching any component (see `changes` above) rather
+  # than being path-scoped per component; splitting this by component to
+  # avoid running both suites when only one changed is deferred to the future
   # full path-based CI matrix, once its skip-logic pattern is verified.
   #
   # bare-metal-fulfillment-operator's image override (bmf.image.repository)
@@ -87,8 +88,13 @@ jobs:
       # standalone-repo default.
       installer-repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       installer-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
-      # Build all component images from the PR's fork/branch (same monorepo checkout)
-      components: '[{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}]'
+      # Build all component images from the PR's fork/branch (same monorepo checkout).
+      # osac-aap's execution-environment is built twice (aap.bootstrap.image and
+      # aap.configAsCode.eeImage): the two are logically the same image but the
+      # override mechanism keys strictly off imageKey, one build per key, so this
+      # is the only way to get both fields covered without changing that mechanism
+      # (which lives in osac-test-infra, not here). See OSAC-3546.
+      components: '[{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}]'
       # Pass author_association for fork PR authorization (empty for non-fork PRs)
       fork-pr-author-association: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association || '' }}
       fork-pr-author: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.user.login || '' }}


### PR DESCRIPTION
## Summary

Independent audit (prompted by review of PR #78/OSAC-3367) of which mono-repo component images each e2e suite actually builds-and-substitutes from the PR under test, versus which silently fall back to a `latest`/`main` published image. Found two real, confirmed gaps — both pre-existing, since none of the three `e2e-*-full-install.yml` workflows were touched by #78 at all:

- **`e2e-caas-full-install.yml` excluded `osac-aap` from its `components[]` array entirely.** Checked whether that's a real technical constraint before "fixing" it: it isn't. `values/caas-ci/values.yaml` sets `provisioning.provider: "aap"` and `controllers.clusterOrder: true` — CaaS's own core cluster-provisioning path runs through AAP exactly as much as vmaas/bmaas's does. The exclusion was deferred scope, not a limitation.
- **`aap.configAsCode.eeImage` was never in any of the three workflows' `components[]` `imageKey` lists, in any flow** — only `aap.bootstrap.image` was. The two are separate `values.yaml` fields for what's logically the same execution-environment image (one for the bootstrap job, one for config-as-code's own automation runs), so a PR changing osac-aap's execution-environment source was silently exercised for one and not the other.

## Fix

Added `aap.bootstrap.image` (caas only — vmaas/bmaas already had it) and `aap.configAsCode.eeImage` (all three) to each workflow's `components[]` array, using the same `execution-environment.yaml` + `ansible-builder` `buildType` already used for `aap.bootstrap.image` elsewhere.

This does mean osac-aap's execution-environment gets built **twice** per e2e run (once per imageKey) — the override mechanism (in `osac-project/osac-test-infra`) keys strictly off `imageKey` with no way to fan one build out to multiple fields, so this is the correct fix on the caller side without touching the reusable workflow's schema. Flagging the double-build cost as a possible follow-up for `osac-test-infra` (e.g. an `imageKeys: [...]` array per component entry) rather than blocking this fix on it.

## A suspected third gap turned out not to be real

Also checked whether `publish-osac-installer-chart.yaml`'s real-release path pins `aap.configAsCode.eeImage` the same way it pins `aap.bootstrap.image`. It already does — both are set to the same release version at lines 126-127. No change needed there.

## Audit coverage

Checked every other image field across all three CI values files (`operator`, `service`, `envoy`, `ui`, `bmf`, `clusterVersions`, `dbMigrate`) against each workflow's `components[]` coverage:
- `operator.image`, `service.images.service`, `bmf.image` — already correctly overridden in all applicable flows (verified against the actual override script in `osac-test-infra`, which splits `.repository`-suffixed keys into both `.repository` and `.tag`, and sets `pullPolicy: IfNotPresent`).
- `envoy`, `osac-ui`, OCP `clusterVersions` release images — legitimately out of scope; none are mono-repo-resident components, and their pinned tags are real, valid, and appropriately version-pinned (verified via the GHCR/quay registries).
- `dbMigrate.image` — globally disabled by default (`enabled: false`, "Currently disabled until the 'migrate' subcommand is released") and absent from all three CI values files. Dormant, not a live gap.

## Test plan

- [x] `pre-commit run` clean on all changed files
- [x] YAML + embedded `components[]` JSON validated
- [ ] Real e2e runs (bmaas/vmaas/caas) triggered by this PR — will confirm osac-aap's execution-environment builds successfully via `ansible-builder` in the now-added caas flow, and that both `aap.bootstrap.image`/`aap.configAsCode.eeImage` resolve to this PR's own built image at install time

Part of [OSAC-3546](https://redhat.atlassian.net/browse/OSAC-3546).

🤖 Generated with [Claude Code](https://claude.com/claude-code)