### PR TITLE
VALIDATION ONLY — DO NOT MERGE — OSAC-3556 conditional AAP build

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -44,6 +44,7 @@ jobs:
       pull-requests: read
     outputs:
       should-run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+      aap-changed: ${{ github.event_name != 'pull_request' || steps.aap-filter.outputs.osac-aap == 'true' }}
     steps:
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         if: github.event_name == 'pull_request'
@@ -57,18 +58,72 @@ jobs:
               - '!**/LICENSE'
               - '!**/*.md'
               - '!**/docs/**'
+      # Separate step, not folded into the filter above: that step's
+      # predicate-quantifier: 'every' means "every changed file matches",
+      # correct for the broad code/no-code split but wrong for a single
+      # component filter (it would only fire true if ALL changed files were
+      # under osac-aap/). This step uses the default 'some' quantifier: true
+      # if ANY changed file is under osac-aap/.
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        if: github.event_name == 'pull_request'
+        id: aap-filter
+        with:
+          filters: |
+            osac-aap:
+              - 'osac-aap/**'
 
-  # Builds fulfillment-service, osac-operator, osac-aap's execution
-  # environment (twice -- once each for aap.bootstrap.image and
-  # aap.configAsCode.eeImage, see OSAC-3546), and bare-metal-fulfillment-operator
-  # from this PR's current code and installs them together in one cluster --
-  # not one "component under test" plus stale pinned images for the others.
-  # Runs for any change touching any component (see `changes` above) rather
-  # than being path-scoped per component; splitting this by component to
-  # avoid running both suites when only one changed is deferred to the future
-  # full path-based CI matrix, once its skip-logic pattern is verified.
-  e2e-bmaas-full-install:
+  # osac-aap's execution-environment build (and the AAP Controller project's
+  # git-URI override that comes with it) is resolved here, before the e2e
+  # job runs, and gated on aap-changed -- unconditionally redirecting the
+  # Controller project's git URI at this PR's own repo/branch, even for PRs
+  # that never touched osac-aap/, breaks job template creation the moment
+  # the first install actually applies that override on its own hook
+  # (see OSAC-3556). Non-PR triggers (schedule/workflow_dispatch/merge_group)
+  # default to true (build+override AAP) via aap-changed's own fallback.
+  resolve-components:
     needs: changes
+    runs-on: ubuntu-latest
+    outputs:
+      components: ${{ steps.build.outputs.components }}
+    steps:
+      - id: build
+        env:
+          REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          AAP_CHANGED: ${{ needs.changes.outputs.aap-changed }}
+        run: |
+          COMPONENTS=$(jq -nc --arg repo "${REPO}" --arg ref "${REF}" '[
+            {"repo":$repo,"ref":$ref,"containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},
+            {"repo":$repo,"ref":$ref,"containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},
+            {"repo":$repo,"ref":$ref,"containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}
+          ]')
+
+          # osac-aap's execution-environment is built twice (aap.bootstrap.image
+          # and aap.configAsCode.eeImage): the two are logically the same image
+          # but the override mechanism keys strictly off imageKey, one build per
+          # key, so this is the only way to get both fields covered without
+          # changing that mechanism (which lives in osac-test-infra, not here).
+          # See OSAC-3546.
+          if [[ "${AAP_CHANGED}" == "true" ]]; then
+            COMPONENTS=$(echo "${COMPONENTS}" | jq -c --arg repo "${REPO}" --arg ref "${REF}" '. + [
+              {"repo":$repo,"ref":$ref,"containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},
+              {"repo":$repo,"ref":$ref,"containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"}
+            ]')
+          fi
+
+          echo "components=${COMPONENTS}" >> "$GITHUB_OUTPUT"
+
+  # Builds fulfillment-service, osac-operator, and bare-metal-fulfillment-operator
+  # (plus osac-aap's execution environment when osac-aap/ changed -- see
+  # resolve-components above) from this PR's current code and installs them
+  # together in one cluster -- not one "component under test" plus stale
+  # pinned images for the others. Runs for any change touching any component
+  # (see `changes` above) rather than being path-scoped per component;
+  # splitting this by component to avoid running both suites when only one
+  # changed is deferred to the future full path-based CI matrix, once its
+  # skip-logic pattern is verified.
+  e2e-bmaas-full-install:
+    needs: [changes, resolve-components]
     if: needs.changes.outputs.should-run == 'true'
     uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-full-install.yml@main
     with:
@@ -81,13 +136,7 @@ jobs:
       # standalone-repo default.
       installer-repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       installer-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
-      # Build all component images from the PR's fork/branch (same monorepo checkout).
-      # osac-aap's execution-environment is built twice (aap.bootstrap.image and
-      # aap.configAsCode.eeImage): the two are logically the same image but the
-      # override mechanism keys strictly off imageKey, one build per key, so this
-      # is the only way to get both fields covered without changing that mechanism
-      # (which lives in osac-test-infra, not here). See OSAC-3546.
-      components: '[{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}]'
+      components: ${{ needs.resolve-components.outputs.components }}
       # Pass author_association for fork PR authorization (empty for non-fork PRs)
       fork-pr-author-association: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association || '' }}
       fork-pr-author: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.user.login || '' }}
