### PR TITLE
OSAC-3547: Rename ansible_eda extra vars to osac_job_vars

### DIFF
--- a/osac-aap/.ai-bot/instructions.md
+++ b/osac-aap/.ai-bot/instructions.md
@@ -107,7 +107,7 @@ samples/                               Example payloads
 
 ## Standard Playbook Pattern
 
-Every playbook receives a K8s CR via `ansible_eda.event.payload`, extracts
+Every playbook receives a K8s CR via `osac_job_vars.resource`, extracts
 `implementation_strategy` from the CR annotation
 (`osac.openshift.io/implementation-strategy`), and dynamically includes the
 matching role from `osac.templates`:

--- a/osac-aap/.ai-bot/new-ticket-workflow.md
+++ b/osac-aap/.ai-bot/new-ticket-workflow.md
@@ -37,7 +37,7 @@ instead. Write the PR description to `.ai-bot/pr.md`.
    - Workflow playbooks: `collections/ansible_collections/osac/workflows/playbooks/`
    - Filter plugins: `collections/ansible_collections/osac/service/plugins/filter/`
    - Custom modules: `collections/ansible_collections/osac/service/plugins/modules/`
-3. Understand the data flow: osac-operator -> EDA event -> playbook ->
+3. Understand the data flow: osac-operator -> osac_job_vars -> playbook ->
    implementation_strategy -> template role -> K8s resources
 4. Check `.claude/rules/playbook-patterns.md` and `.claude/rules/networking-cudn.md`
    for domain-specific patterns

--- a/osac-aap/.claude/rules/playbook-patterns.md
+++ b/osac-aap/.claude/rules/playbook-patterns.md
@@ -49,7 +49,7 @@ AAP job templates: `osac-{action}-{resource}`
 
 ### Show EDA Event and Sensitive `payload.spec` Fields
 
-The bare `debug: var: ansible_eda.event.payload` shown above is safe as long as
+The bare `debug: var: osac_job_vars.resource` shown above is safe as long as
 nothing in `payload.spec` is a secret. Some CR specs are not — e.g.
 `blockEncryptionPassphrase` on Tenant/ClusterOrder/ComputeInstance CRs. Before
 adding this debug task to a new or existing playbook, inspect the CR
@@ -62,17 +62,17 @@ whole object:
     - name: Show EDA Event metadata
       ansible.builtin.include_role:
         name: osac.service.common
-        tasks_from: show_eda_event_metadata
+        tasks_from: show_resource_metadata
       vars:
-        eda_event_extra_fields:
-          template_id: "{{ ansible_eda.event.payload.spec.templateID | default('unknown') }}"
+        resource_extra_fields:
+          template_id: "{{ osac_job_vars.resource.spec.templateID | default('unknown') }}"
 ```
 
 This logs `kind`/`metadata.name`/`metadata.namespace`/`metadata.uid` plus any
-additional non-sensitive fields passed via `eda_event_extra_fields` — never
-source an `eda_event_extra_fields` value from `payload.spec` without first
+additional non-sensitive fields passed via `resource_extra_fields` — never
+source an `resource_extra_fields` value from `payload.spec` without first
 confirming it isn't a secret. See
-`collections/ansible_collections/osac/service/roles/common/tasks/show_eda_event_metadata.yaml`.
+`collections/ansible_collections/osac/service/roles/common/tasks/show_resource_metadata.yaml`.
 
 ## Template Roles
 

--- a/osac-aap/.claude/rules/playbook-patterns.md
+++ b/osac-aap/.claude/rules/playbook-patterns.md
@@ -30,9 +30,9 @@ AAP job templates: `osac-{action}-{resource}`
          | default(osac_job_vars.resource.spec.implementationStrategy, true) }}
 
   pre_tasks:
-    - name: Show job vars
+    - name: Show resource metadata
       ansible.builtin.debug:
-        var: osac_job_vars.resource
+        var: osac_job_vars.resource.metadata
 
   tasks:
     - name: Call the selected implementation role

--- a/osac-aap/.claude/rules/playbook-patterns.md
+++ b/osac-aap/.claude/rules/playbook-patterns.md
@@ -22,17 +22,17 @@ AAP job templates: `osac-{action}-{resource}`
   gather_facts: false
 
   vars:
-    subnet: "{{ ansible_eda.event.payload }}"
-    subnet_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    subnet: "{{ osac_job_vars.resource }}"
+    subnet_name: "{{ osac_job_vars.resource.metadata.name }}"
     implementation_strategy: >-
-      {{ ansible_eda.event.payload.metadata.annotations
+      {{ osac_job_vars.resource.metadata.annotations
          ['osac.openshift.io/implementation-strategy']
-         | default(ansible_eda.event.payload.spec.implementationStrategy, true) }}
+         | default(osac_job_vars.resource.spec.implementationStrategy, true) }}
 
   pre_tasks:
-    - name: Show EDA Event
+    - name: Show job vars
       ansible.builtin.debug:
-        var: ansible_eda.event.payload
+        var: osac_job_vars.resource
 
   tasks:
     - name: Call the selected implementation role
@@ -42,7 +42,7 @@ AAP job templates: `osac-{action}-{resource}`
 ```
 
 **Key pattern:**
-1. Playbook receives K8s CR as `ansible_eda.event.payload`
+1. Playbook receives K8s CR as `osac_job_vars.resource`
 2. Extracts implementation strategy from CR annotation (`osac.openshift.io/implementation-strategy`) or `spec.implementationStrategy` — annotation takes precedence when both are present
 3. Dynamically includes the appropriate role from `osac.templates`
 4. Role performs actual provisioning (creates K8s resources, updates CR)
@@ -160,7 +160,7 @@ Namespace + ClusterUserDefinedNetwork
 
 | Variable | Purpose | Set By |
 |----------|---------|--------|
-| `ansible_eda.event.payload` | K8s CR data | AAP/EDA event |
+| `osac_job_vars.resource` | K8s CR data | osac-operator extra vars |
 | `remote_cluster_kubeconfig` | Path to remote kubeconfig | `osac.service.common` role |
 | `implementation_strategy` | Network implementation to use | Extracted from CR annotation |
 | `OSAC_AAP_URL` | AAP server URL | osac-operator config |

--- a/osac-aap/.claude/rules/playbook-patterns.md
+++ b/osac-aap/.claude/rules/playbook-patterns.md
@@ -47,7 +47,7 @@ AAP job templates: `osac-{action}-{resource}`
 3. Dynamically includes the appropriate role from `osac.templates`
 4. Role performs actual provisioning (creates K8s resources, updates CR)
 
-### Show EDA Event and Sensitive `payload.spec` Fields
+### Show Resource Metadata and Sensitive `payload.spec` Fields
 
 The bare `debug: var: osac_job_vars.resource` shown above is safe as long as
 nothing in `payload.spec` is a secret. Some CR specs are not — e.g.
@@ -59,7 +59,7 @@ whole object:
 
 ```yaml
   pre_tasks:
-    - name: Show EDA Event metadata
+    - name: Show resource metadata
       ansible.builtin.include_role:
         name: osac.service.common
         tasks_from: show_resource_metadata

--- a/osac-aap/collections/ansible_collections/osac/service/roles/common/tasks/show_resource_metadata.yaml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/common/tasks/show_resource_metadata.yaml
@@ -1,5 +1,5 @@
 ---
-# Centralized, redacted replacement for `debug: var: ansible_eda.event.payload`.
+# Centralized, redacted replacement for `debug: var: osac_job_vars.resource`.
 # Use this instead of debugging the whole payload object whenever the calling
 # playbook also reads a sensitive field out of payload.spec (e.g.
 # blockEncryptionPassphrase) -- the whole-object debug prints secrets in
@@ -8,42 +8,42 @@
 # Always logs: payload kind, metadata.name, metadata.namespace, metadata.uid.
 #
 # Optional caller var:
-#   eda_event_extra_fields — dict of additional non-sensitive key/value pairs
+#   resource_extra_fields — dict of additional non-sensitive key/value pairs
 #                            to include. Keys are restricted to the allowlist
 #                            below, and the fixed kind/name/namespace/uid
 #                            fields always win on conflict -- this task is
 #                            the single redaction boundary for
-#                            ansible_eda.event.payload, so a new field must
+#                            osac_job_vars.resource, so a new field must
 #                            be deliberately added to the allowlist here, not
 #                            silently accepted from any caller. Never add a
 #                            key whose value could be sourced from
 #                            payload.spec without confirming it isn't a
 #                            secret first.
-- name: Validate eda_event_extra_fields keys are on the allowlist
+- name: Validate resource_extra_fields keys are on the allowlist
   ansible.builtin.fail:
     msg: >-
-      eda_event_extra_fields contains a key not on the allowlist:
-      {{ (eda_event_extra_fields | default({}) | list) | difference(_eda_event_extra_fields_allowlist) }}.
-      Add it to _eda_event_extra_fields_allowlist in show_eda_event_metadata.yaml
+      resource_extra_fields contains a key not on the allowlist:
+      {{ (resource_extra_fields | default({}) | list) | difference(_resource_extra_fields_allowlist) }}.
+      Add it to _resource_extra_fields_allowlist in show_resource_metadata.yaml
       first -- this task is the single redaction boundary for
-      ansible_eda.event.payload, and new fields must be deliberately approved.
+      osac_job_vars.resource, and new fields must be deliberately approved.
   vars:
-    _eda_event_extra_fields_allowlist:
+    _resource_extra_fields_allowlist:
       - tenant_annotation
       - template_id
   when: >-
-    (eda_event_extra_fields | default({}) | list)
-    | difference(_eda_event_extra_fields_allowlist) | length > 0
+    (resource_extra_fields | default({}) | list)
+    | difference(_resource_extra_fields_allowlist) | length > 0
 
-- name: Show EDA Event metadata
+- name: Show resource metadata
   ansible.builtin.debug:
     msg: >-
       {{
-        (eda_event_extra_fields | default({}))
+        (resource_extra_fields | default({}))
         | combine({
-            'kind': ansible_eda.event.payload.kind | default('unknown'),
-            'name': ansible_eda.event.payload.metadata.name | default('unknown'),
-            'namespace': ansible_eda.event.payload.metadata.namespace | default('unknown'),
-            'uid': ansible_eda.event.payload.metadata.uid | default('unknown'),
+            'kind': osac_job_vars.resource.kind | default('unknown'),
+            'name': osac_job_vars.resource.metadata.name | default('unknown'),
+            'namespace': osac_job_vars.resource.metadata.namespace | default('unknown'),
+            'uid': osac_job_vars.resource.metadata.uid | default('unknown'),
           })
       }}

--- a/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
@@ -410,7 +410,7 @@
 # validation -- that task is unreachable for auto-derived values, since the length-guard
 # rejects any QoS-enabled tier whose name would produce an over-length derived qos_policy
 # before derivation ever runs). Proves the length-guard actually catches this case
-# (OSAC-1992: tiers from ansible_eda.event.storage_tier_definitions never carry
+# (OSAC-1992: tiers from osac_job_vars.storage_tier_definitions never carry
 # qos_policy -- the role derives it as '<name>-qos').
 # ──────────────────────────────────────────────────────────────
 - name: Test storage_provider -- tier name too long for derived qos_policy (should fail)

--- a/osac-aap/collections/ansible_collections/osac/templates/README.md
+++ b/osac-aap/collections/ansible_collections/osac/templates/README.md
@@ -168,7 +168,7 @@ See roles/ocp_virt_vm for more examples
 ### Creating a New Storage Provider Role
 
 Storage provider roles use a tier-based dispatch model: osac-operator resolves storage tiers
-from the Tier API and passes them via the `ansible_eda.event.storage_tier_definitions`
+from the Tier API and passes them via the `osac_job_vars.storage_tier_definitions`
 extra_var, each tier declares its provider, and the service-layer dispatcher
 (`osac.service.storage_provider`) groups tiers by provider and dispatches to each provider's
 template role with the filtered tier subset.
@@ -225,7 +225,7 @@ When implemented, `hcp_data_plane` will support provisioning multiple StorageCla
 into the guest HCP cluster (e.g., separate tiers for databases and general workloads).
 Currently, all CaaS targets return an explicit "not yet implemented" error.
 
-**Configuration:** Storage tiers arrive via the `ansible_eda.event.storage_tier_definitions`
+**Configuration:** Storage tiers arrive via the `osac_job_vars.storage_tier_definitions`
 extra_var, populated by osac-operator from the Tier API:
 
 ```json

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/bm_private_network/meta/argument_specs.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/bm_private_network/meta/argument_specs.yaml
@@ -5,10 +5,10 @@ argument_specs:
       bare_metal_pool:
         type: dict
         required: true
-        description: BareMetalPool CR from fulfillment-api via EDA payload
+        description: BareMetalPool CR from fulfillment-api via osac_job_vars
   delete:
     options:
       bare_metal_pool:
         type: dict
         required: true
-        description: BareMetalPool CR from fulfillment-api via EDA payload
+        description: BareMetalPool CR from fulfillment-api via osac_job_vars

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/cudn_net/README.md
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/cudn_net/README.md
@@ -68,8 +68,8 @@ This role implements the `cudn_net` NetworkClass strategy using OpenShift's Clus
     name: cudn_net
     tasks_from: create_virtual_network
   vars:
-    virtual_network: "{{ ansible_eda.event.payload }}"
-    virtual_network_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    virtual_network: "{{ osac_job_vars.resource }}"
+    virtual_network_name: "{{ osac_job_vars.resource.metadata.name }}"
 ```
 
 ### Example: Subnet Provisioning
@@ -80,6 +80,6 @@ This role implements the `cudn_net` NetworkClass strategy using OpenShift's Clus
     name: cudn_net
     tasks_from: create_subnet
   vars:
-    subnet: "{{ ansible_eda.event.payload }}"
-    subnet_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    subnet: "{{ osac_job_vars.resource }}"
+    subnet_name: "{{ osac_job_vars.resource.metadata.name }}"
 ```

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/cudn_net/meta/argument_specs.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/cudn_net/meta/argument_specs.yaml
@@ -5,7 +5,7 @@ argument_specs:
       subnet:
         type: dict
         required: true
-        description: Subnet CR from fulfillment-api via EDA payload
+        description: Subnet CR from fulfillment-api via osac_job_vars
       subnet_name:
         type: str
         required: true
@@ -21,7 +21,7 @@ argument_specs:
       subnet:
         type: dict
         required: true
