### PR TITLE
OSAC-3699: fix: make ocp_4_20_ai_maas template work on bare metal OpenShift (CaaS)

### DIFF
--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/defaults/main.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/defaults/main.yaml
@@ -23,6 +23,12 @@ ocp_4_20_ai_maas_external_model_namespace: "external-models"
 # --- Platform Operators ---
 
 # cert-manager
+ocp_4_20_ai_maas_nfs_channel: alpha
+ocp_4_20_ai_maas_nfs_path: "/var/nfs-provisioner"
+ocp_4_20_ai_maas_nfs_storage_size: "50Gi"
+ocp_4_20_ai_maas_nfs_sc_name: "nfs"
+ocp_4_20_ai_maas_nfs_node: ""
+ocp_4_20_ai_maas_nfs_setup_image: "registry.access.redhat.com/ubi9/ubi-minimal"
 ocp_4_20_ai_maas_cert_manager_channel: stable-v1.18
 ocp_4_20_ai_maas_cert_manager_source: redhat-operators
 
@@ -41,7 +47,7 @@ ocp_4_20_ai_maas_rhcl_starting_csv: rhcl-operator.v1.3.6
 ocp_4_20_ai_maas_rhcl_source: redhat-operators
 
 # Version to reject/accept in install plans
-ocp_4_20_ai_maas_reject_version: "v1.4"
+ocp_4_20_ai_maas_reject_version: "v1.4."
 ocp_4_20_ai_maas_accept_version: "v1.3"
 
 # Observability operators (COO + OTel, installed in isolated namespaces)

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/defaults/main.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/defaults/main.yaml
@@ -28,7 +28,7 @@ ocp_4_20_ai_maas_nfs_path: "/var/nfs-provisioner"
 ocp_4_20_ai_maas_nfs_storage_size: "50Gi"
 ocp_4_20_ai_maas_nfs_sc_name: "nfs"
 ocp_4_20_ai_maas_nfs_node: ""
-ocp_4_20_ai_maas_nfs_setup_image: "registry.access.redhat.com/ubi9/ubi-minimal"
+ocp_4_20_ai_maas_nfs_setup_image: "registry.access.redhat.com/ubi9/ubi-minimal:9.5"
 ocp_4_20_ai_maas_cert_manager_channel: stable-v1.18
 ocp_4_20_ai_maas_cert_manager_source: redhat-operators
 

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/files/kuadrant-instance.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/files/kuadrant-instance.yaml
@@ -3,6 +3,9 @@ kind: Namespace
 metadata:
   name: kuadrant-system
 ---
+# Pre-create with OpenShift service CA annotation — the Authorino operator
+# creates this service without it, so authorino-server-cert would never be
+# injected. Kuadrant requires the secret before reporting Ready.
 apiVersion: v1
 kind: Service
 metadata:
@@ -30,20 +33,3 @@ metadata:
 spec:
   observability:
     enable: true
----
-apiVersion: operator.authorino.kuadrant.io/v1beta1
-kind: Authorino
-metadata:
-  name: authorino
-  namespace: kuadrant-system
-spec:
-  clusterWide: true
-  replicas: 1
-  listener:
-    tls:
-      enabled: true
-      certSecretRef:
-        name: authorino-server-cert
-  oidcServer:
-    tls:
-      enabled: false

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_cluster.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_cluster.yaml
@@ -3,10 +3,12 @@
 # Discovers cluster domain, creates inference gateway, verifies observability.
 
 # --- Discover cluster domain ---
+# no_log: false prevents kubernetes.core from masking resource values when
+# admin_kubeconfig is passed as an in-memory dict (github.com/ansible-collections/kubernetes.core/issues/870)
 
 - name: Get cluster ingress domain
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: config.openshift.io/v1
     kind: Ingress
     name: cluster
@@ -18,7 +20,7 @@
 
 - name: Get ingress certificate name
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: operator.openshift.io/v1
     kind: IngressController
     name: default
@@ -56,6 +58,39 @@
 # --- openshift-ai-inference gateway ---
 # TEMPORARY WORKAROUND: RHOAI operator does not create openshift-ai-inference
 # gateway. Dashboard-deployed LLMInferenceService models need it. See: RHOAIENG-38214
+
+# HACK: The gateway controller auto-creates a LoadBalancer service for the
+# openshift-ai-inference gateway, requiring a second MetalLB IP in addition
+# to the one already used by the external-ingress service. Expand the existing
+# ingress pool by one IP before creating the gateway so the allocation succeeds.
+# The correct fix is to either have RHOAI provision this gateway (RHOAIENG-38214)
+# or rework the MetalLB pool allocation to reserve capacity for MaaS upfront.
+- name: Get current MetalLB ingress IP pool
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: metallb.io/v1beta1
+    kind: IPAddressPool
+    name: ingress-ipaddresspool
+    namespace: metallb-system
+  register: _metallb_pool
+
+- name: Expand MetalLB ingress pool to accommodate AI inference and MaaS gateway LoadBalancers
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: metallb.io/v1beta1
+      kind: IPAddressPool
+      metadata:
+        name: ingress-ipaddresspool
+        namespace: metallb-system
+      spec:
+        autoAssign: false
+        addresses:
+          - "{{ _start_ip }}-{{ _start_ip | ansible.utils.ipmath(2) }}"
+  vars:
+    _start_ip: "{{ _metallb_pool.resources[0].spec.addresses[0].split('-')[0] }}"
+  when: _metallb_pool.resources | length > 0
 
 - name: Create openshift-ai-inference gateway
   kubernetes.core.k8s:

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_cluster.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_cluster.yaml
@@ -43,7 +43,7 @@
 
 - name: Apply User Workload Monitoring
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition: "{{ item }}"
   loop: "{{ lookup('ansible.builtin.template', 'user-workload-monitoring.yaml.j2') | from_yaml_all | list }}"
@@ -67,16 +67,16 @@
 # or rework the MetalLB pool allocation to reserve capacity for MaaS upfront.
 - name: Get current MetalLB ingress IP pool
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: metallb.io/v1beta1
     kind: IPAddressPool
     name: ingress-ipaddresspool
     namespace: metallb-system
   register: _metallb_pool
 
-- name: Expand MetalLB ingress pool to accommodate AI inference and MaaS gateway LoadBalancers
+- name: Expand MetalLB ingress pool by 2 IPs for gateway LoadBalancers
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: metallb.io/v1beta1
@@ -85,16 +85,19 @@
         name: ingress-ipaddresspool
         namespace: metallb-system
       spec:
-        autoAssign: false
-        addresses:
-          - "{{ _start_ip }}-{{ _start_ip | ansible.utils.ipmath(2) }}"
+        autoAssign: "{{ _metallb_pool.resources[0].spec.autoAssign | default(false) }}"
+        addresses: >-
+          {{ _metallb_pool.resources[0].spec.addresses[1:] +
+             [_start_ip ~ '-' ~ (_end_ip | ansible.utils.ipmath(2))] }}
   vars:
-    _start_ip: "{{ _metallb_pool.resources[0].spec.addresses[0].split('-')[0] }}"
+    _addr0: "{{ _metallb_pool.resources[0].spec.addresses[0] }}"
+    _start_ip: "{{ _addr0.split('-')[0] }}"
+    _end_ip: "{{ _addr0.split('-')[-1] }}"
   when: _metallb_pool.resources | length > 0
 
 - name: Create openshift-ai-inference gateway
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     template: openshift-ai-inference-gateway.yaml.j2
   register: _r
@@ -104,7 +107,7 @@
 
 - name: Wait for openshift-ai-inference gateway Programmed
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: gateway.networking.k8s.io/v1
     kind: Gateway
     name: openshift-ai-inference
@@ -139,7 +142,7 @@
 
 - name: Apply hardware profiles
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition: "{{ item }}"
   loop: >-
@@ -164,7 +167,7 @@
 
 - name: Patch OdhDashboardConfig with observability flag
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     merge_type: merge
     definition:
@@ -186,7 +189,7 @@
 
 - name: Patch OdhDashboardConfig with general flags
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     merge_type: merge
     definition:
@@ -210,7 +213,7 @@
 
 - name: Wait for Monitoring CR Ready
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: services.platform.opendatahub.io/v1alpha1
     kind: Monitoring
     name: default-monitoring
@@ -230,7 +233,7 @@
 
 - name: Verify Perses pod running
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: v1
     kind: Pod
     namespace: redhat-ods-monitoring
@@ -248,7 +251,7 @@
 
 - name: Verify PersesDatasources created
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: perses.dev/v1alpha2
     kind: PersesDatasource
     namespace: redhat-ods-monitoring
@@ -263,7 +266,7 @@
 
 - name: Verify PersesDashboards created
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: perses.dev/v1alpha2
     kind: PersesDashboard
     namespace: redhat-ods-monitoring

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_external_models.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_external_models.yaml
@@ -16,7 +16,7 @@
 
 - name: Clean up leftover external subscriptions
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     api_version: maas.opendatahub.io/v1alpha1
     kind: MaaSSubscription
