### PR TITLE
OSAC-3548: Fix IsRestartComplete to wait for host to power on

### DIFF
--- a/bare-metal-fulfillment-operator/internal/management/metal3.go
+++ b/bare-metal-fulfillment-operator/internal/management/metal3.go
@@ -202,9 +202,12 @@ func (m *Metal3Client) IsRestartComplete(ctx context.Context, hostID string) (bo
 		return false, err
 	}
 
-	// Restart is complete when the reboot annotation is no longer present
+	// Restart is complete when the reboot annotation has been processed and
+	// the host is back online. Checking only the annotation is insufficient
+	// because the BMH controller removes it as soon as the reboot command is
+	// sent to Ironic, before the host finishes rebooting.
 	_, hasRebootAnnotation := bmh.Annotations[metal3api.RebootAnnotationPrefix]
-	return !hasRebootAnnotation, nil
+	return !hasRebootAnnotation && bmh.Status.PoweredOn, nil
 }
 
 func (m *Metal3Client) getBMH(ctx context.Context, hostID string) (*metal3api.BareMetalHost, error) {

--- a/bare-metal-fulfillment-operator/internal/management/metal3_test.go
+++ b/bare-metal-fulfillment-operator/internal/management/metal3_test.go
@@ -260,6 +260,15 @@ var _ = Describe("Metal3 Management Backend", func() {
 			Expect(complete).To(BeTrue())
 		})
 
+		It("returns false when annotation is gone but host is not powered on", func() {
+			bmh := newBMHForManagement("host-rebooting", true, false)
+			m := newMetal3ManagementClient(bmh)
+
+			complete, err := m.IsRestartComplete(ctx, metal3TestNamespace+"/host-rebooting")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(complete).To(BeFalse())
+		})
+
 		It("returns false when reboot annotation is present", func() {
 			annotations := map[string]string{
 				metal3api.RebootAnnotationPrefix: "",

--- a/fulfillment-service/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
+++ b/fulfillment-service/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
@@ -474,14 +474,23 @@ func (t *task) syncStatus(object *bmfov1alpha1.BareMetalInstance) {
 					privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_IN_PROGRESS,
 					privatev1.ConditionStatus_CONDITION_STATUS_FALSE, "", "")
 			} else if cond.Status == metav1.ConditionTrue {
-				t.updateCondition(
-					privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_IN_PROGRESS,
-					privatev1.ConditionStatus_CONDITION_STATUS_FALSE, "", "")
-				t.updateCondition(
-					privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_FAILED,
-					privatev1.ConditionStatus_CONDITION_STATUS_FALSE, "", "")
-				t.bareMetalInstance.GetStatus().SetRestartTrigger(
-					t.bareMetalInstance.GetSpec().GetRestartTrigger())
+				if object.Spec.RestartTrigger == object.Status.RestartTrigger {
+					t.updateCondition(
+						privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_IN_PROGRESS,
+						privatev1.ConditionStatus_CONDITION_STATUS_FALSE, "", "")
+					t.updateCondition(
+						privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_FAILED,
+						privatev1.ConditionStatus_CONDITION_STATUS_FALSE, "", "")
+					t.bareMetalInstance.GetStatus().SetRestartTrigger(
+						t.bareMetalInstance.GetSpec().GetRestartTrigger())
+				} else {
+					t.updateCondition(
+						privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_IN_PROGRESS,
+						privatev1.ConditionStatus_CONDITION_STATUS_TRUE, cond.Reason, "Restart in progress")
+					t.updateCondition(
+						privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_FAILED,
+						privatev1.ConditionStatus_CONDITION_STATUS_FALSE, "", "")
+				}
 			}
 		}
 	}

--- a/fulfillment-service/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
+++ b/fulfillment-service/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
@@ -1588,7 +1588,11 @@ var _ = Describe("syncStatus", func() {
 	It("should clear restart conditions and sync restart trigger when PowerSynced is True", func() {
 		t := newTask(42)
 		object := &bmfov1alpha1.BareMetalInstance{
+			Spec: bmfov1alpha1.BareMetalInstanceSpec{
+				RestartTrigger: 42,
+			},
 			Status: bmfov1alpha1.BareMetalInstanceStatus{
+				RestartTrigger: 42,
 				Conditions: []metav1.Condition{
 					{
 						Type:    string(bmfov1alpha1.HostConditionPowerSynced),
@@ -1612,6 +1616,39 @@ var _ = Describe("syncStatus", func() {
 		Expect(failed.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_FALSE))
 
 		Expect(t.bareMetalInstance.GetStatus().GetRestartTrigger()).To(Equal(int64(42)))
+	})
+
+	It("should not echo restart trigger when operator has not completed restart", func() {
+		t := newTask(42)
+		object := &bmfov1alpha1.BareMetalInstance{
+			Spec: bmfov1alpha1.BareMetalInstanceSpec{
+				RestartTrigger: 42,
+			},
+			Status: bmfov1alpha1.BareMetalInstanceStatus{
+				RestartTrigger: 0,
+				Conditions: []metav1.Condition{
+					{
+						Type:    string(bmfov1alpha1.HostConditionPowerSynced),
+						Status:  metav1.ConditionTrue,
+						Reason:  bmfov1alpha1.HostConditionReasonPowerOn,
+						Message: "Power on complete",
+					},
+				},
+			},
+		}
+		t.syncStatus(object)
+
+		Expect(t.bareMetalInstance.GetStatus().GetRestartTrigger()).To(Equal(int64(0)))
+
+		inProgress := findProtoCondition(t.bareMetalInstance,
+			privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_IN_PROGRESS)
+		Expect(inProgress).ToNot(BeNil())
+		Expect(inProgress.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
+
+		failed := findProtoCondition(t.bareMetalInstance,
+			privatev1.BareMetalInstanceConditionType_BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_FAILED)
+		Expect(failed).ToNot(BeNil())
+		Expect(failed.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_FALSE))
 	})
 
 	It("should not set restart conditions when PowerSynced is False with unhandled reason", func() {


### PR DESCRIPTION
## Summary

Fix BMI restart getting permanently stuck in Starting state. Cherry-picked from [bare-metal-fulfillment-operator PR #83](https://github.com/osac-project/bare-metal-fulfillment-operator/pull/83) (already merged in standalone repo).

## Root Cause

The Metal3 `IsRestartComplete` only checked if the reboot annotation was removed, but the BMH controller removes it as soon as it sends the reboot command — before the host finishes rebooting. The operator declared restart complete while the host was still mid-reboot, leaving `PowerSynced=False/Progressing` stuck.

## Fix

Restart is complete only when the annotation is gone **AND** the host is back online (`bmh.Status.PoweredOn=true`).

## Testing

- Unit tests pass (including new test for annotation-gone-but-not-powered-on scenario)
- Validated end-to-end on remote dev cluster — restart completes in ~30 seconds

## Jira

[OSAC-3548](https://redhat.atlassian.net/browse/OSAC-3548)

## Related

- E2E restart test: [osac-test-infra PR #302](https://github.com/osac-project/osac-test-infra/pull/302)
- Original standalone PR: [bare-metal-fulfillment-operator PR #83](https://github.com/osac-project/bare-metal-fulfillment-operator/pull/83) (merged)

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restart status reporting by confirming that the host is powered on before marking a restart as complete.
  * Prevented older restart requests from being reported as finished prematurely.
  * Ensured restart status accurately reflects whether the current restart request has completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->