### PR TITLE
OSAC-1992: read tier definitions and backend credentials from AAP extra_vars

### DIFF
--- a/osac-aap/.claude/rules/playbook-patterns.md
+++ b/osac-aap/.claude/rules/playbook-patterns.md
@@ -52,9 +52,10 @@ AAP job templates: `osac-{action}-{resource}`
 The bare `debug: var: ansible_eda.event.payload` shown above is safe as long as
 nothing in `payload.spec` is a secret. Some CR specs are not — e.g.
 `blockEncryptionPassphrase` on Tenant/ClusterOrder/ComputeInstance CRs. Before
-adding this debug task to a new or existing playbook, check whether the
-playbook also reads a sensitive field out of `payload.spec`; if it does, use
-the shared, centralized task instead of debugging the whole object:
+adding this debug task to a new or existing playbook, inspect the CR
+schema for every field that can occur in `payload.spec`. If any field can
+contain a secret, use the shared, centralized task instead of debugging the
+whole object:
 
 ```yaml
   pre_tasks:

--- a/osac-aap/.claude/rules/playbook-patterns.md
+++ b/osac-aap/.claude/rules/playbook-patterns.md
@@ -47,6 +47,32 @@ AAP job templates: `osac-{action}-{resource}`
 3. Dynamically includes the appropriate role from `osac.templates`
 4. Role performs actual provisioning (creates K8s resources, updates CR)
 
+### Show EDA Event and Sensitive `payload.spec` Fields
+
+The bare `debug: var: ansible_eda.event.payload` shown above is safe as long as
+nothing in `payload.spec` is a secret. Some CR specs are not — e.g.
+`blockEncryptionPassphrase` on Tenant/ClusterOrder/ComputeInstance CRs. Before
+adding this debug task to a new or existing playbook, check whether the
+playbook also reads a sensitive field out of `payload.spec`; if it does, use
+the shared, centralized task instead of debugging the whole object:
+
+```yaml
+  pre_tasks:
+    - name: Show EDA Event metadata
+      ansible.builtin.include_role:
+        name: osac.service.common
+        tasks_from: show_eda_event_metadata
+      vars:
+        eda_event_extra_fields:
+          template_id: "{{ ansible_eda.event.payload.spec.templateID | default('unknown') }}"
+```
+
+This logs `kind`/`metadata.name`/`metadata.namespace`/`metadata.uid` plus any
+additional non-sensitive fields passed via `eda_event_extra_fields` — never
+source an `eda_event_extra_fields` value from `payload.spec` without first
+confirming it isn't a secret. See
+`collections/ansible_collections/osac/service/roles/common/tasks/show_eda_event_metadata.yaml`.
+
 ## Template Roles
 
 Live in `collections/ansible_collections/osac/templates/roles/`. Each must have `meta/osac.yaml`:

--- a/osac-aap/collections/ansible_collections/osac/config_as_code/roles/aap/templates/compute-instance-operations-ig.j2
+++ b/osac-aap/collections/ansible_collections/osac/config_as_code/roles/aap/templates/compute-instance-operations-ig.j2
@@ -44,10 +44,6 @@ spec:
             name: storage-operations-ig
             optional: true
       env:
-        - name: OSAC_STORAGE_CONFIG_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: OSAC_COMPUTE_INSTANCE_OPERATIONS_NAMESPACE_DEFAULT
           valueFrom:
             fieldRef:

--- a/osac-aap/collections/ansible_collections/osac/config_as_code/roles/aap/templates/storage-operations-ig.j2
+++ b/osac-aap/collections/ansible_collections/osac/config_as_code/roles/aap/templates/storage-operations-ig.j2
@@ -31,14 +31,14 @@ spec:
       envFrom:
         - secretRef:
             name: storage-operations-ig
+            # This IG uses dedicated, isolated credentials — it must never fall
+            # back to a shared/broader-scope credential (e.g. vast-admin-credentials)
+            # if this Secret is absent. See .dev/PROJECT.md 2026-04-22 decision:
+            # "Dedicated storage-operations-ig with isolated VAST credentials."
+            optional: true
         - configMapRef:
             name: storage-operations-ig
             optional: true
-      env:
-        - name: OSAC_STORAGE_CONFIG_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
   volumes:
     - name: kube-api-access
       projected:

--- a/osac-aap/collections/ansible_collections/osac/service/roles/common/tasks/show_eda_event_metadata.yaml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/common/tasks/show_eda_event_metadata.yaml
@@ -1,0 +1,49 @@
+---
+# Centralized, redacted replacement for `debug: var: ansible_eda.event.payload`.
+# Use this instead of debugging the whole payload object whenever the calling
+# playbook also reads a sensitive field out of payload.spec (e.g.
+# blockEncryptionPassphrase) -- the whole-object debug prints secrets in
+# cleartext to the job log, which the runner then tails on failure.
+#
+# Always logs: payload kind, metadata.name, metadata.namespace, metadata.uid.
+#
+# Optional caller var:
+#   eda_event_extra_fields — dict of additional non-sensitive key/value pairs
+#                            to include. Keys are restricted to the allowlist
+#                            below, and the fixed kind/name/namespace/uid
+#                            fields always win on conflict -- this task is
+#                            the single redaction boundary for
+#                            ansible_eda.event.payload, so a new field must
+#                            be deliberately added to the allowlist here, not
+#                            silently accepted from any caller. Never add a
+#                            key whose value could be sourced from
+#                            payload.spec without confirming it isn't a
+#                            secret first.
+- name: Validate eda_event_extra_fields keys are on the allowlist
+  ansible.builtin.fail:
+    msg: >-
+      eda_event_extra_fields contains a key not on the allowlist:
+      {{ (eda_event_extra_fields | default({}) | list) | difference(_eda_event_extra_fields_allowlist) }}.
+      Add it to _eda_event_extra_fields_allowlist in show_eda_event_metadata.yaml
+      first -- this task is the single redaction boundary for
+      ansible_eda.event.payload, and new fields must be deliberately approved.
+  vars:
+    _eda_event_extra_fields_allowlist:
+      - tenant_annotation
+      - template_id
+  when: >-
+    (eda_event_extra_fields | default({}) | list)
+    | difference(_eda_event_extra_fields_allowlist) | length > 0
+
+- name: Show EDA Event metadata
+  ansible.builtin.debug:
+    msg: >-
+      {{
+        (eda_event_extra_fields | default({}))
+        | combine({
+            'kind': ansible_eda.event.payload.kind | default('unknown'),
+            'name': ansible_eda.event.payload.metadata.name | default('unknown'),
+            'namespace': ansible_eda.event.payload.metadata.namespace | default('unknown'),
+            'uid': ansible_eda.event.payload.metadata.uid | default('unknown'),
+          })
+      }}

--- a/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/meta/argument_specs.yaml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/meta/argument_specs.yaml
@@ -12,12 +12,15 @@ argument_specs:
         required: true
         description: >
           List of storage tier definitions. Each tier declares its name, protocol,
-          provider, and optional QoS/quota settings. The dispatcher groups tiers
-          by provider and dispatches to each provider's template role with the
-          filtered tier subset.
+          provider, backend_id, and optional QoS/quota settings. qos_policy is
+          always derived by this role from the tier name — any caller-supplied
+          qos_policy value is ignored and discarded, never used. The dispatcher
+          groups tiers by provider and dispatches to each provider's template
+          role with the filtered tier subset.
           Example: [{name: default, protocol: nfs, provider: vast,
-          qos_policy: default-qos,
-          qos_limits: {static_limits: {max_reads_bw_mbps: 100, max_writes_bw_mbps: 100}}}]
+          backend_id: be-001,
+          qos_limits: {static_limits: {max_reads_bw_mbps: 100, max_writes_bw_mbps: 100}},
+          quota_bytes: 536870912000}]
       storage_provider_action:
         type: str
         required: true
@@ -46,5 +49,19 @@ argument_specs:
         required: false
         default: true
         description: >
-          Create a VolumeSnapshotClass alongside the StorageClass for K8s-native
-          snapshot support. Skipped if the VolumeSnapshot CRD is not installed.
+          Whether to create VolumeSnapshotClasses alongside StorageClasses during
+          ensure_storage_class. Only takes effect when the VolumeSnapshotClass CRD
+          is installed on the target cluster (a live CRD check gates creation
+          regardless of this flag).
+      storage_provider_backend_connections:
+        type: dict
+        required: false
+        default: {}
+        no_log: true
+        description: >
+          Backend connection details (endpoint, username, password), keyed by backend_id,
+          as resolved by osac-operator from the Tier API. Each provider's own
+          credential-sourcing logic looks up the entry for the backend_id(s) present in
+          its dispatched tier subset. Optional because teardown_cluster_storage never
+          needs backend connection details (it only touches cluster-side K8s resources).
+          Example: {be-001: {endpoint: vast.example.com:443, username: admin, password: "***"}}

--- a/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tasks/_dispatch_provider.yaml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tasks/_dispatch_provider.yaml
@@ -9,8 +9,9 @@
 # Uses from play scope:
 #   _storage_provider_tiers              — full tier list, qos_policy-defaulted (filtered here per provider)
 #   storage_provider_backend_connections — backend connection details keyed by backend_id,
-#                                          passed through unfiltered (each provider role looks
-#                                          up its own dispatched tiers' backend_id(s) from it)
+#                                          filtered here to only the backend_id(s) referenced
+#                                          by this provider's dispatched tiers, so a role never
+#                                          sees credentials for a backend it wasn't dispatched
 #   _cluster_name                        — optional target cluster name override (for volume
 #                                          naming); ensure_storage_class self-discovers it from
 #                                          the target cluster's Infrastructure object when unset
@@ -23,6 +24,25 @@
   ansible.builtin.set_fact:
     _computed_provider_tiers: >-
       {{ _storage_provider_tiers | selectattr('provider', 'equalto', _current_provider) | list }}
+
+- name: "Compute filtered backend connections for current provider's dispatched tiers"
+  ansible.builtin.set_fact:
+    _computed_provider_backend_connections: >-
+      {{
+        storage_provider_backend_connections
+        | default({})
+        | dict2items
+        | selectattr(
+            'key',
+            'in',
+            (_computed_provider_tiers
+             | selectattr('backend_id', 'defined')
+             | map(attribute='backend_id')
+             | list)
+          )
+        | items2dict
+      }}
+  no_log: true
 
 - name: "Dispatch provider storage action with remote kubeconfig routing"
   module_defaults:
@@ -40,7 +60,7 @@
         public: true
       vars:
         _provider_tiers: "{{ _computed_provider_tiers }}"
-        _provider_backend_connections: "{{ storage_provider_backend_connections }}"
+        _provider_backend_connections: "{{ _computed_provider_backend_connections }}"
 
 - name: "Accumulate tenant config after dispatch (setup only)"
   ansible.builtin.set_fact:

--- a/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tasks/_dispatch_provider.yaml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tasks/_dispatch_provider.yaml
@@ -7,7 +7,10 @@
 #   _dispatch_action   — task file to invoke (setup, ensure_storage_class, teardown_cluster_storage, teardown_backend)
 #
 # Uses from play scope:
-#   storage_provider_tiers              — full tier list (filtered here per provider)
+#   _storage_provider_tiers              — full tier list, qos_policy-defaulted (filtered here per provider)
+#   storage_provider_backend_connections — backend connection details keyed by backend_id,
+#                                          passed through unfiltered (each provider role looks
+#                                          up its own dispatched tiers' backend_id(s) from it)
 #   _cluster_name                        — optional target cluster name override (for volume
 #                                          naming); ensure_storage_class self-discovers it from
 #                                          the target cluster's Infrastructure object when unset
@@ -19,19 +22,7 @@
 - name: "Compute filtered tiers for current provider"
   ansible.builtin.set_fact:
     _computed_provider_tiers: >-
-      {{ (storage_provider_tiers | selectattr('provider', 'equalto', _current_provider) | list)
-         | selectattr('name', 'in', _requested_tiers) | list
-         if (_requested_tiers is defined and _requested_tiers | length > 0)
-         else (storage_provider_tiers | selectattr('provider', 'equalto', _current_provider) | list) }}
-
-- name: "Fail if requested tier filter produced no matches"
-  when: >-
-    _requested_tiers is defined and _requested_tiers | length > 0 and
-    _computed_provider_tiers | length == 0
-  ansible.builtin.fail:
-    msg: >-
-      None of the requested tiers ({{ _requested_tiers | join(', ') }}) match
-      provider '{{ _current_provider }}' tiers. Check STORAGE_TIERS configuration.
+      {{ _storage_provider_tiers | selectattr('provider', 'equalto', _current_provider) | list }}
 
 - name: "Dispatch provider storage action with remote kubeconfig routing"
   module_defaults:
@@ -49,6 +40,7 @@
         public: true
       vars:
         _provider_tiers: "{{ _computed_provider_tiers }}"
+        _provider_backend_connections: "{{ storage_provider_backend_connections }}"
 
 - name: "Accumulate tenant config after dispatch (setup only)"
   ansible.builtin.set_fact:

--- a/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tasks/main.yaml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tasks/main.yaml
@@ -35,6 +35,28 @@
   loop: "{{ storage_provider_tiers }}"
   when: item.name is not defined or not (item.name | regex_search('^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$'))
 
+# A tier name can be a valid 1-63 char DNS label on its own yet still be unusable: tiers
+# with configured qos_limits get a derived qos_policy of '<name>-qos' below, which must
+# ALSO be a valid (<=63 char) DNS label. Caught here, at the same point as the other
+# tier-name checks, rather than surfacing later as a confusing failure on the derived
+# value. Mirrors the has-QoS-limits condition in the derivation step below — must be
+# kept in sync with it.
+- name: Validate QoS-enabled tier names leave room for the derived '-qos' suffix
+  ansible.builtin.fail:
+    msg: >-
+      Tier name '{{ item.name }}' is {{ item.name | length }} characters. Tiers with
+      configured qos_limits get a derived qos_policy of '{{ item.name }}-qos', which must
+      also be a valid DNS label (max 63 characters) — so tier names with QoS limits
+      configured are capped at 59 characters (63 minus the 4-character '-qos' suffix).
+  loop: "{{ storage_provider_tiers }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: >-
+    (item.name | length > 59) and
+    (item.qos_limits is defined and item.qos_limits.static_limits is defined and
+     ((item.qos_limits.static_limits.max_reads_bw_mbps | default(0) | int) > 0 or
+      (item.qos_limits.static_limits.max_writes_bw_mbps | default(0) | int) > 0))
+
 - name: Validate tier names are unique across the entire list
   ansible.builtin.fail:
     msg: >-
@@ -61,12 +83,45 @@
   loop: "{{ storage_provider_tiers }}"
   when: item.protocol | length == 0
 
-- name: Validate qos_policy is a valid DNS label when specified
+# qos_policy is entirely system-derived — any caller-supplied value is ignored and
+# discarded, never inspected or preserved, consistent with how every other field not
+# in this role's schema is treated (storage_provider_tiers has no elements:/options:
+# schema, so unrecognized tier fields are already silently ignored rather than
+# rejected; qos_policy previously broke that pattern by preserving a caller's value
+# as-is). This is what guarantees every caller actually gets consistent naming, rather
+# than merely being true by convention as long as no caller happens to set it.
+#
+# Written to a role-internal fact, not storage_provider_tiers itself: role/include_role
+# params outrank set_fact for the lifetime of the role invocation, so reassigning
+# storage_provider_tiers here would silently keep the caller-supplied, un-derived value.
+#
+# Only derived for tiers with a configured (non-zero) qos_limits — a tier with no
+# read/write bandwidth limits is treated as "no QoS enforcement wanted" and ends up
+# with no qos_policy at all, even if the caller supplied one. The Tier API always sends
+# a qos_limits block (defaulting to zero when unconfigured), so zero-in-both-directions
+# is the only "opt out" signal available without a dedicated field on the tier definition.
+- name: Derive qos_policy for tiers with configured QoS limits, discarding any caller-supplied value
+  ansible.builtin.set_fact:
+    _storage_provider_tiers: >-
+      {% set _tiers = [] -%}
+      {% for _tier in storage_provider_tiers -%}
+      {% set _has_qos_limits = (_tier.qos_limits is defined and _tier.qos_limits.static_limits is defined and
+           ((_tier.qos_limits.static_limits.max_reads_bw_mbps | default(0) | int) > 0 or
+            (_tier.qos_limits.static_limits.max_writes_bw_mbps | default(0) | int) > 0)) -%}
+      {% set _tier_without_qos_policy = _tier | dict2items | rejectattr('key', 'equalto', 'qos_policy') | items2dict -%}
+      {% set _ = _tiers.append(
+           (_tier_without_qos_policy | combine({'qos_policy': _tier.name + '-qos'})) if _has_qos_limits
+           else _tier_without_qos_policy
+         ) -%}
+      {% endfor -%}
+      {{ _tiers }}
+
+- name: Validate derived qos_policy is a valid DNS label
   ansible.builtin.fail:
     msg: >-
       Tier '{{ item.name }}' has an invalid qos_policy: '{{ item.qos_policy }}'.
       Must be a non-empty string matching DNS label rules (1-63 chars, lowercase alphanumeric and hyphens).
-  loop: "{{ storage_provider_tiers }}"
+  loop: "{{ _storage_provider_tiers }}"
   loop_control:
     label: "{{ item.name }}"
   when:
@@ -92,7 +147,7 @@
 
 - name: Extract unique providers from tier list
   ansible.builtin.set_fact:
-    _unique_providers: "{{ storage_provider_tiers | map(attribute='provider') | unique | sort | list }}"
+    _unique_providers: "{{ _storage_provider_tiers | map(attribute='provider') | unique | sort | list }}"
 
 - name: Set dispatch action
   ansible.builtin.set_fact:

--- a/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tasks/main.yaml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tasks/main.yaml
@@ -39,8 +39,21 @@
 # with configured qos_limits get a derived qos_policy of '<name>-qos' below, which must
 # ALSO be a valid (<=63 char) DNS label. Caught here, at the same point as the other
 # tier-name checks, rather than surfacing later as a confusing failure on the derived
-# value. Mirrors the has-QoS-limits condition in the derivation step below — must be
-# kept in sync with it.
+# value. The has-QoS-limits condition itself is computed once, below, and shared with
+# the derivation step so the two can't drift out of sync.
+- name: Compute QoS-enabled tier names (single source for length-guard and derivation)
+  ansible.builtin.set_fact:
+    _qos_enabled_tier_names: >-
+      {% set _names = [] -%}
+      {% for _tier in storage_provider_tiers -%}
+      {% if _tier.qos_limits is defined and _tier.qos_limits.static_limits is defined and
+            ((_tier.qos_limits.static_limits.max_reads_bw_mbps | default(0) | int) > 0 or
+             (_tier.qos_limits.static_limits.max_writes_bw_mbps | default(0) | int) > 0) -%}
+      {% set _ = _names.append(_tier.name) -%}
+      {% endif -%}
+      {% endfor -%}
+      {{ _names }}
+
 - name: Validate QoS-enabled tier names leave room for the derived '-qos' suffix
   ansible.builtin.fail:
     msg: >-
@@ -52,10 +65,7 @@
   loop_control:
     label: "{{ item.name }}"
   when: >-
-    (item.name | length > 59) and
-    (item.qos_limits is defined and item.qos_limits.static_limits is defined and
-     ((item.qos_limits.static_limits.max_reads_bw_mbps | default(0) | int) > 0 or
-      (item.qos_limits.static_limits.max_writes_bw_mbps | default(0) | int) > 0))
+    (item.name | length > 59) and (item.name in _qos_enabled_tier_names)
 
 - name: Validate tier names are unique across the entire list
   ansible.builtin.fail:
@@ -105,12 +115,9 @@
     _storage_provider_tiers: >-
       {% set _tiers = [] -%}
       {% for _tier in storage_provider_tiers -%}
-      {% set _has_qos_limits = (_tier.qos_limits is defined and _tier.qos_limits.static_limits is defined and
-           ((_tier.qos_limits.static_limits.max_reads_bw_mbps | default(0) | int) > 0 or
-            (_tier.qos_limits.static_limits.max_writes_bw_mbps | default(0) | int) > 0)) -%}
       {% set _tier_without_qos_policy = _tier | dict2items | rejectattr('key', 'equalto', 'qos_policy') | items2dict -%}
       {% set _ = _tiers.append(
-           (_tier_without_qos_policy | combine({'qos_policy': _tier.name + '-qos'})) if _has_qos_limits
+           (_tier_without_qos_policy | combine({'qos_policy': _tier.name + '-qos'})) if (_tier.name in _qos_enabled_tier_names)
            else _tier_without_qos_policy
          ) -%}
       {% endfor -%}

--- a/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
@@ -138,6 +138,11 @@
   hosts: localhost
   gather_facts: false
 
+  pre_tasks:
+    - name: Clear any structured failure artifact from earlier scenarios
+      ansible.builtin.set_fact:
+        osac_storage_provider_failures: []
+
   tasks:
     - name: Run invalid-protocol failure test
       block:
@@ -402,13 +407,15 @@
             success_msg: "Role correctly rejected invalid input"
 
 # ──────────────────────────────────────────────────────────────
-# Test 13: Tier with no qos_policy gets a derived one that exceeds DNS label length -- error path
-# Expected: role fails with the qos_policy DNS label validation message, proving the
-# "Default qos_policy for tiers that do not specify one" step actually ran and that its
-# output feeds the existing qos_policy validation (OSAC-1992: tiers from
-# ansible_eda.event.storage_tier_definitions never carry qos_policy -- the role derives it).
+# Test 13: Tier name too long to safely derive a qos_policy -- error path
+# Expected: role fails at the length-guard task (not the downstream qos_policy DNS-label
+# validation -- that task is unreachable for auto-derived values, since the length-guard
+# rejects any QoS-enabled tier whose name would produce an over-length derived qos_policy
+# before derivation ever runs). Proves the length-guard actually catches this case
+# (OSAC-1992: tiers from ansible_eda.event.storage_tier_definitions never carry
+# qos_policy -- the role derives it as '<name>-qos').
 # ──────────────────────────────────────────────────────────────
-- name: Test storage_provider -- derived qos_policy exceeds DNS label length (should fail)
+- name: Test storage_provider -- tier name too long for derived qos_policy (should fail)
   hosts: localhost
   gather_facts: false
 
@@ -433,45 +440,47 @@
 
         - name: This task should not be reached -- role should have failed
           ansible.builtin.fail:
-            msg: "Role did not fail as expected when the derived qos_policy exceeds the DNS label length limit"
+            msg: "Role did not fail as expected when the tier name is too long for a derived qos_policy"
 
       rescue:
-        - name: Verify role failed with expected qos_policy DNS label message
+        - name: Verify role failed with expected length-guard message
           ansible.builtin.assert:
             that:
               - >-
-                'invalid qos_policy' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
-                and '-qos' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
-                or 'One or more items failed' in (ansible_failed_result.msg | default(''))
+                'capped at 59 characters' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
+              - >-
+                '-qos' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
             fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
-            success_msg: "Role correctly derived and rejected an over-length qos_policy"
+            success_msg: "Role correctly rejected a tier name too long to safely derive a qos_policy"
 
 # ──────────────────────────────────────────────────────────────
-# Test 14: Explicit qos_policy is ignored; derivation always overwrites it -- error path
-# Expected: role fails on the DERIVED qos_policy's DNS-label length, not the caller's short,
-# well-formed supplied value -- proving the caller's value was discarded entirely and
-# derivation ran unconditionally (OSAC-1992 follow-up: closes the gap where an unvalidated
-# override could produce inconsistent naming across callers, or let a caller's qos_policy
-# silently pass through unused). Uses the same 60-char tier name construction as Test 13 --
-# if a bug ever used the caller's value instead of deriving, this test would pass with no
-# DNS-label failure at all, since "short" alone is well within the length limit.
+# Test 14: Explicit qos_policy is ignored; derivation always overwrites it -- success path
+# Expected: role does NOT fail on qos_policy validation even though the caller supplies a
+# deliberately invalid qos_policy value -- proving the caller's value is discarded entirely
+# and replaced by the derived '<name>-qos' (a valid DNS label for this short tier name)
+# (OSAC-1992 follow-up: closes the gap where an unvalidated override could produce
+# inconsistent naming across callers, or let a caller's invalid qos_policy silently pass
+# through unused). A short, valid tier name is used deliberately: a long one would trip the
+# Test 13 length-guard before qos_policy handling is ever reached, proving nothing about
+# discarding. If a bug ever used the caller's value instead of deriving, this test would
+# fail with an "invalid qos_policy" message quoting the caller's malformed string.
 # ──────────────────────────────────────────────────────────────
-- name: Test storage_provider -- explicit qos_policy is ignored, derivation still runs (should fail)
+- name: Test storage_provider -- explicit qos_policy is ignored, derivation still runs (should succeed)
   hosts: localhost
   gather_facts: false
 
   tasks:
     - name: Run explicit-qos_policy-ignored test
       block:
-        - name: Attempt with a 60-char tier name, qos_limits, and a short explicit qos_policy
+        - name: Attempt with a short tier name, qos_limits, and a deliberately invalid explicit qos_policy
           ansible.builtin.include_role:
             name: osac.service.storage_provider
           vars:
             storage_provider_tiers:
-              - name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+              - name: "acme-tier"
                 protocol: nfs
                 provider: vast
-                qos_policy: "short"
+                qos_policy: "Invalid Policy!"
                 qos_limits:
                   static_limits:
                     max_reads_bw_mbps: 100
@@ -480,21 +489,23 @@
             tenant_name: "tenant-acme"
             tenant_namespace: "osac-tenants"
 
-        - name: This task should not be reached -- role should have failed
-          ansible.builtin.fail:
-            msg: "Role did not fail as expected -- the caller's explicit qos_policy may have been used instead of derived"
+        # If we get here, qos_policy validation passed on the DERIVED value
+        # ('acme-tier-qos'), proving the caller's invalid supplied value was discarded.
+        - name: Validation passed (dispatch outcome is not under test)
+          ansible.builtin.debug:
+            msg: "Validation passed -- caller's invalid qos_policy was correctly discarded"
 
       rescue:
-        - name: Verify role failed on the derived qos_policy, not the caller's supplied value
+        - name: Verify any failure is from dispatch, not from the caller's discarded qos_policy
           ansible.builtin.assert:
             that:
               - >-
-                'invalid qos_policy' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
-                and '-qos' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
-                and 'short' not in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
-                or 'One or more items failed' in (ansible_failed_result.msg | default(''))
-            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
-            success_msg: "Role correctly ignored the caller's qos_policy and derived its own, which then failed DNS-label validation as expected"
+                'invalid qos_policy' not in (ansible_failed_result.msg | default(''))
+              - >-
+                'Invalid Policy' not in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
+            fail_msg: >-
+              Role failed on the caller's supplied qos_policy instead of discarding it: {{ ansible_failed_result.msg | default('unknown error') }}
+            success_msg: "Role correctly discarded the caller's invalid qos_policy and derived its own"
 
 # ──────────────────────────────────────────────────────────────
 # Test 15: Tier without configured qos_limits opts out of qos_policy entirely, even if
@@ -503,7 +514,7 @@
 # tier with no read/write bandwidth limits configured -- even a deliberately invalid
 # caller-supplied qos_policy is stripped without ever being format-checked. Uses a 60-char
 # tier name that WOULD fail DNS-label validation if a qos_policy were derived (same
-# construction as Test 13/14) -- if this test ever starts failing with an "invalid qos_policy"
+# construction as Test 13) -- if this test ever starts failing with an "invalid qos_policy"
 # message, the opt-out has regressed.
 # ──────────────────────────────────────────────────────────────
 - name: Test storage_provider -- tier without qos_limits discards qos_policy entirely, even if supplied
@@ -553,6 +564,11 @@
   hosts: localhost
   gather_facts: false
 
+  pre_tasks:
+    - name: Clear any structured failure artifact from earlier scenarios
+      ansible.builtin.set_fact:
+        osac_storage_provider_failures: []
+
   tasks:
     - name: Run ambiguous-backend-association failure test
       block:
@@ -573,11 +589,11 @@
               be-001:
                 endpoint: vast-1.example.com
                 username: admin
-                password: secret
+                password: mock-backend-password
               be-002:
                 endpoint: vast-2.example.com
                 username: admin
-                password: secret
+                password: mock-backend-password
             storage_provider_action: setup
             tenant_name: "tenant-acme"
             tenant_namespace: "osac-tenants"
@@ -619,6 +635,11 @@
 - name: Test storage_provider -- VAST tier's backend_id has no connection entry (should fail)
   hosts: localhost
   gather_facts: false
+
+  pre_tasks:
+    - name: Clear any structured failure artifact from earlier scenarios
+      ansible.builtin.set_fact:
+        osac_storage_provider_failures: []
 
   tasks:
     - name: Run unresolved-backend-connection failure test
@@ -672,6 +693,11 @@
 - name: Test storage_provider -- VAST backend connection missing required fields (should fail)
   hosts: localhost
   gather_facts: false
+
+  pre_tasks:
+    - name: Clear any structured failure artifact from earlier scenarios
+      ansible.builtin.set_fact:
+        osac_storage_provider_failures: []
 
   tasks:
     - name: Run incomplete-backend-connection failure test
@@ -730,6 +756,11 @@
 - name: Test storage_provider -- two tiers simultaneously fail protocol validation (should fail)
   hosts: localhost
   gather_facts: false
+
+  pre_tasks:
+    - name: Clear any structured failure artifact from earlier scenarios
+      ansible.builtin.set_fact:
+        osac_storage_provider_failures: []
 
   tasks:
     - name: Run simultaneous-protocol-failure test
@@ -790,6 +821,11 @@
   hosts: localhost
   gather_facts: false
 
+  pre_tasks:
+    - name: Clear any structured failure artifact from earlier scenarios
+      ansible.builtin.set_fact:
+        osac_storage_provider_failures: []
+
   tasks:
     - name: Run missing-backend_id failure test
       block:
@@ -842,6 +878,11 @@
 - name: Test storage_provider -- invalid protocol via ensure_storage_class (should fail)
   hosts: localhost
   gather_facts: false
+
+  pre_tasks:
+    - name: Clear any structured failure artifact from earlier scenarios
+      ansible.builtin.set_fact:
+        osac_storage_provider_failures: []
 
   tasks:
     - name: Run invalid-protocol-via-ensure_storage_class failure test

--- a/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
@@ -167,9 +167,7 @@
           ansible.builtin.assert:
             that:
               - >-
-                'unsupported protocol' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' ') | lower)
-                or 'Invalid protocol' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
-                or 'One or more items failed' in (ansible_failed_result.msg | default(''))
+                'unsupported protocol' in (ansible_failed_result.msg | default('') | lower)
             fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
             success_msg: "Role correctly rejected invalid protocol"
 
@@ -215,15 +213,15 @@
             msg: "Role did not fail as expected when provider is invalid"
 
       rescue:
+        # ansible_failed_result is NOT refreshed for this kind of failure: a genuinely-missing
+        # role name is a runner-level ERROR! raised during dynamic role resolution, not a normal
+        # task failure, so it never repopulates the rescue block's ansible_failed_result -- it
+        # would still hold whatever an earlier, unrelated task last set it to. There is nothing
+        # reliable to assert about the failure's content from inside the playbook; reaching this
+        # rescue at all already proves the role failed to load for the invalid provider name.
         - name: Verify role failed for invalid provider
-          ansible.builtin.assert:
-            that:
-              - >-
-                'osac.templates.netapp_storage' in (ansible_failed_result.msg | default(''))
-                or 'was not found' in (ansible_failed_result.msg | default(''))
-                or 'One or more items failed' in (ansible_failed_result.msg | default(''))
-            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
-            success_msg: "Role correctly rejected invalid provider"
+          ansible.builtin.debug:
+            msg: "Role correctly rejected invalid provider (rescue reached after role-resolution failure)"
 
 # ──────────────────────────────────────────────────────────────
 # Test 6: Invalid action -- error path
@@ -791,8 +789,7 @@
           ansible.builtin.assert:
             that:
               - >-
-                'unsupported protocol' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' ') | lower)
-                or 'One or more items failed' in (ansible_failed_result.msg | default(''))
+                'unsupported protocol' in (ansible_failed_result.msg | default('') | lower)
             fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
             success_msg: "Role correctly rejected both tiers with unsupported protocols"
 
@@ -850,8 +847,7 @@
           ansible.builtin.assert:
             that:
               - >-
-                'has no backend_id' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
-                or 'One or more items failed' in (ansible_failed_result.msg | default(''))
+                'has no backend_id' in (ansible_failed_result.msg | default(''))
             fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
             success_msg: "Role correctly rejected a tier with no backend_id"
 
@@ -908,8 +904,7 @@
           ansible.builtin.assert:
             that:
               - >-
-                'unsupported protocol' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' ') | lower)
-                or 'One or more items failed' in (ansible_failed_result.msg | default(''))
+                'unsupported protocol' in (ansible_failed_result.msg | default('') | lower)
             fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
             success_msg: "Role correctly rejected invalid protocol via ensure_storage_class"
 

--- a/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
@@ -1,7 +1,14 @@
 ---
 # Unit tests for osac.service.storage_provider dispatcher validation logic.
-# All 12 scenarios run in a single invocation -- no flags needed.
 # Tests verify validation ONLY; they do not dispatch to actual provider roles.
+#
+# A single invocation halts after "Test storage_provider -- invalid provider (should fail)":
+# ansible-core raises a runner-level ERROR! when include_role targets a genuinely-missing role
+# name, which aborts the ansible-playbook process even though that scenario's own rescue block
+# already passed. Run in two invocations to exercise every scenario:
+#   ansible-playbook collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
+#   ansible-playbook --start-at-task "Attempt with invalid action 'destroy' (expected to fail)" \
+#     collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
 
 # ──────────────────────────────────────────────────────────────
 # Test 1: Valid single tier passes all validation
@@ -50,8 +57,6 @@
                 'not a valid DNS label' not in (ansible_failed_result.msg | default(''))
               - >-
                 'duplicate tier names' not in (ansible_failed_result.msg | default(''))
-              - >-
-                'exceeds the maximum' not in (ansible_failed_result.msg | default(''))
             fail_msg: >-
               Validation failed unexpectedly: {{ ansible_failed_result.msg | default('unknown error') }}
             success_msg: "Validation passed -- dispatch failed as expected in unit test context"
@@ -162,6 +167,20 @@
                 or 'One or more items failed' in (ansible_failed_result.msg | default(''))
             fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
             success_msg: "Role correctly rejected invalid protocol"
+
+        - name: Verify structured failure artifact was emitted for unsupported protocol
+          ansible.builtin.assert:
+            that:
+              - osac_storage_provider_failures is defined
+              - osac_storage_provider_failures | length > 0
+              - osac_storage_provider_failures[0].reason == 'unsupported_protocol'
+              - "'default' in osac_storage_provider_failures[0].tiers"
+              - "'unsupported protocol' in (osac_storage_provider_failures[0].message | lower)"
+              - osac_storage_provider_failures[0].backend_ids == []
+            fail_msg: >-
+              osac_storage_provider_failures was not set as expected:
+              {{ osac_storage_provider_failures | default('undefined') }}
+            success_msg: "Structured failure artifact correctly recorded the unsupported protocol"
 
 # ──────────────────────────────────────────────────────────────
 # Test 5: Invalid provider -- error path
@@ -313,50 +332,6 @@
             success_msg: "Role correctly rejected invalid input"
 
 # ──────────────────────────────────────────────────────────────
-# Test 10: Tier count exceeds maximum -- error path
-# Expected: role fails with exceeds-maximum message
-# ──────────────────────────────────────────────────────────────
-- name: Test storage_provider -- tier count exceeds max (should fail)
-  hosts: localhost
-  gather_facts: false
-
-  tasks:
-    - name: Run tier-count-exceeds-max failure test
-      block:
-        - name: Attempt with 3 tiers but max_tiers set to 2 (expected to fail)
-          ansible.builtin.include_role:
-            name: osac.service.storage_provider
-          vars:
-            storage_provider_tiers:
-              - name: tier-a
-                protocol: nfs
-                provider: vast
-              - name: tier-b
-                protocol: nfs
-                provider: vast
-              - name: tier-c
-                protocol: block
-                provider: vast
-            storage_provider_max_tiers: 2
-            storage_provider_action: setup
-            tenant_name: "tenant-acme"
-            tenant_namespace: "osac-tenants"
-
-        - name: This task should not be reached -- role should have failed
-          ansible.builtin.fail:
-            msg: "Role did not fail as expected when tier count exceeds maximum"
-
-      rescue:
-        - name: Verify role failed with expected exceeds-maximum message
-          ansible.builtin.assert:
-            that:
-              - "'exceeds the maximum' in ansible_failed_result.msg"
-              - "'3' in ansible_failed_result.msg"
-              - "'2' in ansible_failed_result.msg"
-            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
-            success_msg: "Role correctly rejected invalid input"
-
-# ──────────────────────────────────────────────────────────────
 # Test 11: Missing tenant_name -- error path
 # Expected: role fails with tenant_name required message
 # ──────────────────────────────────────────────────────────────
@@ -425,3 +400,534 @@
               - "'non-empty string' in ansible_failed_result.msg"
             fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
             success_msg: "Role correctly rejected invalid input"
+
+# ──────────────────────────────────────────────────────────────
+# Test 13: Tier with no qos_policy gets a derived one that exceeds DNS label length -- error path
+# Expected: role fails with the qos_policy DNS label validation message, proving the
+# "Default qos_policy for tiers that do not specify one" step actually ran and that its
+# output feeds the existing qos_policy validation (OSAC-1992: tiers from
+# ansible_eda.event.storage_tier_definitions never carry qos_policy -- the role derives it).
+# ──────────────────────────────────────────────────────────────
+- name: Test storage_provider -- derived qos_policy exceeds DNS label length (should fail)
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run derived-qos_policy-too-long failure test
+      block:
+        - name: Attempt with a 60-char tier name (no explicit qos_policy) whose derived name-qos exceeds 63 chars
+          ansible.builtin.include_role:
+            name: osac.service.storage_provider
+          vars:
+            storage_provider_tiers:
+              - name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                protocol: nfs
+                provider: vast
+                qos_limits:
+                  static_limits:
+                    max_reads_bw_mbps: 100
+                    max_writes_bw_mbps: 100
+            storage_provider_action: setup
+            tenant_name: "tenant-acme"
+            tenant_namespace: "osac-tenants"
+
+        - name: This task should not be reached -- role should have failed
+          ansible.builtin.fail:
+            msg: "Role did not fail as expected when the derived qos_policy exceeds the DNS label length limit"
+
+      rescue:
+        - name: Verify role failed with expected qos_policy DNS label message
+          ansible.builtin.assert:
+            that:
+              - >-
+                'invalid qos_policy' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
+                and '-qos' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
+                or 'One or more items failed' in (ansible_failed_result.msg | default(''))
+            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
+            success_msg: "Role correctly derived and rejected an over-length qos_policy"
+
+# ──────────────────────────────────────────────────────────────
+# Test 14: Explicit qos_policy is ignored; derivation always overwrites it -- error path
+# Expected: role fails on the DERIVED qos_policy's DNS-label length, not the caller's short,
+# well-formed supplied value -- proving the caller's value was discarded entirely and
+# derivation ran unconditionally (OSAC-1992 follow-up: closes the gap where an unvalidated
+# override could produce inconsistent naming across callers, or let a caller's qos_policy
+# silently pass through unused). Uses the same 60-char tier name construction as Test 13 --
+# if a bug ever used the caller's value instead of deriving, this test would pass with no
+# DNS-label failure at all, since "short" alone is well within the length limit.
+# ──────────────────────────────────────────────────────────────
+- name: Test storage_provider -- explicit qos_policy is ignored, derivation still runs (should fail)
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run explicit-qos_policy-ignored test
+      block:
+        - name: Attempt with a 60-char tier name, qos_limits, and a short explicit qos_policy
+          ansible.builtin.include_role:
+            name: osac.service.storage_provider
+          vars:
+            storage_provider_tiers:
+              - name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                protocol: nfs
+                provider: vast
+                qos_policy: "short"
+                qos_limits:
+                  static_limits:
+                    max_reads_bw_mbps: 100
+                    max_writes_bw_mbps: 100
+            storage_provider_action: setup
+            tenant_name: "tenant-acme"
+            tenant_namespace: "osac-tenants"
+
+        - name: This task should not be reached -- role should have failed
+          ansible.builtin.fail:
+            msg: "Role did not fail as expected -- the caller's explicit qos_policy may have been used instead of derived"
+
+      rescue:
+        - name: Verify role failed on the derived qos_policy, not the caller's supplied value
+          ansible.builtin.assert:
+            that:
+              - >-
+                'invalid qos_policy' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
+                and '-qos' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
+                and 'short' not in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
+                or 'One or more items failed' in (ansible_failed_result.msg | default(''))
+            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
+            success_msg: "Role correctly ignored the caller's qos_policy and derived its own, which then failed DNS-label validation as expected"
+
+# ──────────────────────────────────────────────────────────────
+# Test 15: Tier without configured qos_limits opts out of qos_policy entirely, even if
+# the caller supplied one -- ignored, not validated
+# Expected: role does NOT fail on qos_policy validation, proving no qos_policy survives for a
+# tier with no read/write bandwidth limits configured -- even a deliberately invalid
+# caller-supplied qos_policy is stripped without ever being format-checked. Uses a 60-char
+# tier name that WOULD fail DNS-label validation if a qos_policy were derived (same
+# construction as Test 13/14) -- if this test ever starts failing with an "invalid qos_policy"
+# message, the opt-out has regressed.
+# ──────────────────────────────────────────────────────────────
+- name: Test storage_provider -- tier without qos_limits discards qos_policy entirely, even if supplied
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run qos-limits-opt-out test
+      block:
+        - name: Attempt with a 60-char tier name, no qos_limits, and an invalid explicit qos_policy (expected to fail at dispatch, not qos_policy validation)
+          ansible.builtin.include_role:
+            name: osac.service.storage_provider
+          vars:
+            storage_provider_tiers:
+              - name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                protocol: nfs
+                provider: vast
+                qos_policy: "Invalid Policy!"
+            storage_provider_action: setup
+            tenant_name: "tenant-acme"
+            tenant_namespace: "osac-tenants"
+
+        - name: Validation passed (dispatch outcome is not under test)
+          ansible.builtin.debug:
+            msg: "Validation passed -- dispatch was attempted"
+
+      rescue:
+        - name: Verify failure is from dispatch, not qos_policy validation
+          ansible.builtin.assert:
+            that:
+              - >-
+                'invalid qos_policy' not in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
+                and 'invalid qos_policy' not in (ansible_failed_result.msg | default(''))
+            fail_msg: >-
+              Expected no qos_policy validation failure for a tier with no qos_limits, even
+              though the caller supplied a deliberately invalid qos_policy.
+              Got: {{ ansible_failed_result.msg | default('unknown error') }}
+            success_msg: "Tier without qos_limits correctly discarded the caller's qos_policy without validating it"
+
+# ──────────────────────────────────────────────────────────────
+# Test 16: VAST tiers dispatched together reference different backend_ids -- error path
+# Expected: role fails because VAST credential resolution supports exactly one backend_id
+# per role invocation (OSAC-1992 Task 6), and emits a structured osac_storage_provider_failures
+# artifact identifying both tiers and both backend_ids involved.
+# ──────────────────────────────────────────────────────────────
+- name: Test storage_provider -- VAST tiers reference multiple backend_ids (should fail)
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run ambiguous-backend-association failure test
+      block:
+        - name: Attempt with two VAST tiers pointing at different backend_ids (expected to fail)
+          ansible.builtin.include_role:
+            name: osac.service.storage_provider
+          vars:
+            storage_provider_tiers:
+              - name: gold
+                protocol: nfs
+                provider: vast
+                backend_id: be-001
+              - name: silver
+                protocol: nfs
+                provider: vast
+                backend_id: be-002
+            storage_provider_backend_connections:
+              be-001:
+                endpoint: vast-1.example.com
+                username: admin
+                password: secret
+              be-002:
+                endpoint: vast-2.example.com
+                username: admin
+                password: secret
+            storage_provider_action: setup
+            tenant_name: "tenant-acme"
+            tenant_namespace: "osac-tenants"
+
+        - name: This task should not be reached -- role should have failed
+          ansible.builtin.fail:
+            msg: "Role did not fail as expected when VAST tiers reference multiple backend_ids"
+
+      rescue:
+        - name: Verify role failed for ambiguous backend association
+          ansible.builtin.assert:
+            that:
+              - "'Expected exactly one backend_id' in (ansible_failed_result.msg | default(''))"
+            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
+            success_msg: "Role correctly rejected tiers referencing multiple backend_ids"
+
+        - name: Verify structured failure artifact was emitted for ambiguous backend association
+          ansible.builtin.assert:
+            that:
+              - osac_storage_provider_failures is defined
+              - osac_storage_provider_failures | length > 0
+              - osac_storage_provider_failures[0].reason == 'ambiguous_backend_association'
+              - "'gold' in osac_storage_provider_failures[0].tiers"
+              - "'silver' in osac_storage_provider_failures[0].tiers"
+              - "'be-001' in osac_storage_provider_failures[0].backend_ids"
+              - "'be-002' in osac_storage_provider_failures[0].backend_ids"
+              - "'expected exactly one backend_id' in (osac_storage_provider_failures[0].message | lower)"
+            fail_msg: >-
+              osac_storage_provider_failures was not set as expected:
+              {{ osac_storage_provider_failures | default('undefined') }}
+            success_msg: "Structured failure artifact correctly recorded both tiers and backend_ids"
+
+# ──────────────────────────────────────────────────────────────
+# Test 17: VAST tier's backend_id has no entry in storage_backend_connections -- error path
+# Expected: role fails because osac-operator did not resolve connection details for the
+# referenced backend_id (e.g. the StorageBackend was deleted while still referenced by a
+# StorageTier), and emits a structured osac_storage_provider_failures artifact.
+# ──────────────────────────────────────────────────────────────
+- name: Test storage_provider -- VAST tier's backend_id has no connection entry (should fail)
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run unresolved-backend-connection failure test
+      block:
+        - name: Attempt with a VAST tier whose backend_id is absent from storage_backend_connections (expected to fail)
+          ansible.builtin.include_role:
+            name: osac.service.storage_provider
+          vars:
+            storage_provider_tiers:
+              - name: default
+                protocol: nfs
+                provider: vast
+                backend_id: be-999
+            storage_provider_backend_connections: {}
+            storage_provider_action: setup
+            tenant_name: "tenant-acme"
+            tenant_namespace: "osac-tenants"
+
+        - name: This task should not be reached -- role should have failed
+          ansible.builtin.fail:
+            msg: "Role did not fail as expected when the tier's backend_id has no connection entry"
+
+      rescue:
+        - name: Verify role failed for unresolved backend connection
+          ansible.builtin.assert:
+            that:
+              - "\"No entry for backend_id 'be-999'\" in (ansible_failed_result.msg | default(''))"
+            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
+            success_msg: "Role correctly rejected a tier whose backend_id has no connection entry"
+
+        - name: Verify structured failure artifact was emitted for unresolved backend connection
+          ansible.builtin.assert:
+            that:
+              - osac_storage_provider_failures is defined
+              - osac_storage_provider_failures | length > 0
+              - osac_storage_provider_failures[0].reason == 'unresolved_backend_connection'
+              - "'default' in osac_storage_provider_failures[0].tiers"
+              - "'be-999' in osac_storage_provider_failures[0].backend_ids"
+              - "\"No entry for backend_id 'be-999'\" in osac_storage_provider_failures[0].message"
+            fail_msg: >-
+              osac_storage_provider_failures was not set as expected:
+              {{ osac_storage_provider_failures | default('undefined') }}
+            success_msg: "Structured failure artifact correctly recorded the unresolved backend_id"
+
+# ──────────────────────────────────────────────────────────────
+# Test 18: Resolved VAST backend connection is missing a required credential field -- error path
+# Expected: role fails because the connection entry resolved for the tier's backend_id is
+# incomplete (e.g. a StorageBackend updated to blank out a credential), and emits a
+# structured osac_storage_provider_failures artifact.
+# ──────────────────────────────────────────────────────────────
+- name: Test storage_provider -- VAST backend connection missing required fields (should fail)
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run incomplete-backend-connection failure test
+      block:
+        - name: Attempt with a resolved backend connection missing a password (expected to fail)
+          ansible.builtin.include_role:
+            name: osac.service.storage_provider
+          vars:
+            storage_provider_tiers:
+              - name: default
+                protocol: nfs
+                provider: vast
+                backend_id: be-001
+            storage_provider_backend_connections:
+              be-001:
+                endpoint: vast.example.com
+                username: admin
+                password: ""
+            storage_provider_action: setup
+            tenant_name: "tenant-acme"
+            tenant_namespace: "osac-tenants"
+
+        - name: This task should not be reached -- role should have failed
+          ansible.builtin.fail:
+            msg: "Role did not fail as expected when the resolved backend connection is missing a password"
+
+      rescue:
+        - name: Verify role failed for incomplete backend connection
+          ansible.builtin.assert:
+            that:
+              - "'is missing one or more of' in (ansible_failed_result.msg | default(''))"
+            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
+            success_msg: "Role correctly rejected an incomplete backend connection"
+
+        - name: Verify structured failure artifact was emitted for incomplete backend connection
+          ansible.builtin.assert:
+            that:
+              - osac_storage_provider_failures is defined
+              - osac_storage_provider_failures | length > 0
+              - osac_storage_provider_failures[0].reason == 'incomplete_backend_connection'
+              - "'default' in osac_storage_provider_failures[0].tiers"
+              - "'be-001' in osac_storage_provider_failures[0].backend_ids"
+              - "'is missing one or more of' in osac_storage_provider_failures[0].message"
+            fail_msg: >-
+              osac_storage_provider_failures was not set as expected:
+              {{ osac_storage_provider_failures | default('undefined') }}
+            success_msg: "Structured failure artifact correctly recorded the incomplete backend connection"
+
+# ──────────────────────────────────────────────────────────────
+# Test 19: Two tiers sharing a backend_id both have unsupported protocols -- error path
+# Expected: role fails on the loop task for both tiers simultaneously (Ansible loops evaluate
+# every item rather than stopping at the first failure), and the structured
+# osac_storage_provider_failures artifact records both tier names while deduping their shared
+# backend_id to a single entry.
+# ──────────────────────────────────────────────────────────────
+- name: Test storage_provider -- two tiers simultaneously fail protocol validation (should fail)
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run simultaneous-protocol-failure test
+      block:
+        - name: Attempt with two tiers sharing a backend_id, both using an unsupported protocol (expected to fail)
+          ansible.builtin.include_role:
+            name: osac.service.storage_provider
+          vars:
+            storage_provider_tiers:
+              - name: gold
+                protocol: ftp
+                provider: vast
+                backend_id: be-001
+              - name: silver
+                protocol: ftp
+                provider: vast
+                backend_id: be-001
+            storage_provider_action: setup
+            tenant_name: "tenant-acme"
+            tenant_namespace: "osac-tenants"
+
+        - name: This task should not be reached -- role should have failed
+          ansible.builtin.fail:
+            msg: "Role did not fail as expected when two tiers both use an unsupported protocol"
+
+      rescue:
+        - name: Verify role failed for both tiers with unsupported protocols
+          ansible.builtin.assert:
+            that:
+              - >-
+                'unsupported protocol' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' ') | lower)
+                or 'One or more items failed' in (ansible_failed_result.msg | default(''))
+            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
+            success_msg: "Role correctly rejected both tiers with unsupported protocols"
+
+        - name: Verify structured failure artifact records both simultaneously-failing tiers
+          ansible.builtin.assert:
+            that:
+              - osac_storage_provider_failures is defined
+              - osac_storage_provider_failures | length > 0
+              - osac_storage_provider_failures[0].reason == 'unsupported_protocol'
+              - "'gold' in osac_storage_provider_failures[0].tiers"
+              - "'silver' in osac_storage_provider_failures[0].tiers"
+              - osac_storage_provider_failures[0].tiers | length == 2
+              - osac_storage_provider_failures[0].backend_ids == ['be-001']
+            fail_msg: >-
+              osac_storage_provider_failures did not correctly record both simultaneously-failing tiers:
+              {{ osac_storage_provider_failures | default('undefined') }}
+            success_msg: "Structured failure artifact correctly recorded both tiers and deduped the shared backend_id"
+
+# ──────────────────────────────────────────────────────────────
+# Test 20: VAST tier dispatched without a backend_id -- error path
+# Expected: role fails because VAST credential resolution requires every dispatched tier to
+# reference a backend_id, and emits a structured osac_storage_provider_failures artifact
+# consistent with its sibling backend-connection checks (OSAC-1992 follow-up).
+# ──────────────────────────────────────────────────────────────
+- name: Test storage_provider -- VAST tier missing backend_id (should fail)
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run missing-backend_id failure test
+      block:
+        - name: Attempt with a VAST tier that has no backend_id (expected to fail)
+          ansible.builtin.include_role:
+            name: osac.service.storage_provider
+          vars:
+            storage_provider_tiers:
+              - name: default
+                protocol: nfs
+                provider: vast
+            storage_provider_action: setup
+            tenant_name: "tenant-acme"
+            tenant_namespace: "osac-tenants"
+
+        - name: This task should not be reached -- role should have failed
+          ansible.builtin.fail:
+            msg: "Role did not fail as expected when the tier has no backend_id"
+
+      rescue:
+        - name: Verify role failed for missing backend_id
+          ansible.builtin.assert:
+            that:
+              - >-
+                'has no backend_id' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
+                or 'One or more items failed' in (ansible_failed_result.msg | default(''))
+            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
+            success_msg: "Role correctly rejected a tier with no backend_id"
+
+        - name: Verify structured failure artifact was emitted for missing backend_id
+          ansible.builtin.assert:
+            that:
+              - osac_storage_provider_failures is defined
+              - osac_storage_provider_failures | length > 0
+              - osac_storage_provider_failures[0].reason == 'missing_backend_id'
+              - "'default' in osac_storage_provider_failures[0].tiers"
+              - "'has no backend_id' in (osac_storage_provider_failures[0].message | lower)"
+            fail_msg: >-
+              osac_storage_provider_failures was not set as expected:
+              {{ osac_storage_provider_failures | default('undefined') }}
+            success_msg: "Structured failure artifact correctly recorded the missing backend_id"
+
+# ──────────────────────────────────────────────────────────────
+# Test 21: Invalid protocol dispatched via ensure_storage_class -- error path
+# Expected: role fails with the same structured unsupported_protocol artifact as Test 4,
+# proving the closed-set protocol check (factored into _validate_tier_protocols.yaml) is
+# also enforced on the ensure_storage_class action -- the dominant action for cluster-storage
+# reconcile, which previously had no protocol validation of its own at all.
+# ──────────────────────────────────────────────────────────────
+- name: Test storage_provider -- invalid protocol via ensure_storage_class (should fail)
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run invalid-protocol-via-ensure_storage_class failure test
+      block:
+        - name: Attempt with invalid protocol 'ftp' via the ensure_storage_class action (expected to fail)
+          ansible.builtin.include_role:
+            name: osac.service.storage_provider
+          vars:
+            storage_provider_tiers:
+              - name: default
+                protocol: ftp
+                provider: vast
+            storage_provider_action: ensure_storage_class
+            tenant_name: "tenant-acme"
+            tenant_namespace: "osac-tenants"
+
+        - name: This task should not be reached -- role should have failed
+          ansible.builtin.fail:
+            msg: "Role did not fail as expected when protocol is invalid via ensure_storage_class"
+
+      rescue:
+        - name: Verify role failed for invalid protocol via ensure_storage_class
+          ansible.builtin.assert:
+            that:
+              - >-
+                'unsupported protocol' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' ') | lower)
+                or 'One or more items failed' in (ansible_failed_result.msg | default(''))
+            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
+            success_msg: "Role correctly rejected invalid protocol via ensure_storage_class"
+
+        - name: Verify structured failure artifact was emitted for unsupported protocol via ensure_storage_class
+          ansible.builtin.assert:
+            that:
+              - osac_storage_provider_failures is defined
+              - osac_storage_provider_failures | length > 0
+              - osac_storage_provider_failures[0].reason == 'unsupported_protocol'
+              - "'default' in osac_storage_provider_failures[0].tiers"
+              - "'unsupported protocol' in (osac_storage_provider_failures[0].message | lower)"
+            fail_msg: >-
+              osac_storage_provider_failures was not set as expected:
+              {{ osac_storage_provider_failures | default('undefined') }}
+            success_msg: "Structured failure artifact correctly recorded the unsupported protocol via ensure_storage_class"
+
+# ──────────────────────────────────────────────────────────────
+# Test 22: Empty-string protocol (the real UNSPECIFIED shape from osac-operator) -- error path
+# Expected: role fails at the dispatcher-level required-fields check (main.yaml), NOT at the
+# unsupported_protocol structured-failure check -- proving the one bad-protocol value that can
+# actually reach AAP in production today (fulfillment-service silently accepts
+# STORAGE_PROTOCOL_UNSPECIFIED at Create and Update; osac-operator maps it to protocol: "" and
+# passes it through unconditionally) is caught cleanly before dispatch ever reaches
+# action-specific protocol validation. Dispatched via ensure_storage_class -- the action Test 21
+# proves now enforces the closed-set check -- to confirm the empty-string case is intercepted
+# even earlier than that, at the dispatcher level.
+# ──────────────────────────────────────────────────────────────
+- name: Test storage_provider -- empty-string protocol from UNSPECIFIED (should fail)
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run empty-protocol failure test
+      block:
+        - name: Attempt with an otherwise-valid tier whose protocol is an empty string (expected to fail)
+          ansible.builtin.include_role:
+            name: osac.service.storage_provider
+          vars:
+            storage_provider_tiers:
+              - name: default
+                protocol: ""
+                provider: vast
+                backend_id: be-001
+                quota_bytes: 536870912000
+            storage_provider_action: ensure_storage_class
+            tenant_name: "tenant-acme"
+            tenant_namespace: "osac-tenants"
+
+        - name: This task should not be reached -- role should have failed
+          ansible.builtin.fail:
+            msg: "Role did not fail as expected when protocol is an empty string"
+
+      rescue:
+        - name: Verify role failed at the dispatcher-level required-fields check, not the unsupported_protocol check
+          ansible.builtin.assert:
+            that:
+              - >-
+                'must have' in (ansible_failed_result.msg | default(''))
+                or 'One or more items failed' in (ansible_failed_result.msg | default(''))
+              - "'unsupported protocol' not in (ansible_failed_result.msg | default('') | lower)"
+            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
+            success_msg: "Role correctly rejected the empty-string protocol at the dispatcher level, not the unsupported_protocol check"

--- a/osac-aap/collections/ansible_collections/osac/templates/README.md
+++ b/osac-aap/collections/ansible_collections/osac/templates/README.md
@@ -227,6 +227,7 @@ Currently, all CaaS targets return an explicit "not yet implemented" error.
 
 **Configuration:** Storage tiers arrive via the `ansible_eda.event.storage_tier_definitions`
 extra_var, populated by osac-operator from the Tier API:
+
 ```json
 [
   {"name": "default", "protocol": "nfs", "provider": "vast", "backend_id": "be-001",
@@ -235,6 +236,7 @@ extra_var, populated by osac-operator from the Tier API:
    "qos_limits": {"static_limits": {"max_reads_bw_mbps": 500, "max_writes_bw_mbps": 500}}, "quota_bytes": 500}
 ]
 ```
+
 Backend connection details (endpoint, username, password) are resolved separately and
 passed via the `storage_provider_backend_connections` extra_var, keyed by `backend_id`.
 

--- a/osac-aap/collections/ansible_collections/osac/templates/README.md
+++ b/osac-aap/collections/ansible_collections/osac/templates/README.md
@@ -167,8 +167,9 @@ See roles/ocp_virt_vm for more examples
 
 ### Creating a New Storage Provider Role
 
-Storage provider roles use a tier-based dispatch model: deployments define storage tiers
-via `STORAGE_TIERS` JSON, each tier declares its provider, and the service-layer dispatcher
+Storage provider roles use a tier-based dispatch model: osac-operator resolves storage tiers
+from the Tier API and passes them via the `ansible_eda.event.storage_tier_definitions`
+extra_var, each tier declares its provider, and the service-layer dispatcher
 (`osac.service.storage_provider`) groups tiers by provider and dispatches to each provider's
 template role with the filtered tier subset.
 
@@ -209,7 +210,9 @@ template role with the filtered tier subset.
 5. **Credential isolation:** Admin credentials (e.g., VAST VMS admin) must NEVER
    appear in tenant-namespace K8s Secrets. Provider roles must create per-tenant
    data-plane credentials and use only those in CSI Secrets. Admin credentials
-   remain in the AAP-namespace IG Secret, injected via env vars.
+   arrive via the `storage_provider_backend_connections` extra_var (resolved by
+   osac-operator from the Tier API and keyed by `backend_id`) — there is no
+   env-var or K8s Secret fallback for admin credentials.
 
 6. **Provisioning targets:** Each provider handles both VMaaS and CaaS provisioning
    targets via the `_provisioning_target` parameter. Currently supported: `vmaas`.
@@ -222,16 +225,18 @@ When implemented, `hcp_data_plane` will support provisioning multiple StorageCla
 into the guest HCP cluster (e.g., separate tiers for databases and general workloads).
 Currently, all CaaS targets return an explicit "not yet implemented" error.
 
-**Configuration:** Storage tiers are configured via the `STORAGE_TIERS` env var in the
-`storage-operations-ig` ConfigMap:
+**Configuration:** Storage tiers arrive via the `ansible_eda.event.storage_tier_definitions`
+extra_var, populated by osac-operator from the Tier API:
 ```json
 [
-  {"name": "default", "protocol": "nfs", "provider": "vast", "qos_policy": "default-qos",
+  {"name": "default", "protocol": "nfs", "provider": "vast", "backend_id": "be-001",
    "qos_limits": {"static_limits": {"max_reads_bw_mbps": 100, "max_writes_bw_mbps": 100}}},
-  {"name": "high-performance", "protocol": "block", "provider": "vast", "qos_policy": "perf-qos",
-   "qos_limits": {"static_limits": {"max_reads_bw_mbps": 500, "max_writes_bw_mbps": 500}}}
+  {"name": "high-performance", "protocol": "block", "provider": "vast", "backend_id": "be-001",
+   "qos_limits": {"static_limits": {"max_reads_bw_mbps": 500, "max_writes_bw_mbps": 500}}, "quota_bytes": 500}
 ]
 ```
+Backend connection details (endpoint, username, password) are resolved separately and
+passed via the `storage_provider_backend_connections` extra_var, keyed by `backend_id`.
 
 **Tier fields:**
 
@@ -240,14 +245,16 @@ Currently, all CaaS targets return an explicit "not yet implemented" error.
 | `name` | yes | DNS-label tier name (used in StorageClass naming) |
 | `protocol` | yes | `nfs` or `block` |
 | `provider` | yes | Provider name (e.g., `vast`) |
-| `qos_policy` | no | QoS policy name (creates STATIC mode policy on VMS) |
-| `qos_limits` | no | Dict merged into QoS POST body (e.g., `static_limits`, `static_total_limits`) |
-| `quota` | no | Hard quota in bytes for the tier's view |
+| `backend_id` | provider-dependent | Key into `storage_provider_backend_connections` for this tier's backend credentials (required by providers that resolve credentials this way, e.g. VAST) |
+| `qos_policy` | n/a — derived, ignored if set by the caller | QoS policy name (creates STATIC mode policy on VMS), always derived from the tier name (`<name>-qos`). Any caller-supplied value is discarded, never used |
+| `qos_limits` | no | Dict merged into QoS POST body (e.g., `static_limits`, `static_total_limits`). A tier opts out of `qos_policy` derivation unless `qos_limits.static_limits` sets a positive `max_reads_bw_mbps` or `max_writes_bw_mbps` |
+| `quota_bytes` | no | Hard quota in bytes for the tier's view |
 
-**QoS limits:** When `qos_policy` is specified, the role creates a QoS policy via REST API
-(`POST /api/qospolicies/`). The `qos_limits` dict is merged directly into the POST body, so
-its keys must match VMS API fields. Real VMS rejects STATIC mode without at least one limit —
-always include `qos_limits.static_limits` when specifying `qos_policy`.
+**QoS limits:** When a tier has a derived `qos_policy` (see above), the role creates a QoS
+policy via REST API (`POST /api/qospolicies/`). The `qos_limits` dict is merged directly into
+the POST body, so its keys must match VMS API fields. Real VMS rejects STATIC mode without at
+least one limit — always include `qos_limits.static_limits` for a tier that should get QoS
+enforcement.
 
 **Dispatcher pattern:** `osac.service.storage_provider` validates inputs (tier list,
 provider allowlist, protocol allowlist, provisioning target enum, max tier count) then

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/defaults/main.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/defaults/main.yaml
@@ -11,9 +11,16 @@ vast_storage_csi_provisioner_map:
 # K8s Secret on hub cluster that stores per-tenant VAST config
 vast_storage_tenant_config_secret_prefix: "vast-tenant-config-"
 
-# Namespace for hub-cluster config secrets — set via OSAC_STORAGE_CONFIG_NAMESPACE env var
-# in the storage-operations-ig pod spec (downward API metadata.namespace).
-vast_storage_config_namespace: "{{ lookup('env', 'OSAC_STORAGE_CONFIG_NAMESPACE') | default('osac-system', true) }}"
+# Namespace for hub-cluster config secrets. Resolution order:
+#   1. OSAC_STORAGE_CONFIG_NAMESPACE env var — explicit override via the storage-operations-ig
+#      ConfigMap, only needed if the config namespace differs from the IG pod's own namespace.
+#   2. The IG pod's own namespace, read from the standard K8s-mounted service account file —
+#      always accurate for wherever the pod actually runs, no per-deployment config needed.
+#   3. "osac-system" — last-resort fallback for local/test execution outside a pod.
+vast_storage_config_namespace: >-
+  {{ lookup('env', 'OSAC_STORAGE_CONFIG_NAMESPACE')
+     | default(lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/namespace', errors='ignore'), true)
+     | default('osac-system', true) }}
 
 # TLS certificate validation for VAST VMS API calls.
 vast_storage_validate_certs: "{{ lookup('env', 'VAST_VALIDATE_CERTS') | default('true', true) | bool }}"

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/_validate_tier_protocols.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/_validate_tier_protocols.yaml
@@ -1,0 +1,46 @@
+---
+# Shared protocol validation, included by both setup.yaml and ensure_storage_class.yaml
+# so the two action entry points can't drift out of sync on which protocols are allowed.
+# Requires: _provider_tiers (set by the caller).
+
+- name: Validate tier protocols are supported by VAST provider
+  block:
+    - name: Fail if tier protocol is unsupported
+      ansible.builtin.fail:
+        msg: >-
+          Tier '{{ item.name }}' has unsupported protocol '{{ item.protocol }}'.
+          VAST provider supports: nfs, block.
+      loop: "{{ _provider_tiers }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: item.protocol not in ['nfs', 'block']
+  rescue:
+    # Ansible loops evaluate every item rather than stopping at the first failure, so
+    # ansible_failed_result.results may contain more than one failed tier here.
+    - name: Build structured failure artifact for unsupported protocol
+      ansible.builtin.set_fact:
+        osac_storage_provider_failures: >-
+          {% set _tiers = [] -%}
+          {% set _backend_ids = [] -%}
+          {% set _messages = [] -%}
+          {% for _r in (ansible_failed_result.results | default([])) -%}
+          {% if _r.failed | default(false) -%}
+          {% set _ = _tiers.append(_r.item.name) -%}
+          {% set _bid = _r.item.backend_id | default('') -%}
+          {% if (_bid | length > 0) and (_bid not in _backend_ids) -%}
+          {% set _ = _backend_ids.append(_bid) -%}
+          {% endif -%}
+          {% set _ = _messages.append(_r.msg | default('')) -%}
+          {% endif -%}
+          {% endfor -%}
+          {{ [{'reason': 'unsupported_protocol', 'tiers': _tiers, 'backend_ids': _backend_ids, 'message': _messages | join(' ')}] }}
+
+    - name: Emit structured failure artifact for unsupported protocol
+      ansible.builtin.set_stats:
+        data:
+          osac_storage_provider_failures: "{{ osac_storage_provider_failures }}"
+        aggregate: false
+
+    - name: Re-raise the original protocol validation failure
+      ansible.builtin.fail:
+        msg: "{{ ansible_failed_result.msg }}"

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/_validate_tier_protocols.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/_validate_tier_protocols.yaml
@@ -43,4 +43,4 @@
 
     - name: Re-raise the original protocol validation failure
       ansible.builtin.fail:
-        msg: "{{ ansible_failed_result.msg }}"
+        msg: "{{ osac_storage_provider_failures[0].message }}"

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/create_quotas.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/create_quotas.yaml
@@ -1,6 +1,6 @@
 ---
 # Creates per-tier VAST quotas using the vendored vastdata.vms.quotas module.
-# Only creates quotas for tiers that define a quota field.
+# Only creates quotas for tiers that define a quota_bytes field.
 # Idempotent: the module handles create-or-update via state: present.
 #
 # Requires in scope:
@@ -10,16 +10,16 @@
 #   _vast_tenant_uid_hash   — first 8 hex chars of SHA256(tenant_uid)
 #   tenant_name             — play-level var
 
-- name: Create VAST quota per tier (when quota specified)
-  when: _provider_tiers | selectattr('quota', 'defined') | list | length > 0
+- name: Create VAST quota per tier (when quota_bytes specified)
+  when: _provider_tiers | selectattr('quota_bytes', 'defined') | list | length > 0
   vastdata.vms.quotas:
     vms: "{{ _vast_vms_conn }}"
     name: "quota-{{ tenant_name }}-{{ _vast_tenant_uid_hash }}-{{ item.name }}"
     path: "/osac-{{ tenant_name }}-{{ _vast_tenant_uid_hash }}/{{ item.name }}"
     tenant_id: "{{ _vast_tenant_id }}"
-    hard_limit: "{{ item.quota }}"
+    hard_limit: "{{ item.quota_bytes }}"
     state: present
-  loop: "{{ _provider_tiers | selectattr('quota', 'defined') | list }}"
+  loop: "{{ _provider_tiers | selectattr('quota_bytes', 'defined') | list }}"
   loop_control:
     label: "quota-{{ tenant_name }}-{{ _vast_tenant_uid_hash }}-{{ item.name }}"
   no_log: true

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
@@ -12,6 +12,9 @@
     fail_msg: >-
       _provider_tiers must be provided by the service role dispatcher.
 
+- name: Include shared tier protocol validation
+  ansible.builtin.include_tasks: _validate_tier_protocols.yaml
+
 - name: Compute unique protocols from tiers
   ansible.builtin.set_fact:
     _vast_required_protocols: "{{ _provider_tiers | map(attribute='protocol') | unique | sort | list }}"
@@ -103,7 +106,7 @@
     # These are created here (not just in setup) so JIT tiers get their backing
     # VMS resources. Uses admin creds for VMS API access.
 
-    - name: Resolve VAST admin credentials from env vars
+    - name: Resolve VAST admin credentials from storage_backend_connections
       ansible.builtin.include_tasks: read_credentials.yaml
 
     - name: Build VMS connection from admin credentials
@@ -307,17 +310,20 @@
         label: "vast-{{ item.protocol }}-{{ tenant_name }}-{{ item.name }}"
 
     - name: Check if VolumeSnapshot CRD is installed
-      when: storage_provider_snapshots_enabled | default(true)
       kubernetes.core.k8s_info:
         api_version: apiextensions.k8s.io/v1
         kind: CustomResourceDefinition
         name: volumesnapshotclasses.snapshot.storage.k8s.io
       register: _vast_vsc_crd_check
 
+    - name: Set snapshot support fact from live CRD check
+      ansible.builtin.set_fact:
+        _vast_snapshot_crd_available: "{{ _vast_vsc_crd_check.resources | default([]) | length > 0 }}"
+
     - name: Create VolumeSnapshotClass per tier
-      when: >-
-        (storage_provider_snapshots_enabled | default(true)) and
-        (_vast_vsc_crd_check.resources | default([]) | length > 0)
+      when:
+        - _vast_snapshot_crd_available | bool
+        - storage_provider_snapshots_enabled | default(true) | bool
       kubernetes.core.k8s:
         state: present
         definition:

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_credentials.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_credentials.yaml
@@ -43,7 +43,7 @@
 
     - name: Re-raise the original missing-backend_id failure
       ansible.builtin.fail:
-        msg: "{{ ansible_failed_result.msg }}"
+        msg: "{{ osac_storage_provider_failures[0].message }}"
 
 - name: Extract unique backend_id values from the dispatched tier subset
   ansible.builtin.set_fact:

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_credentials.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_credentials.yaml
@@ -1,57 +1,150 @@
 ---
-# Reads VAST admin credentials from environment variables ONLY.
-# Admin credentials are injected via AAP vault -> IG Secret -> pod env vars.
-# There is NO K8s Secret fallback — admin credentials must never be stored
-# in K8s Secrets accessible via the K8s API.
+# Reads VAST admin credentials from storage_backend_connections, resolved by osac-operator
+# from the Tier API and passed through extra_vars (OSAC-1992, absorbing OSAC-1957's AAP-side
+# AC). There is NO env-var or K8s Secret fallback — the prior env-var path (populated via AAP
+# vault -> storage-operations-ig Secret -> pod env vars) is retired outright, clean-slate.
+#
+# Today's credential resolution assumes a single VAST connection per role invocation — the
+# env-var path it replaces was implicitly the same (one global VAST connection for the whole
+# deployment), so this is enforced explicitly here rather than left as a silent assumption.
 
-- name: Read VAST credentials from environment variables
+- name: Fail if any dispatched tier is missing backend_id
+  block:
+    - name: Fail if tier is missing backend_id
+      ansible.builtin.fail:
+        msg: >-
+          Tier '{{ item.name }}' has no backend_id. Every tier dispatched to the VAST
+          provider must reference the backend_id its connection details are keyed by.
+      loop: "{{ _provider_tiers }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: item.backend_id is not defined or item.backend_id | length == 0
+  rescue:
+    # Ansible loops evaluate every item rather than stopping at the first failure, so
+    # ansible_failed_result.results may contain more than one failed tier here.
+    - name: Build structured failure artifact for missing backend_id
+      ansible.builtin.set_fact:
+        osac_storage_provider_failures: >-
+          {% set _tiers = [] -%}
+          {% set _messages = [] -%}
+          {% for _r in (ansible_failed_result.results | default([])) -%}
+          {% if _r.failed | default(false) -%}
+          {% set _ = _tiers.append(_r.item.name) -%}
+          {% set _ = _messages.append(_r.msg | default('')) -%}
+          {% endif -%}
+          {% endfor -%}
+          {{ [{'reason': 'missing_backend_id', 'tiers': _tiers, 'backend_ids': [], 'message': _messages | join(' ')}] }}
+
+    - name: Emit structured failure artifact for missing backend_id
+      ansible.builtin.set_stats:
+        data:
+          osac_storage_provider_failures: "{{ osac_storage_provider_failures }}"
+        aggregate: false
+
+    - name: Re-raise the original missing-backend_id failure
+      ansible.builtin.fail:
+        msg: "{{ ansible_failed_result.msg }}"
+
+- name: Extract unique backend_id values from the dispatched tier subset
   ansible.builtin.set_fact:
-    _vast_endpoint_env: "{{ lookup('env', 'VAST_ENDPOINT') }}"
-    _vast_username_env: "{{ lookup('env', 'VAST_USERNAME') }}"
-    _vast_password_env: "{{ lookup('env', 'VAST_PASSWORD') }}"
-  no_log: true
+    _vast_backend_ids: "{{ _provider_tiers | map(attribute='backend_id') | unique | list }}"
 
-- name: Check if all required env var credentials are available
+- name: Validate the dispatched tiers reference exactly one backend_id
+  block:
+    - name: Fail if the dispatched tiers reference zero or multiple backend_ids
+      ansible.builtin.fail:
+        msg: >-
+          Expected exactly one backend_id across the dispatched VAST tiers, got
+          {{ _vast_backend_ids | length }}: {{ _vast_backend_ids | to_json }}.
+          VAST credential resolution assumes a single backend connection per role invocation —
+          multiple backends dispatched together in one call are not yet supported.
+      when: _vast_backend_ids | length != 1
+  rescue:
+    - name: Build structured failure artifact for ambiguous backend association
+      ansible.builtin.set_fact:
+        osac_storage_provider_failures:
+          - reason: ambiguous_backend_association
+            tiers: "{{ _provider_tiers | map(attribute='name') | list }}"
+            backend_ids: "{{ _vast_backend_ids }}"
+            message: "{{ ansible_failed_result.msg }}"
+
+    - name: Emit structured failure artifact for ambiguous backend association
+      ansible.builtin.set_stats:
+        data:
+          osac_storage_provider_failures: "{{ osac_storage_provider_failures }}"
+        aggregate: false
+
+    - name: Re-raise the original backend_id ambiguity failure
+      ansible.builtin.fail:
+        msg: "{{ ansible_failed_result.msg }}"
+
+- name: Set the resolved backend_id
   ansible.builtin.set_fact:
-    _vast_env_creds_available: >-
-      {{ _vast_endpoint_env | length > 0 and
-         _vast_username_env | length > 0 and
-         _vast_password_env | length > 0 }}
-    _vast_env_creds_partial: >-
-      {{ (_vast_endpoint_env | length > 0 or
-          _vast_username_env | length > 0 or
-          _vast_password_env | length > 0) and
-         not (_vast_endpoint_env | length > 0 and
-              _vast_username_env | length > 0 and
-              _vast_password_env | length > 0) }}
-  no_log: true
+    _vast_backend_id: "{{ _vast_backend_ids[0] }}"
 
-- name: Warn about partial env var credentials
-  when: _vast_env_creds_partial | bool
-  ansible.builtin.debug:
-    msg: >-
-      Partial VAST credential env vars detected — not all of VAST_ENDPOINT,
-      VAST_USERNAME, VAST_PASSWORD are set. All three must be provided together.
+- name: Validate connection details exist for the resolved backend_id
+  block:
+    - name: Fail if no connection details were provided for the resolved backend_id
+      ansible.builtin.fail:
+        msg: >-
+          No entry for backend_id '{{ _vast_backend_id }}' in storage_backend_connections.
+          osac-operator must resolve and pass connection details (endpoint, username, password)
+          for every backend_id referenced by storage_tier_definitions.
+      when: _vast_backend_id not in _provider_backend_connections
+  rescue:
+    - name: Build structured failure artifact for unresolved backend connection
+      ansible.builtin.set_fact:
+        osac_storage_provider_failures:
+          - reason: unresolved_backend_connection
+            tiers: "{{ _provider_tiers | map(attribute='name') | list }}"
+            backend_ids:
+              - "{{ _vast_backend_id }}"
+            message: "{{ ansible_failed_result.msg }}"
 
-- name: Fail if VAST admin credentials are not available
-  when: not (_vast_env_creds_available | bool)
-  ansible.builtin.fail:
-    msg: >-
-      VAST admin credentials not found. VAST_ENDPOINT, VAST_USERNAME, and
-      VAST_PASSWORD environment variables must all be set in the IG pod spec.
-      These are injected via AAP vault into the storage-operations-ig Secret
-      referenced in the IG pod spec envFrom block.
+    - name: Emit structured failure artifact for unresolved backend connection
+      ansible.builtin.set_stats:
+        data:
+          osac_storage_provider_failures: "{{ osac_storage_provider_failures }}"
+        aggregate: false
 
-- name: Set VAST credentials from environment variables
+    - name: Re-raise the original unresolved-connection failure
+      ansible.builtin.fail:
+        msg: "{{ ansible_failed_result.msg }}"
+
+- name: Validate the resolved connection has complete credentials
+  block:
+    - name: Fail if the resolved connection is missing endpoint, username, or password
+      ansible.builtin.fail:
+        msg: >-
+          storage_backend_connections['{{ _vast_backend_id }}'] is missing one or more of
+          endpoint, username, password. All three must be set together.
+      when: >-
+        _provider_backend_connections[_vast_backend_id].endpoint | default('') | length == 0 or
+        _provider_backend_connections[_vast_backend_id].username | default('') | length == 0 or
+        _provider_backend_connections[_vast_backend_id].password | default('') | length == 0
+  rescue:
+    - name: Build structured failure artifact for incomplete backend connection
+      ansible.builtin.set_fact:
+        osac_storage_provider_failures:
+          - reason: incomplete_backend_connection
+            tiers: "{{ _provider_tiers | map(attribute='name') | list }}"
+            backend_ids:
+              - "{{ _vast_backend_id }}"
+            message: "{{ ansible_failed_result.msg }}"
+
+    - name: Emit structured failure artifact for incomplete backend connection
+      ansible.builtin.set_stats:
+        data:
+          osac_storage_provider_failures: "{{ osac_storage_provider_failures }}"
+        aggregate: false
+
+    - name: Re-raise the original incomplete-connection failure
+      ansible.builtin.fail:
+        msg: "{{ ansible_failed_result.msg }}"
+
+- name: Set VAST credentials from the resolved backend connection
   ansible.builtin.set_fact:
-    vast_endpoint: "{{ _vast_endpoint_env }}"
-    vast_username: "{{ _vast_username_env }}"
-    vast_password: "{{ _vast_password_env }}"
-  no_log: true
-
-- name: Clear intermediate env credential facts
-  ansible.builtin.set_fact:
-    _vast_endpoint_env: ""
-    _vast_username_env: ""
-    _vast_password_env: ""
+    vast_endpoint: "{{ _provider_backend_connections[_vast_backend_id].endpoint }}"
+    vast_username: "{{ _provider_backend_connections[_vast_backend_id].username }}"
+    vast_password: "{{ _provider_backend_connections[_vast_backend_id].password }}"
   no_log: true

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_tenant_credentials.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_tenant_credentials.yaml
@@ -1,6 +1,7 @@
 ---
 # Reads per-tenant VMS Manager credentials from the hub-cluster tenant config Secret.
-# This is NOT the admin credentials reader (read_credentials.yaml reads admin creds from env vars).
+# This is NOT the admin credentials reader (read_credentials.yaml resolves admin creds from
+# storage_backend_connections, populated by osac-operator from the Tier API).
 # This file reads the per-tenant Manager username/password generated during setup.
 # The CSI driver authenticates via username/password, not API tokens.
 #

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -35,27 +35,20 @@
     fail_msg: "Tier names must be unique."
     quiet: true
 
-- name: Validate tier protocols are supported by VAST provider
-  ansible.builtin.fail:
-    msg: >-
-      Tier '{{ item.name }}' has unsupported protocol '{{ item.protocol }}'.
-      VAST provider supports: nfs, block.
-  loop: "{{ _provider_tiers }}"
-  loop_control:
-    label: "{{ item.name }}"
-  when: item.protocol not in ['nfs', 'block']
+- name: Include shared tier protocol validation
+  ansible.builtin.include_tasks: _validate_tier_protocols.yaml
 
 - name: Validate tier quotas (when specified)
   ansible.builtin.fail:
     msg: >-
-      Tier '{{ item.name }}' has an invalid quota: '{{ item.quota }}'.
-      Quota must be a positive number (bytes).
+      Tier '{{ item.name }}' has an invalid quota_bytes: '{{ item.quota_bytes }}'.
+      quota_bytes must be a positive number (bytes).
   loop: "{{ _provider_tiers }}"
   loop_control:
     label: "{{ item.name }}"
   when:
-    - item.quota is defined
-    - (item.quota | int) <= 0
+    - item.quota_bytes is defined
+    - (item.quota_bytes | int) <= 0
 
 - name: Compute unique protocols from tiers
   ansible.builtin.set_fact:
@@ -63,7 +56,7 @@
 
 - name: Provision VAST resources for tenant
   block:
-    - name: Resolve VAST admin credentials from env vars
+    - name: Resolve VAST admin credentials from storage_backend_connections
       ansible.builtin.include_tasks: read_credentials.yaml
 
     - name: Build VAST VMS connection dict

--- a/osac-aap/config/base/configmap-storage-operations-ig-example.yaml
+++ b/osac-aap/config/base/configmap-storage-operations-ig-example.yaml
@@ -3,20 +3,14 @@ kind: ConfigMap
 metadata:
   name: storage-operations-ig
 data:
-  # Storage tier definitions — JSON array with per-tier provider selection.
-  # Each tier declares: name (DNS label), protocol (nfs|block), provider (vast).
-  # Optional: qos_policy (string) + qos_limits (dict) for VAST QoS policy creation.
-  # Optional: quota (int, bytes) for per-tier hard quota.
-  STORAGE_TIERS: |
-    [
-      {"name": "default", "protocol": "nfs", "provider": "vast", "qos_policy": "default-qos",
-       "qos_limits": {"static_limits": {"max_reads_bw_mbps": 100, "max_writes_bw_mbps": 100}}},
-      {"name": "high-performance", "protocol": "block", "provider": "vast", "qos_policy": "high-iops",
-       "qos_limits": {"static_limits": {"max_reads_bw_mbps": 500, "max_writes_bw_mbps": 500}}}
-    ]
+  # Storage tier definitions are no longer configured here — osac-operator resolves them
+  # from the Tier API and passes them via the storage_tier_definitions extra_vars key on
+  # each AAP job (OSAC-1992). qos_policy is derived automatically by the storage_provider
+  # role, not configured per tier.
 
-  # Create VolumeSnapshotClass alongside StorageClass (requires snapshot-controller CRD).
-  STORAGE_SNAPSHOTS_ENABLED: "true"
+  # Whether to create a VolumeSnapshotClass alongside each StorageClass is no longer
+  # a configurable toggle — the role always checks live whether the VolumeSnapshot CRD
+  # is installed on the target cluster and creates VolumeSnapshotClasses only if so.
 
   # TLS certificate validation for VAST VMS API calls.
   # Set to "false" for self-signed certificates in dev/test environments.
@@ -27,6 +21,6 @@ data:
   # VAST_VIP_POOL_GW_IPV6: ""
 
   # Namespace on hub cluster where VAST config Secrets (vast-tenant-config-*) are stored.
-  # Overrides the OSAC_STORAGE_CONFIG_NAMESPACE env var injected via downward API in the pod spec.
-  # Only set this if the config namespace differs from the IG pod namespace.
+  # Defaults to the IG pod's own namespace (auto-detected, no config needed).
+  # Only set this if the config namespace differs from the IG pod's own namespace.
   # OSAC_STORAGE_CONFIG_NAMESPACE: "osac-system"

--- a/osac-aap/config/base/secret-storage-operations-ig-example.yaml
+++ b/osac-aap/config/base/secret-storage-operations-ig-example.yaml
@@ -4,18 +4,11 @@ metadata:
   name: storage-operations-ig
 type: Opaque
 data:
-  # VAST admin credentials — used ONLY for VMS API provisioning during tenant_setup.
+  # VAST admin credentials are no longer configured here — osac-operator resolves them
+  # from the Tier API and passes them via the storage_backend_connections extra_vars key
+  # on each AAP job, keyed by backend_id (OSAC-1992, absorbing OSAC-1957's AAP-side AC).
   # These credentials are NEVER placed into K8s Secrets or CSI Secrets in tenant namespaces.
   # Per-tenant data-plane credentials are generated automatically during tenant_setup.
-
-  # Base64-encoded VAST management API URL (e.g., https://vast-vms.example.com)
-  VAST_ENDPOINT: ""
-
-  # Base64-encoded VAST management API username
-  VAST_USERNAME: ""
-
-  # Base64-encoded VAST management API password
-  VAST_PASSWORD: ""
 
   # Block encryption passphrase comes from the Tenant CR event payload (spec.blockEncryptionPassphrase),
   # not from this Secret. It is per-tenant and passed through the EDA event.

--- a/osac-aap/playbook_osac_create_compute_instance.yml
+++ b/osac-aap/playbook_osac_create_compute_instance.yml
@@ -9,13 +9,19 @@
     template_id: "{{ ansible_eda.event.payload.spec.templateID }}"
     template_parameters: {}
     tenant_storage_classes: "{{ ansible_eda.event.tenant_storage_classes | default([]) }}"
-    _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
     _requested_storage_tier: "{{ lookup('env', 'STORAGE_REQUESTED_TIER') | default('default', true) }}"
 
   pre_tasks:
-    - name: Show EDA Event
-      ansible.builtin.debug:
-        var: ansible_eda.event.payload
+    # payload.spec.blockEncryptionPassphrase carries a real secret (see
+    # storage_provider_block_encryption_passphrase below) -- use the shared,
+    # centralized redaction task instead of debugging the whole payload object.
+    - name: Show EDA Event metadata
+      ansible.builtin.include_role:
+        name: osac.service.common
+        tasks_from: show_eda_event_metadata
+      vars:
+        eda_event_extra_fields:
+          template_id: "{{ ansible_eda.event.payload.spec.templateID | default('unknown') }}"
 
     - name: Determine tenant target namespace
       # Brings in variables:
@@ -38,31 +44,33 @@
             else (compute_instance.metadata.annotations | default({})).get('osac.openshift.io/tenant', 'unknown')
           }}
 
-    - name: Parse STORAGE_TIERS for JIT storage
-      when: _storage_tiers_raw | length > 0
-      block:
-        - name: Parse tier list from STORAGE_TIERS env var
-          ansible.builtin.set_fact:
-            _jit_all_tiers: "{{ _storage_tiers_raw | from_json }}"
+    - name: Validate optional storage_tier_definitions type
+      ansible.builtin.fail:
+        msg: >-
+          ansible_eda.event.storage_tier_definitions must be an array when provided.
+          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001"}]
+      when: >-
+        ansible_eda.event.storage_tier_definitions is defined and
+        (ansible_eda.event.storage_tier_definitions is not sequence or
+         ansible_eda.event.storage_tier_definitions is string or
+         ansible_eda.event.storage_tier_definitions is mapping)
 
+    - name: Filter storage tier definitions to the requested tier for JIT storage
+      when: (ansible_eda.event.storage_tier_definitions | default([])) | length > 0
+      block:
         - name: Filter to only the requested tier
           ansible.builtin.set_fact:
-            _jit_storage_tiers: "{{ _jit_all_tiers | selectattr('name', 'equalto', _requested_storage_tier) | list }}"
+            _jit_storage_tiers: >-
+              {{ ansible_eda.event.storage_tier_definitions
+                 | selectattr('name', 'equalto', _requested_storage_tier) | list }}
 
-        - name: Warn if requested tier not found in STORAGE_TIERS
+        - name: Warn if requested tier not found in storage_tier_definitions
           ansible.builtin.debug:
             msg: >-
-              Requested storage tier '{{ _requested_storage_tier }}' not found in STORAGE_TIERS.
-              Available tiers: {{ _jit_all_tiers | map(attribute='name') | list | to_json }}.
+              Requested storage tier '{{ _requested_storage_tier }}' not found in storage_tier_definitions.
+              Available tiers: {{ ansible_eda.event.storage_tier_definitions | map(attribute='name') | list | to_json }}.
               JIT storage provisioning will be skipped.
           when: _jit_storage_tiers | length == 0
-      rescue:
-        - name: Fail on malformed STORAGE_TIERS JSON
-          ansible.builtin.fail:
-            msg: >-
-              STORAGE_TIERS env var contains invalid JSON.
-              Value: '{{ _storage_tiers_raw }}'.
-              Expected a JSON array of tier objects with name, protocol, and provider fields.
 
     - name: Ensure storage is provisioned for tenant (JIT)
       when: _jit_storage_tiers is defined and _jit_storage_tiers | length > 0
@@ -71,9 +79,9 @@
       vars:
         storage_provider_action: ensure_storage_class
         storage_provider_tiers: "{{ _jit_storage_tiers }}"
+        storage_provider_backend_connections: "{{ ansible_eda.event.storage_backend_connections | default({}) }}"
         storage_provider_provisioning_target: vmaas
         storage_provider_block_encryption_passphrase: "{{ ansible_eda.event.payload.spec.blockEncryptionPassphrase | default('') }}"
-        storage_provider_snapshots_enabled: "{{ lookup('env', 'STORAGE_SNAPSHOTS_ENABLED') | default('true', true) | bool }}"
 
     - name: Add JIT-provisioned StorageClasses to resolution list
       ansible.builtin.set_fact:
@@ -89,7 +97,7 @@
           ComputeInstance '{{ compute_instance_name }}' has no tenant_storage_classes
           available. Either the osac-operator CI controller should inject the resolved
           storageClasses list before triggering provisioning, or JIT storage provisioning
-          via STORAGE_TIERS must succeed.
+          via storage_tier_definitions must succeed.
       when:
         - tenant_storage_class_storage_classes | length == 0
         - _jit_storage_tiers is not defined or _jit_storage_tiers | length == 0

--- a/osac-aap/playbook_osac_create_tenant_cluster_storage.yml
+++ b/osac-aap/playbook_osac_create_tenant_cluster_storage.yml
@@ -22,13 +22,18 @@
       {{ ansible_eda.event.payload.metadata.namespace }}
       {%- endif -%}
     tenant_uid: "{{ ansible_eda.event.payload.metadata.uid }}"
-    _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
-    _storage_snapshots: "{{ lookup('env', 'STORAGE_SNAPSHOTS_ENABLED') | default('true', true) | bool }}"
 
   pre_tasks:
-    - name: Show EDA Event
-      ansible.builtin.debug:
-        var: ansible_eda.event.payload
+    # payload.spec.blockEncryptionPassphrase carries a real secret (see
+    # storage_provider_block_encryption_passphrase below) -- use the shared,
+    # centralized redaction task instead of debugging the whole payload object.
+    - name: Show EDA Event metadata
+      ansible.builtin.include_role:
+        name: osac.service.common
+        tasks_from: show_eda_event_metadata
+      vars:
+        eda_event_extra_fields:
+          tenant_annotation: "{{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/tenant'] | default('unknown') }}"
 
     - name: Validate tenant payload is present
       ansible.builtin.fail:
@@ -42,25 +47,18 @@
         ansible_eda.event.payload.metadata.uid is not defined or
         ansible_eda.event.payload.metadata.uid | length == 0
 
-    - name: Validate STORAGE_TIERS env var is configured
+    - name: Validate storage_tier_definitions is a non-empty array in the EDA event
       ansible.builtin.fail:
         msg: >-
-          STORAGE_TIERS env var must be set at deployment time as a JSON array.
-          Example: [{"name":"default","protocol":"nfs","provider":"vast"}]
-      when: _storage_tiers_raw | length == 0
-
-    - name: Parse STORAGE_TIERS JSON
-      block:
-        - name: Parse tier list from env var
-          ansible.builtin.set_fact:
-            _storage_tiers: "{{ _storage_tiers_raw | from_json }}"
-      rescue:
-        - name: Fail on malformed STORAGE_TIERS JSON
-          ansible.builtin.fail:
-            msg: >-
-              STORAGE_TIERS env var contains invalid JSON.
-              Value: '{{ _storage_tiers_raw }}'.
-              Expected a JSON array of tier objects with name, protocol, and provider fields.
+          ansible_eda.event.storage_tier_definitions must be a non-empty array, populated
+          by osac-operator from the Tenant's resolved storage tiers.
+          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota_bytes":500}]
+      when: >-
+        ansible_eda.event.storage_tier_definitions is not defined or
+        ansible_eda.event.storage_tier_definitions is not sequence or
+        ansible_eda.event.storage_tier_definitions is string or
+        ansible_eda.event.storage_tier_definitions is mapping or
+        ansible_eda.event.storage_tier_definitions | length == 0
 
     - name: Write admin_kubeconfig to temporary file when provided
       when: >-
@@ -91,9 +89,9 @@
             name: osac.service.storage_provider
           vars:
             storage_provider_action: ensure_storage_class
-            storage_provider_tiers: "{{ _storage_tiers }}"
+            storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"
+            storage_provider_backend_connections: "{{ ansible_eda.event.storage_backend_connections | default({}) }}"
             storage_provider_block_encryption_passphrase: "{{ ansible_eda.event.payload.spec.blockEncryptionPassphrase | default('') }}"
-            storage_provider_snapshots_enabled: "{{ _storage_snapshots }}"
       rescue:
         - name: Warn about StorageClass creation failure
           ansible.builtin.debug:
@@ -106,6 +104,6 @@
             name: osac.service.storage_provider
           vars:
             storage_provider_action: ensure_storage_class
-            storage_provider_tiers: "{{ _storage_tiers }}"
+            storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"
+            storage_provider_backend_connections: "{{ ansible_eda.event.storage_backend_connections | default({}) }}"
             storage_provider_block_encryption_passphrase: "{{ ansible_eda.event.payload.spec.blockEncryptionPassphrase | default('') }}"
-            storage_provider_snapshots_enabled: "{{ _storage_snapshots }}"

--- a/osac-aap/playbook_osac_create_tenant_storage_backend.yml
+++ b/osac-aap/playbook_osac_create_tenant_storage_backend.yml
@@ -7,12 +7,15 @@
     tenant_name: "{{ ansible_eda.event.payload.metadata.name }}"
     tenant_namespace: "{{ ansible_eda.event.payload.metadata.namespace }}"
     tenant_uid: "{{ ansible_eda.event.payload.metadata.uid }}"
-    _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
 
   pre_tasks:
-    - name: Show EDA Event
-      ansible.builtin.debug:
-        var: ansible_eda.event.payload
+    # payload.spec.blockEncryptionPassphrase carries a real secret (see
+    # storage_provider_block_encryption_passphrase below) -- use the shared,
+    # centralized redaction task instead of debugging the whole payload object.
+    - name: Show EDA Event metadata
+      ansible.builtin.include_role:
+        name: osac.service.common
+        tasks_from: show_eda_event_metadata
 
     - name: Validate tenant payload is present
       ansible.builtin.fail:
@@ -26,31 +29,18 @@
         ansible_eda.event.payload.metadata.uid is not defined or
         ansible_eda.event.payload.metadata.uid | length == 0
 
-    - name: Validate STORAGE_TIERS env var is configured
+    - name: Validate storage_tier_definitions is a non-empty array in the EDA event
       ansible.builtin.fail:
         msg: >-
-          STORAGE_TIERS env var must be set at deployment time as a JSON array.
-          Example: [{"name":"default","protocol":"nfs","provider":"vast"}]
-      when: _storage_tiers_raw | length == 0
-
-    - name: Parse STORAGE_TIERS JSON
-      block:
-        - name: Parse tier list from env var
-          ansible.builtin.set_fact:
-            _storage_tiers: "{{ _storage_tiers_raw | from_json }}"
-        - name: Validate STORAGE_TIERS is a JSON array
-          ansible.builtin.assert:
-            that:
-              - _storage_tiers | type_debug == 'list'
-            fail_msg: >-
-              STORAGE_TIERS must be a JSON array of tier objects.
-      rescue:
-        - name: Fail on malformed STORAGE_TIERS JSON
-          ansible.builtin.fail:
-            msg: >-
-              STORAGE_TIERS env var contains invalid JSON.
-              Value: '{{ _storage_tiers_raw }}'.
-              Expected a JSON array of tier objects with name, protocol, and provider fields.
+          ansible_eda.event.storage_tier_definitions must be a non-empty array, populated
+          by osac-operator from the Tenant's resolved storage tiers.
+          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota_bytes":500}]
+      when: >-
+        ansible_eda.event.storage_tier_definitions is not defined or
+        ansible_eda.event.storage_tier_definitions is not sequence or
+        ansible_eda.event.storage_tier_definitions is string or
+        ansible_eda.event.storage_tier_definitions is mapping or
+        ansible_eda.event.storage_tier_definitions | length == 0
 
   tasks:
     - name: Configure tenant storage backend
@@ -58,6 +48,6 @@
         name: osac.service.storage_provider
       vars:
         storage_provider_action: setup
-        storage_provider_tiers: "{{ _storage_tiers }}"
+        storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"
+        storage_provider_backend_connections: "{{ ansible_eda.event.storage_backend_connections | default({}) }}"
         storage_provider_block_encryption_passphrase: "{{ ansible_eda.event.payload.spec.blockEncryptionPassphrase | default('') }}"
-        storage_provider_snapshots_enabled: "{{ lookup('env', 'STORAGE_SNAPSHOTS_ENABLED') | default('true', true) | bool }}"

--- a/osac-aap/playbook_osac_delete_tenant_cluster_storage.yml
+++ b/osac-aap/playbook_osac_delete_tenant_cluster_storage.yml
@@ -20,12 +20,19 @@
       {%- else -%}
       {{ ansible_eda.event.payload.metadata.namespace }}
       {%- endif -%}
-    _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
 
   pre_tasks:
-    - name: Show EDA Event
-      ansible.builtin.debug:
-        var: ansible_eda.event.payload
+    # Use the shared, centralized redaction task rather than debugging the whole payload
+    # object, matching the create-side playbook -- payload.spec is not currently used
+    # here, but keeping the same convention avoids reintroducing a full-payload debug
+    # if that ever changes.
+    - name: Show EDA Event metadata
+      ansible.builtin.include_role:
+        name: osac.service.common
+        tasks_from: show_eda_event_metadata
+      vars:
+        eda_event_extra_fields:
+          tenant_annotation: "{{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/tenant'] | default('unknown') }}"
 
     - name: Validate tenant payload is present
       ansible.builtin.fail:
@@ -37,25 +44,18 @@
         ansible_eda.event.payload.metadata.namespace is not defined or
         ansible_eda.event.payload.metadata.namespace | length == 0
 
-    - name: Parse STORAGE_TIERS JSON
-      when: _storage_tiers_raw | length > 0
-      block:
-        - name: Parse tier list from env var
-          ansible.builtin.set_fact:
-            _storage_tiers: "{{ _storage_tiers_raw | from_json }}"
-        - name: Validate STORAGE_TIERS is a JSON array
-          ansible.builtin.assert:
-            that:
-              - _storage_tiers | type_debug == 'list'
-            fail_msg: >-
-              STORAGE_TIERS must be a JSON array of tier objects.
-      rescue:
-        - name: Fail on malformed STORAGE_TIERS JSON
-          ansible.builtin.fail:
-            msg: >-
-              STORAGE_TIERS env var contains invalid JSON.
-              Value: '{{ _storage_tiers_raw }}'.
-              Expected a JSON array of tier objects with name, protocol, and provider fields.
+    - name: Validate storage_tier_definitions is a non-empty array in the EDA event
+      ansible.builtin.fail:
+        msg: >-
+          ansible_eda.event.storage_tier_definitions must be a non-empty array, populated
+          by osac-operator from the Tenant's resolved storage tiers.
+          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota_bytes":500}]
+      when: >-
+        ansible_eda.event.storage_tier_definitions is not defined or
+        ansible_eda.event.storage_tier_definitions is not sequence or
+        ansible_eda.event.storage_tier_definitions is string or
+        ansible_eda.event.storage_tier_definitions is mapping or
+        ansible_eda.event.storage_tier_definitions | length == 0
 
     - name: Write admin_kubeconfig to temporary file when provided
       when: >-
@@ -78,15 +78,9 @@
         (_remote_kubeconfig is not defined or _remote_kubeconfig | length == 0)
 
   tasks:
-    - name: Skip cleanup when STORAGE_TIERS is not configured
-      when: _storage_tiers_raw | length == 0
-      ansible.builtin.debug:
-        msg: "STORAGE_TIERS env var is not set — nothing to clean up."
-
     - name: Clean up cluster-side tenant storage resources
-      when: _storage_tiers_raw | length > 0
       ansible.builtin.include_role:
         name: osac.service.storage_provider
       vars:
         storage_provider_action: teardown_cluster_storage
-        storage_provider_tiers: "{{ _storage_tiers }}"
+        storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"

--- a/osac-aap/playbook_osac_delete_tenant_storage_backend.yml
+++ b/osac-aap/playbook_osac_delete_tenant_storage_backend.yml
@@ -6,12 +6,16 @@
   vars:
     tenant_name: "{{ ansible_eda.event.payload.metadata.name }}"
     tenant_namespace: "{{ ansible_eda.event.payload.metadata.namespace }}"
-    _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
 
   pre_tasks:
-    - name: Show EDA Event
-      ansible.builtin.debug:
-        var: ansible_eda.event.payload
+    # Use the shared, centralized redaction task rather than debugging the whole payload
+    # object, matching the create-side playbook -- payload.spec is not currently used
+    # here, but keeping the same convention avoids reintroducing a full-payload debug
+    # if that ever changes.
+    - name: Show EDA Event metadata
+      ansible.builtin.include_role:
+        name: osac.service.common
+        tasks_from: show_eda_event_metadata
 
     - name: Validate tenant payload is present
       ansible.builtin.fail:
@@ -23,30 +27,24 @@
         ansible_eda.event.payload.metadata.namespace is not defined or
         ansible_eda.event.payload.metadata.namespace | length == 0
 
-    - name: Parse STORAGE_TIERS JSON
-      when: _storage_tiers_raw | length > 0
-      block:
-        - name: Parse tier list from env var
-          ansible.builtin.set_fact:
-            _storage_tiers: "{{ _storage_tiers_raw | from_json }}"
-      rescue:
-        - name: Fail on malformed STORAGE_TIERS JSON
-          ansible.builtin.fail:
-            msg: >-
-              STORAGE_TIERS env var contains invalid JSON.
-              Value: '{{ _storage_tiers_raw }}'.
-              Expected a JSON array of tier objects with name, protocol, and provider fields.
+    - name: Validate storage_tier_definitions is a non-empty array in the EDA event
+      ansible.builtin.fail:
+        msg: >-
+          ansible_eda.event.storage_tier_definitions must be a non-empty array, populated
+          by osac-operator from the Tenant's resolved storage tiers.
+          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota_bytes":500}]
+      when: >-
+        ansible_eda.event.storage_tier_definitions is not defined or
+        ansible_eda.event.storage_tier_definitions is not sequence or
+        ansible_eda.event.storage_tier_definitions is string or
+        ansible_eda.event.storage_tier_definitions is mapping or
+        ansible_eda.event.storage_tier_definitions | length == 0
 
   tasks:
-    - name: Skip teardown when STORAGE_TIERS is not configured
-      when: _storage_tiers_raw | length == 0
-      ansible.builtin.debug:
-        msg: "STORAGE_TIERS env var is not set — nothing to tear down."
-
     - name: Delete tenant storage backend
-      when: _storage_tiers_raw | length > 0
       ansible.builtin.include_role:
         name: osac.service.storage_provider
       vars:
         storage_provider_action: teardown_backend
-        storage_provider_tiers: "{{ _storage_tiers }}"
+        storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"
+        storage_provider_backend_connections: "{{ ansible_eda.event.storage_backend_connections | default({}) }}"

--- a/osac-aap/samples/storage_tier_definitions_payload.json
+++ b/osac-aap/samples/storage_tier_definitions_payload.json
@@ -27,7 +27,7 @@
         "be-001": {
           "endpoint": "vast.example.com:443",
           "username": "admin",
-          "password": "admin"
+          "password": "<injected-by-osac-operator>"
         }
       }
     }

--- a/osac-aap/samples/storage_tier_definitions_payload.json
+++ b/osac-aap/samples/storage_tier_definitions_payload.json
@@ -1,0 +1,35 @@
+{
+  "ansible_eda": {
+    "event": {
+      "payload": {
+        "metadata": {
+          "name": "acme",
+          "namespace": "tenant-acme",
+          "uid": "11111111-1111-1111-1111-111111111111"
+        }
+      },
+      "storage_tier_definitions": [
+        {
+          "name": "default",
+          "protocol": "nfs",
+          "provider": "vast",
+          "backend_id": "be-001",
+          "qos_limits": {
+            "static_limits": {
+              "max_reads_bw_mbps": 100,
+              "max_writes_bw_mbps": 100
+            }
+          },
+          "quota_bytes": 536870912000
+        }
+      ],
+      "storage_backend_connections": {
+        "be-001": {
+          "endpoint": "vast.example.com:443",
+          "username": "admin",
+          "password": "admin"
+        }
+      }
+    }
+  }
+}

--- a/osac-aap/tests/integration/integration_config.yml.template
+++ b/osac-aap/tests/integration/integration_config.yml.template
@@ -1,20 +1,53 @@
 # VAST VMS credentials for live API integration tests (Tier 3)
-# Copy to integration_config.yml and fill in values, or render from CI:
-#   envsubst < integration_config.yml.template > integration_config.yml
+# Copy to integration_config.yml and fill in values, or render from CI.
+#
+# Rendering notes (deliberately described in prose below, with no dollar-brace
+# examples inline, since envsubst treats this whole file as flat text and would
+# substitute a literal example the same as it substitutes the real fields):
+#
+# 1. envsubst (GNU gettext) only expands bare dollar-brace variable references.
+#    It does NOT support bash's colon-dash fallback syntax -- a variable
+#    reference with a fallback baked in is left completely untouched by
+#    envsubst, even when the variable is already set, because the colon breaks
+#    its identifier matching. Resolve every fallback below by exporting the
+#    real VAST_* variable first, then run envsubst.
+#
+# 2. When exporting a fallback yourself, do not reuse bash's own colon-dash
+#    form for the tier-definitions variable: bash's own "${VAR:-default}"
+#    stops at the FIRST unescaped closing brace inside default, so a
+#    JSON-object default silently truncates. Guard that one with a plain
+#    if-unset check and a separate export instead.
+#
+# 3. Render with envsubst restricted to exactly this file's VAST_* variable
+#    names, not bare envsubst on the whole file -- unrestricted envsubst would
+#    also expand any other dollar-prefixed variable that happens to be set in
+#    the calling shell or CI environment.
 #
 # WARNING: NEVER commit integration_config.yml with real credentials.
-vast_endpoint: "${VAST_ENDPOINT}"
-vast_username: "${VAST_USERNAME}"
-vast_password: "${VAST_PASSWORD}"
+#
+# NOTE: No automated target in tests/integration/targets/ currently loads this file --
+# there is no live Tier 3 test wired up yet. Keys below are named to match the
+# storage_provider role's extra_vars directly (storage_provider_backend_connections/
+# storage_provider_tiers) so a future live-VMS target can pass this file's parsed
+# content straight through as vars, with no key remapping step.
+storage_provider_backend_connections:
+  ${VAST_BACKEND_ID}:
+    endpoint: "${VAST_BACKEND_ENDPOINT}"
+    username: "${VAST_BACKEND_USERNAME}"
+    password: "${VAST_BACKEND_PASSWORD}"
 vast_tenant_prefix: "osac-test-"
 # TLS validation — set to false for mock server or self-signed cert testing
-vast_validate_certs: ${VAST_VALIDATE_CERTS:-true}
+vast_validate_certs: ${VAST_VALIDATE_CERTS}
 
 # Shared VIP pool configuration
-vast_vip_pool_name: "${VAST_VIP_POOL_NAME:-osac-shared}"
-vast_vip_pool_ip_ranges: '${VAST_VIP_POOL_IP_RANGES:-[["10.0.100.10","10.0.100.50"]]}'
-vast_vip_pool_subnet_cidr: ${VAST_VIP_POOL_SUBNET_CIDR:-24}
+vast_vip_pool_name: "${VAST_VIP_POOL_NAME}"
+vast_vip_pool_ip_ranges: '${VAST_VIP_POOL_IP_RANGES}'
+vast_vip_pool_subnet_cidr: ${VAST_VIP_POOL_SUBNET_CIDR}
 
-# Storage tier definition — JSON array with per-tier provider selection.
-# Used by test playbooks to exercise the multi-tier storage provider interface.
-storage_tiers: '${STORAGE_TIERS}'
+# Storage tier definitions — JSON array with per-tier provider selection and backend_id,
+# matching the storage_provider_tiers/ansible_eda.event.storage_tier_definitions shape.
+# Used by test playbooks to exercise the multi-tier storage provider interface. Left
+# unquoted (unlike vast_vip_pool_ip_ranges above) so it parses as a native YAML list --
+# the storage_provider role's own validation requires storage_provider_tiers to be a
+# sequence, not a JSON-shaped string requiring a separate from_json step.
+storage_provider_tiers: ${VAST_STORAGE_TIERS}

--- a/osac-aap/tests/integration/run_tests.sh
+++ b/osac-aap/tests/integration/run_tests.sh
@@ -161,7 +161,7 @@ echo ""
 # provider" scenario), which aborts the whole process even though that scenario's own rescue
 # block already passed. The second invocation resumes at the next scenario to cover
 # everything after it.
-STORAGE_PROVIDER_UNIT_TEST="../../collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml"
+STORAGE_PROVIDER_UNIT_TEST="${SCRIPT_DIR}/../../collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml"
 
 if ansible-playbook "${STORAGE_PROVIDER_UNIT_TEST}" -v; then
   echo "  ✓ storage_provider unit tests (part 1) passed"
@@ -171,12 +171,15 @@ else
   FAILED+=("storage_provider_unit_tests:part1")
 fi
 
+part2_log="${SCRIPT_DIR}/.storage_provider_unit_part2.log"
 if ansible-playbook --start-at-task "Attempt with invalid action 'destroy' (expected to fail)" \
-  "${STORAGE_PROVIDER_UNIT_TEST}" -v; then
+  "${STORAGE_PROVIDER_UNIT_TEST}" -v > "${part2_log}" 2>&1 \
+  && grep -q 'ok=[1-9]' "${part2_log}"; then
   echo "  ✓ storage_provider unit tests (part 2) passed"
   PASSED+=("storage_provider_unit_tests:part2")
 else
-  echo "  ✗ storage_provider unit tests (part 2) failed"
+  echo "  ✗ storage_provider unit tests (part 2) failed or matched no task (see ${part2_log})"
+  tail -60 "${part2_log}" 2>/dev/null || true
   FAILED+=("storage_provider_unit_tests:part2")
 fi
 

--- a/osac-aap/tests/integration/run_tests.sh
+++ b/osac-aap/tests/integration/run_tests.sh
@@ -151,6 +151,37 @@ done
 # Clean up lease test pod
 kubectl delete pod lease-test-pod -n osac-system --ignore-not-found 2>/dev/null || true
 
+echo "=== Running Storage Provider Dispatcher Unit Tests ==="
+echo ""
+
+# Validation-only tests for the storage_provider role's dispatcher logic -- no kind cluster
+# or mock VMS server required, so these run unconditionally (not gated behind
+# STORAGE_TESTS_ENABLED). Requires two separate invocations: ansible-core raises a
+# runner-level ERROR! when include_role targets a genuinely-missing role name (the "invalid
+# provider" scenario), which aborts the whole process even though that scenario's own rescue
+# block already passed. The second invocation resumes at the next scenario to cover
+# everything after it.
+STORAGE_PROVIDER_UNIT_TEST="../../collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml"
+
+if ansible-playbook "${STORAGE_PROVIDER_UNIT_TEST}" -v; then
+  echo "  ✓ storage_provider unit tests (part 1) passed"
+  PASSED+=("storage_provider_unit_tests:part1")
+else
+  echo "  ✗ storage_provider unit tests (part 1) failed"
+  FAILED+=("storage_provider_unit_tests:part1")
+fi
+
+if ansible-playbook --start-at-task "Attempt with invalid action 'destroy' (expected to fail)" \
+  "${STORAGE_PROVIDER_UNIT_TEST}" -v; then
+  echo "  ✓ storage_provider unit tests (part 2) passed"
+  PASSED+=("storage_provider_unit_tests:part2")
+else
+  echo "  ✗ storage_provider unit tests (part 2) failed"
+  FAILED+=("storage_provider_unit_tests:part2")
+fi
+
+echo ""
+
 # Storage provider tests (conditional)
 if [ "${STORAGE_TESTS_ENABLED:-}" = "true" ]; then
   # Source env vars written by setup_test_env.sh (Make runs each recipe line in a separate shell)

--- a/osac-aap/tests/integration/setup_test_env.sh
+++ b/osac-aap/tests/integration/setup_test_env.sh
@@ -170,15 +170,15 @@ CSIEOF
   kubectl create namespace test-tenant-ns || true
 
   # Write VAST env vars to file for run_tests.sh (Make runs each recipe line in a separate shell)
+  # VAST_ENDPOINT/VAST_USERNAME/VAST_PASSWORD/STORAGE_TIERS are no longer read by any
+  # playbook or role (OSAC-1992 moved credential/tier input to
+  # storage_provider_backend_connections/storage_provider_tiers extra_vars, set directly
+  # by each test target) -- only VIP pool and TLS settings remain relevant here.
   cat > "${SCRIPT_DIR}/.storage_env" <<'ENVEOF'
-export VAST_ENDPOINT="127.0.0.1:18443"
-export VAST_USERNAME="admin"
-export VAST_PASSWORD="admin"
 export VAST_VIP_POOL_NAME="osac-test-pool"
 export VAST_VIP_POOL_IP_RANGES='[["10.0.0.10","10.0.0.50"]]'
 export VAST_VIP_POOL_SUBNET_CIDR="24"
 export VAST_VALIDATE_CERTS="false"
-export STORAGE_TIERS='[{"name":"default","protocol":"nfs","provider":"vast","qos_policy":"test-qos","qos_limits":{"static_limits":{"max_reads_bw_mbps":100,"max_writes_bw_mbps":100}}}]'
 ENVEOF
 fi
 

--- a/osac-aap/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
+++ b/osac-aap/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
@@ -53,6 +53,10 @@
             name: "vast-snapshot-test-ensuresc-default"
           failed_when: false
 
+    - name: Set mock tenant manager credentials for this scenario
+      ansible.builtin.set_fact:
+        mock_tenant_manager_password: "test-csi-password"
+
     - name: Create hub Secret fixture (simulates output from setup action)
       kubernetes.core.k8s:
         state: present
@@ -76,7 +80,7 @@
             storage_provider_type: "vast"
             tenant_manager_name: "osac-test-ensuresc"
             tenant_manager_username: "osac-test-ensuresc"
-            tenant_manager_password: "test-csi-password"
+            tenant_manager_password: "{{ mock_tenant_manager_password }}"
             tenant_manager_id: "42"
             tenant_role_id: "7"
             view_policy_name: "osac-test-ensuresc-nfs"
@@ -88,9 +92,6 @@
   gather_facts: false
 
   environment:
-    VAST_ENDPOINT: "127.0.0.1:18443"
-    VAST_USERNAME: "admin"
-    VAST_PASSWORD: "admin"
     OSAC_STORAGE_CONFIG_NAMESPACE: "osac-system"
 
   vars:
@@ -102,11 +103,17 @@
       - name: default
         protocol: nfs
         provider: vast
+        backend_id: be-test
       - name: block-tier
         protocol: block
         provider: vast
+        backend_id: be-test
+    storage_provider_backend_connections:
+      be-test:
+        endpoint: "127.0.0.1:18443"
+        username: "admin"
+        password: "admin"
     storage_provider_action: ensure_storage_class
-    storage_provider_snapshots_enabled: true
     storage_provider_block_encryption_passphrase: "test-encryption-passphrase"
     vast_storage_validate_certs: false
 
@@ -266,7 +273,7 @@
           - _csi_secret.resources[0].data.username is defined
           - (_csi_secret.resources[0].data.username | b64decode) == "osac-test-ensuresc"
           - _csi_secret.resources[0].data.password is defined
-          - (_csi_secret.resources[0].data.password | b64decode) == "test-csi-password"
+          - (_csi_secret.resources[0].data.password | b64decode) == mock_tenant_manager_password
           - _csi_secret.resources[0].data.endpoint is defined
           - (_csi_secret.resources[0].data.endpoint | b64decode) == "127.0.0.1:18443"
           - _csi_secret.resources[0].data.tenant is defined
@@ -343,9 +350,6 @@
   gather_facts: false
 
   environment:
-    VAST_ENDPOINT: "127.0.0.1:18443"
-    VAST_USERNAME: "admin"
-    VAST_PASSWORD: "admin"
     OSAC_STORAGE_CONFIG_NAMESPACE: "osac-system"
 
   vars:
@@ -356,11 +360,17 @@
       - name: default
         protocol: nfs
         provider: vast
+        backend_id: be-test
       - name: block-tier
         protocol: block
         provider: vast
+        backend_id: be-test
+    storage_provider_backend_connections:
+      be-test:
+        endpoint: "127.0.0.1:18443"
+        username: "admin"
+        password: "admin"
     storage_provider_action: ensure_storage_class
-    storage_provider_snapshots_enabled: true
     storage_provider_block_encryption_passphrase: "test-encryption-passphrase"
     vast_storage_validate_certs: false
 
@@ -411,6 +421,188 @@
           - _call_log | selectattr('path', 'search', 'viewpolicies') | list | length > 0
         fail_msg: "No view policy API calls found — ensure_storage_class should create view policies"
         success_msg: "View policy API calls detected"
+
+# ── Test: storage_provider_snapshots_enabled: false suppresses VolumeSnapshotClass ──
+# Uses a separate tenant from the tests above so this scenario always goes through full
+# provisioning (the short-circuit above would otherwise mask whether the flag is honored).
+- name: "Storage Provider Ensure SC - Setup fixtures (snapshots disabled)"
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Delete any pre-existing snapshots-disabled test resources (clean slate)
+      block:
+        - name: Delete hub Secret if exists
+          kubernetes.core.k8s:
+            state: absent
+            api_version: v1
+            kind: Secret
+            name: "vast-tenant-config-test-ensuresc-nosnap"
+            namespace: "osac-system"
+          failed_when: false
+
+        - name: Delete CSI Secret if exists
+          kubernetes.core.k8s:
+            state: absent
+            api_version: v1
+            kind: Secret
+            name: "vast-csi-test-ensuresc-nosnap"
+            namespace: "osac-system"
+          failed_when: false
+
+        - name: Delete NFS StorageClass if exists
+          kubernetes.core.k8s:
+            state: absent
+            api_version: storage.k8s.io/v1
+            kind: StorageClass
+            name: "vast-nfs-test-ensuresc-nosnap-default"
+          failed_when: false
+
+        - name: Delete VolumeSnapshotClass if exists
+          kubernetes.core.k8s:
+            state: absent
+            api_version: snapshot.storage.k8s.io/v1
+            kind: VolumeSnapshotClass
+            name: "vast-snapshot-test-ensuresc-nosnap-default"
+          failed_when: false
+
+    - name: Create hub Secret fixture for snapshots-disabled tenant
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "vast-tenant-config-test-ensuresc-nosnap"
+            namespace: "osac-system"
+            labels:
+              app.kubernetes.io/managed-by: osac-aap
+              osac.openshift.io/tenant: "test-ensuresc-nosnap"
+          type: Opaque
+          stringData:
+            tenant_uid_hash: "e1a8c287"
+            vast_tenant_id: "998"
+            vip_pool_name: "osac-test-pool"
+            vast_endpoint: "127.0.0.1:18443"
+            tenant_manager_username: "osac-test-ensuresc-nosnap"
+            tenant_manager_password: "{{ mock_tenant_manager_password }}"
+
+- name: "Storage Provider Ensure SC - Run with snapshots disabled"
+  hosts: localhost
+  gather_facts: false
+
+  environment:
+    OSAC_STORAGE_CONFIG_NAMESPACE: "osac-system"
+
+  vars:
+    tenant_name: "test-ensuresc-nosnap"
+    tenant_namespace: "osac-system"
+    _cluster_name: "test-cluster"
+    storage_provider_tiers:
+      - name: default
+        protocol: nfs
+        provider: vast
+        backend_id: be-test
+    storage_provider_backend_connections:
+      be-test:
+        endpoint: "127.0.0.1:18443"
+        username: "admin"
+        password: "admin"
+    storage_provider_action: ensure_storage_class
+    storage_provider_snapshots_enabled: false
+    vast_storage_validate_certs: false
+
+  tasks:
+    - name: Call storage_provider role with snapshots disabled
+      ansible.builtin.include_role:
+        name: osac.service.storage_provider
+      vars:
+        storage_provider_action: ensure_storage_class
+
+- name: "Storage Provider Ensure SC - Verify snapshots_enabled: false is honored"
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Check if VolumeSnapshotClass CRD exists
+      kubernetes.core.k8s_info:
+        api_version: apiextensions.k8s.io/v1
+        kind: CustomResourceDefinition
+        name: volumesnapshotclasses.snapshot.storage.k8s.io
+      register: _nosnap_vsc_crd_check
+
+    - name: Assert VolumeSnapshotClass CRD is present (precondition for this test)
+      ansible.builtin.assert:
+        that:
+          - _nosnap_vsc_crd_check.resources | length > 0
+        fail_msg: >-
+          VolumeSnapshotClass CRD not found in the test cluster — this scenario only
+          proves storage_provider_snapshots_enabled is honored when the CRD IS present.
+
+    - name: Read VolumeSnapshotClass for snapshots-disabled tenant
+      kubernetes.core.k8s_info:
+        api_version: snapshot.storage.k8s.io/v1
+        kind: VolumeSnapshotClass
+        name: "vast-snapshot-test-ensuresc-nosnap-default"
+      register: _nosnap_vsc_result
+
+    - name: Assert VolumeSnapshotClass was NOT created when snapshots_enabled is false
+      ansible.builtin.assert:
+        that:
+          - _nosnap_vsc_result.resources | length == 0
+        fail_msg: >-
+          VolumeSnapshotClass 'vast-snapshot-test-ensuresc-nosnap-default' was created even
+          though storage_provider_snapshots_enabled was false — the CRD-availability check
+          must not bypass this opt-out flag.
+        success_msg: "VolumeSnapshotClass correctly suppressed when snapshots_enabled is false"
+
+# ── Cleanup (snapshots-disabled scenario) ──
+- name: "Storage Provider Ensure SC - Cleanup (snapshots disabled)"
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Delete NFS StorageClass (snapshots-disabled tenant)
+      kubernetes.core.k8s:
+        state: absent
+        api_version: storage.k8s.io/v1
+        kind: StorageClass
+        name: "vast-nfs-test-ensuresc-nosnap-default"
+      failed_when: false
+
+    - name: Delete CSI Secret (snapshots-disabled tenant)
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Secret
+        name: "vast-csi-test-ensuresc-nosnap"
+        namespace: "osac-system"
+      failed_when: false
+
+    - name: Delete hub Secret (snapshots-disabled tenant)
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Secret
+        name: "vast-tenant-config-test-ensuresc-nosnap"
+        namespace: "osac-system"
+      failed_when: false
+
+    - name: Check if VolumeSnapshotClass CRD exists for cleanup (snapshots-disabled tenant)
+      kubernetes.core.k8s_info:
+        api_version: apiextensions.k8s.io/v1
+        kind: CustomResourceDefinition
+        name: volumesnapshotclasses.snapshot.storage.k8s.io
+      register: _nosnap_cleanup_vsc_crd
+
+    - name: Delete VolumeSnapshotClass (snapshots-disabled tenant, safety net in case the flag ever regresses)
+      when: _nosnap_cleanup_vsc_crd.resources | length > 0
+      kubernetes.core.k8s:
+        state: absent
+        api_version: snapshot.storage.k8s.io/v1
+        kind: VolumeSnapshotClass
+        name: "vast-snapshot-test-ensuresc-nosnap-default"
+      failed_when: false
 
 # ── Cleanup ──
 - name: "Storage Provider Ensure SC - Cleanup"

--- a/osac-aap/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
+++ b/osac-aap/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
@@ -112,7 +112,7 @@
       be-test:
         endpoint: "127.0.0.1:18443"
         username: "admin"
-        password: "admin"
+        password: "mock-admin-password"
     storage_provider_action: ensure_storage_class
     storage_provider_block_encryption_passphrase: "test-encryption-passphrase"
     vast_storage_validate_certs: false
@@ -369,7 +369,7 @@
       be-test:
         endpoint: "127.0.0.1:18443"
         username: "admin"
-        password: "admin"
+        password: "mock-admin-password"
     storage_provider_action: ensure_storage_class
     storage_provider_block_encryption_passphrase: "test-encryption-passphrase"
     vast_storage_validate_certs: false
@@ -507,7 +507,7 @@
       be-test:
         endpoint: "127.0.0.1:18443"
         username: "admin"
-        password: "admin"
+        password: "mock-admin-password"
     storage_provider_action: ensure_storage_class
     storage_provider_snapshots_enabled: false
     vast_storage_validate_certs: false
@@ -524,6 +524,21 @@
   gather_facts: false
 
   tasks:
+    - name: Verify NFS StorageClass was provisioned (proves ensure_storage_class completed)
+      kubernetes.core.k8s_info:
+        api_version: storage.k8s.io/v1
+        kind: StorageClass
+        name: "vast-nfs-test-ensuresc-nosnap-default"
+      register: _nosnap_sc_result
+
+    - name: Assert exactly one NFS StorageClass exists for the snapshots-disabled tenant
+      ansible.builtin.assert:
+        that:
+          - _nosnap_sc_result.resources | length == 1
+        fail_msg: >-
+          StorageClass 'vast-nfs-test-ensuresc-nosnap-default' was not found — ensure_storage_class
+          must have failed before snapshot suppression could even be exercised.
+
     - name: Check if VolumeSnapshotClass CRD exists
       kubernetes.core.k8s_info:
         api_version: apiextensions.k8s.io/v1

--- a/osac-aap/tests/integration/targets/storage_provider_onboarding/tasks/main.yml
+++ b/osac-aap/tests/integration/targets/storage_provider_onboarding/tasks/main.yml
@@ -52,9 +52,6 @@
   gather_facts: false
 
   environment:
-    VAST_ENDPOINT: "127.0.0.1:18443"
-    VAST_USERNAME: "admin"
-    VAST_PASSWORD: "admin"
     VAST_VIP_POOL_NAME: "osac-test-pool"
     VAST_VIP_POOL_IP_RANGES: '[["10.0.0.10","10.0.0.50"]]'
     VAST_VIP_POOL_SUBNET_CIDR: "24"
@@ -69,7 +66,12 @@
       - name: default
         protocol: nfs
         provider: vast
-    storage_provider_snapshots_enabled: false
+        backend_id: be-test
+    storage_provider_backend_connections:
+      be-test:
+        endpoint: "127.0.0.1:18443"
+        username: "admin"
+        password: "admin"
     vast_storage_validate_certs: false
 
   tasks:

--- a/osac-aap/tests/integration/targets/storage_provider_onboarding/tasks/main.yml
+++ b/osac-aap/tests/integration/targets/storage_provider_onboarding/tasks/main.yml
@@ -114,6 +114,7 @@
     - name: Decode hub Secret manager credentials
       ansible.builtin.set_fact:
         _hub_csi_username: "{{ _hub_secret.resources[0].data.tenant_manager_username | b64decode }}"
+        _hub_csi_password: "{{ _hub_secret.resources[0].data.tenant_manager_password | b64decode }}"
       no_log: true
 
     - name: Read StorageClass
@@ -161,7 +162,7 @@
           - _csi_secret.resources[0].data.username is defined
           - (_csi_secret.resources[0].data.username | b64decode) == _hub_csi_username
           - _csi_secret.resources[0].data.password is defined
-          - (_csi_secret.resources[0].data.password | b64decode | length) > 0
+          - (_csi_secret.resources[0].data.password | b64decode) == _hub_csi_password
           - _csi_secret.resources[0].data.endpoint is defined
         fail_msg: "CSI Secret credentials do not match hub Secret — credential handoff failed"
         success_msg: "CSI Secret uses manager credentials from hub Secret (credential handoff validated)"
@@ -171,7 +172,7 @@
       ansible.builtin.assert:
         that:
           - (_csi_secret.resources[0].data.username | b64decode) != 'admin'
-          - (_csi_secret.resources[0].data.password | b64decode) != 'admin'
+          - (_csi_secret.resources[0].data.password | b64decode) != 'mock-admin-password'
         fail_msg: "CSI Secret contains admin credentials — security boundary violated"
         success_msg: "CSI Secret confirmed free of admin credentials"
       no_log: true

--- a/osac-aap/tests/integration/targets/storage_provider_onboarding/tasks/main.yml
+++ b/osac-aap/tests/integration/targets/storage_provider_onboarding/tasks/main.yml
@@ -71,7 +71,7 @@
       be-test:
         endpoint: "127.0.0.1:18443"
         username: "admin"
-        password: "admin"
+        password: "mock-admin-password"
     vast_storage_validate_certs: false
 
   tasks:

--- a/osac-aap/tests/integration/targets/storage_provider_setup/tasks/main.yml
+++ b/osac-aap/tests/integration/targets/storage_provider_setup/tasks/main.yml
@@ -9,9 +9,6 @@
   gather_facts: false
 
   environment:
-    VAST_ENDPOINT: "127.0.0.1:18443"
-    VAST_USERNAME: "admin"
-    VAST_PASSWORD: "admin"
     VAST_VIP_POOL_NAME: "osac-test-pool"
     VAST_VIP_POOL_IP_RANGES: '[["10.0.0.10","10.0.0.50"]]'
     VAST_VIP_POOL_SUBNET_CIDR: "24"
@@ -25,14 +22,20 @@
       - name: default
         protocol: nfs
         provider: vast
-        qos_policy: test-qos
+        backend_id: be-test
+        # qos_policy intentionally omitted: the role always derives it from the tier
+        # name now, discarding any caller-supplied value.
         qos_limits:
           static_limits:
             max_reads_bw_mbps: 100
             max_writes_bw_mbps: 100
+    storage_provider_backend_connections:
+      be-test:
+        endpoint: "127.0.0.1:18443"
+        username: "admin"
+        password: "admin"
     storage_provider_action: setup
     storage_provider_provisioning_target: vmaas
-    storage_provider_snapshots_enabled: false
     vast_storage_validate_certs: false
 
   tasks:

--- a/osac-aap/tests/integration/targets/storage_provider_setup/tasks/main.yml
+++ b/osac-aap/tests/integration/targets/storage_provider_setup/tasks/main.yml
@@ -224,15 +224,6 @@
         fail_msg: "No manager creation API call found in mock call log"
         success_msg: "Manager creation API call detected"
 
-    - name: Assert QoS policy was created with the name derived from the tier
-      ansible.builtin.assert:
-        that:
-          - >-
-            _call_log | selectattr('path', 'search', 'qospolicies') | selectattr('method', 'equalto', 'POST')
-            | map(attribute='body') | selectattr('name', 'equalto', 'default-qos') | list | length > 0
-        fail_msg: "No qospolicies POST for the derived policy 'default-qos' found — the derived qos_policy did not reach VMS"
-        success_msg: "Derived qos_policy 'default-qos' created on VMS"
-
 # ── Cleanup ──
 - name: "Storage Provider Setup - Cleanup"
   hosts: localhost

--- a/osac-aap/tests/integration/targets/storage_provider_setup/tasks/main.yml
+++ b/osac-aap/tests/integration/targets/storage_provider_setup/tasks/main.yml
@@ -33,7 +33,7 @@
       be-test:
         endpoint: "127.0.0.1:18443"
         username: "admin"
-        password: "admin"
+        password: "mock-admin-password"
     storage_provider_action: setup
     storage_provider_provisioning_target: vmaas
     vast_storage_validate_certs: false
@@ -223,6 +223,15 @@
           - _call_log | selectattr('path', 'search', 'managers') | list | length > 0
         fail_msg: "No manager creation API call found in mock call log"
         success_msg: "Manager creation API call detected"
+
+    - name: Assert QoS policy was created with the name derived from the tier
+      ansible.builtin.assert:
+        that:
+          - >-
+            _call_log | selectattr('path', 'search', 'qospolicies') | selectattr('method', 'equalto', 'POST')
+            | map(attribute='body') | selectattr('name', 'equalto', 'default-qos') | list | length > 0
+        fail_msg: "No qospolicies POST for the derived policy 'default-qos' found — the derived qos_policy did not reach VMS"
+        success_msg: "Derived qos_policy 'default-qos' created on VMS"
 
 # ── Cleanup ──
 - name: "Storage Provider Setup - Cleanup"

--- a/osac-aap/tests/integration/targets/storage_provider_setup_rollback/tasks/main.yml
+++ b/osac-aap/tests/integration/targets/storage_provider_setup_rollback/tasks/main.yml
@@ -62,7 +62,7 @@
       be-test:
         endpoint: "127.0.0.1:18443"
         username: "admin"
-        password: "admin"
+        password: "mock-admin-password"
     storage_provider_action: setup
     storage_provider_provisioning_target: vmaas
     vast_storage_validate_certs: false

--- a/osac-aap/tests/integration/targets/storage_provider_setup_rollback/tasks/main.yml
+++ b/osac-aap/tests/integration/targets/storage_provider_setup_rollback/tasks/main.yml
@@ -39,9 +39,6 @@
   gather_facts: false
 
   environment:
-    VAST_ENDPOINT: "127.0.0.1:18443"
-    VAST_USERNAME: "admin"
-    VAST_PASSWORD: "admin"
     VAST_VIP_POOL_NAME: "osac-test-pool"
     VAST_VIP_POOL_IP_RANGES: '[["10.0.0.10","10.0.0.50"]]'
     VAST_VIP_POOL_SUBNET_CIDR: "24"
@@ -55,13 +52,19 @@
       - name: default
         protocol: nfs
         provider: vast
-        qos_policy: rollback-qos
+        backend_id: be-test
+        # qos_policy intentionally omitted: the role always derives it from the tier
+        # name now, discarding any caller-supplied value.
         qos_limits:
           static_limits:
             max_reads_bw_mbps: 100
+    storage_provider_backend_connections:
+      be-test:
+        endpoint: "127.0.0.1:18443"
+        username: "admin"
+        password: "admin"
     storage_provider_action: setup
     storage_provider_provisioning_target: vmaas
-    storage_provider_snapshots_enabled: false
     vast_storage_validate_certs: false
 
   tasks:

--- a/osac-aap/tests/integration/targets/storage_provider_teardown/tasks/main.yml
+++ b/osac-aap/tests/integration/targets/storage_provider_teardown/tasks/main.yml
@@ -229,7 +229,7 @@
       be-test:
         endpoint: "127.0.0.1:18443"
         username: "admin"
-        password: "admin"
+        password: "mock-admin-password"
     storage_provider_provisioning_target: vmaas
     vast_storage_validate_certs: false
 

--- a/osac-aap/tests/integration/targets/storage_provider_teardown/tasks/main.yml
+++ b/osac-aap/tests/integration/targets/storage_provider_teardown/tasks/main.yml
@@ -10,6 +10,10 @@
   hosts: localhost
   gather_facts: false
 
+  vars:
+    mock_tenant_manager_password: "test-csi-password"
+    mock_csi_token: "test-api-token-for-csi"
+
   tasks:
     - name: Reset mock VMS server (sequential execution — safe to reset)
       ansible.builtin.uri:
@@ -89,7 +93,7 @@
             storage_provider_type: "vast"
             tenant_manager_name: "osac-test-teardown"
             tenant_manager_username: "osac-test-teardown"
-            tenant_manager_password: "test-csi-password"
+            tenant_manager_password: "{{ mock_tenant_manager_password }}"
             tenant_manager_id: "7"
             tenant_role_id: "8"
 
@@ -150,7 +154,7 @@
               osac.openshift.io/tenant: "test-teardown"
           type: Opaque
           stringData:
-            token: "test-api-token-for-csi"
+            token: "{{ mock_csi_token }}"
             endpoint: "127.0.0.1:18443"
 
     - name: Check if VolumeSnapshotClass CRD exists
@@ -211,9 +215,6 @@
   gather_facts: false
 
   environment:
-    VAST_ENDPOINT: "127.0.0.1:18443"
-    VAST_USERNAME: "admin"
-    VAST_PASSWORD: "admin"
     OSAC_STORAGE_CONFIG_NAMESPACE: "osac-system"
 
   vars:
@@ -223,6 +224,12 @@
       - name: default
         protocol: nfs
         provider: vast
+        backend_id: be-test
+    storage_provider_backend_connections:
+      be-test:
+        endpoint: "127.0.0.1:18443"
+        username: "admin"
+        password: "admin"
     storage_provider_provisioning_target: vmaas
     vast_storage_validate_certs: false
 


### PR DESCRIPTION
## Summary
- Replaces the `STORAGE_TIERS` env var and `storage-operations-ig` VAST admin credentials with `ansible_eda.event.storage_tier_definitions`/`storage_backend_connections` extra_vars populated by osac-operator's new Tier API integration, absorbing OSAC-1957's outstanding AAP-side AC
- Centralizes `qos_policy` derivation in the `storage_provider` role so every caller gets consistent naming without duplicating the logic
- Wraps AAP-discovered tier/backend capability-mismatch checks (unsupported protocol, ambiguous/unresolved/incomplete backend connections) in structured `set_stats` failure artifacts, additive scaffolding for a future osac-operator consumer to attribute job failures to a specific StorageTier/StorageBackend

## Migration note
Ports osac-aap#455 ahead of osac-aap's own cutover into this mono-repo ([OSAC-1732](https://redhat.atlassian.net/browse/OSAC-1732)).
Original PR (full review history): https://github.com/osac-project/osac-aap/pull/455

## Review findings addressed
- Fixed: updated `storage_provider_snapshots_enabled`'s description in `storage_provider/meta/argument_specs.yaml` for clarity on CRD-gating behavior (the field itself already existed on this repo's `main` via an independent upstream change since osac-aap#455 was branched; this port's version supersedes it with clearer live-CRD-check language, no behavior change)
- Fixed: marked `secretRef` optional in `storage-operations-ig.j2` to match `compute-instance-operations-ig.j2` pattern (Secret is empty post-OSAC-1992; credentials now sourced via `storage_backend_connections` extra_vars; no consumer reads from the Secret; no fallback to broader-access credentials exists)
- Retained as-is: teardown fail-on-missing-tiers kept unchanged — warn+skip would let osac-operator mark cleanup as complete when the storage_provider dispatch never ran (no tier data = no provider routing), orphaning cluster-side StorageClasses/VolumeSnapshotClasses/CSI Secrets; hard fail forces reconciliation retry, which is the correct behavior since the only production case for absent tier data is a transient Tier API failure

## Carried-over open discussion (from osac-aap#455, not yet resolved)
Quoted verbatim — not answered here, since these are forward-looking product questions this migration doesn't have the authority to resolve:

**playbook_osac_create_compute_instance.yml:83** (@akshaynadkarni):
> nit:
Is this being used? Are there plans to use this in the future for caas, bmaas etc.? 

**tests/integration/run_tests.sh:202** (@akshaynadkarni):
> nit: The `STORAGE_TESTS` targets (`storage_provider_setup`, `storage_provider_ensure_sc`, etc.) are VAST-specific end-to-end: they hardcode provider: `vast`, assert `vast-*` resource names, and require the mock VMS server. When a second provider lands (e.g. PURE, LVMS), these names will be ambiguous.

Should we add a prefix or a `vast/` sub-directory?
WDYT? 

**_dispatch_provider.yaml:38** (@akshaynadkarni):
> nit: Today this dispatch loop is only exercised with a single provider (vast) in tests. Once LVMS lands (cc @zszabo-rh ), can we add a test with tiers spanning two providers? WDYT?

**storage_provider/tests/test.yml:298** (@akshaynadkarni):
> nit: Test comments jump from 7 to 9 to 11 (missing 8, 10). Likely from removed scenarios during iteration. Perhaps we can skip numbering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Storage tiers and backend credentials are now supplied through event configuration.
  * QoS policies are derived automatically, and quotas use `quota_bytes`.
  * Snapshot support is detected from the target cluster.
* **Bug Fixes**
  * Added validation for unsupported protocols, missing backend details, and invalid tier configuration.
  * Improved namespace detection for storage workloads.
* **Documentation**
  * Updated configuration examples and guidance for storage tiers and credentials.
* **Security**
  * Event diagnostics now display approved metadata without exposing sensitive payload fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->