@@ -30,7 +30,7 @@
 
 - name: Clean up leftover external auth policies
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     api_version: maas.opendatahub.io/v1alpha1
     kind: MaaSAuthPolicy
@@ -44,7 +44,7 @@
 
 - name: Clean up leftover external model refs
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     api_version: maas.opendatahub.io/v1alpha1
     kind: MaaSModelRef
@@ -58,7 +58,7 @@
 
 - name: Clean up leftover external models
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     api_version: maas.opendatahub.io/v1alpha1
     kind: ExternalModel
@@ -72,7 +72,7 @@
 
 - name: Clean up leftover Kuadrant AuthPolicies
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     api_version: kuadrant.io/v1
     kind: AuthPolicy
@@ -86,7 +86,7 @@
 
 - name: Clean up leftover Kuadrant TRLPs
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     api_version: kuadrant.io/v1alpha1
     kind: TokenRateLimitPolicy
@@ -107,7 +107,7 @@
 
 - name: Apply proxy infrastructure
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition: "{{ item }}"
   loop: >-
@@ -123,7 +123,7 @@
 
 - name: Wait for proxy Deployments ready
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: apps/v1
     kind: Deployment
     namespace: "{{ ocp_4_20_ai_maas_proxy_namespace }}"
@@ -144,7 +144,7 @@
 
 - name: Apply ExternalModel resources
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition: "{{ item }}"
   loop: >-
@@ -163,7 +163,7 @@
 
 - name: Wait for external MaaSModelRef Ready
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: maas.opendatahub.io/v1alpha1
     kind: MaaSModelRef
     name: "{{ item.name }}"
@@ -185,7 +185,7 @@
 
 - name: Wait for external subscriptions Active
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: maas.opendatahub.io/v1alpha1
     kind: MaaSSubscription
     name: "{{ item.name }}-sub"
@@ -204,7 +204,7 @@
 
 - name: Wait for external TokenRateLimitPolicy enforcement
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: kuadrant.io/v1alpha1
     kind: TokenRateLimitPolicy
     namespace: "{{ ocp_4_20_ai_maas_external_model_namespace }}"

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_maas.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_maas.yaml
@@ -130,7 +130,7 @@
 
 # --- Phase 2: MaaS Prerequisites ---
 
-- name: Apply Kuadrant resources (namespace, service, Kuadrant, Authorino)
+- name: Apply Kuadrant resources (namespace and Kuadrant CR)
   kubernetes.core.k8s:
     kubeconfig: "{{ admin_kubeconfig }}"
     state: present
@@ -162,6 +162,41 @@
       | selectattr('status', 'equalto', 'True')
       | list | length > 0
 
+# Kuadrant creates the Authorino CR with listener.tls.enabled: false regardless
+# of cert availability. Set enabled: true and add the cluster root CA volume so
+# Authorino trusts the Keycloak ingress cert (signed by OU=openshift,CN=root-ca).
+# kube-root-ca.crt is auto-injected into every namespace by Kubernetes.
+- name: Configure Authorino TLS and cluster root CA volume
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    merge_type: merge
+    definition:
+      apiVersion: operator.authorino.kuadrant.io/v1beta1
+      kind: Authorino
+      metadata:
+        name: authorino
+        namespace: kuadrant-system
+      spec:
+        listener:
+          tls:
+            enabled: true
+            certSecretRef:
+              name: authorino-server-cert
+        volumes:
+          items:
+            - name: cluster-root-ca
+              configMaps:
+                - kube-root-ca.crt
+              items:
+                - key: ca.crt
+                  path: tls-ca-bundle.pem
+              mountPath: /etc/pki/ca-trust/extracted/pem
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
 - name: Apply gateway resources ConfigMap
   kubernetes.core.k8s:
     kubeconfig: "{{ admin_kubeconfig }}"
@@ -177,6 +212,33 @@
     kubeconfig: "{{ admin_kubeconfig }}"
     state: present
     definition: "{{ lookup('ansible.builtin.template', 'gateway.yaml.j2') | from_yaml }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+# The OpenShift Router handles *.apps.* wildcard DNS. Without this Route the
+# Router returns 503 — same pattern as the auto-created data-science-gateway Route.
+- name: Create OpenShift Route for maas-default-gateway
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: route.openshift.io/v1
+      kind: Route
+      metadata:
+        name: maas-default-gateway
+        namespace: openshift-ingress
+      spec:
+        host: "{{ ocp_4_20_ai_maas_gateway_hostname }}.{{ _cluster_domain }}"
+        port:
+          targetPort: 443
+        tls:
+          termination: passthrough
+        to:
+          kind: Service
+          name: maas-default-gateway-data-science-gateway-class
+          weight: 100
   register: _r
   retries: 5
   delay: 10
@@ -563,7 +625,7 @@
 # restart, subscriptions stay Degraded and inference returns 403.
 - name: Restart maas-controller for subscription reconciliation
   environment:
-    KUBECONFIG: "{{ admin_kubeconfig | expanduser }}"
+    KUBECONFIG: "{{ _kubeconfig_tmpfile.path }}"
   ansible.builtin.shell: |
     oc rollout restart deployment/maas-controller -n redhat-ods-applications
     oc rollout status deployment/maas-controller -n redhat-ods-applications --timeout=180s

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_maas.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_maas.yaml
@@ -162,6 +162,17 @@
       | selectattr('status', 'equalto', 'True')
       | list | length > 0
 
+- name: Fail if Kuadrant never became Ready
+  ansible.builtin.fail:
+    msg: "Kuadrant did not become Ready after {{ ocp_4_20_ai_maas_operator_retries }} retries."
+  when: >-
+    _kuadrant.resources is not defined
+    or _kuadrant.resources | length == 0
+    or (_kuadrant.resources[0].status.conditions | default([])
+       | selectattr('type', 'equalto', 'Ready')
+       | selectattr('status', 'equalto', 'True')
+       | list | length == 0)
+
 # Kuadrant creates the Authorino CR with listener.tls.enabled: false regardless
 # of cert availability. Set enabled: true and add the cluster root CA volume so
 # Authorino trusts the Keycloak ingress cert (signed by OU=openshift,CN=root-ca).

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_maas.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_maas.yaml
@@ -27,7 +27,7 @@
   block:
     - name: Apply Keycloak resources (namespace, RHBK, PostgreSQL, instance, route)
       kubernetes.core.k8s:
-        kubeconfig: "{{ admin_kubeconfig }}"
+        kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
         state: present
         definition: "{{ item }}"
       loop: "{{ lookup('ansible.builtin.template', 'keycloak.yaml.j2') | from_yaml_all | list }}"
@@ -41,7 +41,7 @@
 
     - name: Wait for Keycloak PostgreSQL
       kubernetes.core.k8s_info:
-        kubeconfig: "{{ admin_kubeconfig }}"
+        kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
         api_version: apps/v1
         kind: Deployment
         name: keycloak-postgres
@@ -55,7 +55,7 @@
 
     - name: Wait for Keycloak instance ready
       kubernetes.core.k8s_info:
-        kubeconfig: "{{ admin_kubeconfig }}"
+        kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
         api_version: k8s.keycloak.org/v2alpha1
         kind: Keycloak
         name: "{{ ocp_4_20_ai_maas_keycloak_namespace }}"
@@ -87,7 +87,7 @@
 
     - name: Apply Keycloak realm import
       kubernetes.core.k8s:
-        kubeconfig: "{{ admin_kubeconfig }}"
+        kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
         state: present
         definition: "{{ lookup('ansible.builtin.template', 'keycloak-realm-maas.yaml.j2') | from_yaml }}"
       no_log: true
@@ -98,7 +98,7 @@
 
     - name: Wait for realm import
       kubernetes.core.k8s_info:
-        kubeconfig: "{{ admin_kubeconfig }}"
+        kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
         api_version: k8s.keycloak.org/v2alpha1
         kind: KeycloakRealmImport
         name: maas-realm
@@ -132,7 +132,7 @@
 
 - name: Apply Kuadrant resources (namespace and Kuadrant CR)
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition: "{{ item }}"
   loop: "{{ lookup('ansible.builtin.file', role_path + '/files/kuadrant-instance.yaml') | from_yaml_all | list }}"
@@ -145,7 +145,7 @@
 
 - name: Wait for Kuadrant ready
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: kuadrant.io/v1beta1
     kind: Kuadrant
     name: kuadrant
@@ -166,9 +166,14 @@
 # of cert availability. Set enabled: true and add the cluster root CA volume so
 # Authorino trusts the Keycloak ingress cert (signed by OU=openshift,CN=root-ca).
 # kube-root-ca.crt is auto-injected into every namespace by Kubernetes.
+#
+# The root CA is mounted at the RHEL system bundle path, replacing it with just
+# the cluster root CA. This is safe here because Authorino's only outbound HTTPS
+# connections are to Keycloak (for OIDC discovery and JWKS) — both signed by the
+# cluster root CA. No public CA-signed HTTPS endpoints are contacted.
 - name: Configure Authorino TLS and cluster root CA volume
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     merge_type: merge
     definition:
@@ -199,7 +204,7 @@
 
 - name: Apply gateway resources ConfigMap
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition: "{{ lookup('ansible.builtin.template', 'gateway-resources.yaml.j2') | from_yaml }}"
   register: _r