@@ -98,13 +147,14 @@ jobs:
 
   e2e:
     if: always()
-    needs: [changes, e2e-bmaas-full-install]
+    needs: [changes, resolve-components, e2e-bmaas-full-install]
     runs-on: ubuntu-latest
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "Upstream job results:"
           echo "  changes: ${{ needs.changes.result }}"
+          echo "  resolve-components: ${{ needs.resolve-components.result }}"
           echo "  e2e-bmaas-full-install: ${{ needs.e2e-bmaas-full-install.result }}"
           echo ""
           echo "One or more upstream jobs failed or were cancelled."

--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -125,7 +125,7 @@ jobs:
   e2e-bmaas-full-install:
     needs: [changes, resolve-components]
     if: needs.changes.outputs.should-run == 'true'
-    uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-full-install.yml@main
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-full-install.yml@705727fe58e37f71424af9ba92e5ef5a5ea81435
     with:
       test-suite: ${{ inputs.test-suite || 'bmaas' }}
       test-filter: ${{ inputs.test-filter || '' }}

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -44,6 +44,7 @@ jobs:
       pull-requests: read
     outputs:
       should-run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+      aap-changed: ${{ github.event_name != 'pull_request' || steps.aap-filter.outputs.osac-aap == 'true' }}
     steps:
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         if: github.event_name == 'pull_request'
@@ -57,21 +58,75 @@ jobs:
               - '!**/LICENSE'
               - '!**/*.md'
               - '!**/docs/**'
+      # Separate step, not folded into the filter above: that step's
+      # predicate-quantifier: 'every' means "every changed file matches",
+      # correct for the broad code/no-code split but wrong for a single
+      # component filter (it would only fire true if ALL changed files were
+      # under osac-aap/). This step uses the default 'some' quantifier: true
+      # if ANY changed file is under osac-aap/.
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        if: github.event_name == 'pull_request'
+        id: aap-filter
+        with:
+          filters: |
+            osac-aap:
+              - 'osac-aap/**'
 
