### PR TITLE
OSAC-3503: Wire image source_type through BMI provisioning path

### DIFF
--- a/fulfillment-service/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
+++ b/fulfillment-service/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function.go
@@ -595,6 +595,11 @@ func (t *task) mutateBMI(ctx context.Context, object *bmfov1alpha1.BareMetalInst
 	}
 	if t.bareMetalInstance.GetSpec().HasImage() {
 		params["imageURL"] = t.bareMetalInstance.GetSpec().GetImage().GetSourceRef()
+		if st := t.bareMetalInstance.GetSpec().GetImage().GetSourceType(); st != "" {
+			params["imageSourceType"] = st
+		} else {
+			delete(params, "imageSourceType")
+		}
 	}
 	if len(params) > 0 {
 		paramsJSON, err := json.Marshal(params)

--- a/fulfillment-service/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
+++ b/fulfillment-service/internal/controllers/baremetalinstance/baremetalinstance_reconciler_function_test.go
@@ -468,6 +468,7 @@ var _ = Describe("mutateBMI", func() {
 		var params map[string]string
 		Expect(json.Unmarshal([]byte(obj.Spec.TemplateParameters), &params)).To(Succeed())
 		Expect(params["imageURL"]).To(Equal("quay.io/org/rhel9:latest"))
+		Expect(params["imageSourceType"]).To(Equal("registry"))
 	})
 
 	It("should not include imageURL in templateParameters when image is not set", func() {
@@ -494,12 +495,15 @@ var _ = Describe("mutateBMI", func() {
 		var params map[string]string
 		Expect(json.Unmarshal([]byte(obj.Spec.TemplateParameters), &params)).To(Succeed())
 		Expect(params).ToNot(HaveKey("imageURL"))
+		Expect(params).ToNot(HaveKey("imageSourceType"))
 	})
 
 	It("should let system imageURL override user-provided template_parameters value", func() {
 		catalogItemsClient := defaultFakeCatalogItemsClient()
 
 		userImageParam, err := anypb.New(wrapperspb.String("user-provided-image"))
+		Expect(err).ToNot(HaveOccurred())
+		userSourceTypeParam, err := anypb.New(wrapperspb.String("user-provided-type"))
 		Expect(err).ToNot(HaveOccurred())
 
 		t := &task{
@@ -510,8 +514,11 @@ var _ = Describe("mutateBMI", func() {
 			bareMetalInstance: privatev1.BareMetalInstance_builder{
 				Id: "bmi-test",
 				Spec: privatev1.BareMetalInstanceSpec_builder{
-					CatalogItem:        &privatev1.BareMetalInstanceCatalogItemReference{Id: "catalog-1"},
-					TemplateParameters: map[string]*anypb.Any{"imageURL": userImageParam},
+					CatalogItem: &privatev1.BareMetalInstanceCatalogItemReference{Id: "catalog-1"},
+					TemplateParameters: map[string]*anypb.Any{
+						"imageURL":        userImageParam,
+						"imageSourceType": userSourceTypeParam,
+					},
 					Image: privatev1.BareMetalInstanceImage_builder{
 						SourceType: "registry",
 						SourceRef:  "quay.io/org/rhel9:latest",
@@ -528,6 +535,42 @@ var _ = Describe("mutateBMI", func() {
 		Expect(json.Unmarshal([]byte(obj.Spec.TemplateParameters), &params)).To(Succeed())
 		Expect(params["imageURL"]).To(Equal("quay.io/org/rhel9:latest"),
 			"system imageURL must override user-provided template_parameters value")
+		Expect(params["imageSourceType"]).To(Equal("registry"),
+			"system imageSourceType must override user-provided template_parameters value")
+	})
+
+	It("should let system imageSourceType override user-provided template_parameters value", func() {
+		catalogItemsClient := defaultFakeCatalogItemsClient()
+
+		userSourceTypeParam, err := anypb.New(wrapperspb.String("user-provided-type"))
+		Expect(err).ToNot(HaveOccurred())
+
+		t := &task{
+			r: &function{
+				logger:                              logger,
+				bareMetalInstanceCatalogItemsClient: catalogItemsClient,
+			},
+			bareMetalInstance: privatev1.BareMetalInstance_builder{
+				Id: "bmi-test",
+				Spec: privatev1.BareMetalInstanceSpec_builder{
+					CatalogItem:        &privatev1.BareMetalInstanceCatalogItemReference{Id: "catalog-1"},
+					TemplateParameters: map[string]*anypb.Any{"imageSourceType": userSourceTypeParam},
+					Image: privatev1.BareMetalInstanceImage_builder{
+						SourceType: "oci",
+						SourceRef:  "quay.io/org/rhel9:latest",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		}
+
+		var obj bmfov1alpha1.BareMetalInstance
+		err = t.mutateBMI(ctx, &obj)
+		Expect(err).ToNot(HaveOccurred())
+
+		var params map[string]any
+		Expect(json.Unmarshal([]byte(obj.Spec.TemplateParameters), &params)).To(Succeed())
+		Expect(params["imageSourceType"]).To(Equal("oci"),
+			"system imageSourceType must override user-provided template_parameters value")
 	})
 
 	It("should include imageURL alongside sshPublicKey in templateParameters", func() {
@@ -559,6 +602,7 @@ var _ = Describe("mutateBMI", func() {
 		var params map[string]string
 		Expect(json.Unmarshal([]byte(obj.Spec.TemplateParameters), &params)).To(Succeed())
 		Expect(params["imageURL"]).To(Equal("quay.io/org/fedora:latest"))
+		Expect(params["imageSourceType"]).To(Equal("registry"))
 		Expect(params["sshPublicKey"]).To(Equal("ssh-ed25519 AAAA... test@example.com"))
 		Expect(params["userDataSecret"]).To(Equal("bmi-test-user-data"))
 	})
@@ -695,6 +739,70 @@ var _ = Describe("mutateBMI", func() {
 		Expect(obj.Spec.NetworkAttachments[0].Interface).To(BeEmpty())
 		Expect(obj.Spec.NetworkAttachments[0].Primary).To(BeFalse())
 	})
+
+	It("should not include imageSourceType when source_type is empty", func() {
+		catalogItemsClient := defaultFakeCatalogItemsClient()
+
+		t := &task{
+			r: &function{
+				logger:                              logger,
+				bareMetalInstanceCatalogItemsClient: catalogItemsClient,
+			},
+			bareMetalInstance: privatev1.BareMetalInstance_builder{
+				Id: "bmi-test",
+				Spec: privatev1.BareMetalInstanceSpec_builder{
+					CatalogItem: &privatev1.BareMetalInstanceCatalogItemReference{Id: "catalog-1"},
+					Image: privatev1.BareMetalInstanceImage_builder{
+						SourceRef: "quay.io/org/rhel9:latest",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		}
+
+		var obj bmfov1alpha1.BareMetalInstance
+		err := t.mutateBMI(ctx, &obj)
+		Expect(err).ToNot(HaveOccurred())
+
+		var params map[string]any
+		Expect(json.Unmarshal([]byte(obj.Spec.TemplateParameters), &params)).To(Succeed())
+		Expect(params).To(HaveKey("imageURL"))
+		Expect(params).ToNot(HaveKey("imageSourceType"))
+	})
+
+	It("should strip user-provided imageSourceType when image has empty source_type", func() {
+		catalogItemsClient := defaultFakeCatalogItemsClient()
+
+		userSourceTypeParam, err := anypb.New(wrapperspb.String("user-injected-type"))
+		Expect(err).ToNot(HaveOccurred())
+
+		t := &task{
+			r: &function{
+				logger:                              logger,
+				bareMetalInstanceCatalogItemsClient: catalogItemsClient,
+			},
+			bareMetalInstance: privatev1.BareMetalInstance_builder{
+				Id: "bmi-test",
+				Spec: privatev1.BareMetalInstanceSpec_builder{
+					CatalogItem:        &privatev1.BareMetalInstanceCatalogItemReference{Id: "catalog-1"},
+					TemplateParameters: map[string]*anypb.Any{"imageSourceType": userSourceTypeParam},
+					Image: privatev1.BareMetalInstanceImage_builder{
+						SourceRef: "oci://registry.example.com/rhel9:latest",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		}
+
+		var obj bmfov1alpha1.BareMetalInstance
+		err = t.mutateBMI(ctx, &obj)
+		Expect(err).ToNot(HaveOccurred())
+
+		var params map[string]any
+		Expect(json.Unmarshal([]byte(obj.Spec.TemplateParameters), &params)).To(Succeed())
+		Expect(params).To(HaveKey("imageURL"))
+		Expect(params).ToNot(HaveKey("imageSourceType"),
+			"user-provided imageSourceType must be stripped when spec image has no source_type")
+	})
+
 })
 
 var _ = Describe("update", func() {

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/bm_host_provisioning/tasks/build_bmh_patch.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/bm_host_provisioning/tasks/build_bmh_patch.yaml
@@ -8,7 +8,10 @@
         online: true
 
 - name: Add checksum to BMH patch for non-OCI images
-  when: not template_params.imageURL.startswith('oci://')
+  when: >-
+    (template_params.imageSourceType | default('') != 'registry')
+    and
+    (template_params.imageSourceType | default('') != '' or not template_params.imageURL.startswith('oci://'))
   ansible.builtin.set_fact:
     bmh_patch: >-
       {{ bmh_patch | combine({


### PR DESCRIPTION
## Summary

- Add `imageSourceType` to the template parameters map in the BMI reconciler, so the `--image-source-type` CLI flag actually affects provisioning
- Update the Metal3 `build_bmh_patch.yaml` to use `imageSourceType` when present for checksum decisions, falling back to URL-prefix detection for backward compatibility
- Add unit tests for the new parameter: presence, absence, empty source_type, and system-override of user-provided template_parameters

## Problem

The `--image-source-type` flag on `osac create baremetalinstance` was accepted, defaulted, validated, and stored by the API — but never forwarded to the Ansible provisioning pipeline. The reconciler only extracted `imageURL` from the image spec, silently dropping `source_type`. This meant setting `--image-source-type` to any value had zero effect on how the bare metal instance was provisioned.

## Changes

### fulfillment-service (reconciler)
- `baremetalinstance_reconciler_function.go`: Extract `GetSourceType()` into `params["imageSourceType"]` when non-empty (3 lines added)
- `baremetalinstance_reconciler_function_test.go`: Added assertions to 4 existing tests + 2 new tests covering override and empty source_type scenarios

### osac-aap (Ansible)
- `build_bmh_patch.yaml`: Updated checksum condition to prefer explicit `imageSourceType` over URL-prefix detection, with `| default('')` fallback for backward compatibility

## Rollout note

Existing BMIs with `source_type` set will receive an updated `TemplateParameters` on the next reconcile (adding the `imageSourceType` key), which may trigger a config version bump in the BMFO controller.

## Test plan

- [x] `go build ./...` passes
- [x] `ginkgo run -r internal/controllers/baremetalinstance/` — 71 tests pass
- [ ] `ansible-lint` on the changed role
- [ ] E2E: Create BMI with `--image-source-type oci` and verify `imageSourceType` appears in BMFO CR's `TemplateParameters`
- [ ] E2E: Verify BMH patch skips checksum for OCI images

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced bare-metal instance provisioning parameters by including `imageSourceType` when an image source type is provided, and omitting it when not.
  * Prevented checksum injection for OCI images while keeping existing URL-based OCI handling for empty source types.
  * Ensured system-provided image values override any user-provided `imageSourceType`.
* **Tests**
  * Extended reconciler tests to validate `imageSourceType` behavior and precedence rules across image and system overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->