### PR TITLE
OSAC-2249: copy network_attachments from proto to K8s CR in mutateBMI

### DIFF
--- a/fulfillment-service/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
+++ b/fulfillment-service/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
@@ -613,6 +613,20 @@ func (t *task) mutateBMI(ctx context.Context, object *bmfov1alpha1.BareMetalInst
 		}
 	}
 
+	protoAttachments := t.bareMetalInstance.GetSpec().GetNetworkAttachments()
+	if len(protoAttachments) > 0 {
+		networkAttachments := make([]bmfov1alpha1.BareMetalNetworkAttachment, 0, len(protoAttachments))
+		for _, att := range protoAttachments {
+			networkAttachments = append(networkAttachments, bmfov1alpha1.BareMetalNetworkAttachment{
+				SubnetRef:         att.GetSubnet(),
+				SecurityGroupRefs: att.GetSecurityGroups(),
+				Interface:         att.GetInterface(),
+				Primary:           att.GetPrimary(),
+			})
+		}
+		object.Spec.NetworkAttachments = networkAttachments
+	}
+
 	return nil
 }
 

--- a/fulfillment-service/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
+++ b/fulfillment-service/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
@@ -562,6 +562,134 @@ var _ = Describe("mutateBMI", func() {
 		Expect(params["sshPublicKey"]).To(Equal("ssh-ed25519 AAAA... test@example.com"))
 		Expect(params["userDataSecret"]).To(Equal("bmi-test-user-data"))
 	})