@@ -209,7 +214,7 @@
 
 - name: Apply maas-default-gateway
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition: "{{ lookup('ansible.builtin.template', 'gateway.yaml.j2') | from_yaml }}"
   register: _r
@@ -219,9 +224,29 @@
 
 # The OpenShift Router handles *.apps.* wildcard DNS. Without this Route the
 # Router returns 503 — same pattern as the auto-created data-science-gateway Route.
+- name: Wait for maas-default-gateway Service to exist before creating Route
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
+    api_version: v1
+    kind: Service
+    name: maas-default-gateway-data-science-gateway-class
+    namespace: openshift-ingress
+  register: _gw_svc
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  until: _gw_svc.resources | length > 0
+
+- name: Assert gateway Service has expected port 443
+  ansible.builtin.assert:
+    that:
+      - _gw_svc.resources[0].spec.ports | selectattr('port', 'equalto', 443) | list | length > 0
+    fail_msg: >-
+      maas-default-gateway-data-science-gateway-class Service does not expose port 443.
+      The gateway controller may not have created the Service correctly.
+
 - name: Create OpenShift Route for maas-default-gateway
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: route.openshift.io/v1
@@ -246,7 +271,7 @@
 
 - name: Wait for gateway Programmed
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: gateway.networking.k8s.io/v1
     kind: Gateway
     name: maas-default-gateway
@@ -267,7 +292,7 @@
 # isn't fully active (admission webhooks, quota controllers need time).
 - name: Create maas-db namespace
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: v1
@@ -281,7 +306,7 @@
 
 - name: Create maas-postgres PVC
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: v1
@@ -302,7 +327,7 @@
 
 - name: Apply PostgreSQL for maas-api
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition: "{{ item }}"
   loop: "{{ lookup('ansible.builtin.template', 'postgres-maas.yaml.j2') | from_yaml_all | list }}"
@@ -316,7 +341,7 @@
 
 - name: Wait for maas-postgres
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: apps/v1
     kind: Deployment
     name: maas-postgres
@@ -332,7 +357,7 @@
 
 - name: Create maas-db-config secret
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: v1
@@ -354,7 +379,7 @@
 
 - name: Patch DSC to enable MaaS
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: datasciencecluster.opendatahub.io/v1
@@ -375,7 +400,7 @@
 
 - name: Wait for MaaS components ready
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: datasciencecluster.opendatahub.io/v1
     kind: DataScienceCluster
     name: default-dsc
@@ -406,7 +431,7 @@
 
 - name: Configure Tenant CR
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: maas.opendatahub.io/v1alpha1
@@ -441,7 +466,7 @@
 
 - name: Wait for Tenant Active
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: maas.opendatahub.io/v1alpha1
     kind: Tenant
     name: "{{ ocp_4_20_ai_maas_tenant_name }}"
@@ -469,7 +494,7 @@
 
 - name: Patch OdhDashboardConfig with MaaS feature flags
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     merge_type: merge
     definition:
@@ -492,7 +517,7 @@
 
 - name: Create model namespace
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: v1
@@ -506,7 +531,7 @@
 
 - name: Deploy LLMInferenceService
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition: "{{ lookup('ansible.builtin.template', 'model.yaml.j2') | from_yaml }}"
   register: _r
@@ -516,7 +541,7 @@
 
 - name: Wait for LLMInferenceService Ready
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: serving.kserve.io/v1alpha2
     kind: LLMInferenceService
     name: "{{ ocp_4_20_ai_maas_model_name }}"
@@ -547,7 +572,7 @@
 
 - name: Create MaaSModelRef
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition: "{{ lookup('ansible.builtin.template', 'maas-model-ref.yaml.j2') | from_yaml }}"
   register: _r
@@ -557,7 +582,7 @@
 
 - name: Wait for MaaSModelRef Ready
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: maas.opendatahub.io/v1alpha1
     kind: MaaSModelRef
     name: "{{ ocp_4_20_ai_maas_model_name }}"
@@ -584,7 +609,7 @@
 
 - name: Create MaaSAuthPolicy
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition: "{{ lookup('ansible.builtin.template', 'maas-auth-policy.yaml.j2') | from_yaml }}"
   register: _r
@@ -594,7 +619,7 @@
 
 - name: Create MaaSSubscriptions
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition: "{{ item }}"
   loop: "{{ lookup('ansible.builtin.template', 'maas-subscriptions.yaml.j2') | from_yaml_all | list }}"
@@ -607,7 +632,7 @@
 
 - name: Wait for auto-generated AuthPolicy
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: kuadrant.io/v1
     kind: AuthPolicy
     namespace: "{{ ocp_4_20_ai_maas_model_namespace }}"
@@ -635,7 +660,7 @@
 
 - name: Wait for all subscriptions Active
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: maas.opendatahub.io/v1alpha1
     kind: MaaSSubscription
     namespace: models-as-a-service
@@ -669,7 +694,7 @@
 # restart. Without this, rate limiting verify tests fail (all 200, no 429).
 - name: Wait for TokenRateLimitPolicy enforcement
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: kuadrant.io/v1alpha1
     kind: TokenRateLimitPolicy
     namespace: "{{ ocp_4_20_ai_maas_model_namespace }}"

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/delete.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/delete.yaml
@@ -4,6 +4,22 @@
 # gateway, PostgreSQL). Operators are NOT removed — in the OSAC pipeline, the cluster
 # itself is deleted after this step, which removes everything.
 
+# Initialize kubeconfig tmpfile if not already set (delete runs independently
+# of post_install, so _kubeconfig_tmpfile may not exist yet).
+- name: Create kubeconfig temp file for delete flow
+  ansible.builtin.tempfile:
+    suffix: .kubeconfig
+  register: _kubeconfig_tmpfile
+  when: _kubeconfig_tmpfile is not defined or _kubeconfig_tmpfile.path is not defined
+
+- name: Write kubeconfig to temp file
+  ansible.builtin.copy:
+    content: "{{ admin_kubeconfig | to_yaml if admin_kubeconfig is mapping else admin_kubeconfig }}"
+    dest: "{{ _kubeconfig_tmpfile.path }}"
+    mode: "0600"
+  no_log: true
+  when: _kubeconfig_tmpfile.path is defined
+
 - name: Delete external model subscriptions
   kubernetes.core.k8s:
     kubeconfig: "{{ _kubeconfig_tmpfile.path }}"

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/delete.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/delete.yaml
@@ -6,11 +6,23 @@
 
 # Initialize kubeconfig tmpfile if not already set (delete runs independently
 # of post_install, so _kubeconfig_tmpfile may not exist yet).
+# Use a separate register variable (_delete_tmpfile) because Ansible always
+# defines registered variables (even skipped tasks), so re-registering into
+# _kubeconfig_tmpfile would overwrite it with a skipped result.
+- name: Check if kubeconfig temp file already exists from post_install
+  ansible.builtin.set_fact:
+    _delete_needs_tmpfile: "{{ (_kubeconfig_tmpfile | default({})).path | default('') == '' }}"
+
 - name: Create kubeconfig temp file for delete flow
   ansible.builtin.tempfile:
     suffix: .kubeconfig
-  register: _kubeconfig_tmpfile
-  when: _kubeconfig_tmpfile is not defined or _kubeconfig_tmpfile.path is not defined
+  register: _delete_tmpfile
+  when: _delete_needs_tmpfile | bool
+
+- name: Point _kubeconfig_tmpfile at the newly created temp file
+  ansible.builtin.set_fact:
+    _kubeconfig_tmpfile: "{{ _delete_tmpfile }}"
+  when: _delete_needs_tmpfile | bool
 
 - name: Write kubeconfig to temp file
   ansible.builtin.copy:
@@ -18,7 +30,7 @@
     dest: "{{ _kubeconfig_tmpfile.path }}"
     mode: "0600"
   no_log: true
-  when: _kubeconfig_tmpfile.path is defined
+  when: _delete_needs_tmpfile | bool
 
 - name: Delete external model subscriptions
   kubernetes.core.k8s:

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/delete.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/delete.yaml
@@ -6,7 +6,7 @@
 
 - name: Delete external model subscriptions
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     api_version: maas.opendatahub.io/v1alpha1
     kind: MaaSSubscription
@@ -20,7 +20,7 @@
 
 - name: Delete external model auth policies
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     api_version: maas.opendatahub.io/v1alpha1
     kind: MaaSAuthPolicy
@@ -34,7 +34,7 @@
 
 - name: Delete external model namespaces
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     api_version: v1
     kind: Namespace
@@ -47,7 +47,7 @@
 
 - name: Delete hardware profiles
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     api_version: infrastructure.opendatahub.io/v1
     kind: HardwareProfile
@@ -61,7 +61,7 @@
 
 - name: Remove MaaS subscriptions
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     definition: "{{ item }}"
   loop: "{{ lookup('ansible.builtin.template', 'maas-subscriptions.yaml.j2') | from_yaml_all | list }}"
