### PR TITLE
NO-ISSUE: Give scan-workflow-logs its own runner label (osac-ci-small)

### DIFF
--- a/.github/workflows/scan-workflow-logs.yml
+++ b/.github/workflows/scan-workflow-logs.yml
@@ -41,7 +41,11 @@ permissions: {}
 jobs:
   scan-logs:
     name: Scan and purge run logs
-    runs-on: osac-ci
+    # Dedicated label, not the shared `osac-ci` fleet-wide label the e2e jobs
+    # themselves run on: this job needs to run promptly right after each e2e
+    # run to close the credential-exposure window, and sharing a runner pool
+    # with hour-long e2e jobs means it can queue behind them instead.
+    runs-on: osac-ci-small
     timeout-minutes: 15
     permissions:
       # Fetching and deleting the completed run's logs needs actions:write.


### PR DESCRIPTION
## Summary

`scan-workflow-logs.yml` was using `runs-on: osac-ci` — the same shared fleet-wide label the e2e reusable workflows default their own `runner-label` input to (confirmed: none of the callers override it). Since e2e runs take 40min-1h+, the scan job (whose whole purpose is scanning/purging leaked credentials from a run's logs *promptly* to close the exposure window) could end up queued behind a long e2e run on the same shared runner pool instead of running immediately after it.

## Fix

Points `runs-on:` at a new `osac-ci-small` label instead. A dedicated runner slot registered under that label is being added to the fleet separately — this PR is workflow-side only, no fleet/registration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workflow log scanning job to run on a dedicated CI runner, improving execution isolation and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->