### PR TITLE
OSAC-3053: implement fulfillment gRPC client stub

### DIFF
--- a/osac-csi-driver/charts/csi-driver/templates/controller-deployment.yaml
+++ b/osac-csi-driver/charts/csi-driver/templates/controller-deployment.yaml
@@ -29,8 +29,16 @@ spec:
             {{- if .Values.controller.clusterID }}
             - "--cluster-id={{ .Values.controller.clusterID }}"
             {{- end }}
-            {{- if .Values.controller.fulfillmentEndpoint }}
-            - "--fulfillment-endpoint={{ .Values.controller.fulfillmentEndpoint }}"
+            {{- with .Values.controller.fulfillment }}
+            {{- if .endpoint }}
+            - "--fulfillment-endpoint={{ .endpoint }}"
+            {{- if .credentials.secretName }}
+            - "--fulfillment-token-file=/etc/osac-csi/credentials/{{ .credentials.key }}"
+            {{- end }}
+            {{- if .tls.insecureSkipVerify }}
+            - "--grpc-insecure"
+            {{- end }}
+            {{- end }}
             {{- end }}
             {{- if .Values.controller.vendorSockets }}
             - "--vendor-sockets={{ .Values.controller.vendorSockets }}"
@@ -39,6 +47,11 @@ spec:
           volumeMounts:
             - name: osac-socket-dir
               mountPath: /csi/osac
+            {{- if and .Values.controller.fulfillment.endpoint .Values.controller.fulfillment.credentials.secretName }}
+            - name: fulfillment-credentials
+              mountPath: /etc/osac-csi/credentials
+              readOnly: true
+            {{- end }}
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}
           securityContext:
@@ -82,3 +95,11 @@ spec:
       volumes:
         - name: osac-socket-dir
           emptyDir: {}
+        {{- if and .Values.controller.fulfillment.endpoint .Values.controller.fulfillment.credentials.secretName }}
+        - name: fulfillment-credentials
+          secret:
+            secretName: {{ .Values.controller.fulfillment.credentials.secretName }}
+            items:
+              - key: {{ .Values.controller.fulfillment.credentials.key }}
+                path: {{ .Values.controller.fulfillment.credentials.key }}
+        {{- end }}

--- a/osac-csi-driver/charts/csi-driver/values.yaml
+++ b/osac-csi-driver/charts/csi-driver/values.yaml
@@ -10,8 +10,25 @@ image:
 controller:
   replicas: 1
   clusterID: ""
-  fulfillmentEndpoint: ""
   vendorSockets: ""
+  # Connection to the OSAC fulfillment-service (runs on the hub / control plane cluster).
+  # The CSI driver runs on tenant clusters and needs credentials that the
+  # fulfillment-service recognises. AAP provisions a Secret with a bearer token
+  # onto each tenant cluster during cluster setup.
+  fulfillment:
+    # gRPC endpoint of the fulfillment-service (e.g. "fulfillment-api.osac.svc:8000").
+    # Leave empty to use in-memory stubs.
+    endpoint: ""
+    # Secret containing a bearer token for fulfillment-service authentication.
+    # The Secret must exist in the release namespace before the chart is installed.
+    credentials:
+      # Name of the Kubernetes Secret (required when endpoint is set).
+      secretName: ""
+      # Key inside the Secret that holds the bearer token.
+      key: "token"
+    tls:
+      # Skip server certificate verification (use for self-signed certs).
+      insecureSkipVerify: false
   resources:
     limits:
       cpu: 500m

--- a/osac-csi-driver/cmd/osac-csi-driver/main.go
+++ b/osac-csi-driver/cmd/osac-csi-driver/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"os"
@@ -8,6 +9,10 @@ import (
 
 	"github.com/osac-project/osac/osac-csi-driver/pkg/driver"
 	"github.com/osac-project/osac/osac-csi-driver/pkg/fulfillment"
+	"golang.org/x/oauth2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/oauth"
+	experimentalcredentials "google.golang.org/grpc/experimental/credentials"
 	"k8s.io/klog/v2"
 )
 
@@ -24,6 +29,9 @@ func main() {
 	clusterID := flag.String("cluster-id", "", "Cluster ID for volume creation")
 	fulfillmentEndpoint := flag.String("fulfillment-endpoint", "",
 		"gRPC endpoint for the OSAC fulfillment service (uses stub if empty)")
+	fulfillmentTokenFile := flag.String("fulfillment-token-file", "",
+		"Path to a file containing the bearer token for fulfillment-service authentication")
+	grpcInsecure := flag.Bool("grpc-insecure", false, "Skip TLS server certificate verification")
 	vendorSocketsFlag := flag.String("vendor-sockets", "",
 		"Comma-separated backend=socketpath pairs (e.g. ontap=/csi/trident/csi.sock)")
 	driverName := flag.String("driver-name", "csi.osac.openshift.io", "CSI driver name")
@@ -34,8 +42,6 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error: --node-id is required\n")
 		os.Exit(1)
 	}