@@ -71,28 +71,28 @@
 
 - name: Remove MaaSAuthPolicy
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     definition: "{{ lookup('ansible.builtin.template', 'maas-auth-policy.yaml.j2') | from_yaml }}"
   ignore_errors: true
 
 - name: Remove MaaSModelRef
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     definition: "{{ lookup('ansible.builtin.template', 'maas-model-ref.yaml.j2') | from_yaml }}"
   ignore_errors: true
 
 - name: Remove LLMInferenceService
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     definition: "{{ lookup('ansible.builtin.template', 'model.yaml.j2') | from_yaml }}"
   ignore_errors: true
 
 - name: Remove model namespace
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     definition:
       apiVersion: v1
@@ -103,7 +103,7 @@
 
 - name: Remove Tenant CR
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     definition:
       apiVersion: maas.opendatahub.io/v1alpha1
@@ -115,7 +115,7 @@
 
 - name: Disable MaaS in DSC
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: datasciencecluster.opendatahub.io/v1
@@ -132,7 +132,7 @@
 
 - name: Remove maas-db-config secret
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     definition:
       apiVersion: v1
@@ -144,7 +144,7 @@
 
 - name: Remove PostgreSQL
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     definition: "{{ item }}"
   loop: "{{ lookup('ansible.builtin.template', 'postgres-maas.yaml.j2') | from_yaml_all | list }}"
@@ -155,7 +155,7 @@
 
 - name: Remove maas-default-gateway
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     definition:
       apiVersion: gateway.networking.k8s.io/v1
@@ -167,14 +167,14 @@
 
 - name: Remove gateway resources
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     definition: "{{ lookup('ansible.builtin.template', 'gateway-resources.yaml.j2') | from_yaml }}"
   ignore_errors: true
 
 - name: Remove Kuadrant resources
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     definition: "{{ item }}"
   loop: "{{ lookup('ansible.builtin.file', role_path + '/files/kuadrant-instance.yaml') | from_yaml_all | list }}"
@@ -184,7 +184,7 @@
 
 - name: Remove monitoring config
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     definition: "{{ item }}"
   loop: "{{ lookup('ansible.builtin.template', 'user-workload-monitoring.yaml.j2') | from_yaml_all | list }}"
@@ -194,7 +194,7 @@
 
 - name: Remove Keycloak namespace
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     definition:
       apiVersion: v1
@@ -206,7 +206,7 @@
 
 - name: Remove models-as-a-service namespace
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: absent
     definition:
       apiVersion: v1

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install_operators.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install_operators.yaml
@@ -201,6 +201,13 @@
                 securityContext:
                   privileged: true
                   runAsUser: 0
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 64Mi
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
                 volumeMounts:
                   - name: host-root
                     mountPath: /host

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install_operators.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install_operators.yaml
@@ -104,6 +104,214 @@
     label: "{{ item.name | default('unnamed') }}"
   when: ocp_4_20_ai_maas_hardware_profiles | length > 0
 
+# --- Step 0: Default StorageClass via NFS Provisioner ---
+# MaaS requires persistent storage (Keycloak PostgreSQL, observability).
+# On bare metal/HyperShift clusters no default StorageClass exists.
+# Install nfs-provisioner-operator (community-operators) which deploys a
+# ganesha NFS server pod backed by a node hostPath directory, and creates a
+# dynamic NFS StorageClass. The directory is created with default root
+# permissions (755) and the container_file_t SELinux label — no 777 needed.
+# Skipped when a default StorageClass already exists (cloud, ODF, etc.).
+
+- name: Check for existing default StorageClass
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: storage.k8s.io/v1
+    kind: StorageClass
+  register: _existing_scs
+
+- name: Set fact — default StorageClass present
+  ansible.builtin.set_fact:
+    _has_default_sc: >-
+      {{ _existing_scs.resources
+         | map(attribute='metadata.annotations', default={})
+         | map('dict2items')
+         | flatten
+         | selectattr('key', 'equalto', 'storageclass.kubernetes.io/is-default-class')
+         | selectattr('value', 'equalto', 'true')
+         | list | length > 0 }}
+
+- name: Get worker nodes for NFS placement
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: v1
+    kind: Node
+    label_selectors:
+      - node-role.kubernetes.io/worker
+  register: _worker_nodes
+  when: not _has_default_sc | bool
+
+- name: Set NFS target node
+  ansible.builtin.set_fact:
+    _nfs_node: >-
+      {{ ocp_4_20_ai_maas_nfs_node if ocp_4_20_ai_maas_nfs_node
+         else (_worker_nodes.get('resources', []) | json_query('[0].metadata.name') | default('')) }}
+  when: not _has_default_sc | bool
+
+- name: Label node for NFS provisioner
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Node
+      metadata:
+        name: "{{ _nfs_node }}"
+        labels:
+          app: nfs-provisioner
+  when: not _has_default_sc | bool
+
+- name: Create NFS directory on node with container_file_t SELinux context
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: nfs-dir-setup
+        namespace: kube-system
+      spec:
+        ttlSecondsAfterFinished: 60
+        template:
+          spec:
+            restartPolicy: Never
+            nodeSelector:
+              app: nfs-provisioner
+            containers:
+              - name: setup
+                image: "{{ ocp_4_20_ai_maas_nfs_setup_image }}"
+                env:
+                  - name: NFS_PATH
+                    value: "{{ ocp_4_20_ai_maas_nfs_path }}"
+                command:
+                  - bash
+                  - "-c"
+                  - "mkdir -p /host\"$NFS_PATH\" && chcon -Rt container_file_t /host\"$NFS_PATH\""
+                securityContext:
+                  privileged: true
+                  runAsUser: 0
+                volumeMounts:
+                  - name: host-root
+                    mountPath: /host
+            volumes:
+              - name: host-root
+                hostPath:
+                  path: /
+                  type: Directory
+  when: not _has_default_sc | bool
+
+- name: Wait for NFS directory setup job to complete
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: batch/v1
+    kind: Job
+    name: nfs-dir-setup
+    namespace: kube-system
+  register: _nfs_setup_job
+  retries: 10
+  delay: 10
+  until:
+    - _nfs_setup_job.resources | length > 0
+    - _nfs_setup_job.resources[0].status.succeeded | default(0) >= 1
+  when: not _has_default_sc | bool
+
+- name: Install NFS Provisioner operator
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition: "{{ item }}"
+  loop:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: nfs-provisioner
+    - apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        name: nfs-provisioner-operatorgroup
+        namespace: nfs-provisioner
+      spec:
+        targetNamespaces:
+          - nfs-provisioner
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: nfs-provisioner-operator
+        namespace: nfs-provisioner
+      spec:
+        channel: "{{ ocp_4_20_ai_maas_nfs_channel }}"
+        installPlanApproval: Automatic
+        name: nfs-provisioner-operator
+        source: community-operators
+        sourceNamespace: openshift-marketplace
+  when: not _has_default_sc | bool
+
+- name: Wait for NFS Provisioner operator to be ready
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    namespace: nfs-provisioner
+    label_selectors:
+      - operators.coreos.com/nfs-provisioner-operator.nfs-provisioner
+  register: _nfs_csv
+  retries: 30
+  delay: 20
+  until:
+    - _nfs_csv.resources | length > 0
+    - _nfs_csv.resources[0].status.phase | default('') == 'Succeeded'
+  when: not _has_default_sc | bool
+
+- name: Create NFSProvisioner instance
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: cache.jhouse.com/v1alpha1
+      kind: NFSProvisioner
+      metadata:
+        name: nfsprovisioner
+        namespace: nfs-provisioner
+      spec:
+        storageSize: "{{ ocp_4_20_ai_maas_nfs_storage_size }}"
+        scForNFS: "{{ ocp_4_20_ai_maas_nfs_sc_name }}"
+        hostPathDir: "{{ ocp_4_20_ai_maas_nfs_path }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+  when: not _has_default_sc | bool
+
+- name: Wait for NFS server pod to be running
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: v1
+    kind: Pod
+    namespace: nfs-provisioner
+    label_selectors:
+      - app=nfs-provisioner
+  register: _nfs_pod
+  retries: 30
+  delay: 15
+  until:
+    - _nfs_pod.resources | length > 0
+    - _nfs_pod.resources[0].status.phase | default('') == 'Running'
+  when: not _has_default_sc | bool
+
+- name: Set NFS StorageClass as default
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: patched
+    api_version: storage.k8s.io/v1
+    kind: StorageClass
+    name: "{{ ocp_4_20_ai_maas_nfs_sc_name }}"
+    definition:
+      metadata:
+        annotations:
+          storageclass.kubernetes.io/is-default-class: "true"
+  when: not _has_default_sc | bool
+
 # --- Step 1: cert-manager ---
 # RHCL 1.3 requires cert-manager 1.18 per https://access.redhat.com/articles/7092611
 # Parent template may already install cert-manager; skip if found.
@@ -187,12 +395,15 @@
         - _cert_manager_sub.resources | length > 0
         - _cert_manager_sub.resources[0].status.installedCSV is defined
 
+# Kubeconfig temp file (_kubeconfig_tmpfile) created in post_install.yaml
+# and available throughout all task files in this role.
+
 # --- Guard: clean stale sailoperator CRDs ---
 - name: Clean stale sailoperator CRDs (prevents SM install plan failure)
   environment:
