### PR TITLE
OSAC-3544: Report WebSocket console errors as close frames

### DIFF
--- a/fulfillment-service/internal/console/kubevirt_backend.go
+++ b/fulfillment-service/internal/console/kubevirt_backend.go
@@ -117,10 +117,13 @@ func (b *kubeVirtBackend) Connect(ctx context.Context, target Target) (io.ReadWr
 	}
 
 	wsLogger := b.logger.With(slog.String("component", "backend_ws"))
-	dialOpts.OnPingReceived = PingReceivedHandler(wsLogger, ctx)
-	dialOpts.OnPongReceived = PongReceivedHandler(wsLogger, ctx)
+	dialOpts.OnPingReceived = PingReceivedHandler(wsLogger)
+	dialOpts.OnPongReceived = PongReceivedHandler(wsLogger)
 
-	conn, _, err := websocket.Dial(ctx, target.BackendURI, dialOpts)
+	dialCtx, dialCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer dialCancel()
+
+	conn, _, err := websocket.Dial(dialCtx, target.BackendURI, dialOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to console: %w", err)
 	}

--- a/fulfillment-service/internal/console/ping.go
+++ b/fulfillment-service/internal/console/ping.go
@@ -81,8 +81,8 @@ func StartPing(ctx context.Context, conn *websocket.Conn, logger *slog.Logger, c
 // PingReceivedHandler returns an OnPingReceived callback that logs at debug
 // level. The returned function has the signature expected by both
 // websocket.AcceptOptions and websocket.DialOptions.
-func PingReceivedHandler(logger *slog.Logger, ctx context.Context) func(context.Context, []byte) bool {
-	return func(_ context.Context, payload []byte) bool {
+func PingReceivedHandler(logger *slog.Logger) func(context.Context, []byte) bool {
+	return func(ctx context.Context, payload []byte) bool {
 		logger.DebugContext(ctx, "Ping received",
 			slog.Int("payload_len", len(payload)),
 		)
@@ -92,8 +92,8 @@ func PingReceivedHandler(logger *slog.Logger, ctx context.Context) func(context.
 
 // PongReceivedHandler returns an OnPongReceived callback that logs at debug
 // level.
-func PongReceivedHandler(logger *slog.Logger, ctx context.Context) func(context.Context, []byte) {
-	return func(_ context.Context, payload []byte) {
+func PongReceivedHandler(logger *slog.Logger) func(context.Context, []byte) {
+	return func(ctx context.Context, payload []byte) {
 		logger.DebugContext(ctx, "Pong received",
 			slog.Int("payload_len", len(payload)),
 		)

--- a/fulfillment-service/internal/servers/console_http_middleware.go
+++ b/fulfillment-service/internal/servers/console_http_middleware.go
@@ -14,11 +14,8 @@ language governing permissions and limitations under the License.
 package servers
 
 import (
-	"bufio"
 	"context"
-	"errors"
 	"log/slog"
-	"net"
 	"net/http"
 	"runtime/debug"
 	"time"
@@ -31,35 +28,51 @@ import (
 // consoleContextKey is the type used to pass console metadata through context.
 type consoleContextKey int
 
-const (
-	consoleTypeKey consoleContextKey = iota
-)
+const consoleStateKey consoleContextKey = 0
 
-// consoleTypeHolder is a mutable container injected into the request context
-// by ConsoleMetrics. The inner handler sets the value after ticket verification
-// via setConsoleType, and ConsoleMetrics reads it after the handler returns.
-type consoleTypeHolder struct {
-	value string
+// consoleSessionState passes session metadata from the inner WS handler back
+// to ConsoleMetrics via request context. Because the handler upgrades to 101
+// before validating the ticket, a 101 alone does not mean success -- the
+// handler must explicitly set established.
+type consoleSessionState struct {
+	consoleType string
+	established bool
 }
 
-// initConsoleType returns a context with an empty consoleTypeHolder.
-func initConsoleType(ctx context.Context) context.Context {
-	return context.WithValue(ctx, consoleTypeKey, &consoleTypeHolder{})
+// initConsoleState returns a context with a fresh consoleSessionState.
+func initConsoleState(ctx context.Context) context.Context {
+	return context.WithValue(ctx, consoleStateKey, &consoleSessionState{})
 }
 
-// setConsoleType stores the console type in the holder already present in ctx.
+// setConsoleType stores the console type in the state already present in ctx.
 func setConsoleType(ctx context.Context, ct string) {
-	if h, ok := ctx.Value(consoleTypeKey).(*consoleTypeHolder); ok {
-		h.value = ct
+	if s, ok := ctx.Value(consoleStateKey).(*consoleSessionState); ok {
+		s.consoleType = ct
 	}
 }
 
 // consoleTypeFromContext extracts the console type from context, or "" if absent.
 func consoleTypeFromContext(ctx context.Context) string {
-	if h, ok := ctx.Value(consoleTypeKey).(*consoleTypeHolder); ok {
-		return h.value
+	if s, ok := ctx.Value(consoleStateKey).(*consoleSessionState); ok {
+		return s.consoleType
 	}
 	return ""
+}
+
+// setSessionEstablished marks the state already present in ctx as established.
+func setSessionEstablished(ctx context.Context) {
+	if s, ok := ctx.Value(consoleStateKey).(*consoleSessionState); ok {
+		s.established = true
+	}
+}
+
+// sessionEstablishedFromContext reports whether the session was established,
+// or false if absent.
+func sessionEstablishedFromContext(ctx context.Context) bool {
+	if s, ok := ctx.Value(consoleStateKey).(*consoleSessionState); ok {
+		return s.established
+	}
+	return false
 }
 
 // validConsoleTypes is the set of known console type values for metrics labeling.
@@ -87,7 +100,6 @@ func ConsolePanicRecovery(logger *slog.Logger, next http.Handler) http.Handler {
 
 // ConsoleLogging wraps an http.Handler with structured request logging.
 // It logs the sanitized path (without query string) to avoid token exposure.
-// Status code is not captured here — ConsoleMetrics handles that.
 func ConsoleLogging(logger *slog.Logger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
@@ -108,38 +120,6 @@ func ConsoleLogging(logger *slog.Logger, next http.Handler) http.Handler {
 			slog.Duration("duration", time.Since(start)),
 		)
 	})
-}
-
-// statusWriter captures the HTTP status code written by the handler.
-type statusWriter struct {
-	http.ResponseWriter
-	status      int
-	wroteHeader bool
-}
-
-func (w *statusWriter) WriteHeader(code int) {
-	if !w.wroteHeader {
-		w.status = code
-		w.wroteHeader = true
-	}
-	w.ResponseWriter.WriteHeader(code)
-}
-
-func (w *statusWriter) Write(b []byte) (int, error) {
-	if !w.wroteHeader {
-		w.wroteHeader = true
-	}
-	return w.ResponseWriter.Write(b)
-}
-
-// Hijack delegates to the underlying ResponseWriter so that WebSocket upgrades work
-// when the writer is wrapped by logging or metrics middleware.
-func (w *statusWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	h, ok := w.ResponseWriter.(http.Hijacker)
-	if !ok {
-		return nil, nil, errors.New("underlying ResponseWriter does not support hijacking")
-	}
-	return h.Hijack()
 }
 
 // consoleMetricsMiddleware wraps an http.Handler with Prometheus connection metrics.
@@ -195,9 +175,8 @@ func (m *consoleMetricsMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Requ
 	m.activeConns.Inc()
 	defer m.activeConns.Dec()
 
-	r = r.WithContext(initConsoleType(r.Context()))
-	sw := &statusWriter{ResponseWriter: w, status: http.StatusOK}
-	m.next.ServeHTTP(sw, r)
+	r = r.WithContext(initConsoleState(r.Context()))
+	m.next.ServeHTTP(w, r)
 
 	// The handler sets console_type via context after ticket verification.
 	consoleType := consoleTypeFromContext(r.Context())
@@ -205,12 +184,10 @@ func (m *consoleMetricsMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Requ
 		consoleType = "unknown"
 	}
 
-	// coder/websocket writes 101 Switching Protocols before hijacking the
-	// connection, so a successful WebSocket upgrade is detected by the status
-	// code. Pre-upgrade failures (401/403/502) call http.Error which sets a
-	// different status code.
-	upgraded := sw.status == http.StatusSwitchingProtocols
-	if upgraded {
+	// established is set only after a successful backend connection (see
+	// setSessionEstablished), so it already implies success without a
+	// separate HTTP status check.
+	if sessionEstablishedFromContext(r.Context()) {
 		m.connDuration.WithLabelValues(consoleType).Observe(time.Since(start).Seconds())
 		m.connectTotal.WithLabelValues(consoleType, "success").Inc()
 	} else {

--- a/fulfillment-service/internal/servers/console_http_middleware_test.go
+++ b/fulfillment-service/internal/servers/console_http_middleware_test.go
@@ -59,11 +59,13 @@ var _ = Describe("ConsoleMetrics middleware", func() {
 			Expect(metrics).NotTo(osactesting.MatchLine(`console_websocket_connection_duration_seconds_count`))
 		})
 
-		It("should count 101 Switching Protocols as success", func() {
+		It("should count 101 Switching Protocols as success when the session is established", func() {
 			handler := ConsoleMetrics(metricsServer.Registry(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer GinkgoRecover()
 				w.WriteHeader(http.StatusSwitchingProtocols)
 				conn, _, err := w.(http.Hijacker).Hijack()
 				Expect(err).NotTo(HaveOccurred())
+				setSessionEstablished(r.Context())
 				conn.Close()
 			}))
 
@@ -80,9 +82,35 @@ var _ = Describe("ConsoleMetrics middleware", func() {
 			Expect(metrics).To(osactesting.MatchLine(`console_websocket_connection_duration_seconds_count\{.*\} 1`))
 		})
 
+		It("should count 101 Switching Protocols without an established session as error", func() {
+			// The WS handler upgrades to 101 before sending a close frame for
+			// setup failures (bad ticket, backend conflict), so 101 alone must
+			// not count as success.
+			handler := ConsoleMetrics(metricsServer.Registry(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer GinkgoRecover()
+				w.WriteHeader(http.StatusSwitchingProtocols)
+				conn, _, err := w.(http.Hijacker).Hijack()
+				Expect(err).NotTo(HaveOccurred())
+				conn.Close()
+			}))
+
+			srv := httptest.NewServer(handler)
+			defer srv.Close()
+
+			resp, err := http.Get(srv.URL)
+			if err == nil {
+				resp.Body.Close()
+			}
+
+			metrics := metricsServer.Metrics()
+			Expect(metrics).To(osactesting.MatchLine(`console_websocket_connections_total\{.*status="error".*\} 1`))
+			Expect(metrics).NotTo(osactesting.MatchLine(`console_websocket_connection_duration_seconds_count`))
+		})
+
 		It("should distinguish errors from upgrades in the same server", func() {
 			var callCount atomic.Int32
 			handler := ConsoleMetrics(metricsServer.Registry(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer GinkgoRecover()
 				if callCount.Add(1) == 1 {
 					http.Error(w, "unauthorized", http.StatusUnauthorized)
 					return
@@ -90,6 +118,7 @@ var _ = Describe("ConsoleMetrics middleware", func() {
 				w.WriteHeader(http.StatusSwitchingProtocols)
 				conn, _, err := w.(http.Hijacker).Hijack()
 				Expect(err).NotTo(HaveOccurred())
+				setSessionEstablished(r.Context())
 				conn.Close()
 			}))
 
@@ -161,10 +190,12 @@ var _ = Describe("ConsoleMetrics middleware", func() {
 	Describe("console_type label", func() {
 		It("should use the type set by the inner handler", func() {
 			handler := ConsoleMetrics(metricsServer.Registry(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer GinkgoRecover()
 				setConsoleType(r.Context(), "vnc")
 				w.WriteHeader(http.StatusSwitchingProtocols)
 				conn, _, err := w.(http.Hijacker).Hijack()
 				Expect(err).NotTo(HaveOccurred())
+				setSessionEstablished(r.Context())
 				conn.Close()
 			}))
 
@@ -218,11 +249,13 @@ var _ = Describe("ConsoleMetrics middleware", func() {
 	Describe("real WebSocket upgrade", func() {
 		It("should detect coder/websocket upgrade as success", func() {
 			wsHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer GinkgoRecover()
 				setConsoleType(r.Context(), "serial")
 				ws, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 					InsecureSkipVerify: true,
 				})
 				Expect(err).NotTo(HaveOccurred())
+				setSessionEstablished(r.Context())
 				ws.CloseNow()
 			})
 			handler := ConsoleMetrics(metricsServer.Registry(), wsHandler)

--- a/fulfillment-service/internal/servers/console_proxy_ws.go
+++ b/fulfillment-service/internal/servers/console_proxy_ws.go
@@ -14,17 +14,38 @@ language governing permissions and limitations under the License.
 package servers
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/coder/websocket"
 
 	"github.com/osac-project/osac/fulfillment-service/internal/console"
 )
 
-// ConsoleProxyWSHandler serves WebSocket console connections.
-// Auth is verified BEFORE upgrade -- invalid tickets get HTTP 401.
+// WebSocket close codes for setup errors, sent as a Close frame after the
+// upgrade completes. Browsers collapse any non-101 handshake response into a
+// generic error/1006 close, so setup errors can only reach browser JS as a
+// CloseEvent after the WebSocket upgrade succeeds.
+const (
+	wsStatusUnauthorized websocket.StatusCode = 3000 // IANA-registered.
+	wsStatusConsoleInUse websocket.StatusCode = 4409 // Private-use: HTTP 409 equivalent.
+)
+
+// WebSocket close reasons. Fixed and short -- never include validation
+// details, backend URLs, tokens, or raw error messages.
+const (
+	wsReasonUnauthorized = "unauthorized"
+	wsReasonConsoleInUse = "console session already active"
+	wsReasonBadGateway   = "failed to connect to console backend"
+)
+
+// ConsoleProxyWSHandler serves WebSocket console connections. Ticket
+// verification and backend connection happen after the WebSocket upgrade, so
+// that setup errors can be reported as close frames (see wsStatus* codes)
+// instead of an HTTP status.
 type ConsoleProxyWSHandler struct {
 	core           *ConsoleProxyCore
 	allowedOrigins []string
@@ -58,72 +79,107 @@ func extractTicket(r *http.Request) (string, error) {
 	return "", errors.New("missing ticket: set Authorization header or console-ticket cookie")
 }
 
-func (h *ConsoleProxyWSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
+// closeWithStatus sends a WebSocket close frame with an app-level status
+// code and reason. Close performs the close handshake -- up to 5s to write
+// the frame plus up to another 5s waiting for the peer's close frame --
+// unlike CloseNow which drops the connection immediately.
+func closeWithStatus(ctx context.Context, logger *slog.Logger, ws *websocket.Conn, code websocket.StatusCode, reason string) {
+	if err := ws.Close(code, reason); err != nil {
+		logger.DebugContext(ctx, "Failed to complete WS close handshake",
+			slog.Int("code", int(code)),
+			slog.String("reason", reason),
+			slog.Any("error", err),
+		)
+	}
+}
 
+// backendCloseStatus maps a ConnectBackend error to a WebSocket close code
+// and reason.
+func backendCloseStatus(err error) (websocket.StatusCode, string) {
+	if _, ok := errors.AsType[*console.ErrSessionExists](err); ok {
+		return wsStatusConsoleInUse, wsReasonConsoleInUse
+	}
+	return websocket.StatusBadGateway, wsReasonBadGateway
+}
+
+func (h *ConsoleProxyWSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Cookie-based auth (no Authorization header) requires a non-empty Origin
 	// for CSWSH protection. The library's OriginPatterns auto-passes empty
-	// Origin, so we must reject it ourselves for cookie auth.
+	// Origin, so we must reject it ourselves for cookie auth. Handshake-level
+	// rejections abort the upgrade with a plain HTTP 403.
 	if r.Header.Get("Authorization") == "" && r.Header.Get("Origin") == "" {
 		http.Error(w, "origin not allowed", http.StatusForbidden)
 		return
 	}
 
-	// Phase 1: Extract and verify ticket BEFORE upgrade.
-	rawTicket, err := extractTicket(r)
+	// Extract the ticket value now, but defer reporting failure until after
+	// the WebSocket upgrade so the browser can see a close code instead of a
+	// generic 1006.
+	rawTicket, ticketErr := extractTicket(r)
+
+	// Upgrade to WebSocket.
+	// OriginPatterns delegates origin validation to the library. The library
+	// auto-passes empty Origin (hence the CSWSH guard above) and same-origin
+	// requests; a rejected origin aborts the handshake with HTTP 403.
+	wsLogger := h.core.logger.With(slog.String("component", "client_ws"))
+	ws, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		OriginPatterns: h.allowedOrigins,
+		Subprotocols:   []string{"binary"},
+		OnPingReceived: console.PingReceivedHandler(wsLogger),
+		OnPongReceived: console.PongReceivedHandler(wsLogger),
+	})
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusUnauthorized)
+		h.core.logger.ErrorContext(r.Context(), "Failed to accept WebSocket connection",
+			slog.Any("error", err),
+		)
+		return
+	}
+	defer func() { _ = ws.CloseNow() }()
+
+	// r.Context() stays valid for the life of ServeHTTP even after Accept
+	// hijacks the connection (see http.Hijacker), but coder/websocket still
+	// advises against relying on it post-Accept. Own the connection's
+	// context explicitly instead: WithoutCancel keeps the request-scoped
+	// values, and WithCancel gives the handler control of when it ends.
+	connCtx, cancel := context.WithCancel(context.WithoutCancel(r.Context()))
+	defer cancel()
+
+	if ticketErr != nil {
+		closeWithStatus(connCtx, wsLogger, ws, wsStatusUnauthorized, wsReasonUnauthorized)
 		return
 	}
 
-	ticket, err := h.core.OpenTicket(ctx, rawTicket)
+	// OpenTicket may fetch JWKS over the network; bound it.
+	openCtx, openCancel := context.WithTimeout(connCtx, 30*time.Second)
+	defer openCancel()
+
+	ticket, err := h.core.OpenTicket(openCtx, rawTicket)
 	if err != nil {
-		http.Error(w, "invalid ticket", http.StatusUnauthorized)
+		closeWithStatus(connCtx, wsLogger, ws, wsStatusUnauthorized, wsReasonUnauthorized)
 		return
 	}
 
 	// Expose console_type to outer middleware (ConsoleMetrics reads it after handler returns).
 	setConsoleType(r.Context(), ticket.ConsoleType)
 
-	// Phase 2: Connect backend BEFORE upgrade (fail fast with HTTP error).
-	backend, sessionCtx, err := h.core.ConnectBackend(ctx, ticket)
+	backend, sessionCtx, err := h.core.ConnectBackend(connCtx, ticket)
 	if err != nil {
-		h.core.logger.ErrorContext(ctx, "Failed to connect backend", slog.Any("error", err))
-		var sessionErr *console.ErrSessionExists
-		if errors.As(err, &sessionErr) {
-			http.Error(w, "console session already active", http.StatusConflict)
-			return
-		}
-		http.Error(w, "failed to connect to console backend", http.StatusBadGateway)
+		h.core.logger.ErrorContext(connCtx, "Failed to connect backend", slog.Any("error", err))
+		code, reason := backendCloseStatus(err)
+		closeWithStatus(connCtx, wsLogger, ws, code, reason)
 		return
 	}
 
-	// Phase 3: Upgrade to WebSocket.
-	// OriginPatterns delegates origin validation to the library, which matches
-	// each pattern via path.Match against scheme://host (if pattern contains "://")
-	// or host alone. The library also auto-passes when r.Host == Origin host
-	// (same-origin requests) and when Origin is empty.
-	wsLogger := h.core.logger.With(slog.String("component", "client_ws"))
-	ws, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		OriginPatterns: h.allowedOrigins,
-		Subprotocols:   []string{"binary"},
-		OnPingReceived: console.PingReceivedHandler(wsLogger, sessionCtx),
-		OnPongReceived: console.PongReceivedHandler(wsLogger, sessionCtx),
-	})
-	if err != nil {
-		h.core.logger.ErrorContext(ctx, "Failed to accept WebSocket connection",
-			slog.Any("error", err),
-		)
-		backend.Close()
-		return
-	}
-	defer func() { _ = ws.CloseNow() }()
+	// The session is established -- let the outer middleware count this
+	// connection as a success rather than an upgraded-but-rejected attempt.
+	setSessionEstablished(r.Context())
 
 	// Start a ping goroutine to keep the client-facing WebSocket alive.
 	console.StartPing(sessionCtx, ws, wsLogger, h.pingConfig)
 
-	// Phase 4: Relay with sessionCtx: cancelled on eviction, timeout,
-	// or client disconnect. Relay logs errors internally.
+	// Relay uses sessionCtx, which is cancelled on eviction or session
+	// timeout. A client disconnect ends the relay via I/O error instead.
+	// Relay logs errors internally.
 	clientConn := websocket.NetConn(sessionCtx, ws, websocket.MessageBinary)
 	_ = h.core.Relay(sessionCtx, clientConn, backend)
 }

--- a/fulfillment-service/internal/servers/console_proxy_ws_test.go
+++ b/fulfillment-service/internal/servers/console_proxy_ws_test.go
@@ -27,6 +27,28 @@ import (
 	"github.com/osac-project/osac/fulfillment-service/internal/console"
 )
 
+// dialAndExpectClose dials the WebSocket server and expects the connection to
+// be closed with the given app-level code and reason -- either during the
+// Dial handshake itself, or via a subsequent Read once the upgrade succeeds.
+func dialAndExpectClose(url string, opts *websocket.DialOptions, expectedCode websocket.StatusCode, expectedReason string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ws, _, err := websocket.Dial(ctx, url, opts)
+	if err != nil {
+		Expect(websocket.CloseStatus(err)).To(Equal(expectedCode))
+		return
+	}
+	defer ws.CloseNow()
+
+	_, _, err = ws.Read(ctx)
+	Expect(err).To(HaveOccurred())
+	Expect(websocket.CloseStatus(err)).To(Equal(expectedCode))
+	if closeErr, ok := errors.AsType[websocket.CloseError](err); ok {
+		Expect(closeErr.Reason).To(Equal(expectedReason))
+	}
+}
+
 // rejectingOpener is a ticketOpener stub that always returns an error.
 // Used by origin-enforcement tests so the handler reaches a deterministic 401
 // instead of panicking on a nil TicketOpener.
@@ -102,7 +124,7 @@ func (s *succeedingOpener) Open(_ context.Context, _ string) (*console.Ticket, e
 }
 
 var _ = Describe("ServeHTTP ConnectBackend error handling", func() {
-	It("should return 409 when backend reports an active session", func() {
+	It("should close with 4409 when backend reports an active session", func() {
 		backend := &mockBackendForServer{conn: newMockConn("")}
 		manager, err := console.NewManager().
 			SetLogger(logger).
@@ -134,12 +156,6 @@ var _ = Describe("ServeHTTP ConnectBackend error handling", func() {
 			SetManager(manager).
 			Build()
 		Expect(err).NotTo(HaveOccurred())
-		core.opener = &succeedingOpener{ticket: ticket}
-
-		handler := &ConsoleProxyWSHandler{
-			core:           core,
-			allowedOrigins: []string{"*"},
-		}
 
 		// Second connect with different clientID triggers ErrSessionExists.
 		secondTicket := &console.Ticket{
@@ -151,15 +167,22 @@ var _ = Describe("ServeHTTP ConnectBackend error handling", func() {
 		}
 		core.opener = &succeedingOpener{ticket: secondTicket}
 
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
-		req.Header.Set("Authorization", "Bearer some-ticket")
-		w := httptest.NewRecorder()
-		handler.ServeHTTP(w, req)
-		Expect(w.Code).To(Equal(http.StatusConflict))
-		Expect(w.Body.String()).To(ContainSubstring("console session already active"))
+		handler := &ConsoleProxyWSHandler{
+			core:           core,
+			allowedOrigins: []string{"*"},
+		}
+		srv := httptest.NewServer(handler)
+		defer srv.Close()
+
+		dialAndExpectClose(
+			"ws"+srv.URL[len("http"):],
+			&websocket.DialOptions{HTTPHeader: http.Header{"Authorization": []string{"Bearer some-ticket"}}},
+			wsStatusConsoleInUse,
+			wsReasonConsoleInUse,
+		)
 	})
 
-	It("should return 502 for generic backend errors", func() {
+	It("should close with 1014 (bad gateway) for generic backend errors", func() {
 		backend := &mockBackendForServer{
 			connErr: errors.New("dial backend failed"),
 		}
@@ -189,13 +212,15 @@ var _ = Describe("ServeHTTP ConnectBackend error handling", func() {
 			core:           core,
 			allowedOrigins: []string{"*"},
 		}
+		srv := httptest.NewServer(handler)
+		defer srv.Close()
 
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
-		req.Header.Set("Authorization", "Bearer some-ticket")
-		w := httptest.NewRecorder()
-		handler.ServeHTTP(w, req)
-		Expect(w.Code).To(Equal(http.StatusBadGateway))
-		Expect(w.Body.String()).To(ContainSubstring("failed to connect to console backend"))
+		dialAndExpectClose(
+			"ws"+srv.URL[len("http"):],
+			&websocket.DialOptions{HTTPHeader: http.Header{"Authorization": []string{"Bearer some-ticket"}}},
+			websocket.StatusBadGateway,
+			wsReasonBadGateway,
+		)
 	})
 })
 
@@ -218,14 +243,23 @@ var _ = Describe("ServeHTTP Origin enforcement", func() {
 			core:           &ConsoleProxyCore{logger: logger, opener: &rejectingOpener{}},
 			allowedOrigins: []string{"https://good.com"},
 		}
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
-		req.AddCookie(&http.Cookie{Name: "console-ticket", Value: "some-jwt"})
-		req.Header.Set("Origin", "https://good.com")
-		w := httptest.NewRecorder()
-		handler.ServeHTTP(w, req)
-		// Origin is present so the pre-check passes; the stub opener
-		// rejects the token, so we expect 401 (not a 403 origin error).
-		Expect(w.Code).To(Equal(http.StatusUnauthorized))
+		srv := httptest.NewServer(handler)
+		defer srv.Close()
+
+		// Origin is present so the pre-check passes; the stub opener rejects
+		// the token, so the upgrade succeeds and the close code is 3000
+		// (not a 403 origin error).
+		dialAndExpectClose(
+			"ws"+srv.URL[len("http"):],
+			&websocket.DialOptions{
+				HTTPHeader: http.Header{
+					"Cookie": []string{"console-ticket=some-jwt"},
+					"Origin": []string{"https://good.com"},
+				},
+			},
+			wsStatusUnauthorized,
+			wsReasonUnauthorized,
+		)
 	})
 
 	It("should reject cookie auth with disallowed Origin during upgrade", func() {
@@ -257,13 +291,18 @@ var _ = Describe("ServeHTTP Origin enforcement", func() {
 			core:           &ConsoleProxyCore{logger: logger, opener: &rejectingOpener{}},
 			allowedOrigins: []string{"https://good.com"},
 		}
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
-		req.Header.Set("Authorization", "Bearer some-token")
-		w := httptest.NewRecorder()
-		handler.ServeHTTP(w, req)
+		srv := httptest.NewServer(handler)
+		defer srv.Close()
+
 		// Bearer auth with no Origin -- the pre-check only fires for cookie
 		// auth, so this proceeds to ticket verification. The stub opener
-		// rejects the token, yielding 401 (not a 403 origin error).
-		Expect(w.Code).To(Equal(http.StatusUnauthorized))
+		// rejects the token, so the upgrade succeeds and the close code is
+		// 3000 (not a 403 origin error).
+		dialAndExpectClose(
+			"ws"+srv.URL[len("http"):],
+			&websocket.DialOptions{HTTPHeader: http.Header{"Authorization": []string{"Bearer some-token"}}},
+			wsStatusUnauthorized,
+			wsReasonUnauthorized,
+		)
 	})
 })


### PR DESCRIPTION
## Summary

Browsers collapse non-101 WebSocket handshake responses into a generic error event with close code 1006, making error details invisible to JavaScript. This moves setup error reporting to post-upgrade close frames so browser clients can read the actual error code and reason from CloseEvent.

Bad ticket and expired ticket close with 3000 (IANA-registered "Unauthorized"), session conflict with 4409 (private-use, HTTP 409 equivalent), and backend failure with 1014 (StatusBadGateway). The metrics middleware is updated to distinguish successful sessions from upgraded-but-rejected connections using an explicit session-established signal instead of HTTP status code inspection.

Companion test update: https://github.com/osac-project/osac-test-infra/pull/313

## Test plan

Unit tests cover close code delivery, metrics labeling, origin enforcement, and ticket extraction. Run `ginkgo run -r internal` and `uv run dev.py lint go`.

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved console WebSocket connection reliability with managed timeouts and more consistent session validation.
  * Connection setup failures now provide clearer WebSocket close statuses for authentication errors, active sessions, and backend failures.
  * Prevented unsuccessful upgrade attempts from being recorded as established sessions or generating misleading duration metrics.
  * Improved ping and pong handling during console sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->