### PR TITLE
OSAC-1755: Add capabilities intersection to NetworkClass reconciler

### DIFF
--- a/osac-operator/.claude/rules/configuration.md
+++ b/osac-operator/.claude/rules/configuration.md
@@ -20,6 +20,13 @@ Config via environment variables from a Secret (see `config/samples/osac-config-
 - `OSAC_CLUSTER_ORDER_NAMESPACE`, `OSAC_COMPUTE_INSTANCE_NAMESPACE`
 - `OSAC_TENANT_NAMESPACE`, `OSAC_NETWORKING_NAMESPACE`
 
+## Networking Managers
+
+- `OSAC_NETWORK_CLASS_SYNC_INTERVAL` — periodic full resync interval for NetworkClass
+  capabilities intersection, in addition to the immediate resync triggered by manager
+  ConfigMap changes (default: 5m). Only active when the fulfillment-service gRPC
+  connection is configured and `OSAC_NETWORKING_NAMESPACE` is non-empty.
+
 ## Controller Enable Flags
 
 - `OSAC_ENABLE_CLUSTER_CONTROLLER` / `--enable-cluster-controller`

--- a/osac-operator/charts/operator/templates/deployment.yaml
+++ b/osac-operator/charts/operator/templates/deployment.yaml
@@ -62,6 +62,10 @@ spec:
           - name: OSAC_AAP_TEMPLATE_PREFIX
             value: {{ .Values.aap.templatePrefix | quote }}
           {{- end }}
+          {{- if .Values.networkManagers.capabilitiesSyncInterval }}
+          - name: OSAC_NETWORK_CLASS_SYNC_INTERVAL
+            value: {{ .Values.networkManagers.capabilitiesSyncInterval | quote }}
+          {{- end }}
           - name: OSAC_FULFILLMENT_SERVER_ADDRESS
             value: {{ .Values.fulfillment.serverAddress | default "fulfillment-internal-api:8001" | quote }}
           - name: OSAC_FULFILLMENT_TOKEN_FILE

--- a/osac-operator/charts/operator/templates/network-managers.yaml
+++ b/osac-operator/charts/operator/templates/network-managers.yaml
@@ -28,7 +28,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "osac-operator.labels" $ | nindent 4 }}
-    osac.openshift.io/network/fabric-manager: "true"
+    osac.openshift.io/network-fabric-manager: "true"
 data:
   name: {{ $name | quote }}
   {{- if $mgr.description }}
@@ -48,7 +48,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "osac-operator.labels" $ | nindent 4 }}
-    osac.openshift.io/network/k8s-manager: "true"
+    osac.openshift.io/network-k8s-manager: "true"
 data:
   name: {{ $name | quote }}
   {{- if $mgr.description }}

--- a/osac-operator/charts/operator/values.yaml
+++ b/osac-operator/charts/operator/values.yaml
@@ -66,9 +66,13 @@ tenants: []
 # --- Network Manager Registration ---
 # ConfigMaps that register networking managers for the two-manager model.
 # The operator discovers managers by selecting ConfigMaps with labels
-# osac.openshift.io/network/fabric-manager or osac.openshift.io/network/k8s-manager.
+# osac.openshift.io/network-fabric-manager or osac.openshift.io/network-k8s-manager.
 networkManagers:
   enabled: false
+  # capabilitiesSyncInterval controls how often the operator recomputes NetworkClass
+  # capabilities from the fabric/k8s manager ConfigMaps (in addition to reacting
+  # immediately to ConfigMap changes).
+  capabilitiesSyncInterval: "5m"
   fabricManagers:
     netris:
       enabled: false

--- a/osac-operator/cmd/main.go
+++ b/osac-operator/cmd/main.go
@@ -65,6 +65,8 @@ import (
 	"github.com/osac-project/osac/osac-operator/internal/controller"
 	"github.com/osac-project/osac/osac-operator/internal/migrations"
 	"github.com/osac-project/osac/osac-operator/pkg/aap"
+	"github.com/osac-project/osac/osac-operator/pkg/dispatcher"
+	"github.com/osac-project/osac/osac-operator/pkg/networkmanager"
 	"github.com/osac-project/osac/osac-operator/pkg/provisioning"
 	// +kubebuilder:scaffold:imports
 )
@@ -102,6 +104,9 @@ const (
 	// Job history configuration
 	envMaxJobHistory = "OSAC_MAX_JOB_HISTORY"
 
+	// NetworkClass capabilities sync configuration
+	envNetworkClassSyncInterval = "OSAC_NETWORK_CLASS_SYNC_INTERVAL"
+
 	// Tenant configuration
 	envTenantNamespace = "OSAC_TENANT_NAMESPACE"
 
@@ -117,6 +122,12 @@ const (
 	envEnableBareMetalInstanceController = "OSAC_ENABLE_BAREMETAL_INSTANCE_CONTROLLER"
 
 	remoteClusterName = "remote"
+
+	// defaultNetworkClassSyncInterval is the fallback periodic resync interval for
+	// NetworkClass capabilities when OSAC_NETWORK_CLASS_SYNC_INTERVAL is unset or
+	// non-positive. Recommended range: 1m (avoid excessive gRPC load from an overly
+	// aggressive interval) to 1h (avoid capabilities going too stale).
+	defaultNetworkClassSyncInterval = 5 * time.Minute
 )
 
 // controllerFlags holds the enable flags for all controllers.
@@ -496,6 +507,14 @@ func setupNetworkingControllers(
 		return fmt.Errorf("externalip attachment provider: %w", err)
 	}
 
+	if grpcConn != nil && networkingNamespace != "" {
+		if err := setupNetworkClassCapabilitiesController(
+			mgr, localMgr, grpcConn, networkingNamespace,
+		); err != nil {
+			return err
+		}
+	}
+
 	if err := setupVirtualNetworkControllers(
 		mgr, localMgr, grpcConn, networkingNamespace,
 		networkingProvider, statusPollInterval, maxJobHistory, targetCluster,
@@ -540,6 +559,38 @@ func setupNetworkingControllers(
 		return err
 	}
 
+	return nil
+}
+
+// setupNetworkClassCapabilitiesController registers the NetworkClass capabilities
+// reconciler (ConfigMap-triggered) and its periodic resync runnable. Both require the
+// gRPC connection and a manager resolver built from ConfigMap-based discovery, so this
+// is only called when grpcConn is set and a networking namespace is configured.
+func setupNetworkClassCapabilitiesController(
+	mgr mcmanager.Manager, localMgr ctrl.Manager, grpcConn *grpc.ClientConn, networkingNamespace string,
+) error {
+	disc, err := networkmanager.NewDiscovery(localMgr.GetClient(), networkingNamespace)
+	if err != nil {
+		return fmt.Errorf("network manager discovery: %w", err)
+	}
+	networkClassesClient := privatev1.NewNetworkClassesClient(grpcConn)
+	resolver := dispatcher.NewResolver(networkClassesClient, disc)
+
+	ncReconciler := controller.NewNetworkClassCapabilitiesReconciler(
+		networkClassesClient, resolver, networkingNamespace,
+	)
+	if err := ncReconciler.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("networkclass capabilities controller: %w", err)
+	}
+
+	syncInterval := helpers.GetEnvWithDefault(
+		envNetworkClassSyncInterval, defaultNetworkClassSyncInterval, func(v time.Duration) bool {
+			return v > 0
+		},
+	)
+	if err := localMgr.Add(controller.NewNetworkClassCapabilitiesSyncRunnable(ncReconciler, syncInterval)); err != nil {
+		return fmt.Errorf("networkclass capabilities sync runnable: %w", err)
+	}
 	return nil
 }
 

--- a/osac-operator/config/samples/network-manager-fabric-netris.yaml
+++ b/osac-operator/config/samples/network-manager-fabric-netris.yaml
@@ -4,7 +4,7 @@
 # virtual network segments, security groups, external IPs, and NAT gateways.
 #
 # The operator discovers fabric managers by selecting ConfigMaps with the label
-# osac.openshift.io/network/fabric-manager. The data.name value is referenced
+# osac.openshift.io/network-fabric-manager. The data.name value is referenced
 # by NetworkClass.fabricManager.
 apiVersion: v1
 kind: ConfigMap
@@ -12,7 +12,7 @@ metadata:
   name: osac-network-fabric-manager-netris
   namespace: osac
   labels:
-    osac.openshift.io/network/fabric-manager: "true"
+    osac.openshift.io/network-fabric-manager: "true"
 data:
   # Unique identifier for this manager. Must match the fabricManager field
   # on NetworkClass resources that use this backend.

--- a/osac-operator/internal/controller/dispatcher_resolver_helpers_test.go
+++ b/osac-operator/internal/controller/dispatcher_resolver_helpers_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	privatev1 "github.com/osac-project/osac/osac-operator/internal/api/osac/private/v1"
+	"github.com/osac-project/osac/osac-operator/pkg/networkmanager"
+)
+
+// stubNetworkClassesClient is a minimal test double for privatev1.NetworkClassesClient
+// used by controller tests exercising manager-resolution paths (e.g. the OSAC-1755
+// capabilities reconciler). Embedding the interface (nil) satisfies methods that
+// aren't stubbed for a given test, which are not expected to be called.
+type stubNetworkClassesClient struct {
+	privatev1.NetworkClassesClient
+	getFunc    func(ctx context.Context, in *privatev1.NetworkClassesGetRequest, opts ...grpc.CallOption) (*privatev1.NetworkClassesGetResponse, error)
+	listFunc   func(ctx context.Context, in *privatev1.NetworkClassesListRequest, opts ...grpc.CallOption) (*privatev1.NetworkClassesListResponse, error)
+	updateFunc func(ctx context.Context, in *privatev1.NetworkClassesUpdateRequest, opts ...grpc.CallOption) (*privatev1.NetworkClassesUpdateResponse, error)
+}
+
+func (s *stubNetworkClassesClient) Get(
+	ctx context.Context, in *privatev1.NetworkClassesGetRequest, opts ...grpc.CallOption,
+) (*privatev1.NetworkClassesGetResponse, error) {
+	if s.getFunc != nil {
+		return s.getFunc(ctx, in, opts...)
+	}
+	return s.NetworkClassesClient.Get(ctx, in, opts...)
+}
+
+func (s *stubNetworkClassesClient) List(
+	ctx context.Context, in *privatev1.NetworkClassesListRequest, opts ...grpc.CallOption,
+) (*privatev1.NetworkClassesListResponse, error) {
+	if s.listFunc != nil {
+		return s.listFunc(ctx, in, opts...)
+	}
+	return s.NetworkClassesClient.List(ctx, in, opts...)
+}
+
+func (s *stubNetworkClassesClient) Update(
+	ctx context.Context, in *privatev1.NetworkClassesUpdateRequest, opts ...grpc.CallOption,
+) (*privatev1.NetworkClassesUpdateResponse, error) {
+	if s.updateFunc != nil {
+		return s.updateFunc(ctx, in, opts...)
+	}
+	return s.NetworkClassesClient.Update(ctx, in, opts...)
+}
+
+// newListingNetworkClassClient returns a stub NetworkClassesClient whose List method
+// returns the given NetworkClasses and whose Get method finds one by ID among them.
+// Update appends to the captured updates slice so tests can assert on what was saved.
+func newListingNetworkClassClient(
+	items []*privatev1.NetworkClass, updates *[]*privatev1.NetworkClass,
+) *stubNetworkClassesClient {
+	return &stubNetworkClassesClient{
+		listFunc: func(_ context.Context, _ *privatev1.NetworkClassesListRequest, _ ...grpc.CallOption) (*privatev1.NetworkClassesListResponse, error) {
+			return &privatev1.NetworkClassesListResponse{Items: items}, nil
+		},
+		getFunc: func(_ context.Context, in *privatev1.NetworkClassesGetRequest, _ ...grpc.CallOption) (*privatev1.NetworkClassesGetResponse, error) {
+			for _, item := range items {
+				if item.GetId() == in.GetId() {
+					return &privatev1.NetworkClassesGetResponse{Object: item}, nil
+				}
+			}
+			return nil, fmt.Errorf("network class %q not found", in.GetId())
+		},
+		updateFunc: func(_ context.Context, in *privatev1.NetworkClassesUpdateRequest, _ ...grpc.CallOption) (*privatev1.NetworkClassesUpdateResponse, error) {
+			*updates = append(*updates, in.GetObject())
+			return &privatev1.NetworkClassesUpdateResponse{Object: in.GetObject()}, nil
+		},
+	}
+}
+
+// newFabricManagerConfigMap builds a fabric-manager registration ConfigMap for tests
+// that exercise dispatcher-backed manager discovery.
+func newFabricManagerConfigMap(name, namespace, managerName string) *corev1.ConfigMap {
+	return newManagerConfigMap(name, namespace, managerName, networkmanager.LabelFabricManager, "ipv4")
+}
+
+// newK8sManagerConfigMap builds a k8s-manager registration ConfigMap for tests that
+// exercise dispatcher-backed manager discovery.
+func newK8sManagerConfigMap(name, namespace, managerName, capabilities string) *corev1.ConfigMap {
+	return newManagerConfigMap(name, namespace, managerName, networkmanager.LabelK8sManager, capabilities)
+}
+
+func newManagerConfigMap(name, namespace, managerName, labelKey, capabilities string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{labelKey: "true"},
+		},
+		Data: map[string]string{
+			"name":         managerName,
+			"capabilities": capabilities,
+		},
+	}
+}

--- a/osac-operator/internal/controller/networkclass_capabilities_controller.go
+++ b/osac-operator/internal/controller/networkclass_capabilities_controller.go
@@ -1,0 +1,303 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	clnt "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
+
+	privatev1 "github.com/osac-project/osac/osac-operator/internal/api/osac/private/v1"
+	"github.com/osac-project/osac/osac-operator/pkg/dispatcher"
+	"github.com/osac-project/osac/osac-operator/pkg/networkmanager"
+)
+
+// NetworkClassCapabilitiesReconciler computes NetworkClass.capabilities as the
+// intersection of the capabilities declared by its resolved fabric and k8s manager
+// ConfigMaps, and writes the result back to the fulfillment service.
+//
+// NetworkClass has no CRD in this operator, so it can't be watched directly. This
+// reconciler instead watches the manager registration ConfigMaps (a k8s-native event
+// source) and re-checks every NetworkClass on each relevant ConfigMap event. A
+// separate periodic runnable (see NewNetworkClassCapabilitiesSyncRunnable) catches
+// NetworkClass-side spec changes (e.g. a different fabricManager/k8sManager
+// assignment), which have no k8s-native event source at all.
+type NetworkClassCapabilitiesReconciler struct {
+	networkClassesClient privatev1.NetworkClassesClient
+	resolver             *dispatcher.Resolver
+	networkingNamespace  string
+
+	// resyncMu serializes full resyncs between the ConfigMap-triggered Reconcile
+	// path and the periodic sync runnable, so the two never race against each
+	// other listing/updating the same NetworkClasses.
+	resyncMu sync.Mutex
+}
+
+// NewNetworkClassCapabilitiesReconciler creates a reconciler that syncs NetworkClass
+// capabilities using the given gRPC client and manager resolver.
+func NewNetworkClassCapabilitiesReconciler(
+	networkClassesClient privatev1.NetworkClassesClient,
+	resolver *dispatcher.Resolver,
+	networkingNamespace string,
+) *NetworkClassCapabilitiesReconciler {
+	return &NetworkClassCapabilitiesReconciler{
+		networkClassesClient: networkClassesClient,
+		resolver:             resolver,
+		networkingNamespace:  networkingNamespace,
+	}
+}
+
+// SetupWithManager adds the reconciler to the controller manager. It watches manager
+// registration ConfigMaps in the configured networking namespace.
+func (r *NetworkClassCapabilitiesReconciler) SetupWithManager(mgr mcmanager.Manager) error {
+	localMgr := mgr.GetLocalManager()
+	if localMgr == nil {
+		return fmt.Errorf("local manager is nil")
+	}
+
+	return ctrl.NewControllerManagedBy(localMgr).
+		Named("networkclass-capabilities").
+		For(&corev1.ConfigMap{}, builder.WithPredicates(managerConfigMapPredicate(r.networkingNamespace))).
+		Complete(r)
+}
+
+// managerConfigMapPredicate filters ConfigMap events to those in the given namespace
+// that carry either the fabric-manager or k8s-manager registration label.
+func managerConfigMapPredicate(namespace string) predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj clnt.Object) bool {
+		if obj.GetNamespace() != namespace {
+			return false
+		}
+		labels := obj.GetLabels()
+		return labels[networkmanager.LabelFabricManager] == "true" || labels[networkmanager.LabelK8sManager] == "true"
+	})
+}
+
+// Reconcile ignores the triggering request's contents — any relevant ConfigMap event
+// re-checks every NetworkClass, since there's no cheap way to know in advance which
+// NetworkClasses reference the changed manager.
+func (r *NetworkClassCapabilitiesReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
+	return ctrl.Result{}, r.resyncAll(ctx)
+}
+
+// networkClassListPageSize is the page size used to list NetworkClasses for a full
+// capabilities resync. It matches the fulfillment-service's maximum allowed limit, so
+// listing every NetworkClass takes the fewest possible round trips.
+//
+// A single unbounded List call is not sufficient here: the server defaults an unset
+// limit to a fixed page size (currently 100) rather than "no limit", so without paging,
+// any NetworkClasses beyond the first page would be silently skipped on every resync.
+const networkClassListPageSize = 1000
+
+// resyncAll recomputes capabilities for every NetworkClass, waiting for any resync
+// already in progress (e.g. a concurrent periodic tick) to finish first. Used by the
+// ConfigMap-triggered Reconcile path, where a ConfigMap change must eventually be
+// reflected rather than skipped.
+func (r *NetworkClassCapabilitiesReconciler) resyncAll(ctx context.Context) error {
+	r.resyncMu.Lock()
+	defer r.resyncMu.Unlock()
+	return r.resyncAllLocked(ctx)
+}
+
+// resyncAllLocked recomputes capabilities for every NetworkClass. Callers must hold
+// resyncMu. Errors for individual NetworkClasses are logged and joined, but don't stop
+// the rest of the pass — a bad manager reference on one NetworkClass shouldn't block
+// others from being synced.
+func (r *NetworkClassCapabilitiesReconciler) resyncAllLocked(ctx context.Context) error {
+	log := ctrllog.FromContext(ctx)
+
+	items, err := r.listAllNetworkClasses(ctx)
+	if err != nil {
+		return fmt.Errorf("listing network classes: %w", err)
+	}
+
+	var errs []error
+	for _, nc := range items {
+		if syncErr := r.syncOne(ctx, nc); syncErr != nil {
+			log.Error(syncErr, "failed to sync network class capabilities", "networkClassID", nc.GetId())
+			errs = append(errs, syncErr)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// listAllNetworkClasses fetches every NetworkClass from the fulfillment service,
+// paging through results with offset/limit rather than issuing a single List call with
+// neither set (see networkClassListPageSize for why that would silently truncate).
+func (r *NetworkClassCapabilitiesReconciler) listAllNetworkClasses(ctx context.Context) ([]*privatev1.NetworkClass, error) {
+	var items []*privatev1.NetworkClass
+	offset := int32(0)
+	for {
+		resp, err := r.networkClassesClient.List(ctx, privatev1.NetworkClassesListRequest_builder{
+			Offset: ptr.To(offset),
+			Limit:  ptr.To(int32(networkClassListPageSize)),
+		}.Build())
+		if err != nil {
+			return nil, err
+		}
+
+		items = append(items, resp.GetItems()...)
+		offset += resp.GetSize()
+
+		// resp.GetSize() == 0 guards against an infinite loop if the server ever
+		// reports a total larger than what it actually returns.
+		if resp.GetSize() == 0 || offset >= resp.GetTotal() {
+			return items, nil
+		}
+	}
+}
+
+// syncOne resolves and applies the capability intersection for a single NetworkClass,
+// updating it via the fulfillment service only when the computed capabilities differ
+// from what's already stored.
+func (r *NetworkClassCapabilitiesReconciler) syncOne(ctx context.Context, nc *privatev1.NetworkClass) error {
+	log := ctrllog.FromContext(ctx)
+
+	resolved, err := r.resolver.Resolve(ctx, nc.GetId())
+	switch {
+	case errors.Is(err, dispatcher.ErrFabricManagerNotSet):
+		log.V(1).Info("network class has no fabricManager set, skipping capabilities sync",
+			"networkClassID", nc.GetId())
+		return nil
+	case networkmanager.IsManagerNotFound(err):
+		log.Info("network class references an unregistered manager, skipping capabilities sync",
+			"networkClassID", nc.GetId(), "error", err)
+		return nil
+	case err != nil:
+		return fmt.Errorf("resolving managers for network class %q: %w", nc.GetId(), err)
+	}
+
+	newCaps := computeCapabilities(resolved)
+	if capabilitiesEqual(newCaps, nc.GetCapabilities()) {
+		return nil
+	}
+
+	nc.SetCapabilities(newCaps)
+	_, err = r.networkClassesClient.Update(ctx, privatev1.NetworkClassesUpdateRequest_builder{
+		Object: nc,
+	}.Build())
+	if err != nil {
+		return fmt.Errorf("updating capabilities for network class %q: %w", nc.GetId(), err)
+	}
+
+	log.Info("updated network class capabilities", "networkClassID", nc.GetId(), "capabilities", newCaps)
+	return nil
+}
+
+// computeCapabilities returns the capability intersection of the resolved fabric and
+// k8s managers: a capability is enabled only if the fabric manager declares it and,
+// when a k8s manager is configured, the k8s manager declares it too. When no k8s
+// manager is configured, the fabric manager's capabilities are used as-is.
+//
+// NOTE(OSAC-2030): once NetworkClassSpec.disable_capabilities is available in the
+// generated client, subtract those capabilities here before returning.
+func computeCapabilities(resolved *dispatcher.ResolvedManagers) *privatev1.NetworkClassCapabilities {
+	fabric := resolved.FabricManager
+	k8s := resolved.K8sManager
+
+	supports := func(capability networkmanager.Capability) bool {
+		if !fabric.HasCapability(capability) {
+			return false
+		}
+		return k8s == nil || k8s.HasCapability(capability)
+	}
+
+	caps := &privatev1.NetworkClassCapabilities{}
+	caps.SetSupportsIpv4(supports(networkmanager.CapabilityIPv4))
+	caps.SetSupportsIpv6(supports(networkmanager.CapabilityIPv6))
+	caps.SetSupportsDualStack(supports(networkmanager.CapabilityDualStack))
+	caps.SetDpuSupport(supports(networkmanager.CapabilityDPUSupport))
+	return caps
+}
+
+// capabilitiesEqual reports whether two NetworkClassCapabilities have the same
+// values. Nil is treated as all-false, matching the generated getters' behavior.
+func capabilitiesEqual(a, b *privatev1.NetworkClassCapabilities) bool {
+	return a.GetSupportsIpv4() == b.GetSupportsIpv4() &&
+		a.GetSupportsIpv6() == b.GetSupportsIpv6() &&
+		a.GetSupportsDualStack() == b.GetSupportsDualStack() &&
+		a.GetDpuSupport() == b.GetDpuSupport()
+}
+
+// networkClassCapabilitiesSyncRunnable periodically re-syncs NetworkClass
+// capabilities to catch NetworkClass-side spec changes (e.g. a different
+// fabricManager/k8sManager assignment), which have no k8s-native event source.
+type networkClassCapabilitiesSyncRunnable struct {
+	reconciler *NetworkClassCapabilitiesReconciler
+	interval   time.Duration
+}
+
+// NewNetworkClassCapabilitiesSyncRunnable returns a manager.Runnable that periodically
+// resyncs every NetworkClass's capabilities. Register it with mgr.Add(); it requires
+// leader election so only one replica runs the sync loop.
+func NewNetworkClassCapabilitiesSyncRunnable(
+	reconciler *NetworkClassCapabilitiesReconciler, interval time.Duration,
+) manager.Runnable {
+	return &networkClassCapabilitiesSyncRunnable{
+		reconciler: reconciler,
+		interval:   interval,
+	}
+}
+
+// Start runs the periodic resync loop until the context is canceled.
+func (s *networkClassCapabilitiesSyncRunnable) Start(ctx context.Context) error {
+	log := ctrllog.FromContext(ctx).WithName("networkclass-capabilities-sync")
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			s.tick(ctx, log)
+		}
+	}
+}
+
+// tick runs a single periodic resync, skipping it if a resync triggered by the
+// ConfigMap-driven Reconcile path is already in progress rather than blocking (which
+// would delay observing ctx cancellation until that resync finishes).
+func (s *networkClassCapabilitiesSyncRunnable) tick(ctx context.Context, log logr.Logger) {
+	if !s.reconciler.resyncMu.TryLock() {
+		log.V(1).Info("skipping periodic network class capabilities resync: already in progress")
+		return
+	}
+	defer s.reconciler.resyncMu.Unlock()
+
+	if err := s.reconciler.resyncAllLocked(ctx); err != nil {
+		log.Error(err, "periodic network class capabilities resync failed")
+	}
+}
+
+// NeedLeaderElection ensures the periodic resync loop runs on exactly one replica.
+func (s *networkClassCapabilitiesSyncRunnable) NeedLeaderElection() bool {
+	return true
+}

--- a/osac-operator/internal/controller/networkclass_capabilities_controller_test.go
+++ b/osac-operator/internal/controller/networkclass_capabilities_controller_test.go
@@ -1,0 +1,275 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
+	. "github.com/onsi/gomega"    //nolint:revive,staticcheck
+
+	privatev1 "github.com/osac-project/osac/osac-operator/internal/api/osac/private/v1"
+	"github.com/osac-project/osac/osac-operator/pkg/dispatcher"
+	"github.com/osac-project/osac/osac-operator/pkg/networkmanager"
+)
+
+var _ = Describe("computeCapabilities", func() {
+	fabricDualStack := networkmanager.Manager{
+		Name: "netris",
+		Capabilities: []networkmanager.Capability{
+			networkmanager.CapabilityIPv4, networkmanager.CapabilityIPv6, networkmanager.CapabilityDualStack,
+		},
+		Type: networkmanager.FabricManager,
+	}
+	fabricIPv4Only := networkmanager.Manager{
+		Name:         "netris-v4",
+		Capabilities: []networkmanager.Capability{networkmanager.CapabilityIPv4},
+		Type:         networkmanager.FabricManager,
+	}
+	k8sIPv4Only := networkmanager.Manager{
+		Name:         "cudn-localnet",
+		Capabilities: []networkmanager.Capability{networkmanager.CapabilityIPv4},
+		Type:         networkmanager.K8sManager,
+	}
+	k8sIPv4AndDPU := networkmanager.Manager{
+		Name:         "cudn-localnet-dpu",
+		Capabilities: []networkmanager.Capability{networkmanager.CapabilityIPv4, networkmanager.CapabilityDPUSupport},
+		Type:         networkmanager.K8sManager,
+	}
+
+	It("uses the fabric manager's capabilities as-is when no k8s manager is configured", func() {
+		caps := computeCapabilities(&dispatcher.ResolvedManagers{FabricManager: fabricDualStack})
+		Expect(caps.GetSupportsIpv4()).To(BeTrue())
+		Expect(caps.GetSupportsIpv6()).To(BeTrue())
+		Expect(caps.GetSupportsDualStack()).To(BeTrue())
+		Expect(caps.GetDpuSupport()).To(BeFalse())
+	})
+
+	It("intersects fabric and k8s capabilities, dropping what the k8s manager lacks", func() {
+		k8s := k8sIPv4Only
+		caps := computeCapabilities(&dispatcher.ResolvedManagers{FabricManager: fabricDualStack, K8sManager: &k8s})
+		Expect(caps.GetSupportsIpv4()).To(BeTrue())
+		Expect(caps.GetSupportsIpv6()).To(BeFalse())
+		Expect(caps.GetSupportsDualStack()).To(BeFalse())
+		Expect(caps.GetDpuSupport()).To(BeFalse())
+	})
+
+	It("drops capabilities the fabric manager doesn't declare even when the k8s manager does", func() {
+		k8s := k8sIPv4AndDPU
+		caps := computeCapabilities(&dispatcher.ResolvedManagers{FabricManager: fabricIPv4Only, K8sManager: &k8s})
+		Expect(caps.GetSupportsIpv4()).To(BeTrue())
+		Expect(caps.GetDpuSupport()).To(BeFalse())
+	})
+})
+
+var _ = Describe("capabilitiesEqual", func() {
+	It("treats nil as equivalent to all-false", func() {
+		Expect(capabilitiesEqual(nil, &privatev1.NetworkClassCapabilities{})).To(BeTrue())
+	})
+
+	It("returns false when any field differs", func() {
+		a := &privatev1.NetworkClassCapabilities{SupportsIpv4: true}
+		b := &privatev1.NetworkClassCapabilities{}
+		Expect(capabilitiesEqual(a, b)).To(BeFalse())
+	})
+
+	It("returns true when all fields match", func() {
+		a := &privatev1.NetworkClassCapabilities{SupportsIpv4: true, SupportsDualStack: true}
+		b := &privatev1.NetworkClassCapabilities{SupportsIpv4: true, SupportsDualStack: true}
+		Expect(capabilitiesEqual(a, b)).To(BeTrue())
+	})
+})
+
+var _ = Describe("NetworkClassCapabilitiesReconciler", func() {
+	const namespace = "default"
+
+	It("computes the intersection and updates the NetworkClass when capabilities changed", func() {
+		fabricCM := newFabricManagerConfigMap("fm-caps-fabric", namespace, "fabric-caps-1")
+		Expect(k8sClient.Create(ctx, fabricCM)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, fabricCM) }()
+
+		k8sCM := newK8sManagerConfigMap("fm-caps-k8s", namespace, "k8s-caps-1", "ipv4")
+		Expect(k8sClient.Create(ctx, k8sCM)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, k8sCM) }()
+
+		disc, err := networkmanager.NewDiscovery(k8sClient, namespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		k8sManagerName := "k8s-caps-1"
+		nc := &privatev1.NetworkClass{
+			Id:            "nc-caps-1",
+			FabricManager: "fabric-caps-1",
+			K8SManager:    &k8sManagerName,
+		}
+		var updates []*privatev1.NetworkClass
+		stubClient := newListingNetworkClassClient([]*privatev1.NetworkClass{nc}, &updates)
+		resolver := dispatcher.NewResolver(stubClient, disc)
+
+		reconciler := NewNetworkClassCapabilitiesReconciler(stubClient, resolver, namespace)
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(updates).To(HaveLen(1))
+		Expect(updates[0].GetId()).To(Equal("nc-caps-1"))
+		Expect(updates[0].GetCapabilities().GetSupportsIpv4()).To(BeTrue())
+		Expect(updates[0].GetCapabilities().GetSupportsIpv6()).To(BeFalse())
+	})
+
+	It("does not update the NetworkClass when computed capabilities already match", func() {
+		fabricCM := newFabricManagerConfigMap("fm-caps-fabric-noop", namespace, "fabric-caps-noop")
+		Expect(k8sClient.Create(ctx, fabricCM)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, fabricCM) }()
+
+		disc, err := networkmanager.NewDiscovery(k8sClient, namespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		nc := &privatev1.NetworkClass{
+			Id:            "nc-caps-noop",
+			FabricManager: "fabric-caps-noop",
+			Capabilities:  &privatev1.NetworkClassCapabilities{SupportsIpv4: true},
+		}
+		var updates []*privatev1.NetworkClass
+		stubClient := newListingNetworkClassClient([]*privatev1.NetworkClass{nc}, &updates)
+		resolver := dispatcher.NewResolver(stubClient, disc)
+
+		reconciler := NewNetworkClassCapabilitiesReconciler(stubClient, resolver, namespace)
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(updates).To(BeEmpty())
+	})
+
+	It("skips a NetworkClass with no fabricManager set without returning an error", func() {
+		disc, err := networkmanager.NewDiscovery(k8sClient, namespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		nc := &privatev1.NetworkClass{Id: "nc-caps-no-fabric"}
+		var updates []*privatev1.NetworkClass
+		stubClient := newListingNetworkClassClient([]*privatev1.NetworkClass{nc}, &updates)
+		resolver := dispatcher.NewResolver(stubClient, disc)
+
+		reconciler := NewNetworkClassCapabilitiesReconciler(stubClient, resolver, namespace)
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updates).To(BeEmpty())
+	})
+
+	It("skips a NetworkClass referencing an unregistered manager without returning an error", func() {
+		disc, err := networkmanager.NewDiscovery(k8sClient, namespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		nc := &privatev1.NetworkClass{Id: "nc-caps-bad-fabric", FabricManager: "unregistered-fabric"}
+		var updates []*privatev1.NetworkClass
+		stubClient := newListingNetworkClassClient([]*privatev1.NetworkClass{nc}, &updates)
+		resolver := dispatcher.NewResolver(stubClient, disc)
+
+		reconciler := NewNetworkClassCapabilitiesReconciler(stubClient, resolver, namespace)
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updates).To(BeEmpty())
+	})
+
+	It("continues syncing other NetworkClasses when one fails to resolve", func() {
+		fabricCM := newFabricManagerConfigMap("fm-caps-fabric-multi", namespace, "fabric-caps-multi")
+		Expect(k8sClient.Create(ctx, fabricCM)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, fabricCM) }()
+
+		disc, err := networkmanager.NewDiscovery(k8sClient, namespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		goodNC := &privatev1.NetworkClass{Id: "nc-caps-good", FabricManager: "fabric-caps-multi"}
+		badNC := &privatev1.NetworkClass{Id: "nc-caps-bad", FabricManager: "unregistered-fabric-multi"}
+		var updates []*privatev1.NetworkClass
+		stubClient := newListingNetworkClassClient([]*privatev1.NetworkClass{badNC, goodNC}, &updates)
+		resolver := dispatcher.NewResolver(stubClient, disc)
+
+		reconciler := NewNetworkClassCapabilitiesReconciler(stubClient, resolver, namespace)
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(updates).To(HaveLen(1))
+		Expect(updates[0].GetId()).To(Equal("nc-caps-good"))
+	})
+})
+
+var _ = Describe("listAllNetworkClasses", func() {
+	// pagingNetworkClassClient simulates a server that only returns pageSize items per
+	// call regardless of the requested limit, so tests can verify the offset-based
+	// paging loop rather than relying on a single unbounded List call.
+	pagingNetworkClassClient := func(all []*privatev1.NetworkClass, pageSize int) (*stubNetworkClassesClient, *[]int32) {
+		var offsetsSeen []int32
+		stub := &stubNetworkClassesClient{
+			listFunc: func(_ context.Context, in *privatev1.NetworkClassesListRequest, _ ...grpc.CallOption) (*privatev1.NetworkClassesListResponse, error) {
+				offsetsSeen = append(offsetsSeen, in.GetOffset())
+				start := min(int(in.GetOffset()), len(all))
+				end := min(start+pageSize, len(all))
+				page := all[start:end]
+				return &privatev1.NetworkClassesListResponse{
+					Items: page,
+					Size:  int32(len(page)),
+					Total: int32(len(all)),
+				}, nil
+			},
+		}
+		return stub, &offsetsSeen
+	}
+
+	It("pages through results using offset until every item is fetched", func() {
+		all := []*privatev1.NetworkClass{
+			{Id: "nc-page-1"}, {Id: "nc-page-2"}, {Id: "nc-page-3"}, {Id: "nc-page-4"}, {Id: "nc-page-5"},
+		}
+		stub, offsetsSeen := pagingNetworkClassClient(all, 2)
+
+		reconciler := NewNetworkClassCapabilitiesReconciler(stub, nil, "default")
+		items, err := reconciler.listAllNetworkClasses(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		ids := make([]string, 0, len(items))
+		for _, item := range items {
+			ids = append(ids, item.GetId())
+		}
+		Expect(ids).To(Equal([]string{"nc-page-1", "nc-page-2", "nc-page-3", "nc-page-4", "nc-page-5"}))
+		// Three round trips: [0,2), [2,4), [4,5) — not a single unbounded call.
+		Expect(*offsetsSeen).To(Equal([]int32{0, 2, 4}))
+	})
+
+	It("stops after a single call when the server reports no results", func() {
+		stub, offsetsSeen := pagingNetworkClassClient(nil, 2)
+
+		reconciler := NewNetworkClassCapabilitiesReconciler(stub, nil, "default")
+		items, err := reconciler.listAllNetworkClasses(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(items).To(BeEmpty())
+		Expect(*offsetsSeen).To(Equal([]int32{0}))
+	})
+
+	It("propagates an error from any page without retrying", func() {
+		stub := &stubNetworkClassesClient{
+			listFunc: func(_ context.Context, _ *privatev1.NetworkClassesListRequest, _ ...grpc.CallOption) (*privatev1.NetworkClassesListResponse, error) {
+				return nil, fmt.Errorf("fulfillment-service unavailable")
+			},
+		}
+
+		reconciler := NewNetworkClassCapabilitiesReconciler(stub, nil, "default")
+		_, err := reconciler.listAllNetworkClasses(ctx)
+		Expect(err).To(MatchError(ContainSubstring("fulfillment-service unavailable")))
+	})
+})

--- a/osac-operator/pkg/dispatcher/resolver.go
+++ b/osac-operator/pkg/dispatcher/resolver.go
@@ -18,11 +18,17 @@ package dispatcher
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	privatev1 "github.com/osac-project/osac/osac-operator/internal/api/osac/private/v1"
 	"github.com/osac-project/osac/osac-operator/pkg/networkmanager"
 )
+
+// ErrFabricManagerNotSet is returned by Resolve when the NetworkClass has no
+// fabricManager set. It is wrapped in the returned error so callers can match it
+// with errors.Is to distinguish "not configured yet" from other resolution failures.
+var ErrFabricManagerNotSet = errors.New("fabricManager is required but not set")
 
 // ResolvedManagers holds the validated fabric and k8s managers extracted from a NetworkClass.
 type ResolvedManagers struct {
@@ -67,7 +73,7 @@ func (r *Resolver) Resolve(ctx context.Context, networkClassID string) (*Resolve
 
 	fabricManagerName := nc.GetFabricManager()
 	if fabricManagerName == "" {
-		return nil, fmt.Errorf("NetworkClass %q: fabricManager is required but not set", networkClassID)
+		return nil, fmt.Errorf("NetworkClass %q: %w", networkClassID, ErrFabricManagerNotSet)
 	}
 
 	fabricMgr, err := r.discovery.GetFabricManager(ctx, fabricManagerName)

--- a/osac-operator/pkg/networkmanager/doc.go
+++ b/osac-operator/pkg/networkmanager/doc.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package networkmanager provides discovery and validation of network manager
 // registrations. Managers are registered as labeled ConfigMaps in the operator
-// namespace. Fabric managers (osac.openshift.io/network/fabric-manager) handle
-// physical networking, while k8s managers (osac.openshift.io/network/k8s-manager)
+// namespace. Fabric managers (osac.openshift.io/network-fabric-manager) handle
+// physical networking, while k8s managers (osac.openshift.io/network-k8s-manager)
 // bridge the Kubernetes OVN overlay to the physical fabric.
 package networkmanager

--- a/osac-operator/pkg/networkmanager/types.go
+++ b/osac-operator/pkg/networkmanager/types.go
@@ -27,10 +27,14 @@ import (
 
 const (
 	// LabelFabricManager is the label key that identifies a ConfigMap as a fabric manager registration.
-	LabelFabricManager = "osac.openshift.io/network/fabric-manager"
+	//
+	// NOTE: a Kubernetes label key allows at most one '/' (separating an optional DNS
+	// subdomain prefix from the name segment), so "network" is hyphenated into the name
+	// segment here rather than forming a second path segment.
+	LabelFabricManager = "osac.openshift.io/network-fabric-manager"
 
 	// LabelK8sManager is the label key that identifies a ConfigMap as a k8s manager registration.
-	LabelK8sManager = "osac.openshift.io/network/k8s-manager"
+	LabelK8sManager = "osac.openshift.io/network-k8s-manager"
 
 	// DataKeyName is the ConfigMap data key for the manager's unique identifier.
 	DataKeyName = "name"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - NetworkClass capabilities now synchronize automatically with configured network managers.
  - Synchronization runs periodically, with a configurable interval defaulting to five minutes.
  - Capability results reflect supported IP modes and DPU functionality.

- **Configuration**
  - Added configuration for the synchronization interval.
  - Updated network manager discovery labels to use Kubernetes-compliant formats.

- **Bug Fixes**
  - Improved handling of missing, unresolved, or invalid network managers without blocking other resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->