-    KUBECONFIG: "{{ admin_kubeconfig }}"
+    KUBECONFIG: "{{ _kubeconfig_tmpfile.path }}"
   ansible.builtin.shell: |
-    export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
+    export KUBECONFIG="{{ _kubeconfig_tmpfile.path }}"
     SM_OK=$(oc get csv -n openshift-operators -o jsonpath='{.items[*].metadata.name}' 2>/dev/null | tr ' ' '\n' | grep servicemeshoperator3 | head -1)
     if [ -n "$SM_OK" ]; then
       # SM CSV exists (any state) — CRDs are actively needed, don't delete.
@@ -222,10 +433,10 @@
     # v1.4.0 installation before hold-until-clean can reject.
     - name: Delete stale subscriptions, CSVs, and install plans in openshift-operators
       environment:
-        KUBECONFIG: "{{ admin_kubeconfig }}"
+        KUBECONFIG: "{{ _kubeconfig_tmpfile.path }}"
         ACCEPT: "{{ ocp_4_20_ai_maas_accept_version }}"
       ansible.builtin.shell: |
-        export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
+        export KUBECONFIG="{{ _kubeconfig_tmpfile.path }}"
         # Skip cleanup if all operators have a v1.3.x CSV Succeeded
         ALL_OK=true
         for op in authorino-operator limitador-operator dns-operator rhcl-operator; do
@@ -265,15 +476,19 @@
     # See: https://access.redhat.com/solutions/7097633
     - name: Install SM with Ingress Operator race protection
       environment:
-        KUBECONFIG: "{{ admin_kubeconfig | expanduser }}"
+        KUBECONFIG: "{{ _kubeconfig_tmpfile.path }}"
         SM_CSV: "{{ ocp_4_20_ai_maas_sm_starting_csv }}"
         SM_CHANNEL: "{{ ocp_4_20_ai_maas_sm_channel }}"
         SM_SOURCE: "{{ ocp_4_20_ai_maas_sm_source }}"
         REJECT: "{{ ocp_4_20_ai_maas_reject_version }}"
       ansible.builtin.shell: |
+        SUCCEEDED=$(oc get csv -n openshift-operators --no-headers \
+          -o custom-columns=NAME:.metadata.name,PHASE:.status.phase 2>/dev/null \
+          | awk '/servicemeshoperator3/ && /Succeeded/ {print $1}' | head -1)
+        [ -n "$SUCCEEDED" ] && exit 0
+
         PHASE=$(oc get csv "$SM_CSV" -n openshift-operators \
           -o jsonpath='{.status.phase}' 2>/dev/null)
-        [ "$PHASE" = "Succeeded" ] && exit 0
 
         if [ -z "$PHASE" ]; then
           for csv in $(oc get csv -n openshift-operators --no-headers \
@@ -331,9 +546,10 @@
             fi
           done
 
-          PHASE=$(oc get csv "$SM_CSV" -n openshift-operators \
-            -o jsonpath='{.status.phase}' 2>/dev/null)
-          [ "$PHASE" = "Succeeded" ] && exit 0
+          SUCCEEDED=$(oc get csv -n openshift-operators --no-headers \
+            -o custom-columns=NAME:.metadata.name,PHASE:.status.phase 2>/dev/null \
+            | awk '/servicemeshoperator3/ && /Succeeded/ {print $1}' | head -1)
+          [ -n "$SUCCEEDED" ] && exit 0
           echo "Attempt $attempt: channel=OK, CSV phase=$PHASE, waiting..."
           sleep 5
         done
@@ -346,10 +562,61 @@
       until: _sm_result.rc == 0
       changed_when: false
 
-    # --- Step 3: Pre-create sub-operator subscriptions (v1.3.x, Manual) ---
+    # --- Step 3: Discover latest v1.3.x CSVs and pre-create subscriptions ---
+    # Queries the catalog at runtime so startingCSV is always current within the
+    # v1.3.x pin. This avoids manual bumps when Red Hat releases patch versions.
+
+    - name: Discover latest v1.3.x CSVs from PackageManifests
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ admin_kubeconfig }}"
+        api_version: packages.operators.coreos.com/v1
+        kind: PackageManifest
+        name: "{{ item }}"
+        namespace: openshift-marketplace
+      register: _pkgmanifests
+      loop:
+        - authorino-operator
+        - limitador-operator
+        - dns-operator
+        - rhcl-operator
+      loop_control:
+        label: "{{ item }}"
+
+    - name: Set discovered CSV versions
+      ansible.builtin.set_fact:
+        _authorino_csv: >-
+          {{ (_pkgmanifests.results[0].resources[0].status.channels
+             | map(attribute='entries') | flatten
+             | map(attribute='name') | select('search', 'v1\.3\.')
+             | list | sort | last) | default(ocp_4_20_ai_maas_authorino_starting_csv) }}
+        _limitador_csv: >-
+          {{ (_pkgmanifests.results[1].resources[0].status.channels
+             | map(attribute='entries') | flatten
+             | map(attribute='name') | select('search', 'v1\.3\.')
+             | list | sort | last) | default(ocp_4_20_ai_maas_limitador_starting_csv) }}
+        _dns_csv: >-
+          {{ (_pkgmanifests.results[2].resources[0].status.channels
+             | map(attribute='entries') | flatten
+             | map(attribute='name') | select('search', 'v1\.3\.')
+             | list | sort | last) | default(ocp_4_20_ai_maas_dns_starting_csv) }}
+        _rhcl_csv: >-
+          {{ (_pkgmanifests.results[3].resources[0].status.channels
+             | map(attribute='entries') | flatten
+             | map(attribute='name') | select('search', 'v1\.3\.')
+             | list | sort | last) | default(ocp_4_20_ai_maas_rhcl_starting_csv) }}
+
+    - name: Report discovered CSV versions
+      ansible.builtin.debug:
+        msg:
+          - "authorino: {{ _authorino_csv }}"
+          - "limitador: {{ _limitador_csv }}"
+          - "dns: {{ _dns_csv }}"
+          - "rhcl: {{ _rhcl_csv }}"
+
     # TEMPORARY WORKAROUND (continued): Pre-creating sub-operator subscriptions with
-    # Manual approval and startingCSV pins them to v1.3.1 before RHCL creates its own.
-    # Remove once RHCL v1.4.0 compatibility is resolved.
+    # Manual approval prevents RHCL from auto-installing v1.4.x sub-operators that
+    # are incompatible with SM 3.2.x. Remove once RHCL v1.4.x + SM compatibility
+    # is resolved (target: RHOAI 3.5).
 
     - name: Pre-create Authorino Subscription (v1.3.1, Manual)
       kubernetes.core.k8s:
@@ -367,7 +634,7 @@
             name: authorino-operator
             source: "{{ ocp_4_20_ai_maas_rhcl_source }}"
             sourceNamespace: openshift-marketplace
-            startingCSV: "{{ ocp_4_20_ai_maas_authorino_starting_csv }}"
+            startingCSV: "{{ _authorino_csv }}"
       register: _r
       retries: 5
       delay: 10
@@ -389,7 +656,7 @@
             name: limitador-operator
             source: "{{ ocp_4_20_ai_maas_rhcl_source }}"
             sourceNamespace: openshift-marketplace
-            startingCSV: "{{ ocp_4_20_ai_maas_limitador_starting_csv }}"
+            startingCSV: "{{ _limitador_csv }}"
       register: _r
       retries: 5
       delay: 10
@@ -411,7 +678,7 @@
             name: dns-operator
             source: "{{ ocp_4_20_ai_maas_rhcl_source }}"
             sourceNamespace: openshift-marketplace
-            startingCSV: "{{ ocp_4_20_ai_maas_dns_starting_csv }}"
+            startingCSV: "{{ _dns_csv }}"
       register: _r
       retries: 5
       delay: 10
@@ -423,11 +690,11 @@
     # v1.4.0 upgrades, leading to an infinite loop or stuck Replacing CSVs.
     - name: Approve install plans and wait for sub-operator CSVs
       environment:
-        KUBECONFIG: "{{ admin_kubeconfig }}"
+        KUBECONFIG: "{{ _kubeconfig_tmpfile.path }}"
         REJECT: "{{ ocp_4_20_ai_maas_reject_version }}"
         ACCEPT: "{{ ocp_4_20_ai_maas_accept_version }}"
       ansible.builtin.shell: |
-        export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
+        export KUBECONFIG="{{ _kubeconfig_tmpfile.path }}"
 
         # Early exit if all three have a v1.3.x CSV Succeeded
         ALL_OK=true
@@ -498,7 +765,7 @@
             name: rhcl-operator
             source: "{{ ocp_4_20_ai_maas_rhcl_source }}"
             sourceNamespace: openshift-marketplace
-            startingCSV: "{{ ocp_4_20_ai_maas_rhcl_starting_csv }}"
+            startingCSV: "{{ _rhcl_csv }}"
       register: _r
       retries: 5
       delay: 10