-        description: Subnet CR from fulfillment-api via EDA payload
+        description: Subnet CR from fulfillment-api via osac_job_vars
       subnet_name:
         type: str
         required: true
@@ -32,7 +32,7 @@ argument_specs:
       virtual_network:
         type: dict
         required: true
-        description: VirtualNetwork CR from fulfillment-api via EDA payload
+        description: VirtualNetwork CR from fulfillment-api via osac_job_vars
       virtual_network_name:
         type: str
         required: true
@@ -48,7 +48,7 @@ argument_specs:
       virtual_network:
         type: dict
         required: true
-        description: VirtualNetwork CR from fulfillment-api via EDA payload
+        description: VirtualNetwork CR from fulfillment-api via osac_job_vars
       virtual_network_name:
         type: str
         required: true

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_external_ip.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_external_ip.yaml
@@ -65,7 +65,7 @@
   ansible.builtin.set_fact:
     attach_compute_instance_name: "{{ attach_ci_lookup.resources[0].metadata.name }}"
 
-# Check if the LB Service already exists (idempotency for EDA event redelivery).
+# Check if the LB Service already exists (idempotency for job vars redelivery).
 - name: Check if LB Service already exists in VM namespace
   kubernetes.core.k8s_info:
     kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/netris/meta/argument_specs.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/netris/meta/argument_specs.yaml
@@ -5,7 +5,7 @@ argument_specs:
       virtual_network:
         type: dict
         required: true
-        description: VirtualNetwork CR from fulfillment-api via EDA payload
+        description: VirtualNetwork CR from fulfillment-api via osac_job_vars
       template_parameters:
         type: dict
         description: Template-specific parameters (reserved for future use)
@@ -17,14 +17,14 @@ argument_specs:
       virtual_network:
         type: dict
         required: true
-        description: VirtualNetwork CR from fulfillment-api via EDA payload
+        description: VirtualNetwork CR from fulfillment-api via osac_job_vars
 
   create_subnet:
     options:
       subnet:
         type: dict
         required: true
-        description: Subnet CR from fulfillment-api via EDA payload
+        description: Subnet CR from fulfillment-api via osac_job_vars
       template_parameters:
         type: dict
         description: Template-specific parameters (reserved for future use)
@@ -36,14 +36,14 @@ argument_specs:
       subnet:
         type: dict
         required: true
-        description: Subnet CR from fulfillment-api via EDA payload
+        description: Subnet CR from fulfillment-api via osac_job_vars
 
   create_security_group:
     options:
       security_group:
         type: dict
         required: true
-        description: SecurityGroup CR from fulfillment-api via EDA payload
+        description: SecurityGroup CR from fulfillment-api via osac_job_vars
       template_parameters:
         type: dict
         description: Template-specific parameters (reserved for future use)
@@ -55,14 +55,14 @@ argument_specs:
       security_group:
         type: dict
         required: true
-        description: SecurityGroup CR from fulfillment-api via EDA payload
+        description: SecurityGroup CR from fulfillment-api via osac_job_vars
 
   create_external_ip:
     options:
       external_ip:
         type: dict
         required: true
-        description: ExternalIP CR from fulfillment-api via EDA payload
+        description: ExternalIP CR from fulfillment-api via osac_job_vars
       template_parameters:
         type: dict
         description: Template-specific parameters (reserved for future use)
@@ -74,14 +74,14 @@ argument_specs:
       external_ip:
         type: dict
         required: true
-        description: ExternalIP CR from fulfillment-api via EDA payload
+        description: ExternalIP CR from fulfillment-api via osac_job_vars
 
   create_nat_gateway:
     options:
       nat_gateway:
         type: dict
         required: true
-        description: NATGateway CR from fulfillment-api via EDA payload
+        description: NATGateway CR from fulfillment-api via osac_job_vars
       template_parameters:
         type: dict
         description: Template-specific parameters (reserved for future use)
@@ -93,7 +93,7 @@ argument_specs:
       nat_gateway:
         type: dict
         required: true
-        description: NATGateway CR from fulfillment-api via EDA payload
+        description: NATGateway CR from fulfillment-api via osac_job_vars
 
   create_network_attachment:
     options:

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/network_policy/README.md
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/network_policy/README.md
@@ -57,7 +57,7 @@ will be selected by the `sg-web-sg` NetworkPolicy. To apply a different Security
     name: osac.templates.network_policy
     tasks_from: create_security_group
   vars:
-    security_group: "{{ ansible_eda.event.payload }}"
+    security_group: "{{ osac_job_vars.resource }}"
 ```
 
 ```yaml
@@ -66,5 +66,5 @@ will be selected by the `sg-web-sg` NetworkPolicy. To apply a different Security
     name: osac.templates.network_policy
     tasks_from: delete_security_group
   vars:
-    security_group: "{{ ansible_eda.event.payload }}"
+    security_group: "{{ osac_job_vars.resource }}"
 ```

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/network_policy/meta/argument_specs.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/network_policy/meta/argument_specs.yaml
@@ -5,7 +5,7 @@ argument_specs:
       security_group:
         type: dict
         required: true
-        description: SecurityGroup CR from fulfillment-api via EDA payload
+        description: SecurityGroup CR from fulfillment-api via osac_job_vars
       template_parameters:
         type: dict
         description: Template-specific parameters (reserved for future use)
@@ -17,4 +17,4 @@ argument_specs:
       security_group:
         type: dict
         required: true
-        description: SecurityGroup CR from fulfillment-api via EDA payload
+        description: SecurityGroup CR from fulfillment-api via osac_job_vars

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/openstack/README.md
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/openstack/README.md
@@ -83,8 +83,8 @@ This role implements the `openstack` NetworkClass strategy using OpenStack Neutr
     name: openstack
     tasks_from: create_virtual_network
   vars:
-    virtual_network: "{{ ansible_eda.event.payload }}"
-    virtual_network_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    virtual_network: "{{ osac_job_vars.resource }}"
+    virtual_network_name: "{{ osac_job_vars.resource.metadata.name }}"
 ```
 
 ### Example: Subnet Provisioning
@@ -95,8 +95,8 @@ This role implements the `openstack` NetworkClass strategy using OpenStack Neutr
     name: openstack
     tasks_from: create_subnet
   vars:
-    subnet: "{{ ansible_eda.event.payload }}"
-    subnet_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    subnet: "{{ osac_job_vars.resource }}"
+    subnet_name: "{{ osac_job_vars.resource.metadata.name }}"
 ```
 
 ### Example: Custom Subnet Configuration
@@ -107,8 +107,8 @@ This role implements the `openstack` NetworkClass strategy using OpenStack Neutr
     name: openstack
     tasks_from: create_subnet
   vars:
-    subnet: "{{ ansible_eda.event.payload }}"
-    subnet_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    subnet: "{{ osac_job_vars.resource }}"
+    subnet_name: "{{ osac_job_vars.resource.metadata.name }}"
     default_subnet_dns_nameservers:
       - 10.0.0.10
       - 10.0.0.11

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/openstack/meta/argument_specs.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/openstack/meta/argument_specs.yaml
@@ -5,7 +5,7 @@ argument_specs:
       subnet:
         type: dict
         required: true
-        description: Subnet CR from fulfillment-api via EDA payload
+        description: Subnet CR from fulfillment-api via osac_job_vars
       subnet_name:
         type: str
         required: true
@@ -21,7 +21,7 @@ argument_specs:
       subnet:
         type: dict
         required: true
-        description: Subnet CR from fulfillment-api via EDA payload
+        description: Subnet CR from fulfillment-api via osac_job_vars
       subnet_name:
         type: str
         required: true
@@ -32,7 +32,7 @@ argument_specs:
       virtual_network:
         type: dict
         required: true
-        description: VirtualNetwork CR from fulfillment-api via EDA payload
+        description: VirtualNetwork CR from fulfillment-api via osac_job_vars
       virtual_network_name:
         type: str
         required: true
@@ -48,7 +48,7 @@ argument_specs:
       virtual_network:
         type: dict
         required: true
-        description: VirtualNetwork CR from fulfillment-api via EDA payload
+        description: VirtualNetwork CR from fulfillment-api via osac_job_vars
       virtual_network_name:
         type: str
         required: true

--- a/osac-aap/collections/ansible_collections/osac/workflows/README.md
+++ b/osac-aap/collections/ansible_collections/osac/workflows/README.md
@@ -37,7 +37,7 @@ Import a workflow playbook directly:
 - name: Create cluster
   ansible.builtin.import_playbook: osac.workflows.cluster.create
   vars:
-    cluster_order: "{{ ansible_eda.event.payload }}"
+    cluster_order: "{{ osac_job_vars.resource }}"
 ```
 
 ### Override a Workflow Step
@@ -49,7 +49,7 @@ Replace a specific step with your custom role:
 - name: Create cluster with custom infrastructure
   ansible.builtin.import_playbook: osac.workflows.cluster.create
   vars:
-    cluster_order: "{{ ansible_eda.event.payload }}"
+    cluster_order: "{{ osac_job_vars.resource }}"
 
     # Override infrastructure creation step
     template_step_create_infra_override:
@@ -64,7 +64,7 @@ Replace a specific step with your custom role:
 - name: Create cluster with multiple overrides
   ansible.builtin.import_playbook: osac.workflows.cluster.create
   vars:
-    cluster_order: "{{ ansible_eda.event.payload }}"
+    cluster_order: "{{ osac_job_vars.resource }}"
 
     # Override defaults application
     step_apply_defaults_override:
@@ -130,7 +130,7 @@ Templates may define their own override points:
 - name: MOC Cluster Creation
   ansible.builtin.import_playbook: osac.workflows.cluster.create
   vars:
-    cluster_order: "{{ ansible_eda.event.payload }}"
+    cluster_order: "{{ osac_job_vars.resource }}"
 
     # Use MOC template collection
     template_id_override: osac.templates.ocp_small

--- a/osac-aap/collections/ansible_collections/osac/workflows/docs/override_guide.md
+++ b/osac-aap/collections/ansible_collections/osac/workflows/docs/override_guide.md
@@ -44,7 +44,7 @@ Add custom logic at the very beginning or end of workflows:
 - name: Cluster creation with monitoring hooks
   ansible.builtin.import_playbook: osac.workflows.cluster.create
   vars:
-    cluster_order: "{{ ansible_eda.event.payload }}"
+    cluster_order: "{{ osac_job_vars.resource }}"
 
     # Hook at workflow start for initialization
     hook_workflow_start:
@@ -73,7 +73,7 @@ Modify Kubernetes resource definitions before they're applied:
 - name: Cluster with custom labels
   ansible.builtin.import_playbook: osac.workflows.cluster.create
   vars:
-    cluster_order: "{{ ansible_eda.event.payload }}"
+    cluster_order: "{{ osac_job_vars.resource }}"
 
     # Modify HostedCluster YAML
     hosted_cluster_modify_definition_hook:
@@ -101,7 +101,7 @@ Replace entire workflow phases:
 - name: Cluster with custom namespace logic
   ansible.builtin.import_playbook: osac.workflows.cluster.create
   vars:
-    cluster_order: "{{ ansible_eda.event.payload }}"
+    cluster_order: "{{ osac_job_vars.resource }}"
 
     # Replace namespace determination
     step_determine_namespace_override:
@@ -218,7 +218,7 @@ osac-aap-moc/
 - name: MOC Cluster Creation with ESI
   ansible.builtin.import_playbook: osac.workflows.cluster.create
   vars:
-    cluster_order: "{{ ansible_eda.event.payload }}"
+    cluster_order: "{{ osac_job_vars.resource }}"
 
     # Use MOC template
     template_id_override: osac.templates.ocp_small

--- a/osac-aap/collections/ansible_collections/osac/workflows/playbooks/cluster/create.yml
+++ b/osac-aap/collections/ansible_collections/osac/workflows/playbooks/cluster/create.yml
@@ -7,13 +7,13 @@
 #   - name: Create cluster
 #     ansible.builtin.import_playbook: osac.workflows.cluster.create
 #     vars:
-#       cluster_order: "{{ ansible_eda.event.payload }}"
+#       cluster_order: "{{ osac_job_vars.resource }}"
 #
 # Hook example:
 #   - name: Create cluster with custom hooks
 #     ansible.builtin.import_playbook: osac.workflows.cluster.create
 #     vars:
-#       cluster_order: "{{ ansible_eda.event.payload }}"
+#       cluster_order: "{{ osac_job_vars.resource }}"
 #       hook_workflow_start:
 #         name: my_custom_hooks
 #         tasks_from: initialize.yml
@@ -29,7 +29,7 @@
     K8S_AUTH_KUBECONFIG: "{{ lookup('env', 'K8S_AUTH_KUBECONFIG') | default(lookup('env', 'KUBECONFIG'), true) | default(lookup('env', 'HOME') + '/.kube/config', true) }}"
 
   vars:
-    cluster_order: "{{ ansible_eda.event.payload }}"
+    cluster_order: "{{ osac_job_vars.resource }}"
 
     # GENERIC HOOKS - Default to noop
     hook_workflow_start_default:

--- a/osac-aap/collections/ansible_collections/osac/workflows/playbooks/cluster/delete.yml
+++ b/osac-aap/collections/ansible_collections/osac/workflows/playbooks/cluster/delete.yml
@@ -7,13 +7,13 @@
 #   - name: Delete cluster
 #     ansible.builtin.import_playbook: osac.workflows.cluster.delete
 #     vars:
-#       cluster_order: "{{ ansible_eda.event.payload }}"
+#       cluster_order: "{{ osac_job_vars.resource }}"
 #
 # Hook example:
 #   - name: Delete cluster with custom hooks
 #     ansible.builtin.import_playbook: osac.workflows.cluster.delete
 #     vars:
-#       cluster_order: "{{ ansible_eda.event.payload }}"
+#       cluster_order: "{{ osac_job_vars.resource }}"
 #       hook_workflow_start:
 #         name: my_custom_hooks
 #         tasks_from: pre_delete.yml
@@ -26,7 +26,7 @@
 
 
   vars:
-    cluster_order: "{{ ansible_eda.event.payload }}"
+    cluster_order: "{{ osac_job_vars.resource }}"
 
     # GENERIC HOOKS - Default to noop
     hook_workflow_start_default:

--- a/osac-aap/collections/ansible_collections/osac/workflows/playbooks/cluster/post_install.yml
+++ b/osac-aap/collections/ansible_collections/osac/workflows/playbooks/cluster/post_install.yml
@@ -7,14 +7,14 @@
 #   - name: Post-install cluster
 #     ansible.builtin.import_playbook: osac.workflows.cluster.post_install
 #     vars:
-#       cluster_order: "{{ ansible_eda.event.payload }}"
+#       cluster_order: "{{ osac_job_vars.resource }}"
 #       admin_kubeconfig: "{{ kubeconfig_content }}"
 #
 # Hook example:
 #   - name: Post-install with custom hooks
 #     ansible.builtin.import_playbook: osac.workflows.cluster.post_install
 #     vars:
-#       cluster_order: "{{ ansible_eda.event.payload }}"
+#       cluster_order: "{{ osac_job_vars.resource }}"
 #       admin_kubeconfig: "{{ kubeconfig_content }}"
 #       hook_workflow_start:
 #         name: my_custom_hooks
@@ -31,7 +31,7 @@
     K8S_AUTH_KUBECONFIG: "{{ lookup('env', 'K8S_AUTH_KUBECONFIG') | default(lookup('env', 'KUBECONFIG'), true) | default(lookup('env', 'HOME') + '/.kube/config', true) }}"
 
   vars:
-    cluster_order: "{{ ansible_eda.event.payload }}"
+    cluster_order: "{{ osac_job_vars.resource }}"
 
     # GENERIC HOOKS - Default to noop
     hook_workflow_start_default:

--- a/osac-aap/collections/ansible_collections/osac/workflows/playbooks/compute_instance/create.yml
+++ b/osac-aap/collections/ansible_collections/osac/workflows/playbooks/compute_instance/create.yml
@@ -7,13 +7,13 @@
 #   - name: Create compute instance
 #     ansible.builtin.import_playbook: osac.workflows.compute_instance.create
 #     vars:
-#       compute_instance: "{{ ansible_eda.event.payload }}"
+#       compute_instance: "{{ osac_job_vars.resource }}"
 #
 # Hook example:
 #   - name: Create compute instance with custom hooks
 #     ansible.builtin.import_playbook: osac.workflows.compute_instance.create
 #     vars:
-#       compute_instance: "{{ ansible_eda.event.payload }}"
+#       compute_instance: "{{ osac_job_vars.resource }}"
 #       hook_workflow_start:
 #         name: my_custom_hooks
 #         tasks_from: validate_vm.yml
@@ -26,7 +26,7 @@
 
 
   vars:
-    compute_instance: "{{ ansible_eda.event.payload }}"
+    compute_instance: "{{ osac_job_vars.resource }}"
 
     # GENERIC HOOKS - Default to noop
     hook_workflow_start_default:

--- a/osac-aap/collections/ansible_collections/osac/workflows/playbooks/compute_instance/delete.yml
+++ b/osac-aap/collections/ansible_collections/osac/workflows/playbooks/compute_instance/delete.yml
@@ -7,13 +7,13 @@
 #   - name: Delete compute instance
 #     ansible.builtin.import_playbook: osac.workflows.compute_instance.delete
 #     vars:
-#       compute_instance: "{{ ansible_eda.event.payload }}"
+#       compute_instance: "{{ osac_job_vars.resource }}"
 #
 # Hook example:
 #   - name: Delete compute instance with custom hooks
 #     ansible.builtin.import_playbook: osac.workflows.compute_instance.delete
 #     vars:
-#       compute_instance: "{{ ansible_eda.event.payload }}"
+#       compute_instance: "{{ osac_job_vars.resource }}"
 #       hook_workflow_complete:
 #         name: my_custom_hooks
 #         tasks_from: cleanup_vm.yml
@@ -26,7 +26,7 @@
 
 
   vars:
-    compute_instance: "{{ ansible_eda.event.payload }}"
+    compute_instance: "{{ osac_job_vars.resource }}"
 
     # GENERIC HOOKS - Default to noop
     hook_workflow_start_default:

--- a/osac-aap/collections/ansible_collections/osac/workflows/playbooks/reporting/cluster_status.yml
+++ b/osac-aap/collections/ansible_collections/osac/workflows/playbooks/reporting/cluster_status.yml
@@ -7,7 +7,7 @@
 #   - name: Report cluster status
 #     ansible.builtin.import_playbook: osac.workflows.reporting.cluster_status
 #     vars:
-#       cluster_order: "{{ ansible_eda.event.payload }}"
+#       cluster_order: "{{ osac_job_vars.resource }}"
 #       workflow_name: "cluster_create"
 #       workflow_status: "succeeded"
 #
@@ -15,7 +15,7 @@
 #   - name: Report with custom hooks
 #     ansible.builtin.import_playbook: osac.workflows.reporting.cluster_status
 #     vars:
-#       cluster_order: "{{ ansible_eda.event.payload }}"
+#       cluster_order: "{{ osac_job_vars.resource }}"
 #       workflow_name: "cluster_create"
 #       workflow_status: "succeeded"
 #       hook_workflow_complete:
@@ -30,7 +30,7 @@
 
 
   vars:
-    cluster_order: "{{ ansible_eda.event.payload }}"
+    cluster_order: "{{ osac_job_vars.resource }}"
     workflow_name: unknown
     workflow_status: unknown
 

--- a/osac-aap/config/base/secret-storage-operations-ig-example.yaml
+++ b/osac-aap/config/base/secret-storage-operations-ig-example.yaml
@@ -11,4 +11,4 @@ data:
   # Per-tenant data-plane credentials are generated automatically during tenant_setup.
 
   # Block encryption passphrase comes from the Tenant CR event payload (spec.blockEncryptionPassphrase),
-  # not from this Secret. It is per-tenant and passed through the EDA event.
+  # not from this Secret. It is per-tenant and passed through the job vars.

--- a/osac-aap/playbook_osac_attach_external_ip.yml
+++ b/osac-aap/playbook_osac_attach_external_ip.yml
@@ -10,9 +10,9 @@
     template_parameters: {}
 
   pre_tasks:
-    - name: Show job vars
+    - name: Show resource metadata
       ansible.builtin.debug:
-        var: osac_job_vars.resource
+        var: osac_job_vars.resource.metadata
 
   tasks:
     - name: Display ExternalIP attach information

--- a/osac-aap/playbook_osac_attach_external_ip.yml
+++ b/osac-aap/playbook_osac_attach_external_ip.yml
@@ -4,21 +4,21 @@
   gather_facts: false
 
   vars:
-    external_ip_attachment: "{{ ansible_eda.event.payload }}"
+    external_ip_attachment: "{{ osac_job_vars.resource }}"
     implementation_strategy: >-
-      {{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/implementation-strategy'] }}
+      {{ osac_job_vars.resource.metadata.annotations['osac.openshift.io/implementation-strategy'] }}
     template_parameters: {}
 
   pre_tasks:
-    - name: Show EDA Event
+    - name: Show job vars
       ansible.builtin.debug:
-        var: ansible_eda.event.payload
+        var: osac_job_vars.resource
 
   tasks:
     - name: Display ExternalIP attach information
       ansible.builtin.debug:
         msg:
-          - "ExternalIP attachment name: {{ ansible_eda.event.payload.metadata.name }}"
+          - "ExternalIP attachment name: {{ osac_job_vars.resource.metadata.name }}"
           - "Implementation strategy: {{ implementation_strategy }}"
 
     - name: Call the selected ExternalIP attach role

--- a/osac-aap/playbook_osac_create_bare_metal_instance.yml
+++ b/osac-aap/playbook_osac_create_bare_metal_instance.yml
@@ -4,7 +4,7 @@
   gather_facts: false
 
   vars:
-    bare_metal_instance: "{{ ansible_eda.event.payload }}"
+    bare_metal_instance: "{{ osac_job_vars.resource }}"
 
   pre_tasks:
     - name: Display bare metal instance information

--- a/osac-aap/playbook_osac_create_bare_metal_pool.yml
+++ b/osac-aap/playbook_osac_create_bare_metal_pool.yml
@@ -4,7 +4,7 @@
   gather_facts: false
 
   vars:
-    bare_metal_pool: "{{ ansible_eda.event.payload }}"
+    bare_metal_pool: "{{ osac_job_vars.resource }}"
     bare_metal_pool_name: "{{ bare_metal_pool.metadata.name }}"
     bare_metal_pool_namespace: "{{ bare_metal_pool.metadata.namespace }}"
     template_id: "{{ bare_metal_pool.metadata.annotations['osac.openshift.io/templateID'] }}"

--- a/osac-aap/playbook_osac_create_compute_instance.yml
+++ b/osac-aap/playbook_osac_create_compute_instance.yml
@@ -13,7 +13,7 @@
     _requested_storage_tier: "{{ lookup('env', 'STORAGE_REQUESTED_TIER') | default('default', true) }}"
 
   pre_tasks:
-    - name: Show job vars
+    - name: Show resource metadata
       ansible.builtin.debug:
         var: osac_job_vars.resource.metadata
 

--- a/osac-aap/playbook_osac_create_compute_instance.yml
+++ b/osac-aap/playbook_osac_create_compute_instance.yml
@@ -4,24 +4,18 @@
   gather_facts: false
 
   vars:
-    compute_instance: "{{ ansible_eda.event.payload }}"
-    compute_instance_name: "{{ ansible_eda.event.payload.metadata.name }}"
-    template_id: "{{ ansible_eda.event.payload.spec.templateID }}"
+    compute_instance: "{{ osac_job_vars.resource }}"
+    compute_instance_name: "{{ osac_job_vars.resource.metadata.name }}"
+    template_id: "{{ osac_job_vars.resource.spec.templateID }}"
     template_parameters: {}
-    tenant_storage_classes: "{{ ansible_eda.event.tenant_storage_classes | default([]) }}"
+    tenant_storage_classes: "{{ osac_job_vars.tenant_storage_classes | default([]) }}"
+    _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
     _requested_storage_tier: "{{ lookup('env', 'STORAGE_REQUESTED_TIER') | default('default', true) }}"
 
   pre_tasks:
-    # payload.spec.blockEncryptionPassphrase carries a real secret (see
-    # storage_provider_block_encryption_passphrase below) -- use the shared,
-    # centralized redaction task instead of debugging the whole payload object.
-    - name: Show EDA Event metadata
-      ansible.builtin.include_role:
-        name: osac.service.common
-        tasks_from: show_eda_event_metadata
-      vars:
-        eda_event_extra_fields:
-          template_id: "{{ ansible_eda.event.payload.spec.templateID | default('unknown') }}"
+    - name: Show job vars
+      ansible.builtin.debug:
+        var: osac_job_vars.resource.metadata
 
     - name: Determine tenant target namespace
       # Brings in variables:
@@ -44,33 +38,31 @@
             else (compute_instance.metadata.annotations | default({})).get('osac.openshift.io/tenant', 'unknown')
           }}
 
-    - name: Validate optional storage_tier_definitions type
-      ansible.builtin.fail:
-        msg: >-
-          ansible_eda.event.storage_tier_definitions must be an array when provided.
-          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001"}]
-      when: >-
-        ansible_eda.event.storage_tier_definitions is defined and
-        (ansible_eda.event.storage_tier_definitions is not sequence or
-         ansible_eda.event.storage_tier_definitions is string or
-         ansible_eda.event.storage_tier_definitions is mapping)
-
-    - name: Filter storage tier definitions to the requested tier for JIT storage
-      when: (ansible_eda.event.storage_tier_definitions | default([])) | length > 0
+    - name: Parse STORAGE_TIERS for JIT storage
+      when: _storage_tiers_raw | length > 0
       block:
+        - name: Parse tier list from STORAGE_TIERS env var
+          ansible.builtin.set_fact:
+            _jit_all_tiers: "{{ _storage_tiers_raw | from_json }}"
+
         - name: Filter to only the requested tier
           ansible.builtin.set_fact:
-            _jit_storage_tiers: >-
-              {{ ansible_eda.event.storage_tier_definitions
-                 | selectattr('name', 'equalto', _requested_storage_tier) | list }}
+            _jit_storage_tiers: "{{ _jit_all_tiers | selectattr('name', 'equalto', _requested_storage_tier) | list }}"
 
-        - name: Warn if requested tier not found in storage_tier_definitions
+        - name: Warn if requested tier not found in STORAGE_TIERS
           ansible.builtin.debug:
             msg: >-
-              Requested storage tier '{{ _requested_storage_tier }}' not found in storage_tier_definitions.
-              Available tiers: {{ ansible_eda.event.storage_tier_definitions | map(attribute='name') | list | to_json }}.
+              Requested storage tier '{{ _requested_storage_tier }}' not found in STORAGE_TIERS.
+              Available tiers: {{ _jit_all_tiers | map(attribute='name') | list | to_json }}.
               JIT storage provisioning will be skipped.
           when: _jit_storage_tiers | length == 0
+      rescue:
+        - name: Fail on malformed STORAGE_TIERS JSON
+          ansible.builtin.fail:
+            msg: >-
+              STORAGE_TIERS env var contains invalid JSON.
+              Value: '{{ _storage_tiers_raw }}'.
+              Expected a JSON array of tier objects with name, protocol, and provider fields.
 
     - name: Ensure storage is provisioned for tenant (JIT)
       when: _jit_storage_tiers is defined and _jit_storage_tiers | length > 0
@@ -79,9 +71,9 @@
       vars:
         storage_provider_action: ensure_storage_class
         storage_provider_tiers: "{{ _jit_storage_tiers }}"
-        storage_provider_backend_connections: "{{ ansible_eda.event.storage_backend_connections | default({}) }}"
         storage_provider_provisioning_target: vmaas
-        storage_provider_block_encryption_passphrase: "{{ ansible_eda.event.payload.spec.blockEncryptionPassphrase | default('') }}"
+        storage_provider_block_encryption_passphrase: "{{ osac_job_vars.resource.spec.blockEncryptionPassphrase | default('') }}"
+        storage_provider_snapshots_enabled: "{{ lookup('env', 'STORAGE_SNAPSHOTS_ENABLED') | default('true', true) | bool }}"
 
     - name: Add JIT-provisioned StorageClasses to resolution list
       ansible.builtin.set_fact:
@@ -97,7 +89,7 @@
           ComputeInstance '{{ compute_instance_name }}' has no tenant_storage_classes
           available. Either the osac-operator CI controller should inject the resolved
           storageClasses list before triggering provisioning, or JIT storage provisioning
