### PR TITLE
OSAC-3160: Add GPU columns to InstanceType CLI table rendering

### DIFF
--- a/fulfillment-service/internal/rendering/table_renderer_test.go
+++ b/fulfillment-service/internal/rendering/table_renderer_test.go
@@ -222,9 +222,8 @@ var _ = Describe("Table renderer", func() {
 					}.Build(),
 				},
 			)
-			Expect(output).To(ContainSubstring("10DE:20B0"))
 			Expect(output).To(ContainSubstring("nvidia.com/A100"))
-			Expect(output).To(MatchRegexp(`1\s+10DE:20B0\s+nvidia\.com/A100\s+ACTIVE`))
+			Expect(output).To(MatchRegexp(`1\s+nvidia\.com/A100\s+ACTIVE`))
 		})
 
 		It("Renders blank GPU columns for non-GPU InstanceType", func(ctx context.Context) {
@@ -244,8 +243,8 @@ var _ = Describe("Table renderer", func() {
 					}.Build(),
 				},
 			)
-			Expect(output).To(ContainSubstring("GPU DEVICE"))
-			Expect(output).To(MatchRegexp(`16\s+0\s+-\s+-\s+ACTIVE`))
+			Expect(output).To(ContainSubstring("GPU NAME"))
+			Expect(output).To(MatchRegexp(`16\s+0\s+-\s+ACTIVE`))
 		})
 	})
 

--- a/fulfillment-service/internal/rendering/table_renderer_test.go
+++ b/fulfillment-service/internal/rendering/table_renderer_test.go
@@ -224,7 +224,7 @@ var _ = Describe("Table renderer", func() {
 			)
 			Expect(output).To(ContainSubstring("10DE:20B0"))
 			Expect(output).To(ContainSubstring("nvidia.com/A100"))
-			Expect(output).To(MatchRegexp(`nvidia\.com/A100\s+1\s+ACTIVE`))
+			Expect(output).To(MatchRegexp(`1\s+10DE:20B0\s+nvidia\.com/A100\s+ACTIVE`))
 		})
 
 		It("Renders blank GPU columns for non-GPU InstanceType", func(ctx context.Context) {
@@ -245,7 +245,7 @@ var _ = Describe("Table renderer", func() {
 				},
 			)
 			Expect(output).To(ContainSubstring("GPU DEVICE"))
-			Expect(output).To(MatchRegexp(`16\s+-\s+-\s+0\s+ACTIVE`))
+			Expect(output).To(MatchRegexp(`16\s+0\s+-\s+-\s+ACTIVE`))
 		})
 	})
 

--- a/fulfillment-service/internal/rendering/table_renderer_test.go
+++ b/fulfillment-service/internal/rendering/table_renderer_test.go
@@ -150,33 +150,33 @@ var _ = Describe("Table renderer", func() {
 		})
 	})
 