-  # Builds fulfillment-service, osac-operator, osac-aap's execution
-  # environment (twice -- once each for aap.bootstrap.image and
-  # aap.configAsCode.eeImage, see OSAC-3546), and bare-metal-fulfillment-operator
-  # from this PR's current code and installs them together in one cluster --
-  # not one "component under test" plus a stale pinned image for the others.
-  # Runs for any change touching any component (see `changes` above) rather
-  # than being path-scoped per component; splitting this by component to
-  # avoid running both suites when only one changed is deferred to the
-  # future full path-based CI matrix, once its skip-logic pattern is
-  # verified. osac-aap *is* built here (added by OSAC-3546): caas's own
-  # values/caas-ci/values.yaml sets provisioning.provider: "aap" and
-  # controllers.clusterOrder: true, so CaaS's core cluster-provisioning path
-  # runs through AAP just as much as vmaas/bmaas's does -- the prior
-  # exclusion was deferred scope, not a real technical constraint.
+  # osac-aap's execution-environment build (and the AAP Controller project's
+  # git-URI override that comes with it) is resolved here, before the e2e
+  # job runs, and gated on aap-changed -- unconditionally redirecting the
+  # Controller project's git URI at this PR's own repo/branch, even for PRs
+  # that never touched osac-aap/, breaks job template creation the moment
+  # the first install actually applies that override on its own hook
+  # (see OSAC-3556). Non-PR triggers (schedule/workflow_dispatch/merge_group)
+  # default to true (build+override AAP) via aap-changed's own fallback.
+  resolve-components:
+    needs: changes
+    runs-on: ubuntu-latest
+    outputs:
+      components: ${{ steps.build.outputs.components }}
+    steps:
+      - id: build
+        env:
+          REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          AAP_CHANGED: ${{ needs.changes.outputs.aap-changed }}
+        run: |
+          COMPONENTS=$(jq -nc --arg repo "${REPO}" --arg ref "${REF}" '[
+            {"repo":$repo,"ref":$ref,"containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},
+            {"repo":$repo,"ref":$ref,"containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},
+            {"repo":$repo,"ref":$ref,"containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}
+          ]')
+
+          # osac-aap's execution-environment is built twice (aap.bootstrap.image
+          # and aap.configAsCode.eeImage): the two are logically the same image
+          # but the override mechanism keys strictly off imageKey, one build per
+          # key, so this is the only way to get both fields covered without
+          # changing that mechanism (which lives in osac-test-infra, not here).
+          # See OSAC-3546.
+          if [[ "${AAP_CHANGED}" == "true" ]]; then
+            COMPONENTS=$(echo "${COMPONENTS}" | jq -c --arg repo "${REPO}" --arg ref "${REF}" '. + [
+              {"repo":$repo,"ref":$ref,"containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},
+              {"repo":$repo,"ref":$ref,"containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"}
+            ]')
+          fi
+
+          echo "components=${COMPONENTS}" >> "$GITHUB_OUTPUT"
+
+  # Builds fulfillment-service, osac-operator, and bare-metal-fulfillment-operator
+  # (plus osac-aap's execution environment when osac-aap/ changed -- see
+  # resolve-components above) from this PR's current code and installs them
+  # together in one cluster -- not one "component under test" plus a stale
+  # pinned image for the others. Runs for any change touching any component
+  # (see `changes` above) rather than being path-scoped per component;
+  # splitting this by component to avoid running both suites when only one
+  # changed is deferred to the future full path-based CI matrix, once its
+  # skip-logic pattern is verified. osac-aap *can* be built here (added by
+  # OSAC-3546): caas's own values/caas-ci/values.yaml sets
+  # provisioning.provider: "aap" and controllers.clusterOrder: true, so
+  # CaaS's core cluster-provisioning path runs through AAP just as much as
+  # vmaas/bmaas's does -- the prior exclusion was deferred scope, not a real
+  # technical constraint.
   #
   # bare-metal-fulfillment-operator's image override (bmf.image.repository)
   # is currently a no-op in this flow specifically: values/caas-ci/values.yaml
@@ -79,7 +134,7 @@ jobs:
   # built from source for consistency with the other components -- revisit
   # if caas ever needs BMF enabled.
   e2e-caas-full-install:
-    needs: changes
+    needs: [changes, resolve-components]
     if: needs.changes.outputs.should-run == 'true'
     uses: osac-project/osac-test-infra/.github/workflows/e2e-caas-full-install.yml@main
     with:
@@ -92,13 +147,7 @@ jobs:
       # standalone-repo default.
       installer-repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       installer-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
-      # Build all component images from the PR's fork/branch (same monorepo checkout).
-      # osac-aap's execution-environment is built twice (aap.bootstrap.image and
-      # aap.configAsCode.eeImage): the two are logically the same image but the
-      # override mechanism keys strictly off imageKey, one build per key, so this
-      # is the only way to get both fields covered without changing that mechanism
-      # (which lives in osac-test-infra, not here). See OSAC-3546.
-      components: '[{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}]'
+      components: ${{ needs.resolve-components.outputs.components }}
       # Pass author_association for fork PR authorization (empty for non-fork PRs)
       fork-pr-author-association: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association || '' }}
       fork-pr-author: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.user.login || '' }}
@@ -113,13 +162,14 @@ jobs:
 
   e2e:
     if: always()
-    needs: [changes, e2e-caas-full-install]
+    needs: [changes, resolve-components, e2e-caas-full-install]
     runs-on: ubuntu-latest
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "Upstream job results:"
           echo "  changes: ${{ needs.changes.result }}"
+          echo "  resolve-components: ${{ needs.resolve-components.result }}"
           echo "  e2e-caas-full-install: ${{ needs.e2e-caas-full-install.result }}"
           echo ""
           echo "One or more upstream jobs failed or were cancelled."

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -44,6 +44,7 @@ jobs:
       pull-requests: read
     outputs:
       should-run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+      aap-changed: ${{ github.event_name != 'pull_request' || steps.aap-filter.outputs.osac-aap == 'true' }}
     steps:
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         if: github.event_name == 'pull_request'
@@ -57,16 +58,70 @@ jobs:
               - '!**/LICENSE'
               - '!**/*.md'
               - '!**/docs/**'
