### PR TITLE
OSAC-3550: Ignore UBI-versioned go-toolset tags in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,6 +67,11 @@ updates:
     fulfillment-service-container-images:
       patterns:
         - "*"
+  ignore:
+    # go-toolset tags use the Go version (1.x); UBI-versioned tags (10.x)
+    # ship older Go and break go.mod compatibility (see OSAC-3550)
+    - dependency-name: "ubi10/go-toolset"
+      versions: [">= 2"]
   commit-message:
     prefix: "NO-ISSUE"
 
@@ -79,5 +84,10 @@ updates:
     osac-operator-container-images:
       patterns:
         - "*"
+  ignore:
+    # go-toolset tags use the Go version (1.x); UBI-versioned tags (10.x)
+    # ship older Go and break go.mod compatibility (see OSAC-3550)
+    - dependency-name: "ubi10/go-toolset"
+      versions: [">= 2"]
   commit-message:
     prefix: "NO-ISSUE"


### PR DESCRIPTION
## Summary

- Add Dependabot ignore rules for `ubi10/go-toolset` versions >= 2 on both fulfillment-service and osac-operator docker ecosystems
- Blocks UBI-versioned tags (10.x) that ship older Go compilers incompatible with `go.mod` requirements
- Still allows legitimate Go-version tag bumps (1.26 -> 1.27, etc.)

## Problem

Red Hat's `ubi10/go-toolset` container image uses two tag schemes:
- **Go-version tags** (1.26, 1.27) — ship the matching Go compiler
- **UBI-version tags** (10.1, 10.2) — UBI 10 numbering, ship older Go (e.g. 10.1 ships Go 1.25.9)

Dependabot sees `10.1 > 1.26` numerically and proposes the bump. The resulting Containerfile breaks with `go.mod requires go >= 1.26.3 (running go 1.25.9; GOTOOLCHAIN=local)`. In the monorepo, this fails all 3 E2E jobs (3x blast radius).

## Test plan

- [ ] Dependabot no longer proposes `go-toolset:10.x` bumps
- [ ] Dependabot still proposes legitimate `go-toolset:1.27` bumps when available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to ignore specified `ubi10/go-toolset` version updates for select Docker configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->