### PR TITLE
NO-ISSUE: Remove stale EDA references from installer and operator

### DIFF
--- a/osac-installer/charts/osac/values-example.yaml
+++ b/osac-installer/charts/osac/values-example.yaml
@@ -220,8 +220,6 @@ aap:
       # AAP components to enable. Only controller is needed for OSAC.
       controller:
         disabled: false
-      eda:
-        disabled: false
       hub:
         disabled: true
       lightspeed:

--- a/osac-installer/charts/osac/values.schema.json
+++ b/osac-installer/charts/osac/values.schema.json
@@ -377,16 +377,6 @@
                     }
                   }
                 },
-                "eda": {
-                  "type": "object",
-                  "properties": {
-                    "disabled": {
-                      "type": "boolean",
-                      "description": "Disable Event-Driven Ansible",
-                      "default": false
-                    }
-                  }
-                },
                 "hub": {
                   "type": "object",
                   "properties": {
@@ -468,15 +458,6 @@
                 "hostname": {
                   "type": "string",
                   "description": "AAP gateway route hostname"
-                }
-              }
-            },
-            "eda": {
-              "type": "object",
-              "properties": {
-                "hostname": {
-                  "type": "string",
-                  "description": "AAP EDA route hostname"
                 }
               }
             },

--- a/osac-installer/charts/osac/values.yaml
+++ b/osac-installer/charts/osac/values.yaml
@@ -88,8 +88,6 @@ aap:
       name: "osac-aap"
       controller:
         disabled: false
-      eda:
-        disabled: true
       hub:
         disabled: true
       lightspeed:

--- a/osac-operator/config/crd/fakes/osac.openshift.io_baremetalinstances.yaml
+++ b/osac-operator/config/crd/fakes/osac.openshift.io_baremetalinstances.yaml
@@ -222,9 +222,8 @@ spec:
                   properties:
                     blockDeletionOnFailure:
                       description: |-
-                        BlockDeletionOnFailure indicates whether CR deletion should be blocked if this job fails
-                        AAP Direct sets this to true to prevent orphaned cloud resources
-                        EDA sets this to false as webhook handles cleanup
+                        BlockDeletionOnFailure indicates whether CR deletion should be blocked if this job fails.
+                        Set to true to prevent orphaned cloud resources.
                       type: boolean
                     configVersion:
                       description: |-
@@ -235,9 +234,7 @@ spec:
                       type: string
                     jobID:
                       description: |-
-                        JobID is the job identifier from the provisioning provider
-                        For AAP Direct: job ID from AAP API response
-                        For EDA: auto-incremented "eda-webhook-N"
+                        JobID is the job identifier from the provisioning provider (AAP job ID).
                       type: string
                     message:
                       description: Message provides human-readable status or error

--- a/osac-operator/pkg/provisioning/aap_provider_test.go
+++ b/osac-operator/pkg/provisioning/aap_provider_test.go
@@ -97,7 +97,6 @@ var _ = Describe("AAPProvider", func() {
 				}
 				aapClient.launchJobTemplateFunc = func(ctx context.Context, req aap.LaunchJobTemplateRequest) (*aap.LaunchJobTemplateResponse, error) {
 					Expect(req.TemplateName).To(Equal("provision-job"))
-					// Verify EDA event structure for compatibility with EDA-designed templates
 					Expect(req.ExtraVars).To(HaveKey("ansible_eda"))
 					payload := extractEDAPayload(req.ExtraVars)
 					// Verify serialized resource contains the ObjectMeta fields under "metadata"
@@ -132,7 +131,6 @@ var _ = Describe("AAPProvider", func() {
 				}
 				aapClient.launchWorkflowTemplateFunc = func(ctx context.Context, req aap.LaunchWorkflowTemplateRequest) (*aap.LaunchWorkflowTemplateResponse, error) {
 					Expect(req.TemplateName).To(Equal("provision-workflow"))
-					// Verify EDA event structure for compatibility with EDA-designed templates
 					Expect(req.ExtraVars).To(HaveKey("ansible_eda"))
 					payload := extractEDAPayload(req.ExtraVars)
 					// Verify serialized resource contains the ObjectMeta fields under "metadata"


### PR DESCRIPTION
## Summary

- Remove dead EDA config from `osac-installer` Helm values, example values, and JSON schema — no templates consumed these values
- Update stale EDA descriptions in `osac-operator` fake CRD (`osac.openshift.io_baremetalinstances.yaml`)
- Remove stale "Verify EDA event structure" comments in `osac-operator` provisioning tests

The `osac-aap/charts/aap/` EDA config (`eda.disabled: true`) is intentionally kept — it actively tells the AAP operator not to deploy its EDA component.

Related: #97 (renames `ansible_eda` extra vars to `osac_job_vars`)

## Test plan

- [x] No templates in `osac-installer/charts/osac/templates/` reference `.eda` values (verified with grep)
- [x] Changes are config/comment-only — no behavioral impact

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Removed Event-Driven Ansible configuration options from the sample and default deployment settings.
  * Removed Event-Driven Ansible hostname and instance settings from configuration validation.
  * Simplified available AAP deployment configuration by retaining supported components only.

* **Documentation**
  * Clarified BareMetalInstance job status descriptions, including deletion behavior after failures and AAP job identification.
  * Removed outdated provider-specific Event-Driven Ansible references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->