### PR TITLE
OSAC-2352: add dispatcher RBAC for Subnet/NetworkClass CRs

### DIFF
--- a/bare-metal-fulfillment-operator/charts/operator/templates/clusterrole.yaml
+++ b/bare-metal-fulfillment-operator/charts/operator/templates/clusterrole.yaml
@@ -45,3 +45,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - osac.openshift.io
+  resources:
+  - networkclasses
+  - subnets
+  verbs:
+  - get
+  - list
+  - watch

--- a/bare-metal-fulfillment-operator/config/rbac/role.yaml
+++ b/bare-metal-fulfillment-operator/config/rbac/role.yaml
@@ -43,3 +43,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - osac.openshift.io
+  resources:
+  - networkclasses
+  - subnets
+  verbs:
+  - get
+  - list
+  - watch

--- a/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_controller.go
+++ b/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_controller.go
@@ -98,6 +98,8 @@ func NewBareMetalInstanceReconciler(
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=baremetalinstances/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=baremetalinstances/finalizers,verbs=update
 // +kubebuilder:rbac:groups=metal3.io,resources=baremetalhosts,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=subnets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=networkclasses,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the pool closer to the desired state.

--- a/osac-installer/charts/osac/templates/hub-access.yaml
+++ b/osac-installer/charts/osac/templates/hub-access.yaml
@@ -65,6 +65,15 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - subnets
+      - networkclasses
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## [OSAC-2352](https://redhat.atlassian.net/browse/OSAC-2352): Add dispatcher RBAC for Subnet/NetworkClass CRs

**Jira:** https://redhat.atlassian.net/browse/OSAC-2352
**Story type:** [DEV]
**EP:** /enhancements/OSAC-1437-bmaas-networking §RBAC

### Summary

Adds RBAC permissions for the bare-metal-fulfillment-operator to read Subnet and NetworkClass CRs on the hub cluster. These permissions are required by the dispatcher to resolve subnet references during `reconcileNetworking` and to look up fabric_manager names from NetworkClass during dispatcher resolution. This unblocks [OSAC-2047](https://redhat.atlassian.net/browse/OSAC-2047) (BM network_attachments provisioning).

### Changes

**bare-metal-fulfillment-operator:**
- Added kubebuilder RBAC markers for `get/list/watch` on `osac.openshift.io` `subnets` and `networkclasses` to the BareMetalInstance controller
- Regenerated `config/rbac/role.yaml` via `make manifests`
- Synced updated RBAC to Helm chart via `make helm-crds`

**osac-installer:**
- Added `osac.openshift.io` `subnets` and `networkclasses` read rules (`get/list/watch`) to the `hub-access-hosted-clusters` ClusterRole in `charts/osac/templates/hub-access.yaml`

### Testing

- **Unit tests:** All existing tests pass (`make test`). No new behavioral code added.
- **Integration tests:** N/A — RBAC-only change
- **Lint:** 0 issues (`make lint`)
- **Helm lint:** Pass (osac-installer chart)

### Acceptance Criteria

- [x] kubebuilder RBAC markers for Subnet CRs (get/list/watch)
- [x] kubebuilder RBAC markers for NetworkClass CRs (get/list/watch)
- [x] `make manifests` regenerates `config/rbac/role.yaml` with new rules
- [x] `make helm-crds` syncs updated RBAC to Helm charts
- [x] osac-installer hub-access Role updated with matching permissions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved operator integration with network configuration resources.
  * Operators can now read network classes and subnet information to support fulfillment and installation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->