@@ -508,11 +775,11 @@
     # for RHCL itself. End of RHCL version pinning workaround block.
     - name: Approve install plans and wait for RHCL CSV
       environment:
-        KUBECONFIG: "{{ admin_kubeconfig }}"
+        KUBECONFIG: "{{ _kubeconfig_tmpfile.path }}"
         REJECT: "{{ ocp_4_20_ai_maas_reject_version }}"
         ACCEPT: "{{ ocp_4_20_ai_maas_accept_version }}"
       ansible.builtin.shell: |
-        export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
+        export KUBECONFIG="{{ _kubeconfig_tmpfile.path }}"
         for plan in $(oc get installplan -n openshift-operators \
           -o jsonpath='{range .items[?(@.spec.approved==false)]}{.metadata.name}{" "}{end}' 2>/dev/null); do
           csvs=$(oc get installplan "$plan" -n openshift-operators \
@@ -674,9 +941,9 @@
 # retain Manual installPlanApproval. Approve any unapproved SM install plans.
 - name: Approve SM install plans for auto-install (inference-only)
   environment:
-    KUBECONFIG: "{{ admin_kubeconfig }}"
+    KUBECONFIG: "{{ _kubeconfig_tmpfile.path }}"
   ansible.builtin.shell: |
-    export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
+    export KUBECONFIG="{{ _kubeconfig_tmpfile.path }}"
     SM_CSV=$(oc get csv -n openshift-operators --no-headers 2>/dev/null | grep servicemeshoperator3 | head -1 | awk '{print $1}')
     if [ -n "$SM_CSV" ]; then
       PHASE=$(oc get csv "$SM_CSV" -n openshift-operators -o jsonpath='{.status.phase}' 2>/dev/null)
@@ -830,14 +1097,15 @@
 
 - name: Delete stale COO subscription, CSVs, and install plans
   environment:
-    KUBECONFIG: "{{ admin_kubeconfig }}"
+    KUBECONFIG: "{{ _kubeconfig_tmpfile.path }}"
     COO_CSV: "{{ ocp_4_20_ai_maas_coo_starting_csv }}"
   ansible.builtin.shell: |
-    export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
-    # Skip if COO already at target version
-    phase=$(oc get csv "$COO_CSV" -n openshift-cluster-observability-operator \
-      -o jsonpath='{.status.phase}' 2>/dev/null)
-    [ "$phase" = "Succeeded" ] && echo "COO at target version, skipping cleanup" && exit 0
+    export KUBECONFIG="{{ _kubeconfig_tmpfile.path }}"
+    # Skip if any COO CSV is already Succeeded
+    SUCCEEDED=$(oc get csv -n openshift-cluster-observability-operator --no-headers \
+      -o custom-columns=NAME:.metadata.name,PHASE:.status.phase 2>/dev/null \
+      | awk '/cluster-observability-operator/ && /Succeeded/ {print $1}' | head -1)
+    [ -n "$SUCCEEDED" ] && echo "COO already Succeeded ($SUCCEEDED), skipping cleanup" && exit 0
 
     oc delete sub cluster-observability-operator \
       -n openshift-cluster-observability-operator --ignore-not-found 2>/dev/null || true
@@ -875,10 +1143,10 @@
 
 - name: Approve COO v1.4.0 install plan
   environment:
-    KUBECONFIG: "{{ admin_kubeconfig }}"
+    KUBECONFIG: "{{ _kubeconfig_tmpfile.path }}"
     COO_CSV: "{{ ocp_4_20_ai_maas_coo_starting_csv }}"
   ansible.builtin.shell: |
-    export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
+    export KUBECONFIG="{{ _kubeconfig_tmpfile.path }}"
     for plan in $(oc get installplan -n openshift-cluster-observability-operator \
       -o jsonpath='{range .items[?(@.spec.approved==false)]}{.metadata.name}{" "}{end}' 2>/dev/null); do
       csvs=$(oc get installplan "$plan" -n openshift-cluster-observability-operator \
@@ -1023,6 +1291,17 @@
     or _dsc.resources[0].status.phase | default('') != 'Ready'
 
 # TEMPORARY WORKAROUND (end): Restore Ingress Operator after version-pinned install.
+# On HyperShift the Ingress Operator runs on the management cluster, not the guest,
+# so the deployment is absent and there is nothing to restore.
+- name: Check if Ingress Operator deployment exists on guest cluster
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: apps/v1
+    kind: Deployment
+    name: ingress-operator
+    namespace: openshift-ingress-operator
+  register: _ingress_operator_deploy
+
 - name: Scale up Ingress Operator
   kubernetes.core.k8s:
     kubeconfig: "{{ admin_kubeconfig }}"
@@ -1040,7 +1319,12 @@
   retries: 5
   delay: 10
   until: _r is not failed
-  when: ocp_4_20_ai_maas_enable_maas | bool
+  when:
+    - ocp_4_20_ai_maas_enable_maas | bool
+    - _ingress_operator_deploy.resources | length > 0
+
+# Kubeconfig temp file kept for configure_cluster.yaml and configure_maas.yaml.
+# Cleaned up in post_install.yaml after all tasks complete.
 
 - name: Report operator installation complete
   ansible.builtin.debug:

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install_operators.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install_operators.yaml
@@ -39,6 +39,7 @@
       - ocp_4_20_ai_maas_rhcl_starting_csv is regex('^[\w.\-]+$')
       - ocp_4_20_ai_maas_sm_starting_csv is regex('^[\w.\-]+$')
       - ocp_4_20_ai_maas_coo_starting_csv is regex('^[\w.\-]+$')
+      - ocp_4_20_ai_maas_nfs_path is regex('^/[\w/\-]+$')
     fail_msg: "Shell-interpolated variables contain invalid characters"
 
 - name: Validate external models require MaaS
@@ -115,7 +116,7 @@
 
 - name: Check for existing default StorageClass
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: storage.k8s.io/v1
     kind: StorageClass
   register: _existing_scs
@@ -133,7 +134,7 @@
 
 - name: Get worker nodes for NFS placement
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: v1
     kind: Node
     label_selectors:
@@ -148,9 +149,18 @@
          else (_worker_nodes.get('resources', []) | json_query('[0].metadata.name') | default('')) }}
   when: not _has_default_sc | bool
 
+- name: Fail if no NFS node available
+  ansible.builtin.fail:
+    msg: >-
+      No worker node found for NFS provisioner. Set ocp_4_20_ai_maas_nfs_node
+      to a specific node name or ensure worker nodes exist.
+  when:
+    - not _has_default_sc | bool
+    - _nfs_node | length == 0
+
 - name: Label node for NFS provisioner
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: v1
@@ -163,7 +173,7 @@
 
 - name: Create NFS directory on node with container_file_t SELinux context
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: batch/v1
@@ -172,7 +182,7 @@
         name: nfs-dir-setup
         namespace: kube-system
       spec:
-        ttlSecondsAfterFinished: 60
+        ttlSecondsAfterFinished: 600
         template:
           spec:
             restartPolicy: Never
@@ -203,7 +213,7 @@
 
 - name: Wait for NFS directory setup job to complete
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: batch/v1
     kind: Job
     name: nfs-dir-setup
@@ -218,7 +228,7 @@
 
 - name: Install NFS Provisioner operator
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition: "{{ item }}"
   loop:
@@ -245,11 +255,12 @@
         name: nfs-provisioner-operator
         source: community-operators
         sourceNamespace: openshift-marketplace
+        startingCSV: "{{ ocp_4_20_ai_maas_nfs_starting_csv | default(omit) }}"
   when: not _has_default_sc | bool
 
 - name: Wait for NFS Provisioner operator to be ready
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: operators.coreos.com/v1alpha1
     kind: ClusterServiceVersion
     namespace: nfs-provisioner
@@ -265,7 +276,7 @@
 
 - name: Create NFSProvisioner instance
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: cache.jhouse.com/v1alpha1
@@ -285,7 +296,7 @@
 
 - name: Wait for NFS server pod to be running
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: v1
     kind: Pod
     namespace: nfs-provisioner
@@ -299,9 +310,21 @@
     - _nfs_pod.resources[0].status.phase | default('') == 'Running'
   when: not _has_default_sc | bool
 
+- name: Wait for NFS StorageClass to exist before marking default
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
+    api_version: storage.k8s.io/v1
+    kind: StorageClass
+    name: "{{ ocp_4_20_ai_maas_nfs_sc_name }}"
+  register: _nfs_sc
+  retries: 20
+  delay: 15
+  until: _nfs_sc.resources | length > 0
+  when: not _has_default_sc | bool
+
 - name: Set NFS StorageClass as default
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: patched
     api_version: storage.k8s.io/v1
     kind: StorageClass
@@ -318,7 +341,7 @@
 
 - name: Check if cert-manager is already installed
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: operators.coreos.com/v1alpha1
     kind: ClusterServiceVersion
     namespace: cert-manager-operator
@@ -332,7 +355,7 @@
   block:
     - name: Create cert-manager namespace
       kubernetes.core.k8s:
-        kubeconfig: "{{ admin_kubeconfig }}"
+        kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
         state: present
         definition:
           apiVersion: v1
