### PR TITLE
NO-ISSUE: Move cli-ux rule to fulfillment-service CLI directory

### DIFF
--- a/fulfillment-service/internal/cmd/cli/.claude/rules/cli-ux.md
+++ b/fulfillment-service/internal/cmd/cli/.claude/rules/cli-ux.md
@@ -1,6 +1,6 @@
 # CLI UX Guidelines
 
-The OSAC CLI (`fulfillment-service/internal/cmd/cli/`) is a tenant-facing tool for managing infrastructure resources. It is NOT a Kubernetes admin tool - end users should not need to know k8s.
+The OSAC CLI is a tenant-facing tool for managing infrastructure resources. It is NOT a Kubernetes admin tool - end users should not need to know k8s.
 
 ## Design Inspiration
 


### PR DESCRIPTION
## Summary

- Move `.claude/rules/cli-ux.md` to `fulfillment-service/internal/cmd/cli/.claude/rules/cli-ux.md`
- The CLI UX guidelines only apply when working on the `osac` CLI — this scopes the rule so it auto-loads only in that context instead of on every session

## Test plan

- [x] Rule file is valid markdown
- [x] Git detects it as a rename (no content loss)

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CLI description to clearly identify it as the tenant-facing OSAC command-line interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->