+	renderInstanceTypes := func(ctx context.Context, items []*publicv1.InstanceType) string {
+		objectHelper := makeObjectHelper(&publicv1.InstanceType{})
+		lookupHelper := makeLookupHelper()
+
+		helper := reflection.NewMockHelper(ctrl)
+		helper.EXPECT().
+			Lookup(objectHelper.String()).
+			Return(objectHelper).
+			AnyTimes()
+		helper.EXPECT().
+			Lookup(gomock.Any()).
+			Return(lookupHelper).
+			AnyTimes()
+
+		buffer := &bytes.Buffer{}
+		renderer, err := NewTableRenderer().
+			SetLogger(logger).
+			SetHelper(helper).
+			SetWriter(buffer).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		err = renderer.Render(ctx, items)
+		Expect(err).ToNot(HaveOccurred())
+		return buffer.String()
+	}
+
 	Describe("Integer columns", func() {
-		renderInstanceTypes := func(ctx context.Context, items []*publicv1.InstanceType) string {
-			objectHelper := makeObjectHelper(&publicv1.InstanceType{})
-			lookupHelper := makeLookupHelper()
-
-			helper := reflection.NewMockHelper(ctrl)
-			helper.EXPECT().
-				Lookup(objectHelper.String()).
-				Return(objectHelper).
-				AnyTimes()
-			helper.EXPECT().
-				Lookup(gomock.Any()).
-				Return(lookupHelper).
-				AnyTimes()
-
-			buffer := &bytes.Buffer{}
-			renderer, err := NewTableRenderer().
-				SetLogger(logger).
-				SetHelper(helper).
-				SetWriter(buffer).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
-			err = renderer.Render(ctx, items)
-			Expect(err).ToNot(HaveOccurred())
-			return buffer.String()
-		}
-
 		It("Renders integer fields as plain numbers", func(ctx context.Context) {
 			output := renderInstanceTypes(
 				ctx,
@@ -194,8 +194,58 @@ var _ = Describe("Table renderer", func() {
 					}.Build(),
 				},
 			)
-			Expect(output).To(MatchRegexp(`4\s+16\s+ACTIVE`))
+			Expect(output).To(MatchRegexp(`4\s+16\s+.*ACTIVE`))
 			Expect(output).ToNot(ContainSubstring("%!s"))
+		})
+	})
+
+	Describe("Optional GPU columns", func() {
+		It("Renders GPU fields for GPU-enabled InstanceType", func(ctx context.Context) {
+			output := renderInstanceTypes(
+				ctx,
+				[]*publicv1.InstanceType{
+					publicv1.InstanceType_builder{
+						Id: "gpu-a100-8core",
+						Metadata: publicv1.Metadata_builder{
+							Name: "gpu-a100-8core",
+						}.Build(),
+						Spec: publicv1.InstanceTypeSpec_builder{
+							Cores:     8,
+							MemoryGib: 64,
+							State:     publicv1.InstanceTypeState_INSTANCE_TYPE_STATE_ACTIVE,
+							Gpu: publicv1.GpuSpec_builder{
+								PciDeviceSelector: "10DE:20B0",
+								ResourceName:      "nvidia.com/A100",
+								Count:             1,
+							}.Build(),
+						}.Build(),
+					}.Build(),
+				},
+			)
+			Expect(output).To(ContainSubstring("10DE:20B0"))
+			Expect(output).To(ContainSubstring("nvidia.com/A100"))
+			Expect(output).To(MatchRegexp(`nvidia\.com/A100\s+1\s+ACTIVE`))
+		})
+
+		It("Renders blank GPU columns for non-GPU InstanceType", func(ctx context.Context) {
+			output := renderInstanceTypes(
+				ctx,
+				[]*publicv1.InstanceType{
+					publicv1.InstanceType_builder{
+						Id: "standard-4-16",
+						Metadata: publicv1.Metadata_builder{
+							Name: "standard-4-16",
+						}.Build(),
+						Spec: publicv1.InstanceTypeSpec_builder{
+							Cores:     4,
+							MemoryGib: 16,
+							State:     publicv1.InstanceTypeState_INSTANCE_TYPE_STATE_ACTIVE,
+						}.Build(),
+					}.Build(),
+				},
+			)
+			Expect(output).To(ContainSubstring("GPU DEVICE"))
+			Expect(output).To(MatchRegexp(`16\s+-\s+-\s+0\s+ACTIVE`))
 		})
 	})
 

--- a/fulfillment-service/internal/rendering/tables/osac.private.v1.InstanceType.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.private.v1.InstanceType.yaml
@@ -22,14 +22,14 @@ columns:
 - header: MEMORY
   value: this.spec.memory_gib
 
+- header: GPU COUNT
+  value: "has(this.spec.gpu) ? this.spec.gpu.count : 0"
+
 - header: GPU DEVICE
   value: "has(this.spec.gpu) ? this.spec.gpu.pci_device_selector : '-'"
 
 - header: GPU RESOURCE
   value: "has(this.spec.gpu) ? this.spec.gpu.resource_name : '-'"
-
-- header: GPU COUNT
-  value: "has(this.spec.gpu) ? this.spec.gpu.count : 0"
 
 - header: STATE
   value: this.spec.state

--- a/fulfillment-service/internal/rendering/tables/osac.private.v1.InstanceType.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.private.v1.InstanceType.yaml
@@ -22,7 +22,7 @@ columns:
 - header: MEMORY
   value: this.spec.memory_gib
 
-- header: GPUs
+- header: GPUS
   value: "has(this.spec.gpu) ? this.spec.gpu.count : 0"
 
 - header: GPU NAME

--- a/fulfillment-service/internal/rendering/tables/osac.private.v1.InstanceType.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.private.v1.InstanceType.yaml
@@ -22,13 +22,10 @@ columns:
 - header: MEMORY
   value: this.spec.memory_gib
 
-- header: GPU COUNT
+- header: GPUs
   value: "has(this.spec.gpu) ? this.spec.gpu.count : 0"
 
-- header: GPU DEVICE
-  value: "has(this.spec.gpu) ? this.spec.gpu.pci_device_selector : '-'"
-
-- header: GPU RESOURCE
+- header: GPU NAME
   value: "has(this.spec.gpu) ? this.spec.gpu.resource_name : '-'"
 
 - header: STATE

--- a/fulfillment-service/internal/rendering/tables/osac.private.v1.InstanceType.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.private.v1.InstanceType.yaml
@@ -22,6 +22,15 @@ columns:
 - header: MEMORY
   value: this.spec.memory_gib
 
+- header: GPU DEVICE
+  value: "has(this.spec.gpu) ? this.spec.gpu.pci_device_selector : '-'"
+
+- header: GPU RESOURCE
+  value: "has(this.spec.gpu) ? this.spec.gpu.resource_name : '-'"
+
+- header: GPU COUNT
+  value: "has(this.spec.gpu) ? this.spec.gpu.count : 0"
+
 - header: STATE
   value: this.spec.state
   type: osac.private.v1.InstanceTypeState

