### PR TITLE
OSAC-3566: show skipped instead of succeeded for E2E gate on docs-only PRs

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -97,7 +97,10 @@ jobs:
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
 
   e2e:
-    if: always()
+    if: >-
+      always()
+      && !(needs.e2e-bmaas-full-install.result == 'skipped'
+           && needs.changes.result == 'success')
     needs: [changes, e2e-bmaas-full-install]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -112,7 +112,10 @@ jobs:
       # them today.
 
   e2e:
-    if: always()
+    if: >-
+      always()
+      && !(needs.e2e-caas-full-install.result == 'skipped'
+           && needs.changes.result == 'success')
     needs: [changes, e2e-caas-full-install]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -104,7 +104,10 @@ jobs:
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
 
   e2e:
-    if: always()
+    if: >-
+      always()
+      && !(needs.e2e-vmaas-full-install.result == 'skipped'
+           && needs.changes.result == 'success')
     needs: [changes, e2e-vmaas-full-install]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- E2E gate jobs (`e2e`) used `if: always()`, causing them to show "succeeded" even when E2E was intentionally skipped on docs-only PRs
- Added condition to skip the gate when the upstream E2E job was skipped and the `changes` job succeeded — GitHub now renders "skipped" status correctly
- Applied to all 3 E2E workflows: caas, bmaas, vmaas

## Details

The gate job's `if` changes from:
```yaml
if: always()
```
to:
```yaml
if: >-
  always()
  && !(needs.<e2e-job>.result == 'skipped'
       && needs.changes.result == 'success')
```

When the `changes` job detects docs-only changes, the actual E2E job is skipped. Previously the gate still ran and showed green. Now the gate also skips, showing the correct grey "skipped" status. If the `changes` job itself fails, the gate still runs and catches it.

Ref: https://redhat-internal.slack.com/archives/C0B8KR3HK16/p1785743353267319

## Test plan

- [ ] Create a docs-only PR and verify E2E gate shows "skipped" (grey) not "succeeded" (green)
- [ ] Create a code-change PR and verify E2E gate still runs and reports pass/fail correctly
- [ ] Verify branch protection still treats skipped required checks as passing

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end workflow handling so intentionally skipped installation checks no longer trigger unnecessary test jobs.
  * Preserved accurate reporting for downstream failures and cancellations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->