@@ -346,7 +369,7 @@
 
     - name: Create cert-manager OperatorGroup
       kubernetes.core.k8s:
-        kubeconfig: "{{ admin_kubeconfig }}"
+        kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
         state: present
         definition:
           apiVersion: operators.coreos.com/v1
@@ -362,7 +385,7 @@
 
     - name: Create cert-manager Subscription
       kubernetes.core.k8s:
-        kubeconfig: "{{ admin_kubeconfig }}"
+        kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
         state: present
         definition:
           apiVersion: operators.coreos.com/v1alpha1
@@ -383,7 +406,7 @@
 
     - name: Wait for cert-manager CSV
       kubernetes.core.k8s_info:
-        kubeconfig: "{{ admin_kubeconfig }}"
+        kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
         api_version: operators.coreos.com/v1alpha1
         kind: Subscription
         name: openshift-cert-manager-operator
@@ -568,7 +591,7 @@
 
     - name: Discover latest v1.3.x CSVs from PackageManifests
       kubernetes.core.k8s_info:
-        kubeconfig: "{{ admin_kubeconfig }}"
+        kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
         api_version: packages.operators.coreos.com/v1
         kind: PackageManifest
         name: "{{ item }}"
@@ -585,25 +608,25 @@
     - name: Set discovered CSV versions
       ansible.builtin.set_fact:
         _authorino_csv: >-
-          {{ (_pkgmanifests.results[0].resources[0].status.channels
+          {{ ((_pkgmanifests.results[0].resources | default([{}]))[0].status.channels | default([])
              | map(attribute='entries') | flatten
              | map(attribute='name') | select('search', 'v1\.3\.')
-             | list | sort | last) | default(ocp_4_20_ai_maas_authorino_starting_csv) }}
+             | list | community.general.version_sort | last) | default(ocp_4_20_ai_maas_authorino_starting_csv) }}
         _limitador_csv: >-
-          {{ (_pkgmanifests.results[1].resources[0].status.channels
+          {{ ((_pkgmanifests.results[1].resources | default([{}]))[0].status.channels | default([])
              | map(attribute='entries') | flatten
              | map(attribute='name') | select('search', 'v1\.3\.')
-             | list | sort | last) | default(ocp_4_20_ai_maas_limitador_starting_csv) }}
+             | list | community.general.version_sort | last) | default(ocp_4_20_ai_maas_limitador_starting_csv) }}
         _dns_csv: >-
-          {{ (_pkgmanifests.results[2].resources[0].status.channels
+          {{ ((_pkgmanifests.results[2].resources | default([{}]))[0].status.channels | default([])
              | map(attribute='entries') | flatten
              | map(attribute='name') | select('search', 'v1\.3\.')
-             | list | sort | last) | default(ocp_4_20_ai_maas_dns_starting_csv) }}
+             | list | community.general.version_sort | last) | default(ocp_4_20_ai_maas_dns_starting_csv) }}
         _rhcl_csv: >-
-          {{ (_pkgmanifests.results[3].resources[0].status.channels
+          {{ ((_pkgmanifests.results[3].resources | default([{}]))[0].status.channels | default([])
              | map(attribute='entries') | flatten
              | map(attribute='name') | select('search', 'v1\.3\.')
-             | list | sort | last) | default(ocp_4_20_ai_maas_rhcl_starting_csv) }}
+             | list | community.general.version_sort | last) | default(ocp_4_20_ai_maas_rhcl_starting_csv) }}
 
     - name: Report discovered CSV versions
       ansible.builtin.debug:
@@ -620,7 +643,7 @@
 
     - name: Pre-create Authorino Subscription (v1.3.1, Manual)
       kubernetes.core.k8s:
-        kubeconfig: "{{ admin_kubeconfig }}"
+        kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
         state: present
         definition:
           apiVersion: operators.coreos.com/v1alpha1
@@ -642,7 +665,7 @@
 
     - name: Pre-create Limitador Subscription (v1.3.1, Manual)
       kubernetes.core.k8s:
-        kubeconfig: "{{ admin_kubeconfig }}"
+        kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
         state: present
         definition:
           apiVersion: operators.coreos.com/v1alpha1
@@ -664,7 +687,7 @@
 
     - name: Pre-create DNS Subscription (v1.3.1, Manual)
       kubernetes.core.k8s:
-        kubeconfig: "{{ admin_kubeconfig }}"
+        kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
         state: present
         definition:
           apiVersion: operators.coreos.com/v1alpha1
@@ -751,7 +774,7 @@
 
     - name: Create RHCL Subscription (v1.3.4, Manual)
       kubernetes.core.k8s:
-        kubeconfig: "{{ admin_kubeconfig }}"
+        kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
         state: present
         definition:
           apiVersion: operators.coreos.com/v1alpha1
@@ -804,7 +827,7 @@
 
 - name: Create LWS namespace
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: v1
@@ -818,7 +841,7 @@
 
 - name: Create LWS OperatorGroup
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: operators.coreos.com/v1
@@ -836,7 +859,7 @@
 
 - name: Create LWS Subscription
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: operators.coreos.com/v1alpha1
@@ -857,7 +880,7 @@
 
 - name: Wait for LWS CSV
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription
     name: leader-worker-set
@@ -873,7 +896,7 @@
 
 - name: Create RHOAI namespace
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: v1
@@ -887,7 +910,7 @@
 
 - name: Create RHOAI OperatorGroup
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: operators.coreos.com/v1
@@ -903,7 +926,7 @@
 
 - name: Create RHOAI Subscription
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: operators.coreos.com/v1alpha1
@@ -924,7 +947,7 @@
 
 - name: Wait for RHOAI CSV
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription
     name: rhods-operator
@@ -990,7 +1013,7 @@
 
 - name: Create OTel namespace
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: v1
@@ -1005,7 +1028,7 @@
 
 - name: Create OTel OperatorGroup
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: operators.coreos.com/v1
@@ -1022,7 +1045,7 @@
 
 - name: Create OTel Subscription
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: operators.coreos.com/v1alpha1
@@ -1044,7 +1067,7 @@
 
 - name: Wait for OTel CSV
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription
     name: "{{ ocp_4_20_ai_maas_otel_package }}"
@@ -1065,7 +1088,7 @@
 
 - name: Create COO namespace
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: v1
@@ -1080,7 +1103,7 @@
 
 - name: Create COO OperatorGroup
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: operators.coreos.com/v1
@@ -1120,7 +1143,7 @@
 
 - name: Create COO Subscription (Manual approval, pinned to v1.4.0)
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: operators.coreos.com/v1alpha1
@@ -1171,7 +1194,7 @@
 
 - name: Wait for DSCInitialization to be ready
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: dscinitialization.opendatahub.io/v1
     kind: DSCInitialization
     name: default-dsci
@@ -1197,7 +1220,7 @@
 # Step 6c: Patch DSCI metrics (before DSC creation so operator sees it on first reconciliation)
 - name: Patch DSCI with monitoring metrics configuration
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     merge_type: merge
     definition:
@@ -1220,7 +1243,7 @@
 
 - name: Wait for RHOAI webhook endpoints ready
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: v1
     kind: Endpoints
     name: rhods-operator-service
@@ -1251,7 +1274,7 @@
 
 - name: Create DataScienceCluster
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: datasciencecluster.opendatahub.io/v1
@@ -1267,7 +1290,7 @@
 
 - name: Wait for DataScienceCluster Ready
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: datasciencecluster.opendatahub.io/v1
     kind: DataScienceCluster
     name: default-dsc
@@ -1295,7 +1318,7 @@
 # so the deployment is absent and there is nothing to restore.
 - name: Check if Ingress Operator deployment exists on guest cluster
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: apps/v1
     kind: Deployment
     name: ingress-operator
@@ -1304,7 +1327,7 @@
 
 - name: Scale up Ingress Operator
   kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     state: present
     definition:
       apiVersion: apps/v1

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install_operators.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install_operators.yaml
@@ -251,7 +251,7 @@
         namespace: nfs-provisioner
       spec:
         channel: "{{ ocp_4_20_ai_maas_nfs_channel }}"
-        installPlanApproval: Automatic
+        installPlanApproval: Manual
         name: nfs-provisioner-operator
         source: community-operators
         sourceNamespace: openshift-marketplace
@@ -288,6 +288,8 @@
         storageSize: "{{ ocp_4_20_ai_maas_nfs_storage_size }}"
         scForNFS: "{{ ocp_4_20_ai_maas_nfs_sc_name }}"
         hostPathDir: "{{ ocp_4_20_ai_maas_nfs_path }}"
+        nodeSelector:
+          app: nfs-provisioner
   register: _r
   retries: 5
   delay: 10

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/post_install.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/post_install.yaml
@@ -3,15 +3,16 @@
 # Orchestrates: operator installation → MaaS configuration → verification.
 # Uses admin_kubeconfig from the parent pipeline (retrieved at step 5).
 
-- name: Verify admin_kubeconfig is available
+- name: Verify admin_kubeconfig is available and is not a file path
   ansible.builtin.assert:
     that:
       - admin_kubeconfig is defined
       - admin_kubeconfig | length > 0