+      # Separate step, not folded into the filter above: that step's
+      # predicate-quantifier: 'every' means "every changed file matches",
+      # correct for the broad code/no-code split but wrong for a single
+      # component filter (it would only fire true if ALL changed files were
+      # under osac-aap/). This step uses the default 'some' quantifier: true
+      # if ANY changed file is under osac-aap/.
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        if: github.event_name == 'pull_request'
+        id: aap-filter
+        with:
+          filters: |
+            osac-aap:
+              - 'osac-aap/**'
 
-  # Builds fulfillment-service, osac-operator, osac-aap's execution
-  # environment (twice -- once each for aap.bootstrap.image and
-  # aap.configAsCode.eeImage, see OSAC-3546), and bare-metal-fulfillment-operator
-  # from this PR's current code and installs them together in one cluster --
-  # not one "component under test" plus stale pinned images for the others.
-  # Runs for any change touching any component (see `changes` above) rather
-  # than being path-scoped per component; splitting this by component to
-  # avoid running both suites when only one changed is deferred to the future
-  # full path-based CI matrix, once its skip-logic pattern is verified.
+  # osac-aap's execution-environment build (and the AAP Controller project's
+  # git-URI override that comes with it) is resolved here, before the e2e
+  # job runs, and gated on aap-changed -- unconditionally redirecting the
+  # Controller project's git URI at this PR's own repo/branch, even for PRs
+  # that never touched osac-aap/, breaks job template creation the moment
+  # the first install actually applies that override on its own hook
+  # (see OSAC-3556). Non-PR triggers (schedule/workflow_dispatch/merge_group)
+  # default to true (build+override AAP) via aap-changed's own fallback.
+  resolve-components:
+    needs: changes
+    runs-on: ubuntu-latest
+    outputs:
+      components: ${{ steps.build.outputs.components }}
+    steps:
+      - id: build
+        env:
+          REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          AAP_CHANGED: ${{ needs.changes.outputs.aap-changed }}
+        run: |
+          COMPONENTS=$(jq -nc --arg repo "${REPO}" --arg ref "${REF}" '[
+            {"repo":$repo,"ref":$ref,"containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},
+            {"repo":$repo,"ref":$ref,"containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},
+            {"repo":$repo,"ref":$ref,"containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}
+          ]')
+
+          # osac-aap's execution-environment is built twice (aap.bootstrap.image
+          # and aap.configAsCode.eeImage): the two are logically the same image
+          # but the override mechanism keys strictly off imageKey, one build per
+          # key, so this is the only way to get both fields covered without
+          # changing that mechanism (which lives in osac-test-infra, not here).
+          # See OSAC-3546.
+          if [[ "${AAP_CHANGED}" == "true" ]]; then
+            COMPONENTS=$(echo "${COMPONENTS}" | jq -c --arg repo "${REPO}" --arg ref "${REF}" '. + [
+              {"repo":$repo,"ref":$ref,"containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},
+              {"repo":$repo,"ref":$ref,"containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"}
+            ]')
+          fi
+
+          echo "components=${COMPONENTS}" >> "$GITHUB_OUTPUT"
+
+  # Builds fulfillment-service, osac-operator, and bare-metal-fulfillment-operator
+  # (plus osac-aap's execution environment when osac-aap/ changed -- see
+  # resolve-components above) from this PR's current code and installs them
+  # together in one cluster -- not one "component under test" plus stale
+  # pinned images for the others. Runs for any change touching any component
+  # (see `changes` above) rather than being path-scoped per component;
+  # splitting this by component to avoid running both suites when only one
+  # changed is deferred to the future full path-based CI matrix, once its
+  # skip-logic pattern is verified.
   #
   # bare-metal-fulfillment-operator's image override (bmf.image.repository)
   # is currently a no-op in this flow specifically: values/vmaas-ci/values.yaml
@@ -75,7 +130,7 @@ jobs:
   # should build from the PR in every e2e flow, even where one isn't
   # currently deployed) -- revisit if vmaas ever needs BMF enabled.
   e2e-vmaas-full-install:
-    needs: changes
+    needs: [changes, resolve-components]
     if: needs.changes.outputs.should-run == 'true'
     uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main
     with:
@@ -88,13 +143,7 @@ jobs:
       # standalone-repo default.
       installer-repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       installer-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
-      # Build all component images from the PR's fork/branch (same monorepo checkout).
-      # osac-aap's execution-environment is built twice (aap.bootstrap.image and
-      # aap.configAsCode.eeImage): the two are logically the same image but the
-      # override mechanism keys strictly off imageKey, one build per key, so this
-      # is the only way to get both fields covered without changing that mechanism
-      # (which lives in osac-test-infra, not here). See OSAC-3546.
-      components: '[{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}]'
+      components: ${{ needs.resolve-components.outputs.components }}
       # Pass author_association for fork PR authorization (empty for non-fork PRs)
       fork-pr-author-association: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association || '' }}
       fork-pr-author: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.user.login || '' }}