+
+	It("should copy single network attachment with all fields", func() {
+		catalogItemsClient := defaultFakeCatalogItemsClient()
+
+		t := &task{
+			r: &function{
+				logger:                              logger,
+				bareMetalInstanceCatalogItemsClient: catalogItemsClient,
+			},
+			bareMetalInstance: privatev1.BareMetalInstance_builder{
+				Id: "bmi-test",
+				Spec: privatev1.BareMetalInstanceSpec_builder{
+					CatalogItem: "catalog-1",
+					NetworkAttachments: []*privatev1.BareMetalNetworkAttachment{
+						privatev1.BareMetalNetworkAttachment_builder{
+							Subnet:         "subnet-1",
+							SecurityGroups: []string{"sg-1", "sg-2"},
+							Interface:      new("data-0"),
+							Primary:        new(true),
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+		}
+
+		var obj bmfov1alpha1.BareMetalInstance
+		err := t.mutateBMI(ctx, &obj)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(obj.Spec.NetworkAttachments).To(HaveLen(1))
+		Expect(obj.Spec.NetworkAttachments[0].SubnetRef).To(Equal("subnet-1"))
+		Expect(obj.Spec.NetworkAttachments[0].SecurityGroupRefs).To(Equal([]string{"sg-1", "sg-2"}))
+		Expect(obj.Spec.NetworkAttachments[0].Interface).To(Equal("data-0"))
+		Expect(obj.Spec.NetworkAttachments[0].Primary).To(BeTrue())
+	})
+
+	It("should copy multiple network attachments preserving order", func() {
+		catalogItemsClient := defaultFakeCatalogItemsClient()
+
+		t := &task{
+			r: &function{
+				logger:                              logger,
+				bareMetalInstanceCatalogItemsClient: catalogItemsClient,
+			},
+			bareMetalInstance: privatev1.BareMetalInstance_builder{
+				Id: "bmi-test",
+				Spec: privatev1.BareMetalInstanceSpec_builder{
+					CatalogItem: "catalog-1",
+					NetworkAttachments: []*privatev1.BareMetalNetworkAttachment{
+						privatev1.BareMetalNetworkAttachment_builder{
+							Subnet:    "subnet-data",
+							Interface: new("data-0"),
+							Primary:   new(true),
+						}.Build(),
+						privatev1.BareMetalNetworkAttachment_builder{
+							Subnet:         "subnet-storage",
+							SecurityGroups: []string{"sg-storage"},
+							Interface:      new("data-1"),
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+		}
+
+		var obj bmfov1alpha1.BareMetalInstance
+		err := t.mutateBMI(ctx, &obj)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(obj.Spec.NetworkAttachments).To(HaveLen(2))
+		Expect(obj.Spec.NetworkAttachments[0].SubnetRef).To(Equal("subnet-data"))
+		Expect(obj.Spec.NetworkAttachments[0].Interface).To(Equal("data-0"))
+		Expect(obj.Spec.NetworkAttachments[0].Primary).To(BeTrue())
+		Expect(obj.Spec.NetworkAttachments[1].SubnetRef).To(Equal("subnet-storage"))
+		Expect(obj.Spec.NetworkAttachments[1].SecurityGroupRefs).To(Equal([]string{"sg-storage"}))
+		Expect(obj.Spec.NetworkAttachments[1].Interface).To(Equal("data-1"))
+		Expect(obj.Spec.NetworkAttachments[1].Primary).To(BeFalse())
+	})
+
+	It("should leave NetworkAttachments empty when proto has none", func() {
+		catalogItemsClient := defaultFakeCatalogItemsClient()
+
+		t := &task{
+			r: &function{
+				logger:                              logger,
+				bareMetalInstanceCatalogItemsClient: catalogItemsClient,
+			},
+			bareMetalInstance: privatev1.BareMetalInstance_builder{
+				Id: "bmi-test",
+				Spec: privatev1.BareMetalInstanceSpec_builder{
+					CatalogItem: "catalog-1",
+				}.Build(),
+			}.Build(),
+		}
+
+		var obj bmfov1alpha1.BareMetalInstance
+		err := t.mutateBMI(ctx, &obj)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(obj.Spec.NetworkAttachments).To(BeEmpty())
+	})
+
+	It("should handle attachment with optional fields omitted", func() {
+		catalogItemsClient := defaultFakeCatalogItemsClient()
+
+		t := &task{
+			r: &function{
+				logger:                              logger,
+				bareMetalInstanceCatalogItemsClient: catalogItemsClient,
+			},
+			bareMetalInstance: privatev1.BareMetalInstance_builder{
+				Id: "bmi-test",
+				Spec: privatev1.BareMetalInstanceSpec_builder{
+					CatalogItem: "catalog-1",
+					NetworkAttachments: []*privatev1.BareMetalNetworkAttachment{
+						privatev1.BareMetalNetworkAttachment_builder{
+							Subnet: "subnet-1",
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+		}
+
+		var obj bmfov1alpha1.BareMetalInstance
+		err := t.mutateBMI(ctx, &obj)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(obj.Spec.NetworkAttachments).To(HaveLen(1))
+		Expect(obj.Spec.NetworkAttachments[0].SubnetRef).To(Equal("subnet-1"))
+		Expect(obj.Spec.NetworkAttachments[0].SecurityGroupRefs).To(BeEmpty())
+		Expect(obj.Spec.NetworkAttachments[0].Interface).To(BeEmpty())
+		Expect(obj.Spec.NetworkAttachments[0].Primary).To(BeFalse())
+	})
 })
 
 var _ = Describe("update", func() {


### PR DESCRIPTION
blocked by https://redhat.atlassian.net/browse/OSAC-3572

## [OSAC-2249](https://redhat.atlassian.net/browse/OSAC-2249): Update mutateBMI to copy network_attachments from proto to K8s CR

**Jira:** https://redhat.atlassian.net/browse/OSAC-2249
**Story type:** [DEV]
**Depends on:** #TBD ([OSAC-2248](https://redhat.atlassian.net/browse/OSAC-2248): Add NetworkAttachments to BareMetalInstance CRD)

### Summary

Extends `mutateBMI()` in the fulfillment-service BM reconciler to copy `network_attachments` from the proto `BareMetalInstanceSpec` to the K8s CR `BareMetalInstanceSpec.NetworkAttachments`. This bridges the proto model ([OSAC-1508](https://redhat.atlassian.net/browse/OSAC-1508)) and the CRD model ([OSAC-2248](https://redhat.atlassian.net/browse/OSAC-2248)) so the bare-metal-fulfillment-operator can read network attachments during `reconcileNetworking` ([OSAC-2047](https://redhat.atlassian.net/browse/OSAC-2047)).

Unlike ComputeInstance's `buildSpecNetworkAttachments()` which resolves fulfillment-service IDs to K8s CR names, BM stores fulfillment-service IDs directly in the CRD — the bare-metal-fulfillment-operator uses these IDs when dispatching to the fabric manager.

### Changes

- **`fulfillment-service/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go`**: Added network_attachments copy loop in `mutateBMI()` — iterates proto attachments and maps `subnet` → `SubnetRef`, `security_groups` → `SecurityGroupRefs`, `interface` → `Interface`, `primary` → `Primary`

### Testing

- **Unit tests:** 4 new test cases in `baremetalinstance_reconciler_function_test.go` — single attachment with all fields, multiple attachments with order preservation, empty/nil input, optional fields omitted
- **Integration tests:** N/A — field copy is internal to the controller
- **Coverage:** mutateBMI at 93.3%, all 73 package tests pass

### Acceptance Criteria

- [x] AC-1: mutateBMI copies each BareMetalNetworkAttachment from proto to CR
- [x] AC-2: Field mapping: subnet→SubnetRef, security_groups→SecurityGroupRefs, interface→Interface, primary→Primary
- [x] AC-3: Empty/nil network_attachments leaves CR field empty
- [x] AC-4: Existing mutateBMI behavior unchanged (all pre-existing tests pass)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bare metal instances now retain configured network attachment details, including subnet, security groups, interface, and primary-interface settings.
  * Multiple network attachments are preserved in their configured order.

* **Bug Fixes**
  * Optional network attachment fields are handled correctly when omitted or empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->