+      - admin_kubeconfig is not string or not admin_kubeconfig.startswith('/')
     fail_msg: >-
-      admin_kubeconfig is not set. In production, this is provided by the
-      ocp_small pipeline. For local testing, set KUBECONFIG env var
-      or pass admin_kubeconfig as a playbook variable.
+      admin_kubeconfig must be a kubeconfig dict or raw YAML string, not a
+      file path. In production this is provided by the ocp_small pipeline.
+      For local testing pass the kubeconfig content, not a path.
 
 # Write kubeconfig to a temp file once for the entire post-install flow.
 # Using a file path prevents kubernetes.core from masking resource values

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/post_install.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/post_install.yaml
@@ -23,33 +23,35 @@
 
 - name: Write kubeconfig to temp file
   ansible.builtin.copy:
-    content: "{{ admin_kubeconfig | to_yaml }}"
+    content: "{{ admin_kubeconfig | to_yaml if admin_kubeconfig is mapping else admin_kubeconfig }}"
     dest: "{{ _kubeconfig_tmpfile.path }}"
     mode: "0600"
   no_log: true
 
-- name: Install platform operators (BOM Phase 2 + 3)
-  ansible.builtin.include_tasks: install_operators.yaml
+- name: Run post-install phases with guaranteed tmpfile cleanup
+  block:
+    - name: Install platform operators (BOM Phase 2 + 3)
+      ansible.builtin.include_tasks: install_operators.yaml
 
-- name: Configure cluster (gateway, observability)
-  ansible.builtin.include_tasks: configure_cluster.yaml
+    - name: Configure cluster (gateway, observability)
+      ansible.builtin.include_tasks: configure_cluster.yaml
 
-- name: Configure MaaS platform (Phases 1-5)
-  ansible.builtin.include_tasks: configure_maas.yaml
-  when: ocp_4_20_ai_maas_enable_maas | default(true) | bool
+    - name: Configure MaaS platform (Phases 1-5)
+      ansible.builtin.include_tasks: configure_maas.yaml
+      when: ocp_4_20_ai_maas_enable_maas | default(true) | bool
 
-- name: Run verification smoke tests
-  ansible.builtin.include_tasks: verify.yaml
-  when: ocp_4_20_ai_maas_run_verify | default(true)
+    - name: Run verification smoke tests
+      ansible.builtin.include_tasks: verify.yaml
+      when: ocp_4_20_ai_maas_run_verify | default(true)
 
-- name: Configure external models (Phase 6 — after verify)
-  ansible.builtin.include_tasks: configure_external_models.yaml
-  when:
-    - ocp_4_20_ai_maas_enable_maas | default(true) | bool
-    - ocp_4_20_ai_maas_external_models | default([]) | length > 0
-
-- name: Remove kubeconfig temp file
-  ansible.builtin.file:
-    path: "{{ _kubeconfig_tmpfile.path }}"
-    state: absent
-  when: _kubeconfig_tmpfile.path is defined
+    - name: Configure external models (Phase 6 — after verify)
+      ansible.builtin.include_tasks: configure_external_models.yaml
+      when:
+        - ocp_4_20_ai_maas_enable_maas | default(true) | bool
+        - ocp_4_20_ai_maas_external_models | default([]) | length > 0
+  always:
+    - name: Remove kubeconfig temp file
+      ansible.builtin.file:
+        path: "{{ _kubeconfig_tmpfile.path }}"
+        state: absent
+      when: _kubeconfig_tmpfile.path is defined

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/post_install.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/post_install.yaml
@@ -13,6 +13,21 @@
       ocp_small pipeline. For local testing, set KUBECONFIG env var
       or pass admin_kubeconfig as a playbook variable.
 
+# Write kubeconfig to a temp file once for the entire post-install flow.
+# Using a file path prevents kubernetes.core from masking resource values
+# when kubeconfig is passed as an in-memory dict (kubernetes.core/issues/870).
+- name: Create kubeconfig temp file
+  ansible.builtin.tempfile:
+    suffix: .kubeconfig
+  register: _kubeconfig_tmpfile
+
+- name: Write kubeconfig to temp file
+  ansible.builtin.copy:
+    content: "{{ admin_kubeconfig | to_yaml }}"
+    dest: "{{ _kubeconfig_tmpfile.path }}"
+    mode: "0600"
+  no_log: true
+
 - name: Install platform operators (BOM Phase 2 + 3)
   ansible.builtin.include_tasks: install_operators.yaml
 
@@ -32,3 +47,9 @@
   when:
     - ocp_4_20_ai_maas_enable_maas | default(true) | bool
     - ocp_4_20_ai_maas_external_models | default([]) | length > 0
+
+- name: Remove kubeconfig temp file
+  ansible.builtin.file:
+    path: "{{ _kubeconfig_tmpfile.path }}"
+    state: absent
+  when: _kubeconfig_tmpfile.path is defined

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/verify.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/verify.yaml
@@ -159,7 +159,7 @@
 
 - name: Check RHCL operator versions
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: operators.coreos.com/v1alpha1
     kind: ClusterServiceVersion
     namespace: openshift-operators
@@ -183,7 +183,7 @@
 
 - name: Get COO CSV status
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: operators.coreos.com/v1alpha1
     kind: ClusterServiceVersion
     name: "{{ ocp_4_20_ai_maas_coo_starting_csv }}"
@@ -193,7 +193,7 @@
 
 - name: Get OTel Subscription status
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription
     name: "{{ ocp_4_20_ai_maas_otel_package }}"
@@ -203,7 +203,7 @@
 
 - name: Wait for Perses pod running
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: v1
     kind: Pod
     namespace: redhat-ods-monitoring

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/verify.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/verify.yaml
@@ -3,7 +3,7 @@
 
 - name: Get cluster ingress domain (if not already set)
   kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
+    kubeconfig: "{{ _kubeconfig_tmpfile.path }}"
     api_version: config.openshift.io/v1
     kind: Ingress
     name: cluster

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/gateway.yaml.j2
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/gateway.yaml.j2
@@ -9,6 +9,8 @@ metadata:
 spec:
   gatewayClassName: data-science-gateway-class
   infrastructure:
+    annotations:
+      metallb.universe.tf/address-pool: ingress-ipaddresspool
     parametersRef:
       group: ""
       kind: ConfigMap

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/keycloak.yaml.j2
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/keycloak.yaml.j2
@@ -127,21 +127,7 @@ spec:
     httpEnabled: true
   hostname:
     hostname: "{{ ocp_4_20_ai_maas_keycloak_namespace }}.{{ _cluster_domain }}"
+  ingress:
+    enabled: true
   proxy:
     headers: xforwarded
----
-apiVersion: route.openshift.io/v1
-kind: Route
-metadata:
-  name: {{ ocp_4_20_ai_maas_keycloak_namespace }}
-  namespace: {{ ocp_4_20_ai_maas_keycloak_namespace }}
-spec:
-  host: "{{ ocp_4_20_ai_maas_keycloak_namespace }}.{{ _cluster_domain }}"
-  to:
-    kind: Service
-    name: {{ ocp_4_20_ai_maas_keycloak_namespace }}-service
-  port:
-    targetPort: http
-  tls:
-    termination: edge
-    insecureEdgeTerminationPolicy: Redirect

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/openshift-ai-inference-gateway.yaml.j2
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/openshift-ai-inference-gateway.yaml.j2
@@ -10,6 +10,9 @@ metadata:
     istio.io/rev: openshift-gateway
 spec:
   gatewayClassName: data-science-gateway-class
+  infrastructure:
+    annotations:
+      metallb.universe.tf/address-pool: ingress-ipaddresspool
   listeners:
     - name: https
       port: 443


### PR DESCRIPTION
- Write admin_kubeconfig to a tmpfile to fix kubernetes.core value masking (issues/870) and expanduser failures on dict kubeconfigs
- Install NFS provisioner when no default StorageClass exists
- Expand MetalLB ingress pool by 2 for openshift-ai-inference and maas-default-gateway LoadBalancers (required for Programmed:True)
- Add MetalLB address-pool annotation to both gateway templates
- Create passthrough OpenShift Route for maas-default-gateway (*.apps.* DNS resolves to Router, not directly to MetalLB IP)
- Replace explicit Keycloak Route with RHBK ingress.enabled:true
- Remove Authorino CR from kuadrant-instance.yaml (Kuadrant manages it); patch enabled:true and cluster root CA volume after Kuadrant is Ready
- Guard Ingress Operator scale-up when deployment is absent on guest clusters
- Add no_log:true to kubeconfig write task; quote NFS path in shell command

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable NFS storage provisioning when no default StorageClass is available.
  * Added MetalLB address-pool support for AI inference gateway ingress.
  * Enabled secure Authorino TLS and passthrough routing for the MaaS gateway.
  * Enabled Keycloak ingress configuration.

* **Bug Fixes**
  * Improved cluster setup compatibility across standard and HyperShift environments.
  * Improved ingress address allocation, certificate discovery, and operator readiness checks.
  * Secured administrator credentials during installation and cleanup.
  * Updated operator version discovery and RHCL 1.4 release handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->