@@ -105,13 +154,14 @@ jobs:
 
   e2e:
     if: always()
-    needs: [changes, e2e-vmaas-full-install]
+    needs: [changes, resolve-components, e2e-vmaas-full-install]
     runs-on: ubuntu-latest
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "Upstream job results:"
           echo "  changes: ${{ needs.changes.result }}"
+          echo "  resolve-components: ${{ needs.resolve-components.result }}"
           echo "  e2e-vmaas-full-install: ${{ needs.e2e-vmaas-full-install.result }}"
           echo ""
           echo "One or more upstream jobs failed or were cancelled."

--- a/bare-metal-fulfillment-operator/api/v1alpha1/baremetalinstance_types.go
+++ b/bare-metal-fulfillment-operator/api/v1alpha1/baremetalinstance_types.go
@@ -54,8 +54,6 @@ type BareMetalInstanceSpec struct {
 	ExternalHostName string `json:"externalHostName,omitempty"`
 	// HostClass is host management backend class (e.g. openstack).
 	HostClass string `json:"hostClass,omitempty"`
-	// NetworkClass is the network class for this host (e.g. openstack).
-	NetworkClass string `json:"networkClass,omitempty"`
 	// Selector defines additional host selection filters.
 	// hostSelector accepts arbitrary key/value selectors such as managedBy or topology.
 	// +kubebuilder:validation:Optional
@@ -221,7 +219,6 @@ func (h *BareMetalInstance) GetPoolID() (string, bool) {
 // +kubebuilder:printcolumn:name="HostType",type=string,JSONPath=`.spec.hostType`
 // +kubebuilder:printcolumn:name="Template",type=string,JSONPath=`.spec.templateID`
 // +kubebuilder:printcolumn:name="HostClass",type=string,JSONPath=`.spec.hostClass`
-// +kubebuilder:printcolumn:name="NetworkClass",type=string,JSONPath=`.spec.networkClass`
 // +kubebuilder:printcolumn:name="ExternalHostID",type=string,JSONPath=`.spec.externalHostID`
 
 // BareMetalInstance is the Schema for the baremetalinstances API.

--- a/bare-metal-fulfillment-operator/charts/operator-crds/templates/osac.openshift.io_baremetalinstances.yaml
+++ b/bare-metal-fulfillment-operator/charts/operator-crds/templates/osac.openshift.io_baremetalinstances.yaml
@@ -30,9 +30,6 @@ spec:
     - jsonPath: .spec.hostClass
       name: HostClass
       type: string
-    - jsonPath: .spec.networkClass
-      name: NetworkClass
-      type: string
     - jsonPath: .spec.externalHostID
       name: ExternalHostID
       type: string
@@ -98,10 +95,6 @@ spec:
                 x-kubernetes-validations:
                 - message: field is immutable
                   rule: self == oldSelf
-              networkClass:
-                description: NetworkClass is the network class for this host (e.g.
-                  openstack).
-                type: string
               restartTrigger:
                 description: |-
                   RestartTrigger is used to trigger a restart of the physical machine.

--- a/bare-metal-fulfillment-operator/config/crd/bases/osac.openshift.io_baremetalinstances.yaml
+++ b/bare-metal-fulfillment-operator/config/crd/bases/osac.openshift.io_baremetalinstances.yaml
@@ -29,9 +29,6 @@ spec:
     - jsonPath: .spec.hostClass
       name: HostClass
       type: string
-    - jsonPath: .spec.networkClass
-      name: NetworkClass
-      type: string
     - jsonPath: .spec.externalHostID
       name: ExternalHostID
       type: string
@@ -97,10 +94,6 @@ spec:
                 x-kubernetes-validations:
                 - message: field is immutable
                   rule: self == oldSelf
-              networkClass:
-                description: NetworkClass is the network class for this host (e.g.
-                  openstack).
-                type: string
               restartTrigger:
                 description: |-
                   RestartTrigger is used to trigger a restart of the physical machine.

--- a/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_controller.go
+++ b/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_controller.go
@@ -282,7 +282,6 @@ func (r *BareMetalInstanceReconciler) reconcileInventory(ctx context.Context, ba
 	}
 
 	bareMetalInstance.Spec.HostClass = inventoryHost.HostClass
-	bareMetalInstance.Spec.NetworkClass = inventoryHost.NetworkClass
 	if err = r.Update(ctx, bareMetalInstance); err != nil {
 		log.Error(err, "Failed to update BareMetalInstance CR with HostClass", "HostClass", inventoryHost.HostClass)
 		return ctrl.Result{}, err
@@ -457,7 +456,6 @@ func (r *BareMetalInstanceReconciler) reconcileProvisioning(ctx context.Context,
 		ExternalHostID            string
 		ExternalHostName          string
 		HostClass                 string
-		NetworkClass              string
 		Selector                  v1alpha1.HostSelectorSpec
 		InventoryLabels           map[string]string
 		InventoryPersistentLabels map[string]string
@@ -468,7 +466,6 @@ func (r *BareMetalInstanceReconciler) reconcileProvisioning(ctx context.Context,
 		bareMetalInstance.Spec.ExternalHostID,
 		bareMetalInstance.Spec.ExternalHostName,
 		bareMetalInstance.Spec.HostClass,
-		bareMetalInstance.Spec.NetworkClass,
 		bareMetalInstance.Spec.Selector,
 		bareMetalInstance.Spec.InventoryLabels,
 		bareMetalInstance.Spec.InventoryPersistentLabels,

--- a/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_metal3_integration_test.go
+++ b/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_metal3_integration_test.go
@@ -38,9 +38,8 @@ import (
 )
 
 const (
-	metal3TestNS       = "metal3-test"
-	metal3HostClass    = "metal3"
-	metal3NetworkClass = "metal3"
+	metal3TestNS    = "metal3-test"
+	metal3HostClass = "metal3"
 )
 
 func createMetal3BMH(name string, labels map[string]string, opStatus metal3api.OperationalStatus, provState metal3api.ProvisioningState) *metal3api.BareMetalHost {
@@ -65,7 +64,7 @@ func createMetal3BMH(name string, labels map[string]string, opStatus metal3api.O
 }
 
 func newMetal3Reconciler() *BareMetalInstanceReconciler {
-	invClient := inventory.NewMetal3ClientForTest(k8sClient, metal3TestNS, metal3HostClass, metal3NetworkClass)
+	invClient := inventory.NewMetal3ClientForTest(k8sClient, metal3TestNS, metal3HostClass)
 	mgmtClient := management.NewMetal3ClientForTest(k8sClient, metal3TestNS)
 	return NewBareMetalInstanceReconciler(
 		k8sClient,

--- a/bare-metal-fulfillment-operator/internal/inventory/client.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/client.go
@@ -23,11 +23,10 @@ import (
 
 // Config is a struct that holds info needed to create a new client implementation
 type Config struct {
-	Name         string         `json:"name"`
-	Type         string         `json:"type"`
-	Options      map[string]any `json:"options"`
-	HostClass    string         `json:"hostClass"`
-	NetworkClass string         `json:"networkClass"`
+	Name      string         `json:"name"`
+	Type      string         `json:"type"`
+	Options   map[string]any `json:"options"`
+	HostClass string         `json:"hostClass"`
 }
 
 // Host is the common return type all clients must use
@@ -38,7 +37,6 @@ type Host struct {
 	Name                string
 	HostType            string
 	HostClass           string
-	NetworkClass        string
 	ProvisionState      string
 	ManagedBy           string
 }

--- a/bare-metal-fulfillment-operator/internal/inventory/metal3.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/metal3.go
@@ -53,19 +53,17 @@ func init() {
 }
 
 type Metal3Client struct {
-	client       client.Client
-	namespace    string
-	hostClass    string
-	networkClass string
+	client    client.Client
+	namespace string
+	hostClass string
 }
 
 // NewMetal3ClientForTest creates a Metal3Client with an injected client for testing.
-func NewMetal3ClientForTest(k8sClient client.Client, namespace, hostClass, networkClass string) *Metal3Client {
+func NewMetal3ClientForTest(k8sClient client.Client, namespace, hostClass string) *Metal3Client {
 	return &Metal3Client{
-		client:       k8sClient,
-		namespace:    namespace,
-		hostClass:    hostClass,
-		networkClass: networkClass,
+		client:    k8sClient,
+		namespace: namespace,
+		hostClass: hostClass,
 	}
 }
 
@@ -95,10 +93,9 @@ func NewMetal3Client(ctx context.Context, cfg *Config) (Client, error) {
 	}
 
 	return &Metal3Client{
-		client:       k8sClient,
-		namespace:    namespace,
-		hostClass:    cfg.HostClass,
-		networkClass: cfg.NetworkClass,
+		client:    k8sClient,
+		namespace: namespace,
+		hostClass: cfg.HostClass,
 	}, nil
 }
 
@@ -198,7 +195,7 @@ func (m *Metal3Client) FindFreeHost(ctx context.Context, matchExpressions map[st
 	})
 
 	bmh := &candidates[0]
-	return bmhToHost(bmh, m.hostClass, m.networkClass), nil
+	return bmhToHost(bmh, m.hostClass), nil
 }
 
 func (m *Metal3Client) AssignHost(ctx context.Context, inventoryHostID string, bareMetalInstanceID string, labels map[string]string) (*Host, error) {
@@ -253,7 +250,7 @@ func (m *Metal3Client) AssignHost(ctx context.Context, inventoryHostID string, b
 		return nil, fmt.Errorf("failed to assign BareMetalHost %s: %w", inventoryHostID, err)
 	}
 
-	return bmhToHost(bmh, m.hostClass, m.networkClass), nil
+	return bmhToHost(bmh, m.hostClass), nil
 }
 
 func (m *Metal3Client) UnassignHost(ctx context.Context, inventoryHostID string, labels []string) error {
@@ -288,7 +285,7 @@ func ParseHostID(hostID string) (namespace, name string, err error) {
 	return parts[0], parts[1], nil
 }
 
-func bmhToHost(bmh *metal3api.BareMetalHost, hostClass, networkClass string) *Host {
+func bmhToHost(bmh *metal3api.BareMetalHost, hostClass string) *Host {
 	labels := bmh.Labels
 	if labels == nil {
 		labels = map[string]string{}
@@ -311,7 +308,6 @@ func bmhToHost(bmh *metal3api.BareMetalHost, hostClass, networkClass string) *Ho
 		Name:                bmh.Name,
 		HostType:            labels[Metal3HostTypeLabel],
 		HostClass:           hostClass,
-		NetworkClass:        networkClass,
 		ProvisionState:      string(bmh.Status.Provisioning.State),
 		ManagedBy:           managedBy,
 	}

--- a/bare-metal-fulfillment-operator/internal/inventory/metal3_test.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/metal3_test.go
@@ -31,7 +31,6 @@ import (
 const (
 	testNamespace = "test-bmaas"
 	testHostClass = "metal3"
-	testNetClass  = "metal3"
 )
 
 func newTestScheme() *runtime.Scheme {
@@ -48,10 +47,9 @@ func newMetal3ClientForTest(objects ...client.Object) *Metal3Client {
 		WithStatusSubresource(&metal3api.BareMetalHost{}).
 		Build()
 	return &Metal3Client{
-		client:       fakeClient,
-		namespace:    testNamespace,
-		hostClass:    testHostClass,
-		networkClass: testNetClass,
+		client:    fakeClient,
+		namespace: testNamespace,
+		hostClass: testHostClass,
 	}
 }
 
@@ -175,9 +173,6 @@ func TestFindFreeHost(t *testing.T) {
 		}
 		if host.HostClass != testHostClass {
 			t.Errorf("HostClass = %q, want %q", host.HostClass, testHostClass)
-		}
-		if host.NetworkClass != testNetClass {
-			t.Errorf("NetworkClass = %q, want %q", host.NetworkClass, testNetClass)
 		}
 		if host.ProvisionState != "available" {
 			t.Errorf("ProvisionState = %q, want %q", host.ProvisionState, "available")

--- a/bare-metal-fulfillment-operator/internal/inventory/openstack.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/openstack.go
@@ -56,7 +56,6 @@ type OpenStackClient struct {
 	client           *gophercloud.ServiceClient
 	newServiceClient func(ctx context.Context) (*gophercloud.ServiceClient, error)
 	HostClass        string
-	NetworkClass     string
 }
 
 // NewOpenStackClient creates a new OpenStack inventory client
@@ -72,7 +71,6 @@ func NewOpenStackClient(ctx context.Context, cfg *Config) (Client, error) {
 		client:           sc,
 		newServiceClient: factory,
 		HostClass:        cfg.HostClass,
-		NetworkClass:     cfg.NetworkClass,
 	}, nil
 }
 
@@ -228,7 +226,6 @@ func (c *OpenStackClient) findFreeHost(ctx context.Context, matchExpressions map
 				Name:                node.Name,
 				HostType:            node.ResourceClass,
 				HostClass:           c.HostClass,
-				NetworkClass:        c.NetworkClass,
 				ProvisionState:      node.ProvisionState,
 				ManagedBy:           managedBy,
 			}
@@ -333,7 +330,6 @@ func (c *OpenStackClient) assignHost(ctx context.Context, inventoryHostID string
 		Name:                node.Name,
 		HostType:            node.ResourceClass,
 		HostClass:           c.HostClass,
-		NetworkClass:        c.NetworkClass,
 		ProvisionState:      node.ProvisionState,
 		ManagedBy:           managedBy,
 	}, nil

--- a/fulfillment-service/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
+++ b/fulfillment-service/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
@@ -549,7 +549,7 @@ func sanitizeConditionMessage(condType bmfov1alpha1.BareMetalInstanceConditionTy
 }
 
 // mutateBMI sets the fulfillment-service-owned metadata and spec fields, leaving
-// operator-managed fields (ExternalHostID, HostClass, NetworkClass, etc.) untouched.
+// operator-managed fields (ExternalHostID, HostClass, etc.) untouched.
 func (t *task) mutateBMI(ctx context.Context, object *bmfov1alpha1.BareMetalInstance) error {
 	if object.Labels == nil {
 		object.Labels = make(map[string]string)

--- a/fulfillment-service/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
+++ b/fulfillment-service/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
@@ -588,7 +588,7 @@ var _ = Describe("update", func() {
 				HostType:       "default",
 				TemplateID:     "osac.templates.default",
 				ExternalHostID: "host-42",
-				HostClass: "openstack",
+				HostClass:      "openstack",
 			},
 		}
 

--- a/fulfillment-service/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
+++ b/fulfillment-service/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
@@ -588,8 +588,7 @@ var _ = Describe("update", func() {
 				HostType:       "default",
 				TemplateID:     "osac.templates.default",
 				ExternalHostID: "host-42",
-				HostClass:      "openstack",
-				NetworkClass:   "openstack",
+				HostClass: "openstack",
 			},
 		}
 
@@ -644,8 +643,6 @@ var _ = Describe("update", func() {
 			"ExternalHostID must be preserved — it is managed by the bare-metal-fulfillment-operator")
 		Expect(updatedCR.Spec.HostClass).To(Equal("openstack"),
 			"HostClass must be preserved — it is managed by the bare-metal-fulfillment-operator")
-		Expect(updatedCR.Spec.NetworkClass).To(Equal("openstack"),
-			"NetworkClass must be preserved — it is managed by the bare-metal-fulfillment-operator")
 	})
 })
 

--- a/osac-installer/Makefile
+++ b/osac-installer/Makefile
@@ -1,5 +1,9 @@
 INSTALLER_NAMESPACE ?= osac
 VALUES_FILE ?= values/development/values.yaml
+# Extra helm --set/--set-string args appended to install-osac's install command
+# (e.g. e2e passing component image overrides), so the FIRST install already
+# uses them instead of a separate patch applied after the fact.
+EXTRA_HELM_ARGS ?=
 
 .PHONY: help
 help: ## Display this help
@@ -89,6 +93,7 @@ install-osac: helm-deps install-secrets check-postgres ## Phase 3: Install OSAC
 		--set service.externalHostname=fulfillment-api-$(INSTALLER_NAMESPACE).$(DOMAIN) \
 		--set service.internalHostname=fulfillment-internal-api-$(INSTALLER_NAMESPACE).$(DOMAIN) \
 		--set service.auth.issuerUrl=https://keycloak-keycloak.$(DOMAIN)/realms/osac \
+		$(EXTRA_HELM_ARGS) \
 		--timeout 40m --wait
 
 .PHONY: uninstall


### PR DESCRIPTION
Disposable validation PR for [OSAC-3556](https://redhat.atlassian.net/browse/OSAC-3556). Combines PR #92's real content
(osac-operator-only, non-AAP) with [OSAC-3556](https://redhat.atlassian.net/browse/OSAC-3556)'s Makefile + conditional
AAP-build-on-change-only changes, and pins the bmaas e2e wrapper's `uses:`
to the [OSAC-3556](https://redhat.atlassian.net/browse/OSAC-3556) osac-test-infra branch (see the "VALIDATION ONLY" commit).

Goal: confirm that with a real `pull_request` event (workflow_dispatch
can't test this -- github.event_name != 'pull_request' short-circuits the
aap-changed output to always-true, so the conditional logic is a no-op
under workflow_dispatch), a PR that never touches osac-aap/ gets ZERO AAP
components in the resolved components[] list, instead of the org/playbook
mismatch failure seen before.

Will be closed without merging once e2e-bmaas-full-install's result is
confirmed. Do not merge.