--- a/fulfillment-service/internal/rendering/tables/osac.public.v1.InstanceType.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.public.v1.InstanceType.yaml
@@ -22,14 +22,14 @@ columns:
 - header: MEMORY
   value: this.spec.memory_gib
 
+- header: GPU COUNT
+  value: "has(this.spec.gpu) ? this.spec.gpu.count : 0"
+
 - header: GPU DEVICE
   value: "has(this.spec.gpu) ? this.spec.gpu.pci_device_selector : '-'"
 
 - header: GPU RESOURCE
   value: "has(this.spec.gpu) ? this.spec.gpu.resource_name : '-'"
-
-- header: GPU COUNT
-  value: "has(this.spec.gpu) ? this.spec.gpu.count : 0"
 
 - header: STATE
   value: this.spec.state

--- a/fulfillment-service/internal/rendering/tables/osac.public.v1.InstanceType.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.public.v1.InstanceType.yaml
@@ -22,7 +22,7 @@ columns:
 - header: MEMORY
   value: this.spec.memory_gib
 
-- header: GPUs
+- header: GPUS
   value: "has(this.spec.gpu) ? this.spec.gpu.count : 0"
 
 - header: GPU NAME

--- a/fulfillment-service/internal/rendering/tables/osac.public.v1.InstanceType.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.public.v1.InstanceType.yaml
@@ -22,6 +22,15 @@ columns:
 - header: MEMORY
   value: this.spec.memory_gib
 
+- header: GPU DEVICE
+  value: "has(this.spec.gpu) ? this.spec.gpu.pci_device_selector : '-'"
+
+- header: GPU RESOURCE
+  value: "has(this.spec.gpu) ? this.spec.gpu.resource_name : '-'"
+
+- header: GPU COUNT
+  value: "has(this.spec.gpu) ? this.spec.gpu.count : 0"
+
 - header: STATE
   value: this.spec.state
   type: osac.public.v1.InstanceTypeState

--- a/fulfillment-service/internal/rendering/tables/osac.public.v1.InstanceType.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.public.v1.InstanceType.yaml
@@ -22,13 +22,10 @@ columns:
 - header: MEMORY
   value: this.spec.memory_gib
 
-- header: GPU COUNT
+- header: GPUs
   value: "has(this.spec.gpu) ? this.spec.gpu.count : 0"
 
-- header: GPU DEVICE
-  value: "has(this.spec.gpu) ? this.spec.gpu.pci_device_selector : '-'"
-
-- header: GPU RESOURCE
+- header: GPU NAME
   value: "has(this.spec.gpu) ? this.spec.gpu.resource_name : '-'"
 
 - header: STATE


### PR DESCRIPTION
## [OSAC-3160](https://redhat.atlassian.net/browse/OSAC-3160): Add GPU columns to InstanceType CLI table rendering

**Jira:** [OSAC-3160](https://redhat.atlassian.net/browse/OSAC-3160)
**Story type:** [DEV]

### Summary

Adds GPUS and GPU NAME columns to the InstanceType CLI table output (both public and private APIs), so users can identify which InstanceTypes include GPU hardware at a glance. Uses CEL `has()` guards to safely render blank values for non-GPU InstanceTypes.

### Changes

- **`internal/rendering/tables/osac.public.v1.InstanceType.yaml`** — Added GPUS, GPU NAME columns between MEMORY and STATE
- **`internal/rendering/tables/osac.private.v1.InstanceType.yaml`** — Same GPU columns for the private/admin API
- **`internal/rendering/table_renderer_test.go`** — Added "Optional GPU columns" test block verifying GPU-enabled and non-GPU InstanceType rendering; hoisted shared `renderInstanceTypes` helper

### Example Output
<img width="910" height="109" alt="image" src="https://github.com/user-attachments/assets/c756bc27-9862-4786-adbd-2f7d009c4ed7" />


### Testing

- **Unit tests:** 2 new specs in "Optional GPU columns" block — GPU-enabled rendering and non-GPU blank columns
- **CEL compilation:** Existing "Compiles CEL expressions successfully for all table definitions" test covers nil-safety of `has()` guards for both public and private YAMLs
- **Integration tests:** Not affected — no API or server changes, table rendering only

### Acceptance Criteria

- [x] AC-1: InstanceType CLI table includes GPUS and GPU NAME columns
- [x] AC-2: GPU columns appear between MEMORY and STATE columns
- [x] AC-3: Non-GPU InstanceTypes show `0` / `-` in GPU columns
- [x] AC-4: GPU-enabled InstanceTypes show count and resource_name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPU count and GPU resource name columns to instance type tables.
  * Displays configured GPU details for GPU-enabled instance types.
  * Shows `0` and `-` placeholders when GPU information is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->