### PR TITLE
WIP: OSAC-3572: fix fulfillment-service container build for mono-repo cross-module deps

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,18 @@
+# Allowlist: exclude everything, then include only what Containerfiles need.
+# This keeps the build context lean when building from the mono-repo root.
+*
+
+# Go workspace
+!go.work
+!go.work.sum
+
+# fulfillment-service (full source)
+!fulfillment-service/
+
+# Cross-module dependencies resolved via go.work
+!bare-metal-fulfillment-operator/
+!osac-operator/go.mod
+!osac-operator/go.sum
+!osac-operator/api/
+!osac-csi-driver/go.mod
+!osac-csi-driver/go.sum

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -101,7 +101,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
-          context: fulfillment-service
+          context: .
           file: fulfillment-service/Containerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/fulfillment-service/.dockerignore
+++ b/fulfillment-service/.dockerignore
@@ -1,3 +1,0 @@
-*.log
-*.test
-/fulfillment-service

--- a/fulfillment-service/Containerfile
+++ b/fulfillment-service/Containerfile
@@ -1,24 +1,32 @@
-# First stage is to build the image that contains the image with all the development tools needed to build the binary.
+# Build context: mono-repo root (not fulfillment-service/ alone).
+# Invoke with: podman build -f fulfillment-service/Containerfile .
+
 FROM registry.access.redhat.com/ubi10/go-toolset:1.26 AS builder
 
-# Set this to 'true' to build the binary with debugging symbols and disabling optimizations.
 ARG DEBUG=false
 
-# Copy only the 'go.mod' and 'go.sum' files and try to download the required modules, so that hopefully this will be
-# in a layer that can be cached reused for builds that don't change the dependencies.
+# Copy go.work and all workspace go.mod/go.sum files for dependency caching.
+# go.work ensures cross-module deps (e.g., bare-metal-fulfillment-operator)
+# resolve from sibling directories instead of the Go module proxy.
 WORKDIR /opt/app-root/src
-COPY go.mod go.sum /opt/app-root/src/
+COPY go.work go.work.sum ./
+COPY fulfillment-service/go.mod fulfillment-service/go.sum fulfillment-service/
+COPY bare-metal-fulfillment-operator/go.mod bare-metal-fulfillment-operator/go.sum bare-metal-fulfillment-operator/
+COPY osac-operator/go.mod osac-operator/go.sum osac-operator/
+COPY osac-operator/api/go.mod osac-operator/api/go.sum osac-operator/api/
+COPY osac-csi-driver/go.mod osac-csi-driver/go.sum osac-csi-driver/
 RUN \
   set -e; \
-  go mod download
+  cd fulfillment-service && GOWORK=off go mod download
 
-# Version can be passed as a build arg to avoid requiring git inside the container.
-# This is necessary when building from a git worktree, where the .git reference
-# cannot be resolved inside the container context.
 ARG VERSION=""
 
-# Copy the rest of the source and build the binary:
-COPY --chown=1001:1001 . /opt/app-root/src/
+# Copy source for fulfillment-service and its workspace dependencies.
+COPY --chown=1001:1001 fulfillment-service/ fulfillment-service/
+COPY --chown=1001:1001 bare-metal-fulfillment-operator/ bare-metal-fulfillment-operator/
+COPY --chown=1001:1001 osac-operator/api/ osac-operator/api/
+
+WORKDIR /opt/app-root/src/fulfillment-service
 RUN \
   set -e; \
   version="${VERSION}"; \
@@ -38,7 +46,7 @@ RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Common runtime base with the service binary.
 FROM registry.access.redhat.com/ubi10-minimal:10.2 AS runtime-base
-COPY --from=builder /opt/app-root/src/fulfillment-service /usr/local/bin
+COPY --from=builder /opt/app-root/src/fulfillment-service/fulfillment-service /usr/local/bin
 USER 1001
 
 # Debug variant — adds dlv on top of the base; build with: podman build --target runtime-debug .

--- a/fulfillment-service/it/it_tool.go
+++ b/fulfillment-service/it/it_tool.go
@@ -484,10 +484,20 @@ func (t *Tool) buildImage(ctx context.Context) (result string, err error) {
 	if t.debug {
 		buildTarget = "runtime-debug"
 	}
+	// The Containerfile expects the mono-repo root as build context so
+	// that cross-module dependencies (go.work) resolve from sibling dirs.
+	buildContext := t.projectDir
+	containerfile := "Containerfile"
+	monoRepoRoot := filepath.Dir(t.projectDir)
+	if _, statErr := os.Stat(filepath.Join(monoRepoRoot, "go.work")); statErr == nil {
+		buildContext = monoRepoRoot
+		containerfile = filepath.Join(filepath.Base(t.projectDir), "Containerfile")
+	}
+
 	buildCmd, err := testing.NewCommand().
 		SetLogger(t.logger).
 		SetHome(t.projectDir).
-		SetDir(t.projectDir).
+		SetDir(buildContext).
 		SetName(podmanCmd).
 		SetArgs(
 			"build",
@@ -495,7 +505,7 @@ func (t *Tool) buildImage(ctx context.Context) (result string, err error) {
 			"--build-arg", fmt.Sprintf("VERSION=%s", gitVersion),
 			"--target", buildTarget,
 			"--tag", imageRef,
-			"--file", "Containerfile",
+			"--file", containerfile,
 			".",
 		).
 		Build()


### PR DESCRIPTION
## Summary

Fixes the fulfillment-service container build to resolve cross-module Go dependencies from the mono-repo instead of stale standalone repos.

**Jira:** https://redhat.atlassian.net/browse/OSAC-3572

### Problem

After the mono-repo migration, each component's `go.mod` still uses the old standalone module paths. Locally `go.work` resolves these from sibling dirs, but CI builds each component in isolation — `go mod download` fetches stale versions from the Go proxy. First hit: [OSAC-2249](https://redhat.atlassian.net/browse/OSAC-2249) fails CI because `BareMetalNetworkAttachment` (added by [OSAC-2248](https://redhat.atlassian.net/browse/OSAC-2248)) doesn't exist in the published `v0.0.10` of the standalone repo.

### Changes

- **`fulfillment-service/Containerfile`**: Rewritten to accept the mono-repo root as build context. Copies `go.work` and sibling module source so cross-module deps resolve locally.
- **`.github/workflows/publish-image.yaml`**: Build context changed from `fulfillment-service` to `.` (repo root).
- **`fulfillment-service/it/it_tool.go`**: `buildImage()` now detects `go.work` in the parent directory and uses the mono-repo root as podman build context.
- **`.containerignore`**: New allowlist file at repo root to keep the build context lean.
- **`fulfillment-service/.dockerignore`**: Removed (no longer applies with repo-root context).

### Testing

- [ ] `podman build -f fulfillment-service/Containerfile .` from repo root builds successfully
- [ ] CI publish-image workflow builds successfully
- [ ] CI integration tests build the container and pass
- [ ] E2E workflows still build correctly