### PR TITLE
NO-ISSUE: Run user statusline before checking disable flag

### DIFF
--- a/.claude/hooks/statusline.sh
+++ b/.claude/hooks/statusline.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
 # Project statusline: extends user statusline with osac + ai-workflows sync status
 # Opt out: set CLAUDE_REPO_STATUSLINE_DISABLED=1 in .claude/settings.local.json env
+# to skip the osac + ai-workflows sync status (the user's own statusline still runs)
 
 input=$(cat)
-
-if [[ "${CLAUDE_REPO_STATUSLINE_DISABLED:-}" == "1" ]]; then
-  exit 0
-fi
 
 project_dir="${1:-}"
 
@@ -15,6 +12,10 @@ if command -v jq >/dev/null 2>&1 && [[ -f "${HOME}/.claude/settings.json" ]]; th
   if [[ -n "${USER_STATUSLINE_CMD}" ]]; then
     printf "%s\n" "$input" | bash -c "${USER_STATUSLINE_CMD}"
   fi
+fi
+
+if [[ "${CLAUDE_REPO_STATUSLINE_DISABLED:-}" == "1" ]]; then
+  exit 0
 fi
 
 GREEN='\033[32m'


### PR DESCRIPTION
## Summary
- The project statusline hook exited on the disable flag before ever invoking the user's personal `statusLine.command`, so opting out of the project's repo-sync line also silently dropped the user's own statusline.
- Moves the disable check after the user statusline invocation, so disabling only skips the osac/ai-workflows sync status.

## Test plan
- [x] Ran `.claude/hooks/statusline.sh` with `CLAUDE_REPO_STATUSLINE_DISABLED` unset — user statusline and repo-sync status both appear
- [x] Ran with `CLAUDE_REPO_STATUSLINE_DISABLED=1` — user statusline appears, repo-sync status is skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User-defined statusline commands now run even when repository status output is disabled.
  * Disabling repository status only suppresses repository sync information, while other statusline content remains available.

* **Documentation**
  * Clarified the scope of the repository status opt-out setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->