### PR TITLE
Fix check-generated-code workflow: matrix context not allowed in job-level if

### DIFF
--- a/.github/workflows/check-floating-tags.yaml
+++ b/.github/workflows/check-floating-tags.yaml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      changes: ${{ steps.filter.outputs.changes }}
+      changes: ${{ steps.filter.outputs.changes || '[]' }}
     steps:
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         if: github.event_name == 'pull_request'
@@ -54,8 +54,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        component: [fulfillment-service, osac-operator, bare-metal-fulfillment-operator, osac-installer]
-    if: github.event_name != 'pull_request' || contains(fromJSON(needs.changes.outputs.changes), matrix.component)
+        component: ${{ fromJSON(needs.changes.outputs.changes) }}
+    if: needs.changes.outputs.changes != '[]'
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/check-generated-code.yaml
+++ b/.github/workflows/check-generated-code.yaml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      changes: ${{ steps.filter.outputs.changes }}
+      changes: ${{ steps.filter.outputs.changes || '[]' }}
     steps:
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         if: github.event_name == 'pull_request'
@@ -52,8 +52,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        component: [fulfillment-service, osac-operator]
-    if: github.event_name != 'pull_request' || contains(fromJSON(needs.changes.outputs.changes), matrix.component)
+        component: ${{ fromJSON(needs.changes.outputs.changes) }}
+    if: needs.changes.outputs.changes != '[]'
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      changes: ${{ steps.filter.outputs.changes }}
+      changes: ${{ steps.filter.outputs.changes || '[]' }}
     steps:
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         if: github.event_name == 'pull_request'
@@ -78,19 +78,26 @@ jobs:
       fail-fast: false
       matrix:
         component: [osac-operator, bare-metal-fulfillment-operator]
-    if: github.event_name != 'pull_request' || contains(fromJSON(needs.changes.outputs.changes), matrix.component)
     steps:
+    - name: Check component changes
+      id: should-run
+      if: github.event_name != 'pull_request' || contains(fromJSON(needs.changes.outputs.changes), matrix.component)
+      run: echo "run=true" >> "$GITHUB_OUTPUT"
+
     - name: Checkout repository
+      if: steps.should-run.outputs.run
       uses: actions/checkout@v7
       with:
         persist-credentials: false
 
     - name: Set up Go
+      if: steps.should-run.outputs.run
       uses: actions/setup-go@v6
       with:
         go-version: stable
 
     - name: Verify Helm CRD templates match bases
+      if: steps.should-run.outputs.run
       working-directory: ${{ matrix.component }}
       run: make check-helm-crds
 
@@ -123,19 +130,26 @@ jobs:
             chart: csi-driver
           - component: osac-csi-driver
             chart: csi-backends
-    if: github.event_name != 'pull_request' || contains(fromJSON(needs.changes.outputs.changes), matrix.component)
     steps:
+    - name: Check component changes
+      id: should-run
+      if: github.event_name != 'pull_request' || contains(fromJSON(needs.changes.outputs.changes), matrix.component)
+      run: echo "run=true" >> "$GITHUB_OUTPUT"
+
     - name: Checkout repository
+      if: steps.should-run.outputs.run
       uses: actions/checkout@v7
       with:
         persist-credentials: false
 
     - name: Set up Helm
+      if: steps.should-run.outputs.run
       uses: azure/setup-helm@v5
       with:
         version: v3.17.0
 
     - name: Lint chart
+      if: steps.should-run.outputs.run
       working-directory: ${{ matrix.component }}
       run: |
         if [ -n "${{ matrix.values-file }}" ]; then
@@ -145,6 +159,7 @@ jobs:
         fi
 
     - name: Template chart
+      if: steps.should-run.outputs.run
       working-directory: ${{ matrix.component }}
       run: |
         if [ -n "${{ matrix.values-file }}" ]; then


### PR DESCRIPTION
## Summary
- The `matrix` context is not available in job-level `if` conditions — only `github`, `inputs`, `needs`, and `vars` are allowed
- Replaced the static matrix + `contains()` filter with a dynamic matrix built from `dorny/paths-filter`'s `changes` output
- Added `|| '[]'` fallback to ensure `fromJSON` always receives valid JSON

## Test plan
- [ ] Open a PR touching only `fulfillment-service/` files — verify only the `fulfillment-service` matrix job runs
- [ ] Open a PR touching only `osac-operator/` files — verify only the `osac-operator` matrix job runs
- [ ] Open a PR touching both — verify both matrix jobs run

🤖 Generated with [Claude Code](https://claude.com/claude-code)