### PR TITLE
OSAC-3556: EXTRA_HELM_ARGS passthrough + conditional AAP build-on-change

### DIFF
--- a/.github/actions/resolve-e2e-components/action.yaml
+++ b/.github/actions/resolve-e2e-components/action.yaml
@@ -1,0 +1,61 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+name: Resolve E2E components
+description: >-
+  Builds the components[] JSON passed to an e2e-*-full-install reusable
+  workflow, so fulfillment-service/osac-operator/bare-metal-fulfillment-operator
+  are always built from this PR's fork/branch, and osac-aap's
+  execution-environment is only built (and only overrides the AAP Controller
+  project's git URI, see OSAC-3556) when osac-aap/ actually changed.
+inputs:
+  aap-changed:
+    description: >-
+      'true' to also build+override osac-aap's execution-environment
+      (aap.bootstrap.image and aap.configAsCode.eeImage); 'false' to omit it.
+    required: true
+outputs:
+  components:
+    description: Resolved components[] JSON for the e2e reusable workflow's `components` input
+    value: ${{ steps.build.outputs.components }}
+runs:
+  using: composite
+  steps:
+    - id: build
+      shell: bash
+      env:
+        REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+        REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+        AAP_CHANGED: ${{ inputs.aap-changed }}
+      run: |
+        COMPONENTS=$(jq -nc --arg repo "${REPO}" --arg ref "${REF}" '[
+          {"repo":$repo,"ref":$ref,"containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},
+          {"repo":$repo,"ref":$ref,"containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},
+          {"repo":$repo,"ref":$ref,"containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}
+        ]')
+
+        # osac-aap's execution-environment is built twice (aap.bootstrap.image
+        # and aap.configAsCode.eeImage): the two are logically the same image
+        # but the override mechanism keys strictly off imageKey, one build per
+        # key, so this is the only way to get both fields covered without
+        # changing that mechanism (which lives in osac-test-infra, not here).
+        # See OSAC-3546.
+        if [[ "${AAP_CHANGED}" == "true" ]]; then
+          COMPONENTS=$(echo "${COMPONENTS}" | jq -c --arg repo "${REPO}" --arg ref "${REF}" '. + [
+            {"repo":$repo,"ref":$ref,"containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},
+            {"repo":$repo,"ref":$ref,"containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"}
+          ]')
+        fi
+
+        echo "components=${COMPONENTS}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -44,6 +44,7 @@ jobs:
       pull-requests: read
     outputs:
       should-run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+      aap-changed: ${{ github.event_name != 'pull_request' || steps.aap-filter.outputs.osac-aap == 'true' }}
     steps:
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         if: github.event_name == 'pull_request'
@@ -57,18 +58,72 @@ jobs:
               - '!**/LICENSE'
               - '!**/*.md'
               - '!**/docs/**'
+      # Separate step, not folded into the filter above: that step's
+      # predicate-quantifier: 'every' means "every changed file matches",
+      # correct for the broad code/no-code split but wrong for a single
+      # component filter (it would only fire true if ALL changed files were
+      # under osac-aap/). This step uses the default 'some' quantifier: true
+      # if ANY changed file is under osac-aap/.
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        if: github.event_name == 'pull_request'
+        id: aap-filter
+        with:
+          filters: |
+            osac-aap:
+              - 'osac-aap/**'
 
-  # Builds fulfillment-service, osac-operator, osac-aap's execution
-  # environment (twice -- once each for aap.bootstrap.image and
-  # aap.configAsCode.eeImage, see OSAC-3546), and bare-metal-fulfillment-operator
-  # from this PR's current code and installs them together in one cluster --
-  # not one "component under test" plus stale pinned images for the others.
-  # Runs for any change touching any component (see `changes` above) rather
-  # than being path-scoped per component; splitting this by component to
-  # avoid running both suites when only one changed is deferred to the future
-  # full path-based CI matrix, once its skip-logic pattern is verified.
-  e2e-bmaas-full-install:
+  # osac-aap's execution-environment build (and the AAP Controller project's
+  # git-URI override that comes with it) is resolved here, before the e2e
+  # job runs, and gated on aap-changed -- unconditionally redirecting the
+  # Controller project's git URI at this PR's own repo/branch, even for PRs
+  # that never touched osac-aap/, breaks job template creation the moment
+  # the first install actually applies that override on its own hook
+  # (see OSAC-3556). Non-PR triggers (schedule/workflow_dispatch/merge_group)
+  # default to true (build+override AAP) via aap-changed's own fallback.
+  resolve-components:
     needs: changes
+    runs-on: ubuntu-latest
+    outputs:
+      components: ${{ steps.build.outputs.components }}
+    steps:
+      - id: build
+        env:
+          REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          AAP_CHANGED: ${{ needs.changes.outputs.aap-changed }}
+        run: |
+          COMPONENTS=$(jq -nc --arg repo "${REPO}" --arg ref "${REF}" '[
+            {"repo":$repo,"ref":$ref,"containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},
+            {"repo":$repo,"ref":$ref,"containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},
+            {"repo":$repo,"ref":$ref,"containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}
+          ]')
+
+          # osac-aap's execution-environment is built twice (aap.bootstrap.image
+          # and aap.configAsCode.eeImage): the two are logically the same image
+          # but the override mechanism keys strictly off imageKey, one build per
+          # key, so this is the only way to get both fields covered without
+          # changing that mechanism (which lives in osac-test-infra, not here).
+          # See OSAC-3546.
+          if [[ "${AAP_CHANGED}" == "true" ]]; then
+            COMPONENTS=$(echo "${COMPONENTS}" | jq -c --arg repo "${REPO}" --arg ref "${REF}" '. + [
+              {"repo":$repo,"ref":$ref,"containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},
+              {"repo":$repo,"ref":$ref,"containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"}
+            ]')
+          fi
+
+          echo "components=${COMPONENTS}" >> "$GITHUB_OUTPUT"
+
+  # Builds fulfillment-service, osac-operator, and bare-metal-fulfillment-operator
+  # (plus osac-aap's execution environment when osac-aap/ changed -- see
+  # resolve-components above) from this PR's current code and installs them
+  # together in one cluster -- not one "component under test" plus stale
+  # pinned images for the others. Runs for any change touching any component
+  # (see `changes` above) rather than being path-scoped per component;
+  # splitting this by component to avoid running both suites when only one
+  # changed is deferred to the future full path-based CI matrix, once its
+  # skip-logic pattern is verified.
+  e2e-bmaas-full-install:
+    needs: [changes, resolve-components]
     if: needs.changes.outputs.should-run == 'true'
     uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-full-install.yml@main
     with:
@@ -81,13 +136,7 @@ jobs:
       # standalone-repo default.
       installer-repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       installer-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
-      # Build all component images from the PR's fork/branch (same monorepo checkout).
-      # osac-aap's execution-environment is built twice (aap.bootstrap.image and
-      # aap.configAsCode.eeImage): the two are logically the same image but the
-      # override mechanism keys strictly off imageKey, one build per key, so this
-      # is the only way to get both fields covered without changing that mechanism
-      # (which lives in osac-test-infra, not here). See OSAC-3546.
-      components: '[{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}]'
+      components: ${{ needs.resolve-components.outputs.components }}
       # Pass author_association for fork PR authorization (empty for non-fork PRs)
       fork-pr-author-association: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association || '' }}
       fork-pr-author: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.user.login || '' }}
@@ -101,13 +150,14 @@ jobs:
       always()
       && !(needs.e2e-bmaas-full-install.result == 'skipped'
            && needs.changes.result == 'success')
-    needs: [changes, e2e-bmaas-full-install]
+    needs: [changes, resolve-components, e2e-bmaas-full-install]
     runs-on: ubuntu-latest
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "Upstream job results:"
           echo "  changes: ${{ needs.changes.result }}"
+          echo "  resolve-components: ${{ needs.resolve-components.result }}"
           echo "  e2e-bmaas-full-install: ${{ needs.e2e-bmaas-full-install.result }}"
           echo ""
           echo "One or more upstream jobs failed or were cancelled."

--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -84,34 +84,15 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     outputs:
-      components: ${{ steps.build.outputs.components }}
+      components: ${{ steps.resolve.outputs.components }}
     steps:
-      - id: build
-        env:
-          REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
-          AAP_CHANGED: ${{ needs.changes.outputs.aap-changed }}
-        run: |
-          COMPONENTS=$(jq -nc --arg repo "${REPO}" --arg ref "${REF}" '[
-            {"repo":$repo,"ref":$ref,"containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},
-            {"repo":$repo,"ref":$ref,"containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},
-            {"repo":$repo,"ref":$ref,"containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}
-          ]')
-
-          # osac-aap's execution-environment is built twice (aap.bootstrap.image
-          # and aap.configAsCode.eeImage): the two are logically the same image
-          # but the override mechanism keys strictly off imageKey, one build per
-          # key, so this is the only way to get both fields covered without
-          # changing that mechanism (which lives in osac-test-infra, not here).
-          # See OSAC-3546.
-          if [[ "${AAP_CHANGED}" == "true" ]]; then
-            COMPONENTS=$(echo "${COMPONENTS}" | jq -c --arg repo "${REPO}" --arg ref "${REF}" '. + [
-              {"repo":$repo,"ref":$ref,"containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},
-              {"repo":$repo,"ref":$ref,"containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"}
-            ]')
-          fi
-
-          echo "components=${COMPONENTS}" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - id: resolve
+        uses: ./.github/actions/resolve-e2e-components
+        with:
+          aap-changed: ${{ needs.changes.outputs.aap-changed }}
 
   # Builds fulfillment-service, osac-operator, and bare-metal-fulfillment-operator
   # (plus osac-aap's execution environment when osac-aap/ changed -- see
@@ -149,7 +130,8 @@ jobs:
     if: >-
       always()
       && !(needs.e2e-bmaas-full-install.result == 'skipped'
-           && needs.changes.result == 'success')
+           && needs.changes.result == 'success'
+           && needs.resolve-components.result == 'success')
     needs: [changes, resolve-components, e2e-bmaas-full-install]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -84,34 +84,15 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     outputs:
-      components: ${{ steps.build.outputs.components }}
+      components: ${{ steps.resolve.outputs.components }}
     steps:
-      - id: build
-        env:
-          REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
-          AAP_CHANGED: ${{ needs.changes.outputs.aap-changed }}
-        run: |
-          COMPONENTS=$(jq -nc --arg repo "${REPO}" --arg ref "${REF}" '[
-            {"repo":$repo,"ref":$ref,"containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},
-            {"repo":$repo,"ref":$ref,"containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},
-            {"repo":$repo,"ref":$ref,"containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}
-          ]')
-
-          # osac-aap's execution-environment is built twice (aap.bootstrap.image
-          # and aap.configAsCode.eeImage): the two are logically the same image
-          # but the override mechanism keys strictly off imageKey, one build per
-          # key, so this is the only way to get both fields covered without
-          # changing that mechanism (which lives in osac-test-infra, not here).
-          # See OSAC-3546.
-          if [[ "${AAP_CHANGED}" == "true" ]]; then
-            COMPONENTS=$(echo "${COMPONENTS}" | jq -c --arg repo "${REPO}" --arg ref "${REF}" '. + [
-              {"repo":$repo,"ref":$ref,"containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},
-              {"repo":$repo,"ref":$ref,"containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"}
-            ]')
-          fi
-
-          echo "components=${COMPONENTS}" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - id: resolve
+        uses: ./.github/actions/resolve-e2e-components
+        with:
+          aap-changed: ${{ needs.changes.outputs.aap-changed }}
 
   # Builds fulfillment-service, osac-operator, and bare-metal-fulfillment-operator
   # (plus osac-aap's execution environment when osac-aap/ changed -- see
@@ -164,7 +145,8 @@ jobs:
     if: >-
       always()
       && !(needs.e2e-caas-full-install.result == 'skipped'
-           && needs.changes.result == 'success')
+           && needs.changes.result == 'success'
+           && needs.resolve-components.result == 'success')
     needs: [changes, resolve-components, e2e-caas-full-install]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -44,6 +44,7 @@ jobs:
       pull-requests: read
     outputs:
       should-run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+      aap-changed: ${{ github.event_name != 'pull_request' || steps.aap-filter.outputs.osac-aap == 'true' }}
     steps:
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         if: github.event_name == 'pull_request'
@@ -57,21 +58,75 @@ jobs:
               - '!**/LICENSE'
               - '!**/*.md'
               - '!**/docs/**'
+      # Separate step, not folded into the filter above: that step's
+      # predicate-quantifier: 'every' means "every changed file matches",
+      # correct for the broad code/no-code split but wrong for a single
+      # component filter (it would only fire true if ALL changed files were
+      # under osac-aap/). This step uses the default 'some' quantifier: true
+      # if ANY changed file is under osac-aap/.
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        if: github.event_name == 'pull_request'
+        id: aap-filter
+        with:
+          filters: |
+            osac-aap:
+              - 'osac-aap/**'
 
-  # Builds fulfillment-service, osac-operator, osac-aap's execution
-  # environment (twice -- once each for aap.bootstrap.image and
-  # aap.configAsCode.eeImage, see OSAC-3546), and bare-metal-fulfillment-operator
-  # from this PR's current code and installs them together in one cluster --
-  # not one "component under test" plus a stale pinned image for the others.
-  # Runs for any change touching any component (see `changes` above) rather
-  # than being path-scoped per component; splitting this by component to
-  # avoid running both suites when only one changed is deferred to the
-  # future full path-based CI matrix, once its skip-logic pattern is
-  # verified. osac-aap *is* built here (added by OSAC-3546): caas's own
-  # values/caas-ci/values.yaml sets provisioning.provider: "aap" and
-  # controllers.clusterOrder: true, so CaaS's core cluster-provisioning path
-  # runs through AAP just as much as vmaas/bmaas's does -- the prior
-  # exclusion was deferred scope, not a real technical constraint.
+  # osac-aap's execution-environment build (and the AAP Controller project's
+  # git-URI override that comes with it) is resolved here, before the e2e
+  # job runs, and gated on aap-changed -- unconditionally redirecting the
+  # Controller project's git URI at this PR's own repo/branch, even for PRs
+  # that never touched osac-aap/, breaks job template creation the moment
+  # the first install actually applies that override on its own hook
+  # (see OSAC-3556). Non-PR triggers (schedule/workflow_dispatch/merge_group)
+  # default to true (build+override AAP) via aap-changed's own fallback.
+  resolve-components:
+    needs: changes
+    runs-on: ubuntu-latest
+    outputs:
+      components: ${{ steps.build.outputs.components }}
+    steps:
+      - id: build
+        env:
+          REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          AAP_CHANGED: ${{ needs.changes.outputs.aap-changed }}
+        run: |
+          COMPONENTS=$(jq -nc --arg repo "${REPO}" --arg ref "${REF}" '[
+            {"repo":$repo,"ref":$ref,"containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},
+            {"repo":$repo,"ref":$ref,"containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},
+            {"repo":$repo,"ref":$ref,"containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}
+          ]')
+
+          # osac-aap's execution-environment is built twice (aap.bootstrap.image
+          # and aap.configAsCode.eeImage): the two are logically the same image
+          # but the override mechanism keys strictly off imageKey, one build per
+          # key, so this is the only way to get both fields covered without
+          # changing that mechanism (which lives in osac-test-infra, not here).
+          # See OSAC-3546.
+          if [[ "${AAP_CHANGED}" == "true" ]]; then
+            COMPONENTS=$(echo "${COMPONENTS}" | jq -c --arg repo "${REPO}" --arg ref "${REF}" '. + [
+              {"repo":$repo,"ref":$ref,"containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},
+              {"repo":$repo,"ref":$ref,"containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"}
+            ]')
+          fi
+
+          echo "components=${COMPONENTS}" >> "$GITHUB_OUTPUT"
+
+  # Builds fulfillment-service, osac-operator, and bare-metal-fulfillment-operator
+  # (plus osac-aap's execution environment when osac-aap/ changed -- see
+  # resolve-components above) from this PR's current code and installs them
+  # together in one cluster -- not one "component under test" plus a stale
+  # pinned image for the others. Runs for any change touching any component
+  # (see `changes` above) rather than being path-scoped per component;
+  # splitting this by component to avoid running both suites when only one
+  # changed is deferred to the future full path-based CI matrix, once its
+  # skip-logic pattern is verified. osac-aap *can* be built here (added by
+  # OSAC-3546): caas's own values/caas-ci/values.yaml sets
+  # provisioning.provider: "aap" and controllers.clusterOrder: true, so
+  # CaaS's core cluster-provisioning path runs through AAP just as much as
+  # vmaas/bmaas's does -- the prior exclusion was deferred scope, not a real
+  # technical constraint.
   #
   # bare-metal-fulfillment-operator's image override (bmf.image.repository)
   # is currently a no-op in this flow specifically: values/caas-ci/values.yaml
@@ -79,7 +134,7 @@ jobs:
   # built from source for consistency with the other components -- revisit
   # if caas ever needs BMF enabled.
   e2e-caas-full-install:
-    needs: changes
+    needs: [changes, resolve-components]
     if: needs.changes.outputs.should-run == 'true'
     uses: osac-project/osac-test-infra/.github/workflows/e2e-caas-full-install.yml@main
     with:
@@ -92,13 +147,7 @@ jobs:
       # standalone-repo default.
       installer-repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       installer-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
-      # Build all component images from the PR's fork/branch (same monorepo checkout).
-      # osac-aap's execution-environment is built twice (aap.bootstrap.image and
-      # aap.configAsCode.eeImage): the two are logically the same image but the
-      # override mechanism keys strictly off imageKey, one build per key, so this
-      # is the only way to get both fields covered without changing that mechanism
-      # (which lives in osac-test-infra, not here). See OSAC-3546.
-      components: '[{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}]'
+      components: ${{ needs.resolve-components.outputs.components }}
       # Pass author_association for fork PR authorization (empty for non-fork PRs)
       fork-pr-author-association: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association || '' }}
       fork-pr-author: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.user.login || '' }}
@@ -116,13 +165,14 @@ jobs:
       always()
       && !(needs.e2e-caas-full-install.result == 'skipped'
            && needs.changes.result == 'success')
-    needs: [changes, e2e-caas-full-install]
+    needs: [changes, resolve-components, e2e-caas-full-install]
     runs-on: ubuntu-latest
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "Upstream job results:"
           echo "  changes: ${{ needs.changes.result }}"
+          echo "  resolve-components: ${{ needs.resolve-components.result }}"
           echo "  e2e-caas-full-install: ${{ needs.e2e-caas-full-install.result }}"
           echo ""
           echo "One or more upstream jobs failed or were cancelled."

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -44,6 +44,7 @@ jobs:
       pull-requests: read
     outputs:
       should-run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+      aap-changed: ${{ github.event_name != 'pull_request' || steps.aap-filter.outputs.osac-aap == 'true' }}
     steps:
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         if: github.event_name == 'pull_request'
@@ -57,16 +58,70 @@ jobs:
               - '!**/LICENSE'
               - '!**/*.md'
               - '!**/docs/**'
+      # Separate step, not folded into the filter above: that step's
+      # predicate-quantifier: 'every' means "every changed file matches",
+      # correct for the broad code/no-code split but wrong for a single
+      # component filter (it would only fire true if ALL changed files were
+      # under osac-aap/). This step uses the default 'some' quantifier: true
+      # if ANY changed file is under osac-aap/.
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        if: github.event_name == 'pull_request'
+        id: aap-filter
+        with:
+          filters: |
+            osac-aap:
+              - 'osac-aap/**'
 
-  # Builds fulfillment-service, osac-operator, osac-aap's execution
-  # environment (twice -- once each for aap.bootstrap.image and
-  # aap.configAsCode.eeImage, see OSAC-3546), and bare-metal-fulfillment-operator
-  # from this PR's current code and installs them together in one cluster --
-  # not one "component under test" plus stale pinned images for the others.
-  # Runs for any change touching any component (see `changes` above) rather
-  # than being path-scoped per component; splitting this by component to
-  # avoid running both suites when only one changed is deferred to the future
-  # full path-based CI matrix, once its skip-logic pattern is verified.
+  # osac-aap's execution-environment build (and the AAP Controller project's
+  # git-URI override that comes with it) is resolved here, before the e2e
+  # job runs, and gated on aap-changed -- unconditionally redirecting the
+  # Controller project's git URI at this PR's own repo/branch, even for PRs
+  # that never touched osac-aap/, breaks job template creation the moment
+  # the first install actually applies that override on its own hook
+  # (see OSAC-3556). Non-PR triggers (schedule/workflow_dispatch/merge_group)
+  # default to true (build+override AAP) via aap-changed's own fallback.
+  resolve-components:
+    needs: changes
+    runs-on: ubuntu-latest
+    outputs:
+      components: ${{ steps.build.outputs.components }}
+    steps:
+      - id: build
+        env:
+          REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          AAP_CHANGED: ${{ needs.changes.outputs.aap-changed }}
+        run: |
+          COMPONENTS=$(jq -nc --arg repo "${REPO}" --arg ref "${REF}" '[
+            {"repo":$repo,"ref":$ref,"containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},
+            {"repo":$repo,"ref":$ref,"containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},
+            {"repo":$repo,"ref":$ref,"containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}
+          ]')
+
+          # osac-aap's execution-environment is built twice (aap.bootstrap.image
+          # and aap.configAsCode.eeImage): the two are logically the same image
+          # but the override mechanism keys strictly off imageKey, one build per
+          # key, so this is the only way to get both fields covered without
+          # changing that mechanism (which lives in osac-test-infra, not here).
+          # See OSAC-3546.
+          if [[ "${AAP_CHANGED}" == "true" ]]; then
+            COMPONENTS=$(echo "${COMPONENTS}" | jq -c --arg repo "${REPO}" --arg ref "${REF}" '. + [
+              {"repo":$repo,"ref":$ref,"containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},
+              {"repo":$repo,"ref":$ref,"containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"}
+            ]')
+          fi
+
+          echo "components=${COMPONENTS}" >> "$GITHUB_OUTPUT"
+
+  # Builds fulfillment-service, osac-operator, and bare-metal-fulfillment-operator
+  # (plus osac-aap's execution environment when osac-aap/ changed -- see
+  # resolve-components above) from this PR's current code and installs them
+  # together in one cluster -- not one "component under test" plus stale
+  # pinned images for the others. Runs for any change touching any component
+  # (see `changes` above) rather than being path-scoped per component;
+  # splitting this by component to avoid running both suites when only one
+  # changed is deferred to the future full path-based CI matrix, once its
+  # skip-logic pattern is verified.
   #
   # bare-metal-fulfillment-operator's image override (bmf.image.repository)
   # is currently a no-op in this flow specifically: values/vmaas-ci/values.yaml
@@ -75,7 +130,7 @@ jobs:
   # should build from the PR in every e2e flow, even where one isn't
   # currently deployed) -- revisit if vmaas ever needs BMF enabled.
   e2e-vmaas-full-install:
-    needs: changes
+    needs: [changes, resolve-components]
     if: needs.changes.outputs.should-run == 'true'
     uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main
     with:
@@ -88,13 +143,7 @@ jobs:
       # standalone-repo default.
       installer-repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       installer-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
-      # Build all component images from the PR's fork/branch (same monorepo checkout).
-      # osac-aap's execution-environment is built twice (aap.bootstrap.image and
-      # aap.configAsCode.eeImage): the two are logically the same image but the
-      # override mechanism keys strictly off imageKey, one build per key, so this
-      # is the only way to get both fields covered without changing that mechanism
-      # (which lives in osac-test-infra, not here). See OSAC-3546.
-      components: '[{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"},{"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}]'
+      components: ${{ needs.resolve-components.outputs.components }}
       # Pass author_association for fork PR authorization (empty for non-fork PRs)
       fork-pr-author-association: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association || '' }}
       fork-pr-author: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.user.login || '' }}
@@ -108,13 +157,14 @@ jobs:
       always()
       && !(needs.e2e-vmaas-full-install.result == 'skipped'
            && needs.changes.result == 'success')
-    needs: [changes, e2e-vmaas-full-install]
+    needs: [changes, resolve-components, e2e-vmaas-full-install]
     runs-on: ubuntu-latest
     steps:
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "Upstream job results:"
           echo "  changes: ${{ needs.changes.result }}"
+          echo "  resolve-components: ${{ needs.resolve-components.result }}"
           echo "  e2e-vmaas-full-install: ${{ needs.e2e-vmaas-full-install.result }}"
           echo ""
           echo "One or more upstream jobs failed or were cancelled."

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -84,34 +84,15 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     outputs:
-      components: ${{ steps.build.outputs.components }}
+      components: ${{ steps.resolve.outputs.components }}
     steps:
-      - id: build
-        env:
-          REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
-          AAP_CHANGED: ${{ needs.changes.outputs.aap-changed }}
-        run: |
-          COMPONENTS=$(jq -nc --arg repo "${REPO}" --arg ref "${REF}" '[
-            {"repo":$repo,"ref":$ref,"containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},
-            {"repo":$repo,"ref":$ref,"containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},
-            {"repo":$repo,"ref":$ref,"containerfile":"bare-metal-fulfillment-operator/Containerfile","imageKey":"bmf.image.repository"}
-          ]')
-
-          # osac-aap's execution-environment is built twice (aap.bootstrap.image
-          # and aap.configAsCode.eeImage): the two are logically the same image
-          # but the override mechanism keys strictly off imageKey, one build per
-          # key, so this is the only way to get both fields covered without
-          # changing that mechanism (which lives in osac-test-infra, not here).
-          # See OSAC-3546.
-          if [[ "${AAP_CHANGED}" == "true" ]]; then
-            COMPONENTS=$(echo "${COMPONENTS}" | jq -c --arg repo "${REPO}" --arg ref "${REF}" '. + [
-              {"repo":$repo,"ref":$ref,"containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},
-              {"repo":$repo,"ref":$ref,"containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"}
-            ]')
-          fi
-
-          echo "components=${COMPONENTS}" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - id: resolve
+        uses: ./.github/actions/resolve-e2e-components
+        with:
+          aap-changed: ${{ needs.changes.outputs.aap-changed }}
 
   # Builds fulfillment-service, osac-operator, and bare-metal-fulfillment-operator
   # (plus osac-aap's execution environment when osac-aap/ changed -- see
@@ -156,7 +137,8 @@ jobs:
     if: >-
       always()
       && !(needs.e2e-vmaas-full-install.result == 'skipped'
-           && needs.changes.result == 'success')
+           && needs.changes.result == 'success'
+           && needs.resolve-components.result == 'success')
     needs: [changes, resolve-components, e2e-vmaas-full-install]
     runs-on: ubuntu-latest
     steps:

--- a/osac-installer/Makefile
+++ b/osac-installer/Makefile
@@ -1,5 +1,9 @@
 INSTALLER_NAMESPACE ?= osac
 VALUES_FILE ?= values/development/values.yaml
+# Extra helm --set/--set-string args appended to install-osac's install command
+# (e.g. e2e passing component image overrides), so the FIRST install already
+# uses them instead of a separate patch applied after the fact.
+EXTRA_HELM_ARGS ?=
 
 .PHONY: help
 help: ## Display this help
@@ -89,6 +93,7 @@ install-osac: helm-deps install-secrets check-postgres ## Phase 3: Install OSAC
 		--set service.externalHostname=fulfillment-api-$(INSTALLER_NAMESPACE).$(DOMAIN) \
 		--set service.internalHostname=fulfillment-internal-api-$(INSTALLER_NAMESPACE).$(DOMAIN) \
 		--set service.auth.issuerUrl=https://keycloak-keycloak.$(DOMAIN)/realms/osac \
+		$(EXTRA_HELM_ARGS) \
 		--timeout 40m --wait
 
 .PHONY: uninstall

--- a/osac-installer/README.md
+++ b/osac-installer/README.md
@@ -148,6 +148,7 @@ make install-osac VALUES_FILE=values/<env>/values.yaml        # Phase 3: OSAC ap
 |----------|---------|-------------|
 | `INSTALLER_NAMESPACE` | `osac` | Target namespace for the OSAC deployment |
 | `VALUES_FILE` | `values/development/values.yaml` | Helm values file to use |
+| `EXTRA_HELM_ARGS` | (empty) | Extra `--set`/`--set-string` args appended to `install-osac`'s helm command, e.g. `EXTRA_HELM_ARGS='--set-string aap.bootstrap.image=my-image:tag'` |
 
 #### Configure Values
 


### PR DESCRIPTION
## Summary

- Adds `EXTRA_HELM_ARGS` passthrough to `osac-installer/Makefile`'s `install-osac` target, so e2e's image overrides can be supplied to the FIRST helm install instead of a separate patch applied after the fact (companion PR: osac-project/osac-test-infra#300).
- Makes the `aap.bootstrap.image`/`aap.configAsCode.eeImage` build+override conditional on `osac-aap/` actually changing in the PR, reusing OSAC-3482's per-component `dorny/paths-filter` pattern, across all three e2e wrappers (bmaas/vmaas/caas).

## Why

Companion PR osac-project/osac-test-infra#300 makes e2e's image overrides apply on the FIRST helm install instead of a later `--no-hooks` patch that never actually reached install-time hooks. That's necessary to fix OSAC-3513/PR#72 (AAP mono-repo repoint), but it has a side effect: the `aap.bootstrap.image` override already redirects the AAP Controller project's git URI at the PR's own repo/branch (pre-existing logic, previously inert under the old two-phase design) — and the `components[]` list built by each e2e wrapper unconditionally included AAP for *every* PR, regardless of whether it touched `osac-aap/`.

Confirmed live: with overrides applying on the first install, this broke `e2e-bmaas-full-install` for a PR that never touches AAP (PR #92, osac-operator-only) with `"Playbook not found for project"` — because the override pointed the AAP project at the mono-repo while `osac-aap/`'s own `controller.yml` (unchanged by that PR) doesn't have OSAC-3513's mono-repo path-prefix fix. That created a circular merge dependency between this PR and OSAC-3513/PR#72.

Fixing the AAP build to be conditional removes that dependency entirely: non-AAP PRs get zero AAP override (matching today's status quo exactly), so this PR is safely mergeable on its own, and OSAC-3513/PR#72 (which *does* touch `osac-aap/`) validates against an already-merged, already-safe base afterward.

## Validation

- `make -n install-osac ... EXTRA_HELM_ARGS="..."` confirmed the extra arg lands correctly in the generated helm command.
- Live-validated the conditional build logic via a real (disposable) PR against PR #92's content: confirmed via job logs `AAP_CHANGED=false` and the resolved `components[]` had exactly 3 entries (no AAP), the bootstrap pod used the stock `ghcr.io/osac-project/osac-aap:latest` image with `projectGitUri` unchanged, and the full bmaas e2e run passed end-to-end.
- Note: this conditional logic only engages under a real `pull_request` event — `workflow_dispatch` always reports `github.event_name != 'pull_request'`, which short-circuits `aap-changed` to its safe non-PR default (always build AAP), so it can't be used to test this path.

## Test plan

- [x] `pre-commit run yamllint` clean on all 3 modified workflow files
- [x] `make -n install-osac` dry-run confirms `EXTRA_HELM_ARGS` positioning
- [x] Real PR-triggered e2e run (PR #92 content) passed end-to-end with zero AAP components built
- [ ] OSAC-3513/PR#72 (the original motivating case, which *does* touch `osac-aap/`) to be validated once osac-test-infra#300 and this PR both merge

Part of [OSAC-3556](https://redhat.atlassian.net/browse/OSAC-3556) / OSAC-1732.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for passing additional Helm installation settings through the installer.
* **Improvements**
  * End-to-end installation checks now automatically determine which components require testing based on the files changed.
  * Execution-environment validation runs conditionally when relevant application changes are detected.
  * Improved workflow status reporting and coordination across installation test stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->