-	// --cluster-id is optional; the fulfillment service may identify the
-	// cluster from connection credentials or a mounted ConfigMap.
 
 	vendorSockets, err := parseVendorSockets(*vendorSocketsFlag)
 	if err != nil {
@@ -52,10 +58,18 @@ func main() {
 	var controlPlaneClient fulfillment.ControlPlaneClient
 
 	if *fulfillmentEndpoint != "" {
-		fmt.Fprintf(os.Stderr, "Error: --fulfillment-endpoint is set but the gRPC client is not implemented yet\n")
-		os.Exit(1)
+		// Establish the gRPC connection to the fulfillment-service.
+		// TODO(OSAC-2872): use the connection to create real VolumeClient
+		// and ControlPlaneClient once the Volume API is implemented.
+		conn, err := dialFulfillment(*fulfillmentEndpoint, *grpcInsecure, *fulfillmentTokenFile)
+		if err != nil {
+			klog.Fatalf("Failed to connect to fulfillment-service: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+		klog.Infof("Fulfillment endpoint: %s (connected, using stubs until Volume API is implemented)", *fulfillmentEndpoint)
+	} else {
+		klog.Infof("No fulfillment endpoint configured, using in-memory stubs")
 	}
-	klog.Infof("No fulfillment endpoint configured, using in-memory stubs")
 	volumeClient = fulfillment.NewVolumeStub("default-backend", "nfs")
 	controlPlaneClient = &fulfillment.ControlPlaneStub{}
 
@@ -70,6 +84,42 @@ func main() {
 	if err := d.Run(); err != nil {
 		klog.Fatalf("Failed to run driver: %v", err)
 	}
+}
+
+func dialFulfillment(endpoint string, insecureSkipVerify bool, tokenFile string) (*grpc.ClientConn, error) {
+	tlsCfg := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: insecureSkipVerify, //nolint:gosec // user-controlled flag
+	}
+	// The OpenShift router does not support ALPN, so we use the
+	// experimental credentials package that disables the ALPN check.
+	// See https://github.com/grpc/grpc-go/issues/434
+	dialOpts := []grpc.DialOption{
+		grpc.WithTransportCredentials(experimentalcredentials.NewTLSWithALPNDisabled(tlsCfg)),
+	}
+
+	if tokenFile != "" {
+		dialOpts = append(dialOpts, grpc.WithPerRPCCredentials(
+			oauth.TokenSource{TokenSource: &fileTokenSource{path: tokenFile}},
+		))
+	}
+
+	return grpc.NewClient(endpoint, dialOpts...)
+}
+
+type fileTokenSource struct {
+	path string
+}
+
+func (f *fileTokenSource) Token() (*oauth2.Token, error) {
+	data, err := os.ReadFile(f.path)
+	if err != nil {
+		return nil, fmt.Errorf("reading token file %s: %w", f.path, err)
+	}
+	return &oauth2.Token{
+		AccessToken: strings.TrimSpace(string(data)),
+		TokenType:   "Bearer",
+	}, nil
 }
 
 func parseVendorSockets(s string) (map[string]string, error) {

--- a/osac-csi-driver/go.mod
+++ b/osac-csi-driver/go.mod
@@ -5,12 +5,14 @@ go 1.26.3
 require (
 	github.com/container-storage-interface/spec v1.12.0
 	github.com/kubernetes-csi/csi-test/v5 v5.5.0
+	golang.org/x/oauth2 v0.36.0
 	google.golang.org/grpc v1.83.0
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	k8s.io/klog/v2 v2.140.0
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/go-logr/logr v1.4.4 // indirect

--- a/osac-csi-driver/go.sum
+++ b/osac-csi-driver/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
+cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -81,6 +83,8 @@ golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
 golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
 golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
 golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
 golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=


### PR DESCRIPTION
## Summary

Wire the gRPC connection to the fulfillment-service in the CSI driver. When `--fulfillment-endpoint` is set, `dialFulfillment()` establishes a TLS connection with optional file-based bearer token auth. The connection is established but stubs are still used for `VolumeClient` and `ControlPlaneClient` until the Volume API is implemented server-side ([OSAC-2872](https://redhat.atlassian.net/browse/OSAC-2872)).

**Only `osac-csi-driver/` files changed.** No operator, fulfillment-service, or other component changes.

### What's added
- `--fulfillment-token-file` and `--grpc-insecure` CLI flags
- `dialFulfillment()` with TLS (ALPN-disabled for OpenShift router compat, `MinVersion: tls.VersionTLS12`), `fileTokenSource` for rotated token auth
- Helm chart: `controller.fulfillment.endpoint`, `controller.fulfillment.credentials.secretName/.key`, `controller.fulfillment.tls.insecureSkipVerify`
- Credentials Secret mounted at `/etc/osac-csi/credentials/` — CSI driver runs on tenant clusters, AAP provisions the Secret

## Test plan

- [x] `go build ./osac-csi-driver/...` — builds
- [x] `helm lint` — passes
- [x] `helm template` — all value combinations render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable fulfillment service connectivity for the CSI driver.
  * Added bearer-token authentication using a Kubernetes Secret and token file.
  * Added optional TLS certificate verification settings.
  * Fulfillment credentials are mounted securely as read-only configuration.
  * Added support for authenticated gRPC connections to the configured fulfillment service.

* **Bug Fixes**
  * The driver now establishes the configured fulfillment connection during startup and reports connection failures immediately.
  * Replaced the legacy fulfillment endpoint setting with the nested fulfillment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->