-          via storage_tier_definitions must succeed.
+          via STORAGE_TIERS must succeed.
       when:
         - tenant_storage_class_storage_classes | length == 0
         - _jit_storage_tiers is not defined or _jit_storage_tiers | length == 0

--- a/osac-aap/playbook_osac_create_external_ip.yml
+++ b/osac-aap/playbook_osac_create_external_ip.yml
@@ -4,17 +4,17 @@
   gather_facts: false
 
   vars:
-    external_ip: "{{ ansible_eda.event.payload }}"
-    external_ip_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    external_ip: "{{ osac_job_vars.resource }}"
+    external_ip_name: "{{ osac_job_vars.resource.metadata.name }}"
     implementation_strategy: >-
-      {{ ansible_eda.event.payload.metadata.annotations
+      {{ osac_job_vars.resource.metadata.annotations
          ['osac.openshift.io/implementation-strategy'] }}
     template_parameters: {}
 
   pre_tasks:
-    - name: Show EDA Event
+    - name: Show job vars
       ansible.builtin.debug:
-        var: ansible_eda.event.payload
+        var: osac_job_vars.resource
 
   tasks:
     - name: Display ExternalIP information

--- a/osac-aap/playbook_osac_create_external_ip.yml
+++ b/osac-aap/playbook_osac_create_external_ip.yml
@@ -12,9 +12,9 @@
     template_parameters: {}
 
   pre_tasks:
-    - name: Show job vars
+    - name: Show resource metadata
       ansible.builtin.debug:
-        var: osac_job_vars.resource
+        var: osac_job_vars.resource.metadata
 
   tasks:
     - name: Display ExternalIP information

--- a/osac-aap/playbook_osac_create_external_ip_pool.yml
+++ b/osac-aap/playbook_osac_create_external_ip_pool.yml
@@ -12,9 +12,9 @@
     template_parameters: {}
 
   pre_tasks:
-    - name: Show job vars
+    - name: Show resource metadata
       ansible.builtin.debug:
-        var: osac_job_vars.resource
+        var: osac_job_vars.resource.metadata
 
   tasks:
     - name: Display ExternalIPPool information

--- a/osac-aap/playbook_osac_create_external_ip_pool.yml
+++ b/osac-aap/playbook_osac_create_external_ip_pool.yml
@@ -4,17 +4,17 @@
   gather_facts: false
 
   vars:
-    external_ip_pool: "{{ ansible_eda.event.payload }}"
-    external_ip_pool_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    external_ip_pool: "{{ osac_job_vars.resource }}"
+    external_ip_pool_name: "{{ osac_job_vars.resource.metadata.name }}"
     implementation_strategy: >-
-      {{ ansible_eda.event.payload.metadata.annotations
+      {{ osac_job_vars.resource.metadata.annotations
          ['osac.openshift.io/implementation-strategy'] }}
     template_parameters: {}
 
   pre_tasks:
-    - name: Show EDA Event
+    - name: Show job vars
       ansible.builtin.debug:
-        var: ansible_eda.event.payload
+        var: osac_job_vars.resource
 
   tasks:
     - name: Display ExternalIPPool information

--- a/osac-aap/playbook_osac_create_hosted_cluster.yml
+++ b/osac-aap/playbook_osac_create_hosted_cluster.yml
@@ -4,7 +4,7 @@
   gather_facts: false
 
   vars:
-    cluster_order: "{{ ansible_eda.event.payload }}"
+    cluster_order: "{{ osac_job_vars.resource }}"
 
   pre_tasks:
     - name: Write SSH keys from env vars to files

--- a/osac-aap/playbook_osac_create_hosted_cluster_post_install.yml
+++ b/osac-aap/playbook_osac_create_hosted_cluster_post_install.yml
@@ -9,7 +9,7 @@
       {{ admin_kubeconfig | default("{}") | to_yaml | osac.service.to_temp_file }}
 
   vars:
-    cluster_order: "{{ ansible_eda.event.payload }}"
+    cluster_order: "{{ osac_job_vars.resource }}"
 
   pre_tasks:
     - name: Apply default settings

--- a/osac-aap/playbook_osac_create_nat_gateway.yml
+++ b/osac-aap/playbook_osac_create_nat_gateway.yml
@@ -10,9 +10,9 @@
       {{ osac_job_vars.resource.metadata.annotations['osac.openshift.io/implementation-strategy'] }}
 
   pre_tasks:
-    - name: Show job vars
+    - name: Show resource metadata
       ansible.builtin.debug:
-        var: osac_job_vars.resource
+        var: osac_job_vars.resource.metadata
 
   tasks:
     - name: Display NATGateway information

--- a/osac-aap/playbook_osac_create_nat_gateway.yml
+++ b/osac-aap/playbook_osac_create_nat_gateway.yml
@@ -4,15 +4,15 @@
   gather_facts: false
 
   vars:
-    nat_gateway: "{{ ansible_eda.event.payload }}"
-    nat_gateway_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    nat_gateway: "{{ osac_job_vars.resource }}"
+    nat_gateway_name: "{{ osac_job_vars.resource.metadata.name }}"
     implementation_strategy: >-
-      {{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/implementation-strategy'] }}
+      {{ osac_job_vars.resource.metadata.annotations['osac.openshift.io/implementation-strategy'] }}
 
   pre_tasks:
-    - name: Show EDA Event
+    - name: Show job vars
       ansible.builtin.debug:
-        var: ansible_eda.event.payload
+        var: osac_job_vars.resource
 
   tasks:
     - name: Display NATGateway information

--- a/osac-aap/playbook_osac_create_security_group.yml
+++ b/osac-aap/playbook_osac_create_security_group.yml
@@ -13,9 +13,9 @@
     template_parameters: {}
 
   pre_tasks:
-    - name: Show job vars
+    - name: Show resource metadata
       ansible.builtin.debug:
-        var: osac_job_vars.resource
+        var: osac_job_vars.resource.metadata
 
   tasks:
     - name: Display SecurityGroup information

--- a/osac-aap/playbook_osac_create_security_group.yml
+++ b/osac-aap/playbook_osac_create_security_group.yml
@@ -4,18 +4,18 @@
   gather_facts: false
 
   vars:
-    security_group: "{{ ansible_eda.event.payload }}"
-    security_group_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    security_group: "{{ osac_job_vars.resource }}"
+    security_group_name: "{{ osac_job_vars.resource.metadata.name }}"
     # Implementation strategy set by osac-operator from parent VirtualNetwork spec
     implementation_strategy: >-
-      {{ ansible_eda.event.payload.metadata.annotations
+      {{ osac_job_vars.resource.metadata.annotations
          ['osac.openshift.io/implementation-strategy'] }}
     template_parameters: {}
 
   pre_tasks:
-    - name: Show EDA Event
+    - name: Show job vars
       ansible.builtin.debug:
-        var: ansible_eda.event.payload
+        var: osac_job_vars.resource
 
   tasks:
     - name: Display SecurityGroup information

--- a/osac-aap/playbook_osac_create_subnet.yml
+++ b/osac-aap/playbook_osac_create_subnet.yml
@@ -13,9 +13,9 @@
     template_parameters: {}
 
   pre_tasks:
-    - name: Show job vars
+    - name: Show resource metadata
       ansible.builtin.debug:
-        var: osac_job_vars.resource
+        var: osac_job_vars.resource.metadata
 
   tasks:
     - name: Display Subnet information

--- a/osac-aap/playbook_osac_create_subnet.yml
+++ b/osac-aap/playbook_osac_create_subnet.yml
@@ -4,18 +4,18 @@
   gather_facts: false
 
   vars:
-    subnet: "{{ ansible_eda.event.payload }}"
-    subnet_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    subnet: "{{ osac_job_vars.resource }}"
+    subnet_name: "{{ osac_job_vars.resource.metadata.name }}"
     # Implementation strategy set by osac-operator from parent VirtualNetwork spec
     implementation_strategy: >-
-      {{ ansible_eda.event.payload.metadata.annotations
+      {{ osac_job_vars.resource.metadata.annotations
          ['osac.openshift.io/implementation-strategy'] }}
     template_parameters: {}
 
   pre_tasks:
-    - name: Show EDA Event
+    - name: Show job vars
       ansible.builtin.debug:
-        var: ansible_eda.event.payload
+        var: osac_job_vars.resource
 
   tasks:
     - name: Display Subnet information

--- a/osac-aap/playbook_osac_create_tenant_cluster_storage.yml
+++ b/osac-aap/playbook_osac_create_tenant_cluster_storage.yml
@@ -26,7 +26,7 @@
     _storage_snapshots: "{{ lookup('env', 'STORAGE_SNAPSHOTS_ENABLED') | default('true', true) | bool }}"
 
   pre_tasks:
-    - name: Show job vars
+    - name: Show resource metadata
       ansible.builtin.debug:
         var: osac_job_vars.resource.metadata
 

--- a/osac-aap/playbook_osac_create_tenant_cluster_storage.yml
+++ b/osac-aap/playbook_osac_create_tenant_cluster_storage.yml
@@ -4,7 +4,7 @@
   gather_facts: false
 
   vars:
-    tenant_name: "{{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/tenant'] }}"
+    tenant_name: "{{ osac_job_vars.resource.metadata.annotations['osac.openshift.io/tenant'] }}"
     # This template is triggered from two different call sites in storage_controller.go,
     # sharing the same AAP job template but passing different resource kinds as payload:
     #   - handleClusterStorageProvisioning (hub storage) sends a Tenant object, whose own
@@ -16,56 +16,58 @@
     #     cluster instead (mirrors vast_storage_csi_operator_namespace's "vast-csi-system"
     #     pattern; openshift-* is appropriate here since OSAC is a Red Hat product).
     tenant_namespace: >-
-      {%- if ansible_eda.event.payload.kind == 'ClusterOrder' -%}
+      {%- if osac_job_vars.resource.kind == 'ClusterOrder' -%}
       openshift-osac-storage
       {%- else -%}
-      {{ ansible_eda.event.payload.metadata.namespace }}
+      {{ osac_job_vars.resource.metadata.namespace }}
       {%- endif -%}
-    tenant_uid: "{{ ansible_eda.event.payload.metadata.uid }}"
+    tenant_uid: "{{ osac_job_vars.resource.metadata.uid }}"
+    _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
+    _storage_snapshots: "{{ lookup('env', 'STORAGE_SNAPSHOTS_ENABLED') | default('true', true) | bool }}"
 
   pre_tasks:
-    # payload.spec.blockEncryptionPassphrase carries a real secret (see
-    # storage_provider_block_encryption_passphrase below) -- use the shared,
-    # centralized redaction task instead of debugging the whole payload object.
-    - name: Show EDA Event metadata
-      ansible.builtin.include_role:
-        name: osac.service.common
-        tasks_from: show_eda_event_metadata
-      vars:
-        eda_event_extra_fields:
-          tenant_annotation: "{{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/tenant'] | default('unknown') }}"
+    - name: Show job vars
+      ansible.builtin.debug:
+        var: osac_job_vars.resource.metadata
 
     - name: Validate tenant payload is present
       ansible.builtin.fail:
-        msg: "tenant must be provided via ansible_eda.event.payload with metadata.name, metadata.namespace, and metadata.uid set"
+        msg: "tenant must be provided via osac_job_vars.resource with metadata.name, metadata.namespace, and metadata.uid set"
       when: >-
-        ansible_eda is not defined or
-        ansible_eda.event.payload.metadata.name is not defined or
-        ansible_eda.event.payload.metadata.name | length == 0 or
-        ansible_eda.event.payload.metadata.namespace is not defined or
-        ansible_eda.event.payload.metadata.namespace | length == 0 or
-        ansible_eda.event.payload.metadata.uid is not defined or
-        ansible_eda.event.payload.metadata.uid | length == 0
+        osac_job_vars is not defined or
+        osac_job_vars.resource.metadata.name is not defined or
+        osac_job_vars.resource.metadata.name | length == 0 or
+        osac_job_vars.resource.metadata.namespace is not defined or
+        osac_job_vars.resource.metadata.namespace | length == 0 or
+        osac_job_vars.resource.metadata.uid is not defined or
+        osac_job_vars.resource.metadata.uid | length == 0
 
-    - name: Validate storage_tier_definitions is a non-empty array in the EDA event
+    - name: Validate STORAGE_TIERS env var is configured
       ansible.builtin.fail:
         msg: >-
-          ansible_eda.event.storage_tier_definitions must be a non-empty array, populated
-          by osac-operator from the Tenant's resolved storage tiers.
-          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota_bytes":500}]
-      when: >-
-        ansible_eda.event.storage_tier_definitions is not defined or
-        ansible_eda.event.storage_tier_definitions is not sequence or
-        ansible_eda.event.storage_tier_definitions is string or
-        ansible_eda.event.storage_tier_definitions is mapping or
-        ansible_eda.event.storage_tier_definitions | length == 0
+          STORAGE_TIERS env var must be set at deployment time as a JSON array.
+          Example: [{"name":"default","protocol":"nfs","provider":"vast"}]
+      when: _storage_tiers_raw | length == 0
+
+    - name: Parse STORAGE_TIERS JSON
+      block:
+        - name: Parse tier list from env var
+          ansible.builtin.set_fact:
+            _storage_tiers: "{{ _storage_tiers_raw | from_json }}"
+      rescue:
+        - name: Fail on malformed STORAGE_TIERS JSON
+          ansible.builtin.fail:
+            msg: >-
+              STORAGE_TIERS env var contains invalid JSON.
+              Value: '{{ _storage_tiers_raw }}'.
+              Expected a JSON array of tier objects with name, protocol, and provider fields.
 
     - name: Write admin_kubeconfig to temporary file when provided
       when: >-
-        ansible_eda.event.admin_kubeconfig is defined and
-        ansible_eda.event.admin_kubeconfig | length > 0
+        osac_job_vars.admin_kubeconfig is defined and
+        osac_job_vars.admin_kubeconfig | length > 0
       ansible.builtin.set_fact:
-        _remote_kubeconfig: "{{ ansible_eda.event.admin_kubeconfig | osac.service.to_temp_file(suffix='.kubeconfig') }}"
+        _remote_kubeconfig: "{{ osac_job_vars.admin_kubeconfig | osac.service.to_temp_file(suffix='.kubeconfig') }}"
         # HCP guest-cluster kubeconfigs are typically accessed via an external Route whose
         # serving cert doesn't match the CA bundled in the admin kubeconfig.
         _remote_kubeconfig_insecure: true
@@ -73,12 +75,12 @@
     - name: Fail when guest-cluster storage is requested without admin_kubeconfig
       ansible.builtin.fail:
         msg: >-
-          admin_kubeconfig is required in the EDA event for ClusterOrder
+          admin_kubeconfig is required in the job vars for ClusterOrder
           (guest-cluster) storage provisioning; without it this play would
           target the controller's default cluster instead of the intended
           guest cluster.
       when: >-
-        ansible_eda.event.payload.kind == 'ClusterOrder' and
+        osac_job_vars.resource.kind == 'ClusterOrder' and
         (_remote_kubeconfig is not defined or _remote_kubeconfig | length == 0)
 
   tasks:
@@ -89,9 +91,9 @@
             name: osac.service.storage_provider
           vars:
             storage_provider_action: ensure_storage_class
-            storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"
-            storage_provider_backend_connections: "{{ ansible_eda.event.storage_backend_connections | default({}) }}"
-            storage_provider_block_encryption_passphrase: "{{ ansible_eda.event.payload.spec.blockEncryptionPassphrase | default('') }}"
+            storage_provider_tiers: "{{ _storage_tiers }}"
+            storage_provider_block_encryption_passphrase: "{{ osac_job_vars.resource.spec.blockEncryptionPassphrase | default('') }}"
+            storage_provider_snapshots_enabled: "{{ _storage_snapshots }}"
       rescue:
         - name: Warn about StorageClass creation failure
           ansible.builtin.debug:
@@ -104,6 +106,6 @@
             name: osac.service.storage_provider
           vars:
             storage_provider_action: ensure_storage_class
-            storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"
-            storage_provider_backend_connections: "{{ ansible_eda.event.storage_backend_connections | default({}) }}"
-            storage_provider_block_encryption_passphrase: "{{ ansible_eda.event.payload.spec.blockEncryptionPassphrase | default('') }}"
+            storage_provider_tiers: "{{ _storage_tiers }}"
+            storage_provider_block_encryption_passphrase: "{{ osac_job_vars.resource.spec.blockEncryptionPassphrase | default('') }}"
+            storage_provider_snapshots_enabled: "{{ _storage_snapshots }}"

--- a/osac-aap/playbook_osac_create_tenant_storage_backend.yml
+++ b/osac-aap/playbook_osac_create_tenant_storage_backend.yml
@@ -4,43 +4,53 @@
   gather_facts: false
 
   vars:
-    tenant_name: "{{ ansible_eda.event.payload.metadata.name }}"
-    tenant_namespace: "{{ ansible_eda.event.payload.metadata.namespace }}"
-    tenant_uid: "{{ ansible_eda.event.payload.metadata.uid }}"
+    tenant_name: "{{ osac_job_vars.resource.metadata.name }}"
+    tenant_namespace: "{{ osac_job_vars.resource.metadata.namespace }}"
+    tenant_uid: "{{ osac_job_vars.resource.metadata.uid }}"
+    _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
 
   pre_tasks:
-    # payload.spec.blockEncryptionPassphrase carries a real secret (see
-    # storage_provider_block_encryption_passphrase below) -- use the shared,
-    # centralized redaction task instead of debugging the whole payload object.
-    - name: Show EDA Event metadata
-      ansible.builtin.include_role:
-        name: osac.service.common
-        tasks_from: show_eda_event_metadata
+    - name: Show job vars
+      ansible.builtin.debug:
+        var: osac_job_vars.resource.metadata
 
     - name: Validate tenant payload is present
       ansible.builtin.fail:
-        msg: "tenant must be provided via ansible_eda.event.payload with metadata.name, metadata.namespace, and metadata.uid set"
+        msg: "tenant must be provided via osac_job_vars.resource with metadata.name, metadata.namespace, and metadata.uid set"
       when: >-
-        ansible_eda is not defined or
-        ansible_eda.event.payload.metadata.name is not defined or
-        ansible_eda.event.payload.metadata.name | length == 0 or
-        ansible_eda.event.payload.metadata.namespace is not defined or
-        ansible_eda.event.payload.metadata.namespace | length == 0 or
-        ansible_eda.event.payload.metadata.uid is not defined or
-        ansible_eda.event.payload.metadata.uid | length == 0
+        osac_job_vars is not defined or
+        osac_job_vars.resource.metadata.name is not defined or
+        osac_job_vars.resource.metadata.name | length == 0 or
+        osac_job_vars.resource.metadata.namespace is not defined or
+        osac_job_vars.resource.metadata.namespace | length == 0 or
+        osac_job_vars.resource.metadata.uid is not defined or
+        osac_job_vars.resource.metadata.uid | length == 0
 
-    - name: Validate storage_tier_definitions is a non-empty array in the EDA event
+    - name: Validate STORAGE_TIERS env var is configured
       ansible.builtin.fail:
         msg: >-
-          ansible_eda.event.storage_tier_definitions must be a non-empty array, populated
-          by osac-operator from the Tenant's resolved storage tiers.
-          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota_bytes":500}]
-      when: >-
-        ansible_eda.event.storage_tier_definitions is not defined or
-        ansible_eda.event.storage_tier_definitions is not sequence or
-        ansible_eda.event.storage_tier_definitions is string or
-        ansible_eda.event.storage_tier_definitions is mapping or
-        ansible_eda.event.storage_tier_definitions | length == 0
+          STORAGE_TIERS env var must be set at deployment time as a JSON array.
+          Example: [{"name":"default","protocol":"nfs","provider":"vast"}]
+      when: _storage_tiers_raw | length == 0
+
+    - name: Parse STORAGE_TIERS JSON
+      block:
+        - name: Parse tier list from env var
+          ansible.builtin.set_fact:
+            _storage_tiers: "{{ _storage_tiers_raw | from_json }}"
+        - name: Validate STORAGE_TIERS is a JSON array
+          ansible.builtin.assert:
+            that:
+              - _storage_tiers | type_debug == 'list'
+            fail_msg: >-
+              STORAGE_TIERS must be a JSON array of tier objects.
+      rescue:
+        - name: Fail on malformed STORAGE_TIERS JSON
+          ansible.builtin.fail:
+            msg: >-
+              STORAGE_TIERS env var contains invalid JSON.
+              Value: '{{ _storage_tiers_raw }}'.
+              Expected a JSON array of tier objects with name, protocol, and provider fields.
 
   tasks:
     - name: Configure tenant storage backend
@@ -48,6 +58,6 @@
         name: osac.service.storage_provider
       vars:
         storage_provider_action: setup
-        storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"
-        storage_provider_backend_connections: "{{ ansible_eda.event.storage_backend_connections | default({}) }}"
-        storage_provider_block_encryption_passphrase: "{{ ansible_eda.event.payload.spec.blockEncryptionPassphrase | default('') }}"
+        storage_provider_tiers: "{{ _storage_tiers }}"
+        storage_provider_block_encryption_passphrase: "{{ osac_job_vars.resource.spec.blockEncryptionPassphrase | default('') }}"
+        storage_provider_snapshots_enabled: "{{ lookup('env', 'STORAGE_SNAPSHOTS_ENABLED') | default('true', true) | bool }}"

--- a/osac-aap/playbook_osac_create_tenant_storage_backend.yml
+++ b/osac-aap/playbook_osac_create_tenant_storage_backend.yml
@@ -10,7 +10,7 @@
     _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
 
   pre_tasks:
-    - name: Show job vars
+    - name: Show resource metadata
       ansible.builtin.debug:
         var: osac_job_vars.resource.metadata
 

--- a/osac-aap/playbook_osac_create_virtual_network.yml
+++ b/osac-aap/playbook_osac_create_virtual_network.yml
@@ -11,9 +11,9 @@
     template_parameters: {}
 
   pre_tasks:
-    - name: Show job vars
+    - name: Show resource metadata
       ansible.builtin.debug:
-        var: osac_job_vars.resource
+        var: osac_job_vars.resource.metadata
 
   tasks:
     - name: Display VirtualNetwork information

--- a/osac-aap/playbook_osac_create_virtual_network.yml
+++ b/osac-aap/playbook_osac_create_virtual_network.yml
@@ -4,16 +4,16 @@
   gather_facts: false
 
   vars:
-    virtual_network: "{{ ansible_eda.event.payload }}"
-    virtual_network_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    virtual_network: "{{ osac_job_vars.resource }}"
+    virtual_network_name: "{{ osac_job_vars.resource.metadata.name }}"
     # Implementation strategy set by fulfillment-service in VirtualNetwork spec
-    implementation_strategy: "{{ ansible_eda.event.payload.spec.implementationStrategy }}"
+    implementation_strategy: "{{ osac_job_vars.resource.spec.implementationStrategy }}"
     template_parameters: {}
 
   pre_tasks:
-    - name: Show EDA Event
+    - name: Show job vars
       ansible.builtin.debug:
-        var: ansible_eda.event.payload
+        var: osac_job_vars.resource
 
   tasks:
     - name: Display VirtualNetwork information

--- a/osac-aap/playbook_osac_delete_bare_metal_instance.yml
+++ b/osac-aap/playbook_osac_delete_bare_metal_instance.yml
@@ -4,7 +4,7 @@
   gather_facts: false
 
   vars:
-    bare_metal_instance: "{{ ansible_eda.event.payload }}"
+    bare_metal_instance: "{{ osac_job_vars.resource }}"
 
   pre_tasks:
     - name: Display bare metal instance information

--- a/osac-aap/playbook_osac_delete_bare_metal_pool.yml
+++ b/osac-aap/playbook_osac_delete_bare_metal_pool.yml
@@ -4,7 +4,7 @@
   gather_facts: false
 
   vars:
-    bare_metal_pool: "{{ ansible_eda.event.payload }}"
+    bare_metal_pool: "{{ osac_job_vars.resource }}"
     bare_metal_pool_name: "{{ bare_metal_pool.metadata.name }}"
     bare_metal_pool_namespace: "{{ bare_metal_pool.metadata.namespace }}"
     template_id: "{{ bare_metal_pool.metadata.annotations['osac.openshift.io/templateID'] }}"

--- a/osac-aap/playbook_osac_delete_compute_instance.yml
+++ b/osac-aap/playbook_osac_delete_compute_instance.yml
@@ -4,9 +4,9 @@
   gather_facts: false
 
   vars:
-    compute_instance: "{{ ansible_eda.event.payload }}"
-    compute_instance_name: "{{ ansible_eda.event.payload.metadata.name }}"
-    template_id: "{{ ansible_eda.event.payload.spec.templateID }}"
+    compute_instance: "{{ osac_job_vars.resource }}"
+    compute_instance_name: "{{ osac_job_vars.resource.metadata.name }}"
+    template_id: "{{ osac_job_vars.resource.spec.templateID }}"
 
   pre_tasks:
     - name: Determine tenant target namespace

--- a/osac-aap/playbook_osac_delete_external_ip.yml
+++ b/osac-aap/playbook_osac_delete_external_ip.yml
@@ -4,17 +4,17 @@
   gather_facts: false
 
   vars:
-    external_ip: "{{ ansible_eda.event.payload }}"
-    external_ip_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    external_ip: "{{ osac_job_vars.resource }}"
+    external_ip_name: "{{ osac_job_vars.resource.metadata.name }}"
     implementation_strategy: >-
-      {{ ansible_eda.event.payload.metadata.annotations
+      {{ osac_job_vars.resource.metadata.annotations
          ['osac.openshift.io/implementation-strategy'] }}
     template_parameters: {}
 
   pre_tasks:
-    - name: Show EDA Event
+    - name: Show job vars
       ansible.builtin.debug:
-        var: ansible_eda.event.payload
+        var: osac_job_vars.resource
 
   tasks:
     - name: Display ExternalIP information

--- a/osac-aap/playbook_osac_delete_external_ip.yml
+++ b/osac-aap/playbook_osac_delete_external_ip.yml
@@ -12,9 +12,9 @@
     template_parameters: {}
 
   pre_tasks:
-    - name: Show job vars
+    - name: Show resource metadata
       ansible.builtin.debug:
-        var: osac_job_vars.resource
+        var: osac_job_vars.resource.metadata
 
   tasks:
     - name: Display ExternalIP information

--- a/osac-aap/playbook_osac_delete_external_ip_pool.yml
+++ b/osac-aap/playbook_osac_delete_external_ip_pool.yml
@@ -12,9 +12,9 @@
     template_parameters: {}
 
   pre_tasks:
-    - name: Show job vars
+    - name: Show resource metadata
       ansible.builtin.debug:
-        var: osac_job_vars.resource
+        var: osac_job_vars.resource.metadata
 
   tasks:
     - name: Display ExternalIPPool information

--- a/osac-aap/playbook_osac_delete_external_ip_pool.yml
+++ b/osac-aap/playbook_osac_delete_external_ip_pool.yml
@@ -4,17 +4,17 @@
   gather_facts: false
 
   vars:
-    external_ip_pool: "{{ ansible_eda.event.payload }}"
-    external_ip_pool_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    external_ip_pool: "{{ osac_job_vars.resource }}"
+    external_ip_pool_name: "{{ osac_job_vars.resource.metadata.name }}"
     implementation_strategy: >-
-      {{ ansible_eda.event.payload.metadata.annotations
+      {{ osac_job_vars.resource.metadata.annotations
          ['osac.openshift.io/implementation-strategy'] }}
     template_parameters: {}
 
   pre_tasks:
-    - name: Show EDA Event
+    - name: Show job vars
       ansible.builtin.debug:
-        var: ansible_eda.event.payload
+        var: osac_job_vars.resource
 
   tasks:
     - name: Display ExternalIPPool information

--- a/osac-aap/playbook_osac_delete_hosted_cluster.yml
+++ b/osac-aap/playbook_osac_delete_hosted_cluster.yml
@@ -4,7 +4,7 @@
   gather_facts: false
 
   vars:
-    cluster_order: "{{ ansible_eda.event.payload }}"
+    cluster_order: "{{ osac_job_vars.resource }}"
 
   pre_tasks:
     - name: Apply default settings

--- a/osac-aap/playbook_osac_delete_nat_gateway.yml
+++ b/osac-aap/playbook_osac_delete_nat_gateway.yml
@@ -10,9 +10,9 @@
       {{ osac_job_vars.resource.metadata.annotations['osac.openshift.io/implementation-strategy'] }}
 
   pre_tasks:
-    - name: Show job vars
+    - name: Show resource metadata
       ansible.builtin.debug:
-        var: osac_job_vars.resource
+        var: osac_job_vars.resource.metadata
 
   tasks:
     - name: Display NATGateway information

--- a/osac-aap/playbook_osac_delete_nat_gateway.yml
+++ b/osac-aap/playbook_osac_delete_nat_gateway.yml
@@ -4,15 +4,15 @@
   gather_facts: false
 
   vars:
-    nat_gateway: "{{ ansible_eda.event.payload }}"
-    nat_gateway_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    nat_gateway: "{{ osac_job_vars.resource }}"
+    nat_gateway_name: "{{ osac_job_vars.resource.metadata.name }}"
     implementation_strategy: >-
-      {{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/implementation-strategy'] }}
+      {{ osac_job_vars.resource.metadata.annotations['osac.openshift.io/implementation-strategy'] }}
 
   pre_tasks:
-    - name: Show EDA Event
+    - name: Show job vars
       ansible.builtin.debug:
-        var: ansible_eda.event.payload
+        var: osac_job_vars.resource
 
   tasks:
     - name: Display NATGateway information

--- a/osac-aap/playbook_osac_delete_security_group.yml
+++ b/osac-aap/playbook_osac_delete_security_group.yml
@@ -13,9 +13,9 @@
     template_parameters: {}
 
   pre_tasks:
-    - name: Show job vars
+    - name: Show resource metadata
       ansible.builtin.debug:
-        var: osac_job_vars.resource
+        var: osac_job_vars.resource.metadata
 
   tasks:
     - name: Display SecurityGroup information

--- a/osac-aap/playbook_osac_delete_security_group.yml
+++ b/osac-aap/playbook_osac_delete_security_group.yml
@@ -4,18 +4,18 @@
   gather_facts: false
 
   vars:
-    security_group: "{{ ansible_eda.event.payload }}"
-    security_group_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    security_group: "{{ osac_job_vars.resource }}"
+    security_group_name: "{{ osac_job_vars.resource.metadata.name }}"
     # Implementation strategy set by osac-operator from parent VirtualNetwork spec
     implementation_strategy: >-
-      {{ ansible_eda.event.payload.metadata.annotations
+      {{ osac_job_vars.resource.metadata.annotations
          ['osac.openshift.io/implementation-strategy'] }}
     template_parameters: {}
 
   pre_tasks:
-    - name: Show EDA Event
+    - name: Show job vars
       ansible.builtin.debug:
-        var: ansible_eda.event.payload
+        var: osac_job_vars.resource
 
   tasks:
     - name: Display SecurityGroup information

--- a/osac-aap/playbook_osac_delete_subnet.yml
+++ b/osac-aap/playbook_osac_delete_subnet.yml
@@ -13,9 +13,9 @@
     template_parameters: {}
 
   pre_tasks:
-    - name: Show job vars
+    - name: Show resource metadata
       ansible.builtin.debug:
-        var: osac_job_vars.resource
+        var: osac_job_vars.resource.metadata
 
   tasks:
     - name: Display Subnet information

--- a/osac-aap/playbook_osac_delete_subnet.yml
+++ b/osac-aap/playbook_osac_delete_subnet.yml
@@ -4,18 +4,18 @@
   gather_facts: false
 
   vars:
-    subnet: "{{ ansible_eda.event.payload }}"
-    subnet_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    subnet: "{{ osac_job_vars.resource }}"
+    subnet_name: "{{ osac_job_vars.resource.metadata.name }}"
     # Implementation strategy set by osac-operator from parent VirtualNetwork spec
     implementation_strategy: >-
-      {{ ansible_eda.event.payload.metadata.annotations
+      {{ osac_job_vars.resource.metadata.annotations
          ['osac.openshift.io/implementation-strategy'] }}
     template_parameters: {}
 
   pre_tasks:
-    - name: Show EDA Event
+    - name: Show job vars
       ansible.builtin.debug:
-        var: ansible_eda.event.payload
+        var: osac_job_vars.resource
 
   tasks:
     - name: Display Subnet information

--- a/osac-aap/playbook_osac_delete_tenant_cluster_storage.yml
+++ b/osac-aap/playbook_osac_delete_tenant_cluster_storage.yml
@@ -23,7 +23,7 @@
     _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
 
   pre_tasks:
-    - name: Show job vars
+    - name: Show resource metadata
       ansible.builtin.debug:
         var: osac_job_vars.resource.metadata
 

--- a/osac-aap/playbook_osac_delete_tenant_cluster_storage.yml
+++ b/osac-aap/playbook_osac_delete_tenant_cluster_storage.yml
@@ -4,7 +4,7 @@
   gather_facts: false
 
   vars:
-    tenant_name: "{{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/tenant'] }}"
+    tenant_name: "{{ osac_job_vars.resource.metadata.annotations['osac.openshift.io/tenant'] }}"
     # This template is triggered from two different call sites in storage_controller.go,
     # sharing the same AAP job template but passing different resource kinds as payload:
     #   - handleClusterStorageDeprovisioning (hub storage) sends a Tenant object, whose own
@@ -15,54 +15,54 @@
     #     guest cluster. For that case we target the fixed OSAC system namespace on the guest
     #     cluster instead (mirrors the create playbook's routing).
     tenant_namespace: >-
-      {%- if ansible_eda.event.payload.kind == 'ClusterOrder' -%}
+      {%- if osac_job_vars.resource.kind == 'ClusterOrder' -%}
       openshift-osac-storage
       {%- else -%}
-      {{ ansible_eda.event.payload.metadata.namespace }}
+      {{ osac_job_vars.resource.metadata.namespace }}
       {%- endif -%}
+    _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
 
   pre_tasks:
-    # Use the shared, centralized redaction task rather than debugging the whole payload
-    # object, matching the create-side playbook -- payload.spec is not currently used
-    # here, but keeping the same convention avoids reintroducing a full-payload debug
-    # if that ever changes.
-    - name: Show EDA Event metadata
-      ansible.builtin.include_role:
-        name: osac.service.common
-        tasks_from: show_eda_event_metadata
-      vars:
-        eda_event_extra_fields:
-          tenant_annotation: "{{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/tenant'] | default('unknown') }}"
+    - name: Show job vars
+      ansible.builtin.debug:
+        var: osac_job_vars.resource.metadata
 
     - name: Validate tenant payload is present
       ansible.builtin.fail:
-        msg: "tenant must be provided via ansible_eda.event.payload with metadata.name and metadata.namespace set"
+        msg: "tenant must be provided via osac_job_vars.resource with metadata.name and metadata.namespace set"
       when: >-
-        ansible_eda is not defined or
-        ansible_eda.event.payload.metadata.name is not defined or
-        ansible_eda.event.payload.metadata.name | length == 0 or
-        ansible_eda.event.payload.metadata.namespace is not defined or
-        ansible_eda.event.payload.metadata.namespace | length == 0
+        osac_job_vars is not defined or
+        osac_job_vars.resource.metadata.name is not defined or
+        osac_job_vars.resource.metadata.name | length == 0 or
+        osac_job_vars.resource.metadata.namespace is not defined or
+        osac_job_vars.resource.metadata.namespace | length == 0
 
-    - name: Validate storage_tier_definitions is a non-empty array in the EDA event
-      ansible.builtin.fail:
-        msg: >-
-          ansible_eda.event.storage_tier_definitions must be a non-empty array, populated
-          by osac-operator from the Tenant's resolved storage tiers.
-          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota_bytes":500}]
-      when: >-
-        ansible_eda.event.storage_tier_definitions is not defined or
-        ansible_eda.event.storage_tier_definitions is not sequence or
-        ansible_eda.event.storage_tier_definitions is string or
-        ansible_eda.event.storage_tier_definitions is mapping or
-        ansible_eda.event.storage_tier_definitions | length == 0
+    - name: Parse STORAGE_TIERS JSON
+      when: _storage_tiers_raw | length > 0
+      block:
+        - name: Parse tier list from env var
+          ansible.builtin.set_fact:
+            _storage_tiers: "{{ _storage_tiers_raw | from_json }}"
+        - name: Validate STORAGE_TIERS is a JSON array
+          ansible.builtin.assert:
+            that:
+              - _storage_tiers | type_debug == 'list'
+            fail_msg: >-
+              STORAGE_TIERS must be a JSON array of tier objects.
+      rescue:
+        - name: Fail on malformed STORAGE_TIERS JSON
+          ansible.builtin.fail:
+            msg: >-
+              STORAGE_TIERS env var contains invalid JSON.
+              Value: '{{ _storage_tiers_raw }}'.
+              Expected a JSON array of tier objects with name, protocol, and provider fields.
 
     - name: Write admin_kubeconfig to temporary file when provided
       when: >-
-        ansible_eda.event.admin_kubeconfig is defined and
-        ansible_eda.event.admin_kubeconfig | length > 0
+        osac_job_vars.admin_kubeconfig is defined and
+        osac_job_vars.admin_kubeconfig | length > 0
       ansible.builtin.set_fact:
-        _remote_kubeconfig: "{{ ansible_eda.event.admin_kubeconfig | osac.service.to_temp_file(suffix='.kubeconfig') }}"
+        _remote_kubeconfig: "{{ osac_job_vars.admin_kubeconfig | osac.service.to_temp_file(suffix='.kubeconfig') }}"
         # HCP guest-cluster kubeconfigs are typically accessed via an external Route whose
         # serving cert doesn't match the CA bundled in the admin kubeconfig.
         _remote_kubeconfig_insecure: true
@@ -70,17 +70,23 @@
     - name: Fail when guest-cluster teardown is requested without admin_kubeconfig
       ansible.builtin.fail:
         msg: >-
-          admin_kubeconfig is required in the EDA event for ClusterOrder
+          admin_kubeconfig is required in the job vars for ClusterOrder
           (guest-cluster) storage teardown; without it cleanup would target
           the controller's default cluster instead of the guest cluster.
       when: >-
-        ansible_eda.event.payload.kind == 'ClusterOrder' and
+        osac_job_vars.resource.kind == 'ClusterOrder' and
         (_remote_kubeconfig is not defined or _remote_kubeconfig | length == 0)
 
   tasks:
+    - name: Skip cleanup when STORAGE_TIERS is not configured
+      when: _storage_tiers_raw | length == 0
+      ansible.builtin.debug:
+        msg: "STORAGE_TIERS env var is not set — nothing to clean up."
+
     - name: Clean up cluster-side tenant storage resources
+      when: _storage_tiers_raw | length > 0
       ansible.builtin.include_role:
         name: osac.service.storage_provider
       vars:
         storage_provider_action: teardown_cluster_storage
-        storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"
+        storage_provider_tiers: "{{ _storage_tiers }}"

--- a/osac-aap/playbook_osac_delete_tenant_storage_backend.yml
+++ b/osac-aap/playbook_osac_delete_tenant_storage_backend.yml
@@ -9,7 +9,7 @@
     _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
 
   pre_tasks:
-    - name: Show job vars
+    - name: Show resource metadata
       ansible.builtin.debug:
         var: osac_job_vars.resource.metadata
 

--- a/osac-aap/playbook_osac_delete_tenant_storage_backend.yml
+++ b/osac-aap/playbook_osac_delete_tenant_storage_backend.yml
@@ -4,47 +4,49 @@
   gather_facts: false
 
   vars:
-    tenant_name: "{{ ansible_eda.event.payload.metadata.name }}"
-    tenant_namespace: "{{ ansible_eda.event.payload.metadata.namespace }}"
+    tenant_name: "{{ osac_job_vars.resource.metadata.name }}"
+    tenant_namespace: "{{ osac_job_vars.resource.metadata.namespace }}"
+    _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
 
   pre_tasks:
-    # Use the shared, centralized redaction task rather than debugging the whole payload
-    # object, matching the create-side playbook -- payload.spec is not currently used
-    # here, but keeping the same convention avoids reintroducing a full-payload debug
-    # if that ever changes.
-    - name: Show EDA Event metadata
-      ansible.builtin.include_role:
-        name: osac.service.common
-        tasks_from: show_eda_event_metadata
+    - name: Show job vars
+      ansible.builtin.debug:
+        var: osac_job_vars.resource.metadata
 
     - name: Validate tenant payload is present
       ansible.builtin.fail:
-        msg: "tenant must be provided via ansible_eda.event.payload with metadata.name and metadata.namespace set"
+        msg: "tenant must be provided via osac_job_vars.resource with metadata.name and metadata.namespace set"
       when: >-
-        ansible_eda is not defined or
-        ansible_eda.event.payload.metadata.name is not defined or
-        ansible_eda.event.payload.metadata.name | length == 0 or
-        ansible_eda.event.payload.metadata.namespace is not defined or
-        ansible_eda.event.payload.metadata.namespace | length == 0
+        osac_job_vars is not defined or
+        osac_job_vars.resource.metadata.name is not defined or
+        osac_job_vars.resource.metadata.name | length == 0 or
+        osac_job_vars.resource.metadata.namespace is not defined or
+        osac_job_vars.resource.metadata.namespace | length == 0
 
-    - name: Validate storage_tier_definitions is a non-empty array in the EDA event
-      ansible.builtin.fail:
-        msg: >-
-          ansible_eda.event.storage_tier_definitions must be a non-empty array, populated
-          by osac-operator from the Tenant's resolved storage tiers.
-          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota_bytes":500}]
-      when: >-
-        ansible_eda.event.storage_tier_definitions is not defined or
-        ansible_eda.event.storage_tier_definitions is not sequence or
-        ansible_eda.event.storage_tier_definitions is string or
-        ansible_eda.event.storage_tier_definitions is mapping or
-        ansible_eda.event.storage_tier_definitions | length == 0
+    - name: Parse STORAGE_TIERS JSON
+      when: _storage_tiers_raw | length > 0
+      block:
+        - name: Parse tier list from env var
+          ansible.builtin.set_fact:
+            _storage_tiers: "{{ _storage_tiers_raw | from_json }}"
+      rescue:
+        - name: Fail on malformed STORAGE_TIERS JSON
+          ansible.builtin.fail:
+            msg: >-
+              STORAGE_TIERS env var contains invalid JSON.
+              Value: '{{ _storage_tiers_raw }}'.
+              Expected a JSON array of tier objects with name, protocol, and provider fields.
 
   tasks:
+    - name: Skip teardown when STORAGE_TIERS is not configured
+      when: _storage_tiers_raw | length == 0
+      ansible.builtin.debug:
+        msg: "STORAGE_TIERS env var is not set — nothing to tear down."
+
     - name: Delete tenant storage backend
+      when: _storage_tiers_raw | length > 0
       ansible.builtin.include_role:
         name: osac.service.storage_provider
       vars:
         storage_provider_action: teardown_backend
-        storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"
-        storage_provider_backend_connections: "{{ ansible_eda.event.storage_backend_connections | default({}) }}"
+        storage_provider_tiers: "{{ _storage_tiers }}"

--- a/osac-aap/playbook_osac_delete_virtual_network.yml
+++ b/osac-aap/playbook_osac_delete_virtual_network.yml
@@ -11,9 +11,9 @@
     template_parameters: {}
 
   pre_tasks:
-    - name: Show job vars
+    - name: Show resource metadata
       ansible.builtin.debug:
-        var: osac_job_vars.resource
+        var: osac_job_vars.resource.metadata
 
   tasks:
     - name: Display VirtualNetwork information

--- a/osac-aap/playbook_osac_delete_virtual_network.yml
+++ b/osac-aap/playbook_osac_delete_virtual_network.yml
@@ -4,16 +4,16 @@
   gather_facts: false
 
   vars:
-    virtual_network: "{{ ansible_eda.event.payload }}"
-    virtual_network_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    virtual_network: "{{ osac_job_vars.resource }}"
+    virtual_network_name: "{{ osac_job_vars.resource.metadata.name }}"
     # Implementation strategy set by fulfillment-service in VirtualNetwork spec
-    implementation_strategy: "{{ ansible_eda.event.payload.spec.implementationStrategy }}"
+    implementation_strategy: "{{ osac_job_vars.resource.spec.implementationStrategy }}"
     template_parameters: {}
 
   pre_tasks:
-    - name: Show EDA Event
+    - name: Show job vars
       ansible.builtin.debug:
-        var: ansible_eda.event.payload
+        var: osac_job_vars.resource
 
   tasks:
     - name: Display VirtualNetwork information

--- a/osac-aap/playbook_osac_detach_external_ip.yml
+++ b/osac-aap/playbook_osac_detach_external_ip.yml
@@ -10,9 +10,9 @@
     template_parameters: {}
 
   pre_tasks:
-    - name: Show job vars
+    - name: Show resource metadata
       ansible.builtin.debug:
-        var: osac_job_vars.resource
+        var: osac_job_vars.resource.metadata
 
   tasks:
     - name: Display ExternalIP detach information

--- a/osac-aap/playbook_osac_detach_external_ip.yml
+++ b/osac-aap/playbook_osac_detach_external_ip.yml
@@ -4,21 +4,21 @@
   gather_facts: false
 
   vars:
-    external_ip_attachment: "{{ ansible_eda.event.payload }}"
+    external_ip_attachment: "{{ osac_job_vars.resource }}"
     implementation_strategy: >-
-      {{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/implementation-strategy'] }}
+      {{ osac_job_vars.resource.metadata.annotations['osac.openshift.io/implementation-strategy'] }}
     template_parameters: {}
 
   pre_tasks:
-    - name: Show EDA Event
+    - name: Show job vars
       ansible.builtin.debug:
-        var: ansible_eda.event.payload
+        var: osac_job_vars.resource
 
   tasks:
     - name: Display ExternalIP detach information
       ansible.builtin.debug:
         msg:
-          - "ExternalIP attachment name: {{ ansible_eda.event.payload.metadata.name }}"
+          - "ExternalIP attachment name: {{ osac_job_vars.resource.metadata.name }}"
           - "Implementation strategy: {{ implementation_strategy }}"
 
     - name: Call the selected ExternalIP detach role

--- a/osac-aap/playbook_osac_report_hosted_cluster_status.yml
+++ b/osac-aap/playbook_osac_report_hosted_cluster_status.yml
@@ -2,7 +2,7 @@
   hosts: localhost
   gather_facts: true
   vars:
-    cluster_order: "{{ ansible_eda.event.payload }}"
+    cluster_order: "{{ osac_job_vars.resource }}"
     workflow_name: unknown
     workflow_status: unknown
   tasks:

--- a/osac-aap/samples/storage_tier_definitions_payload.json
+++ b/osac-aap/samples/storage_tier_definitions_payload.json
@@ -1,34 +1,32 @@
 {
-  "ansible_eda": {
-    "event": {
-      "payload": {
-        "metadata": {
-          "name": "acme",
-          "namespace": "tenant-acme",
-          "uid": "11111111-1111-1111-1111-111111111111"
-        }
-      },
-      "storage_tier_definitions": [
-        {
-          "name": "default",
-          "protocol": "nfs",
-          "provider": "vast",
-          "backend_id": "be-001",
-          "qos_limits": {
-            "static_limits": {
-              "max_reads_bw_mbps": 100,
-              "max_writes_bw_mbps": 100
-            }
-          },
-          "quota_bytes": 536870912000
-        }
-      ],
-      "storage_backend_connections": {
-        "be-001": {
-          "endpoint": "vast.example.com:443",
-          "username": "admin",
-          "password": "<injected-by-osac-operator>"
-        }
+  "osac_job_vars": {
+    "resource": {
+      "metadata": {
+        "name": "acme",
+        "namespace": "tenant-acme",
+        "uid": "11111111-1111-1111-1111-111111111111"
+      }
+    },
+    "storage_tier_definitions": [
+      {
+        "name": "default",
+        "protocol": "nfs",
+        "provider": "vast",
+        "backend_id": "be-001",
+        "qos_limits": {
+          "static_limits": {
+            "max_reads_bw_mbps": 100,
+            "max_writes_bw_mbps": 100
+          }
+        },
+        "quota_bytes": 536870912000
+      }
+    ],
+    "storage_backend_connections": {
+      "be-001": {
+        "endpoint": "vast.example.com:443",
+        "username": "admin",
+        "password": "<injected-by-osac-operator>"
       }
     }
   }

--- a/osac-aap/tests/integration/integration_config.yml.template
+++ b/osac-aap/tests/integration/integration_config.yml.template
@@ -45,7 +45,7 @@ vast_vip_pool_ip_ranges: '${VAST_VIP_POOL_IP_RANGES}'
 vast_vip_pool_subnet_cidr: ${VAST_VIP_POOL_SUBNET_CIDR}
 
 # Storage tier definitions — JSON array with per-tier provider selection and backend_id,
-# matching the storage_provider_tiers/ansible_eda.event.storage_tier_definitions shape.
+# matching the storage_provider_tiers/osac_job_vars.storage_tier_definitions shape.
 # Used by test playbooks to exercise the multi-tier storage provider interface. Left
 # unquoted (unlike vast_vip_pool_ip_ranges above) so it parses as a native YAML list --
 # the storage_provider role's own validation requires storage_provider_tiers to be a

--- a/osac-aap/tests/integration/targets/cluster_create/tasks/baseline.yml
+++ b/osac-aap/tests/integration/targets/cluster_create/tasks/baseline.yml
@@ -12,9 +12,8 @@
 
     - name: Set test variables for baseline workflow
       ansible.builtin.set_fact:
-        ansible_eda:
-          event:
-            payload: "{{ test_cluster_order }}"
+        osac_job_vars:
+          resource: "{{ test_cluster_order }}"
         cluster_working_namespace: "cluster-test-cluster-work"
         # NOTE: Using real template (osac.templates.ocp_small from fixture)
         # Override infrastructure-creating steps to avoid actual resource creation

--- a/osac-aap/tests/integration/targets/cluster_create/tasks/overrides.yml
+++ b/osac-aap/tests/integration/targets/cluster_create/tasks/overrides.yml
@@ -22,9 +22,8 @@
 
     - name: Set test variables with all overrides
       ansible.builtin.set_fact:
-        ansible_eda:
-          event:
-            payload: "{{ test_cluster_order }}"
+        osac_job_vars:
+          resource: "{{ test_cluster_order }}"
         cluster_working_namespace: "cluster-test-cluster-work"
 
         # Override all 6 extension points

--- a/osac-aap/tests/integration/targets/cluster_delete/tasks/baseline.yml
+++ b/osac-aap/tests/integration/targets/cluster_delete/tasks/baseline.yml
@@ -12,9 +12,8 @@
 
     - name: Set test variables for baseline workflow
       ansible.builtin.set_fact:
-        ansible_eda:
-          event:
-            payload: "{{ test_cluster_order }}"
+        osac_job_vars:
+          resource: "{{ test_cluster_order }}"
         cluster_working_namespace: "cluster-test-cluster-work"
         # NOTE: Using real template (osac.templates.ocp_small from fixture)
         # Override infrastructure-deleting steps to avoid actual resource deletion

--- a/osac-aap/tests/integration/targets/cluster_delete/tasks/overrides.yml
+++ b/osac-aap/tests/integration/targets/cluster_delete/tasks/overrides.yml
@@ -22,9 +22,8 @@
 
     - name: Set test variables with all overrides
       ansible.builtin.set_fact:
-        ansible_eda:
-          event:
-            payload: "{{ test_cluster_order }}"
+        osac_job_vars:
+          resource: "{{ test_cluster_order }}"
         cluster_working_namespace: "cluster-test-cluster-work"
 
         # Override all 4 extension points

--- a/osac-aap/tests/integration/targets/cluster_post_install/tasks/baseline.yml
+++ b/osac-aap/tests/integration/targets/cluster_post_install/tasks/baseline.yml
@@ -12,9 +12,8 @@
 
     - name: Set test variables for baseline workflow
       ansible.builtin.set_fact:
-        ansible_eda:
-          event:
-            payload: "{{ test_cluster_order }}"
+        osac_job_vars:
+          resource: "{{ test_cluster_order }}"
         cluster_working_namespace: "cluster-test-cluster-work"
         # Override template to use no-op version for testing
         template_id_override: "osac.test_overrides.noop_template"

--- a/osac-aap/tests/integration/targets/cluster_post_install/tasks/overrides.yml
+++ b/osac-aap/tests/integration/targets/cluster_post_install/tasks/overrides.yml
@@ -22,9 +22,8 @@
 
     - name: Set test variables with all overrides
       ansible.builtin.set_fact:
-        ansible_eda:
-          event:
-            payload: "{{ test_cluster_order }}"
+        osac_job_vars:
+          resource: "{{ test_cluster_order }}"
         cluster_working_namespace: "cluster-test-cluster-work"
         admin_kubeconfig: |
           apiVersion: v1

--- a/osac-aap/tests/integration/targets/cluster_status_reporting/tasks/baseline.yml
+++ b/osac-aap/tests/integration/targets/cluster_status_reporting/tasks/baseline.yml
@@ -12,9 +12,8 @@
 
     - name: Set test variables for baseline workflow
       ansible.builtin.set_fact:
-        ansible_eda:
-          event:
-            payload: "{{ test_cluster_order }}"
+        osac_job_vars:
+          resource: "{{ test_cluster_order }}"
         cluster_working_namespace: "cluster-test-cluster-work"
         workflow_name: test_workflow
         workflow_status: succeeded

--- a/osac-aap/tests/integration/targets/cluster_status_reporting/tasks/overrides.yml
+++ b/osac-aap/tests/integration/targets/cluster_status_reporting/tasks/overrides.yml
@@ -22,9 +22,8 @@
 
     - name: Set test variables with all overrides
       ansible.builtin.set_fact:
-        ansible_eda:
-          event:
-            payload: "{{ test_cluster_order }}"
+        osac_job_vars:
+          resource: "{{ test_cluster_order }}"
         cluster_working_namespace: "cluster-test-cluster-work"
         workflow_name: cluster_status_reporting
         workflow_status: succeeded

--- a/osac-aap/tests/integration/targets/compute_instance_create/tasks/baseline.yml
+++ b/osac-aap/tests/integration/targets/compute_instance_create/tasks/baseline.yml
@@ -12,9 +12,8 @@
 
     - name: Set test variables for baseline workflow
       ansible.builtin.set_fact:
-        ansible_eda:
-          event:
-            payload: "{{ test_compute_instance }}"
+        osac_job_vars:
+          resource: "{{ test_compute_instance }}"
         tenant_target_namespace: "computeinstance-test-vm-work"
         tenant_storage_class_name: "test-storage-class"
         # Override only resource creation to prevent actual VM/DataVolume creation

--- a/osac-aap/tests/integration/targets/compute_instance_create/tasks/overrides.yml
+++ b/osac-aap/tests/integration/targets/compute_instance_create/tasks/overrides.yml
@@ -22,9 +22,8 @@
 
     - name: Set test variables with all overrides
       ansible.builtin.set_fact:
-        ansible_eda:
-          event:
-            payload: "{{ test_compute_instance }}"
+        osac_job_vars:
+          resource: "{{ test_compute_instance }}"
         tenant_target_namespace: "computeinstance-test-vm-work"
         tenant_storage_class_name: "test-storage-class"
 

--- a/osac-aap/tests/integration/targets/compute_instance_delete/tasks/baseline.yml
+++ b/osac-aap/tests/integration/targets/compute_instance_delete/tasks/baseline.yml
@@ -12,9 +12,8 @@
 
     - name: Set test variables for baseline workflow
       ansible.builtin.set_fact:
-        ansible_eda:
-          event:
-            payload: "{{ test_compute_instance }}"
+        osac_job_vars:
+          resource: "{{ test_compute_instance }}"
         tenant_target_namespace: "computeinstance-test-vm-work"
         # Note: delete.yaml doesn't have override hooks yet, so we use noop_template
         # TODO: Refactor ocp_virt_vm delete.yaml to add override points

--- a/osac-aap/tests/integration/targets/compute_instance_delete/tasks/overrides.yml
+++ b/osac-aap/tests/integration/targets/compute_instance_delete/tasks/overrides.yml
@@ -22,9 +22,8 @@
 
     - name: Set test variables with all overrides
       ansible.builtin.set_fact:
-        ansible_eda:
-          event:
-            payload: "{{ test_compute_instance }}"
+        osac_job_vars:
+          resource: "{{ test_compute_instance }}"
         tenant_target_namespace: "computeinstance-test-vm-work"
 
         # Override 3 workflow extension points

--- a/osac-aap/tests/integration/targets/compute_instance_with_gpu_create/tasks/baseline.yml
+++ b/osac-aap/tests/integration/targets/compute_instance_with_gpu_create/tasks/baseline.yml
@@ -12,9 +12,8 @@
 
     - name: Set test variables for baseline workflow
       ansible.builtin.set_fact:
-        ansible_eda:
-          event:
-            payload: "{{ test_compute_instance }}"
+        osac_job_vars:
+          resource: "{{ test_compute_instance }}"
         tenant_target_namespace: "computeinstance-test-vm-gpu-work"
         tenant_storage_class_name: "test-storage-class"
         create_step_resources_override:

--- a/osac-operator/pkg/provisioning/aap_provider.go
+++ b/osac-operator/pkg/provisioning/aap_provider.go
@@ -330,46 +330,40 @@ func mapAAPStatusToJobState(aapStatus string) v1alpha1.JobState {
 
 // extractExtraVars extracts extra variables from a resource to pass to AAP.
 //
-// AAP templates expect the Kubernetes resource wrapped in an ansible_eda.event.payload
-// structure. Playbooks read fields such as ansible_eda.event.payload.spec and
-// ansible_eda.event.payload.metadata.
+// Playbooks read fields such as osac_job_vars.resource.spec and
+// osac_job_vars.resource.metadata.
 func extractExtraVars(ctx context.Context, resource client.Object) (map[string]any, error) {
-	// Convert the resource to map using JSON marshaling (respects JSON tags)
 	resourceMap, err := serializeResource(resource)
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize resource: %w", err)
 	}
 
-	event := map[string]any{
-		"payload": resourceMap,
+	vars := map[string]any{
+		"resource": resourceMap,
 	}
 
-	// Inject tenant storage classes if present in context (set by CI controller)
 	if scs := TenantStorageClassesFromContext(ctx); len(scs) > 0 {
 		scList := make([]map[string]string, len(scs))
 		for i, sc := range scs {
 			scList[i] = map[string]string{"name": sc.Name, "tier": sc.Tier}
 		}
-		event["tenant_storage_classes"] = scList
+		vars["tenant_storage_classes"] = scList
 	}
 
 	if kc := AdminKubeconfigFromContext(ctx); kc != "" {
-		event["admin_kubeconfig"] = kc
+		vars["admin_kubeconfig"] = kc
 	}
 
 	if tiers := StorageTierDefinitionsFromContext(ctx); len(tiers) > 0 {
-		event["storage_tier_definitions"] = tierDefinitionsToExtraVars(tiers)
+		vars["storage_tier_definitions"] = tierDefinitionsToExtraVars(tiers)
 	}
 
 	if conns := StorageBackendConnectionsFromContext(ctx); len(conns) > 0 {
-		event["storage_backend_connections"] = backendConnectionsToExtraVars(conns)
+		vars["storage_backend_connections"] = backendConnectionsToExtraVars(conns)
 	}
 
-	// Wrap in ansible_eda.event structure for AAP template compatibility.
 	return map[string]any{
-		"ansible_eda": map[string]any{
-			"event": event,
-		},
+		"osac_job_vars": vars,
 	}, nil
 }
 

--- a/osac-operator/pkg/provisioning/aap_provider_test.go
+++ b/osac-operator/pkg/provisioning/aap_provider_test.go
@@ -69,11 +69,8 @@ func (m *mockAAPClient) CancelJob(ctx context.Context, jobID string) error {
 	return nil
 }
 
-// extractEDAPayload extracts the payload from EDA event structure in extra_vars.
-// This helper function is used to verify the EDA compatibility wrapper.
-func extractEDAPayload(extraVars map[string]any) map[string]any {
-	edaEvent := extraVars["ansible_eda"].(map[string]any)
-	return edaEvent["event"].(map[string]any)["payload"].(map[string]any)
+func extractJobVarsResource(extraVars map[string]any) map[string]any {
+	return extraVars["osac_job_vars"].(map[string]any)["resource"].(map[string]any)
 }
 
 var _ = Describe("AAPProvider", func() {
@@ -97,8 +94,8 @@ var _ = Describe("AAPProvider", func() {
 				}
 				aapClient.launchJobTemplateFunc = func(ctx context.Context, req aap.LaunchJobTemplateRequest) (*aap.LaunchJobTemplateResponse, error) {
 					Expect(req.TemplateName).To(Equal("provision-job"))
-					Expect(req.ExtraVars).To(HaveKey("ansible_eda"))
-					payload := extractEDAPayload(req.ExtraVars)
+					Expect(req.ExtraVars).To(HaveKey("osac_job_vars"))
+					payload := extractJobVarsResource(req.ExtraVars)
 					// Verify serialized resource contains the ObjectMeta fields under "metadata"
 					Expect(payload).To(HaveKey("metadata"))
 					metadata := payload["metadata"].(map[string]any)
@@ -131,8 +128,8 @@ var _ = Describe("AAPProvider", func() {
 				}
 				aapClient.launchWorkflowTemplateFunc = func(ctx context.Context, req aap.LaunchWorkflowTemplateRequest) (*aap.LaunchWorkflowTemplateResponse, error) {
 					Expect(req.TemplateName).To(Equal("provision-workflow"))
-					Expect(req.ExtraVars).To(HaveKey("ansible_eda"))
-					payload := extractEDAPayload(req.ExtraVars)
+					Expect(req.ExtraVars).To(HaveKey("osac_job_vars"))
+					payload := extractJobVarsResource(req.ExtraVars)
 					// Verify serialized resource contains the ObjectMeta fields under "metadata"
 					Expect(payload).To(HaveKey("metadata"))
 					metadata := payload["metadata"].(map[string]any)
@@ -166,10 +163,10 @@ var _ = Describe("AAPProvider", func() {
 
 			It("should inject tenant_storage_classes into extra_vars", func() {
 				aapClient.launchJobTemplateFunc = func(ctx context.Context, req aap.LaunchJobTemplateRequest) (*aap.LaunchJobTemplateResponse, error) {
-					edaEvent := req.ExtraVars["ansible_eda"].(map[string]any)["event"].(map[string]any)
-					Expect(edaEvent).To(HaveKey("payload"))
-					Expect(edaEvent).To(HaveKey("tenant_storage_classes"))
-					scList := edaEvent["tenant_storage_classes"].([]map[string]string)
+					jobVars := req.ExtraVars["osac_job_vars"].(map[string]any)
+					Expect(jobVars).To(HaveKey("resource"))
+					Expect(jobVars).To(HaveKey("tenant_storage_classes"))
+					scList := jobVars["tenant_storage_classes"].([]map[string]string)
 					Expect(scList).To(HaveLen(2))
 					Expect(scList[0]).To(Equal(map[string]string{"name": "ceph-fast", "tier": "fast"}))
 					Expect(scList[1]).To(Equal(map[string]string{"name": "ceph-default", "tier": "default"}))
@@ -194,9 +191,9 @@ var _ = Describe("AAPProvider", func() {
 
 			It("should not inject tenant_storage_classes when context has no storage classes", func() {
 				aapClient.launchJobTemplateFunc = func(ctx context.Context, req aap.LaunchJobTemplateRequest) (*aap.LaunchJobTemplateResponse, error) {
-					edaEvent := req.ExtraVars["ansible_eda"].(map[string]any)["event"].(map[string]any)
-					Expect(edaEvent).To(HaveKey("payload"))
-					Expect(edaEvent).NotTo(HaveKey("tenant_storage_classes"))
+					jobVars := req.ExtraVars["osac_job_vars"].(map[string]any)
+					Expect(jobVars).To(HaveKey("resource"))
+					Expect(jobVars).NotTo(HaveKey("tenant_storage_classes"))
 					return &aap.LaunchJobTemplateResponse{JobID: 790}, nil
 				}
 
@@ -811,8 +808,8 @@ var _ = Describe("AAPProvider", func() {
 			ctx = provisioning.WithAdminKubeconfig(ctx, kubeconfig)
 
 			aapClient.launchJobTemplateFunc = func(ctx context.Context, req aap.LaunchJobTemplateRequest) (*aap.LaunchJobTemplateResponse, error) {
-				edaEvent := req.ExtraVars["ansible_eda"].(map[string]any)["event"].(map[string]any)
-				Expect(edaEvent).To(HaveKeyWithValue("admin_kubeconfig", kubeconfig))
+				jobVars := req.ExtraVars["osac_job_vars"].(map[string]any)
+				Expect(jobVars).To(HaveKeyWithValue("admin_kubeconfig", kubeconfig))
 				return &aap.LaunchJobTemplateResponse{JobID: 100}, nil
 			}
 
@@ -825,8 +822,8 @@ var _ = Describe("AAPProvider", func() {
 
 		It("should omit admin_kubeconfig from event when not set in context", func() {
 			aapClient.launchJobTemplateFunc = func(ctx context.Context, req aap.LaunchJobTemplateRequest) (*aap.LaunchJobTemplateResponse, error) {
-				edaEvent := req.ExtraVars["ansible_eda"].(map[string]any)["event"].(map[string]any)
-				Expect(edaEvent).NotTo(HaveKey("admin_kubeconfig"))
+				jobVars := req.ExtraVars["osac_job_vars"].(map[string]any)
+				Expect(jobVars).NotTo(HaveKey("admin_kubeconfig"))
 				return &aap.LaunchJobTemplateResponse{JobID: 101}, nil
 			}
 
@@ -859,9 +856,9 @@ var _ = Describe("AAPProvider", func() {
 			})
 
 			aapClient.launchJobTemplateFunc = func(ctx context.Context, req aap.LaunchJobTemplateRequest) (*aap.LaunchJobTemplateResponse, error) {
-				edaEvent := req.ExtraVars["ansible_eda"].(map[string]any)["event"].(map[string]any)
-				Expect(edaEvent).To(HaveKey("storage_tier_definitions"))
-				tiers := edaEvent["storage_tier_definitions"].([]map[string]any)
+				jobVars := req.ExtraVars["osac_job_vars"].(map[string]any)
+				Expect(jobVars).To(HaveKey("storage_tier_definitions"))
+				tiers := jobVars["storage_tier_definitions"].([]map[string]any)
 				Expect(tiers).To(HaveLen(1))
 				Expect(tiers[0]).To(Equal(map[string]any{
 					"name":       "fast",
@@ -889,8 +886,8 @@ var _ = Describe("AAPProvider", func() {
 
 		It("should omit storage_tier_definitions when not set in context", func() {
 			aapClient.launchJobTemplateFunc = func(ctx context.Context, req aap.LaunchJobTemplateRequest) (*aap.LaunchJobTemplateResponse, error) {
-				edaEvent := req.ExtraVars["ansible_eda"].(map[string]any)["event"].(map[string]any)
-				Expect(edaEvent).NotTo(HaveKey("storage_tier_definitions"))
+				jobVars := req.ExtraVars["osac_job_vars"].(map[string]any)
+				Expect(jobVars).NotTo(HaveKey("storage_tier_definitions"))
 				return &aap.LaunchJobTemplateResponse{JobID: 112}, nil
 			}
 
@@ -916,9 +913,9 @@ var _ = Describe("AAPProvider", func() {
 			})
 
 			aapClient.launchJobTemplateFunc = func(ctx context.Context, req aap.LaunchJobTemplateRequest) (*aap.LaunchJobTemplateResponse, error) {
-				edaEvent := req.ExtraVars["ansible_eda"].(map[string]any)["event"].(map[string]any)
-				Expect(edaEvent).To(HaveKey("storage_backend_connections"))
-				conns := edaEvent["storage_backend_connections"].(map[string]map[string]any)
+				jobVars := req.ExtraVars["osac_job_vars"].(map[string]any)
+				Expect(jobVars).To(HaveKey("storage_backend_connections"))
+				conns := jobVars["storage_backend_connections"].(map[string]map[string]any)
 				Expect(conns).To(Equal(map[string]map[string]any{
 					"backend-1": {
 						"endpoint": "https://vast.example.com",
@@ -938,8 +935,8 @@ var _ = Describe("AAPProvider", func() {
 
 		It("should omit storage_backend_connections when not set in context", func() {
 			aapClient.launchJobTemplateFunc = func(ctx context.Context, req aap.LaunchJobTemplateRequest) (*aap.LaunchJobTemplateResponse, error) {
-				edaEvent := req.ExtraVars["ansible_eda"].(map[string]any)["event"].(map[string]any)
-				Expect(edaEvent).NotTo(HaveKey("storage_backend_connections"))
+				jobVars := req.ExtraVars["osac_job_vars"].(map[string]any)
+				Expect(jobVars).NotTo(HaveKey("storage_backend_connections"))
 				return &aap.LaunchJobTemplateResponse{JobID: 122}, nil
 			}
 


### PR DESCRIPTION
## Summary

- Renames the legacy `ansible_eda.event.payload` extra vars structure to `osac_job_vars.resource` across both **osac-operator** and **osac-aap**
- Removes the intermediate `event` nesting level — `osac_job_vars` is now a flat namespace with `resource`, `tenant_storage_classes`, `admin_kubeconfig`, etc. as direct children
- Cleans up stale "EDA" references in task names, error messages, argument specs, and documentation

The `ansible_eda` naming was a vestige from when the operator sent events through Ansible EDA. Now that the operator calls AAP job templates directly via REST API, the naming is misleading.

**osac-operator** (2 files):
- `pkg/provisioning/aap_provider.go` — flatten map structure, rename keys
- `pkg/provisioning/aap_provider_test.go` — update helper and all assertions

**osac-aap** (62 files):
- 28 top-level playbooks, 6 collection workflow playbooks
- 13 integration test fixtures (collapsed `event:` YAML nesting)
- Role argument specs, README docs, AI instruction files

## Test plan

- [x] `make lint test` passes on osac-operator (0 issues, all tests pass)
- [x] Pre-commit hooks pass (yamllint, golangci-lint, etc.)
- [x] `grep -rl ansible_eda` returns zero hits across both components (excluding vendor)
- [ ] e2e-vmaas-full-install CI job validates the full operator→AAP contract

Jira: https://redhat.atlassian.net/browse/OSAC-3547

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playbooks now receive resource details through a unified job-variable format.
  * Resource data and provisioning context are handled consistently across infrastructure, networking, storage, and cluster workflows.
  * Runtime diagnostics now display resource metadata for improved visibility.

* **Documentation**
  * Updated usage examples, argument descriptions, workflow guides, and troubleshooting references for the new resource input format.

* **Tests**
  * Updated integration and provider coverage to validate the new job-variable structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->