### PR TITLE
OSAC-2864: Implement tenant isolation for BareMetalInstanceType resources

### DIFF
--- a/fulfillment-service/internal/auth/shared_tenancy_logic.go
+++ b/fulfillment-service/internal/auth/shared_tenancy_logic.go
@@ -1,0 +1,77 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/osac-project/fulfillment-service/internal/collections"
+)
+
+// SharedTenancyLogicBuilder contains the data and logic needed to create shared tenancy logic.
+type SharedTenancyLogicBuilder struct {
+	logger *slog.Logger
+}
+
+// SharedTenancyLogic is a tenancy logic implementation that assigns the shared tenant to all objects
+// and makes the shared tenant visible to all users. This is used for platform-scoped resources like
+// BareMetalInstanceType that should be globally visible across tenants.
+type SharedTenancyLogic struct {
+	logger *slog.Logger
+}
+
+// NewSharedTenancyLogic creates a new builder for shared tenancy logic.
+func NewSharedTenancyLogic() *SharedTenancyLogicBuilder {
+	return &SharedTenancyLogicBuilder{}
+}
+
+// SetLogger sets the logger that will be used by the tenancy logic.
+func (b *SharedTenancyLogicBuilder) SetLogger(value *slog.Logger) *SharedTenancyLogicBuilder {
+	b.logger = value
+	return b
+}
+
+// Build creates the shared tenancy logic.
+func (b *SharedTenancyLogicBuilder) Build() (result *SharedTenancyLogic, err error) {
+	result = &SharedTenancyLogic{
+		logger: b.logger,
+	}
+	return
+}
+
+// DetermineAssignableTenants returns a set containing only the shared tenant, regardless of the user's identity.
+// Platform-scoped resources like BareMetalInstanceType can only be assigned to the shared tenant.
+func (p *SharedTenancyLogic) DetermineAssignableTenants(_ context.Context) (result collections.Set[string], err error) {
+	result = SharedTenants
+	return
+}
+
+// DetermineDefaultTenant returns the shared tenant, regardless of the user's identity.
+// All platform-scoped resources default to the shared tenant for global visibility.
+func (p *SharedTenancyLogic) DetermineDefaultTenant(_ context.Context) (result string, err error) {
+	result = SharedTenant
+	return
+}
+
+// DetermineVisibleTenants returns a set containing the shared tenant plus any tenants the user can access.
+// This ensures shared resources are visible to all authenticated users while preserving tenant isolation.
+func (p *SharedTenancyLogic) DetermineVisibleTenants(ctx context.Context) (result collections.Set[string], err error) {
+	subject := SubjectFromContext(ctx)
+	result = subject.Tenants
+	if result.Finite() {
+		result = SharedTenants.Union(result)
+	}
+	return
+}

--- a/fulfillment-service/internal/auth/shared_tenancy_logic_test.go
+++ b/fulfillment-service/internal/auth/shared_tenancy_logic_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package auth_test
+
+import (
+	"context"
+	"log/slog"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+
+	"github.com/osac-project/fulfillment-service/internal/auth"
+	"github.com/osac-project/fulfillment-service/internal/collections"
+)
+
+var _ = Describe("SharedTenancyLogic", func() {
+	var (
+		ctx    context.Context
+		logger *slog.Logger
+		logic  *auth.SharedTenancyLogic
+		err    error
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		logger = slog.Default()
+
+		logic, err = auth.NewSharedTenancyLogic().
+			SetLogger(logger).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(logic).ToNot(BeNil())
+	})
+
+	Describe("DetermineAssignableTenants", func() {
+		It("Always returns shared tenants regardless of user context", func() {
+			// Test with no subject in context
+			result, err := logic.DetermineAssignableTenants(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(auth.SharedTenants))
+
+			// Test with regular user subject
+			userSubject := &auth.Subject{
+				User:    "test-user",
+				Tenants: collections.NewSet("tenant-a", "tenant-b"),
+			}
+			userCtx := auth.ContextWithSubject(ctx, userSubject)
+
+			result, err = logic.DetermineAssignableTenants(userCtx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(auth.SharedTenants))
+			Expect(result.Contains("shared")).To(BeTrue())
+			Expect(result.Contains("tenant-a")).To(BeFalse())
+			Expect(result.Contains("tenant-b")).To(BeFalse())
+
+			// Test with admin user (universal tenant set)
+			adminSubject := &auth.Subject{
+				User:    "admin-user",
+				Tenants: auth.AllTenants,
+			}
+			adminCtx := auth.ContextWithSubject(ctx, adminSubject)
+
+			result, err = logic.DetermineAssignableTenants(adminCtx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(auth.SharedTenants))
+		})
+	})
+
+	Describe("DetermineDefaultTenant", func() {
+		It("Always returns shared tenant regardless of user context", func() {
+			// Test with no subject in context
+			result, err := logic.DetermineDefaultTenant(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal("shared"))
+
+			// Test with regular user subject
+			userSubject := &auth.Subject{
+				User:    "test-user",
+				Tenants: collections.NewSet("tenant-a", "tenant-b"),
+			}
+			userCtx := auth.ContextWithSubject(ctx, userSubject)
+
+			result, err = logic.DetermineDefaultTenant(userCtx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal("shared"))
+
+			// Test with admin user (universal tenant set)
+			adminSubject := &auth.Subject{
+				User:    "admin-user",
+				Tenants: auth.AllTenants,
+			}
+			adminCtx := auth.ContextWithSubject(ctx, adminSubject)
+
+			result, err = logic.DetermineDefaultTenant(adminCtx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal("shared"))
+		})
+	})
+
+	Describe("DetermineVisibleTenants", func() {
+		It("Returns shared tenant plus user's tenants for regular users", func() {
+			// Test with regular user subject
+			userSubject := &auth.Subject{
+				User:    "test-user",
+				Tenants: collections.NewSet("tenant-a", "tenant-b"),
+			}
+			userCtx := auth.ContextWithSubject(ctx, userSubject)
+
+			result, err := logic.DetermineVisibleTenants(userCtx)
+			Expect(err).ToNot(HaveOccurred())
+
+			expected := auth.SharedTenants.Union(collections.NewSet("tenant-a", "tenant-b"))
+			Expect(result).To(Equal(expected))
+			Expect(result.Contains("shared")).To(BeTrue())
+			Expect(result.Contains("tenant-a")).To(BeTrue())
+			Expect(result.Contains("tenant-b")).To(BeTrue())
+		})
+
+		It("Returns all tenants for admin users", func() {
+			// Test with admin user (universal tenant set)
+			adminSubject := &auth.Subject{
+				User:    "admin-user",
+				Tenants: auth.AllTenants,
+			}
+			adminCtx := auth.ContextWithSubject(ctx, adminSubject)
+
+			result, err := logic.DetermineVisibleTenants(adminCtx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(auth.AllTenants))
+		})
+
+		It("Returns only shared tenant for users with empty tenant set", func() {
+			// Test with user that has empty tenant set
+			emptyTenantSubject := &auth.Subject{
+				User:    "empty-tenant-user",
+				Tenants: collections.NewSet[string](),
+			}
+			emptyCtx := auth.ContextWithSubject(ctx, emptyTenantSubject)
+
+			result, err := logic.DetermineVisibleTenants(emptyCtx)
+			Expect(err).ToNot(HaveOccurred())
+
+			expected := auth.SharedTenants.Union(collections.NewSet[string]())
+			Expect(result).To(Equal(expected))
+			Expect(result.Contains("shared")).To(BeTrue())
+		})
+	})
+})

--- a/fulfillment-service/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -362,6 +362,16 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 		return fmt.Errorf("failed to create default tenancy logic: %w", err)
 	}
 
+	// Create shared tenancy logic for platform-scoped resources like BareMetalInstanceType:
+	c.logger.InfoContext(ctx, "Creating shared tenancy logic")
+	var sharedTenancyLogic auth.TenancyLogic
+	sharedTenancyLogic, err = auth.NewSharedTenancyLogic().
+		SetLogger(c.logger).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create shared tenancy logic: %w", err)
+	}
+
 	// Prepare the authorization interceptor:
 	c.logger.InfoContext(ctx, "Creating Rego authorization interceptor")
 	authzInterceptor, err := auth.NewGrpcAuthzInterceptor().
@@ -1020,7 +1030,7 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 		SetLogger(c.logger).
 		SetNotifier(notifier).
 		SetAttributionLogic(publicAttributionLogic).
-		SetTenancyLogic(tenancyLogic).
+		SetTenancyLogic(sharedTenancyLogic).
 		SetMetricsRegisterer(metricsRegisterer).
 		Build()
 	if err != nil {
@@ -1034,7 +1044,7 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 		SetLogger(c.logger).
 		SetNotifier(notifier).
 		SetAttributionLogic(privateAttributionLogic).
-		SetTenancyLogic(tenancyLogic).
+		SetTenancyLogic(sharedTenancyLogic).
 		SetMetricsRegisterer(metricsRegisterer).
 		Build()
 	if err != nil {

--- a/fulfillment-service/internal/servers/private_baremetal_instance_types_server_test.go
+++ b/fulfillment-service/internal/servers/private_baremetal_instance_types_server_test.go
@@ -18,11 +18,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/fulfillment-service/internal/auth"
 )
 
 var _ = Describe("Private bare metal instance types server", func() {
@@ -512,6 +514,290 @@ var _ = Describe("Private bare metal instance types server", func() {
 				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
 				Expect(status.Message()).To(ContainSubstring("name"))
 				Expect(status.Message()).To(ContainSubstring("immutable"))
+			})
+		})
+
+		Describe("Tenant isolation", func() {
+			var sharedTenancyServer *PrivateBareMetalInstanceTypesServer
+
+			BeforeEach(func() {
+				var err error
+
+				// Create a separate mock tenancy logic that returns SharedTenant for BareMetalInstanceTypes
+				sharedTenancy := auth.NewMockTenancyLogic(ctrl)
+				sharedTenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+					Return(auth.SharedTenants, nil).
+					AnyTimes()
+				sharedTenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).
+					Return(auth.SharedTenant, nil).
+					AnyTimes()
+				sharedTenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+					Return(auth.SharedTenants, nil).
+					AnyTimes()
+
+				// Create a server configured for shared tenant behavior
+				sharedTenancyServer, err = NewPrivateBareMetalInstanceTypesServer().
+					SetLogger(logger).
+					SetAttributionLogic(attribution).
+					SetTenancyLogic(sharedTenancy).
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("Sets tenant metadata to shared for created objects", func() {
+				response, err := sharedTenancyServer.Create(ctx, privatev1.BareMetalInstanceTypesCreateRequest_builder{
+					Object: privatev1.BareMetalInstanceType_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "shared-tenant-test",
+						}.Build(),
+						Spec: privatev1.BareMetalInstanceTypeSpec_builder{
+							Hardware: privatev1.BareMetalHardwareSpec_builder{
+								Cpu: privatev1.BareMetalCPUSpec_builder{
+									Cores:          16,
+									Architecture:   "x86_64",
+									ThreadsPerCore: 2,
+								}.Build(),
+								Memory: privatev1.BareMetalMemorySpec_builder{
+									TotalGb: 64,
+								}.Build(),
+							}.Build(),
+							HostLabelSelector: privatev1.BareMetalLabelSelector_builder{
+								MatchLabels: map[string]string{
+									"hardware.profile": "shared-test",
+								},
+							}.Build(),
+							Description: "Test instance type for tenant isolation validation.",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+
+				object := response.GetObject()
+				Expect(object).ToNot(BeNil())
+				Expect(object.GetMetadata().GetTenant()).To(Equal("shared"))
+			})
+
+			It("Verifies tenant field is set correctly for different operations", func() {
+				// Test Create operation
+				createResponse, err := sharedTenancyServer.Create(ctx, privatev1.BareMetalInstanceTypesCreateRequest_builder{
+					Object: privatev1.BareMetalInstanceType_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "tenant-ops-test",
+						}.Build(),
+						Spec: privatev1.BareMetalInstanceTypeSpec_builder{
+							Hardware: privatev1.BareMetalHardwareSpec_builder{
+								Cpu: privatev1.BareMetalCPUSpec_builder{
+									Cores:          8,
+									Architecture:   "x86_64",
+									ThreadsPerCore: 2,
+								}.Build(),
+								Memory: privatev1.BareMetalMemorySpec_builder{
+									TotalGb: 32,
+								}.Build(),
+							}.Build(),
+							HostLabelSelector: privatev1.BareMetalLabelSelector_builder{
+								MatchLabels: map[string]string{
+									"test": "operations",
+								},
+							}.Build(),
+							Description: "Initial description",
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(createResponse).ToNot(BeNil())
+
+				createObject := createResponse.GetObject()
+				Expect(createObject).ToNot(BeNil())
+				Expect(createObject.GetMetadata().GetTenant()).To(Equal("shared"))
+
+				// Test Get operation
+				getResponse, err := sharedTenancyServer.Get(ctx, privatev1.BareMetalInstanceTypesGetRequest_builder{
+					Id: createObject.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getResponse).ToNot(BeNil())
+
+				getObject := getResponse.GetObject()
+				Expect(getObject).ToNot(BeNil())
+				Expect(getObject.GetMetadata().GetTenant()).To(Equal("shared"))
+
+				// Test Update operation (only description is mutable)
+				updateResponse, err := sharedTenancyServer.Update(ctx, privatev1.BareMetalInstanceTypesUpdateRequest_builder{
+					Object: privatev1.BareMetalInstanceType_builder{
+						Id: createObject.GetId(),
+						Spec: privatev1.BareMetalInstanceTypeSpec_builder{
+							Description: "Updated description",
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{
+						Paths: []string{"spec.description"},
+					},
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updateResponse).ToNot(BeNil())
+
+				updateObject := updateResponse.GetObject()
+				Expect(updateObject).ToNot(BeNil())
+				Expect(updateObject.GetMetadata().GetTenant()).To(Equal("shared"))
+				Expect(updateObject.GetSpec().GetDescription()).To(Equal("Updated description"))
+			})
+
+			It("Filters objects correctly for user tenant visibility", func() {
+				// Create a few BareMetalInstanceTypes
+				_, err := sharedTenancyServer.Create(ctx, privatev1.BareMetalInstanceTypesCreateRequest_builder{
+					Object: privatev1.BareMetalInstanceType_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "visible-type-1",
+						}.Build(),
+						Spec: privatev1.BareMetalInstanceTypeSpec_builder{
+							Hardware: privatev1.BareMetalHardwareSpec_builder{
+								Cpu: privatev1.BareMetalCPUSpec_builder{
+									Cores:          4,
+									Architecture:   "x86_64",
+									ThreadsPerCore: 2,
+								}.Build(),
+								Memory: privatev1.BareMetalMemorySpec_builder{
+									TotalGb: 16,
+								}.Build(),
+							}.Build(),
+							HostLabelSelector: privatev1.BareMetalLabelSelector_builder{
+								MatchLabels: map[string]string{
+									"visibility": "test1",
+								},
+							}.Build(),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = sharedTenancyServer.Create(ctx, privatev1.BareMetalInstanceTypesCreateRequest_builder{
+					Object: privatev1.BareMetalInstanceType_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "visible-type-2",
+						}.Build(),
+						Spec: privatev1.BareMetalInstanceTypeSpec_builder{
+							Hardware: privatev1.BareMetalHardwareSpec_builder{
+								Cpu: privatev1.BareMetalCPUSpec_builder{
+									Cores:          8,
+									Architecture:   "x86_64",
+									ThreadsPerCore: 2,
+								}.Build(),
+								Memory: privatev1.BareMetalMemorySpec_builder{
+									TotalGb: 32,
+								}.Build(),
+							}.Build(),
+							HostLabelSelector: privatev1.BareMetalLabelSelector_builder{
+								MatchLabels: map[string]string{
+									"visibility": "test2",
+								},
+							}.Build(),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				// List all objects - should see both since they're in user's tenant
+				response, err := sharedTenancyServer.List(ctx, privatev1.BareMetalInstanceTypesListRequest_builder{}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+				Expect(response.GetItems()).To(HaveLen(2))
+
+				// Verify all returned objects have user's tenant
+				for _, item := range response.GetItems() {
+					Expect(item.GetMetadata().GetTenant()).To(Equal("shared"))
+				}
+			})
+
+			It("Does not set owner-reference annotations for standalone resources", func() {
+				// BareMetalInstanceTypes are tenant-scoped catalog resources without parent resources
+				// Therefore, they should not have owner-reference annotations
+				response, err := sharedTenancyServer.Create(ctx, privatev1.BareMetalInstanceTypesCreateRequest_builder{
+					Object: privatev1.BareMetalInstanceType_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "standalone-resource",
+						}.Build(),
+						Spec: privatev1.BareMetalInstanceTypeSpec_builder{
+							Hardware: privatev1.BareMetalHardwareSpec_builder{
+								Cpu: privatev1.BareMetalCPUSpec_builder{
+									Cores:          4,
+									Architecture:   "x86_64",
+									ThreadsPerCore: 2,
+								}.Build(),
+								Memory: privatev1.BareMetalMemorySpec_builder{
+									TotalGb: 16,
+								}.Build(),
+							}.Build(),
+							HostLabelSelector: privatev1.BareMetalLabelSelector_builder{
+								MatchLabels: map[string]string{
+									"test": "standalone",
+								},
+							}.Build(),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+
+				object := response.GetObject()
+				Expect(object).ToNot(BeNil())
+
+				// Verify tenant field is set to user's tenant (this is what we care about for tenant isolation)
+				Expect(object.GetMetadata().GetTenant()).To(Equal("shared"))
+
+				// Verify owner-reference annotation is NOT set (BareMetalInstanceTypes are standalone)
+				annotations := object.GetMetadata().GetAnnotations()
+				if annotations != nil {
+					Expect(annotations).ToNot(HaveKey("osac.openshift.io/owner-reference"))
+				}
+			})
+
+			It("Preserves manually set owner-reference annotations if provided", func() {
+				// While BareMetalInstanceTypes don't automatically set owner-reference,
+				// they should preserve any manually set annotations
+				response, err := sharedTenancyServer.Create(ctx, privatev1.BareMetalInstanceTypesCreateRequest_builder{
+					Object: privatev1.BareMetalInstanceType_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "manual-owner-ref",
+							Annotations: map[string]string{
+								"osac.openshift.io/owner-reference": "manual-parent",
+								"custom.annotation":                 "test-value",
+							},
+						}.Build(),
+						Spec: privatev1.BareMetalInstanceTypeSpec_builder{
+							Hardware: privatev1.BareMetalHardwareSpec_builder{
+								Cpu: privatev1.BareMetalCPUSpec_builder{
+									Cores:          8,
+									Architecture:   "x86_64",
+									ThreadsPerCore: 2,
+								}.Build(),
+								Memory: privatev1.BareMetalMemorySpec_builder{
+									TotalGb: 32,
+								}.Build(),
+							}.Build(),
+							HostLabelSelector: privatev1.BareMetalLabelSelector_builder{
+								MatchLabels: map[string]string{
+									"test": "manual",
+								},
+							}.Build(),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+
+				object := response.GetObject()
+				Expect(object).ToNot(BeNil())
+
+				// Verify tenant field is set to user's tenant
+				Expect(object.GetMetadata().GetTenant()).To(Equal("shared"))
+
+				// Verify manually set annotations are preserved
+				annotations := object.GetMetadata().GetAnnotations()
+				Expect(annotations).ToNot(BeNil())
+				Expect(annotations).To(HaveKeyWithValue("osac.openshift.io/owner-reference", "manual-parent"))
+				Expect(annotations).To(HaveKeyWithValue("custom.annotation", "test-value"))
 			})
 		})
 	})


### PR DESCRIPTION
## [OSAC-2864](https://redhat.atlassian.net/browse/OSAC-2864): Implement tenant isolation for BareMetalInstanceType resources

**Jira:** https://issues.redhat.com/browse/OSAC-2864  
**Story type:** [DEV]

### Summary
Implements tenant isolation for BareMetalInstanceType resources using shared tenancy semantics. BareMetalInstanceTypes are platform-scoped catalog resources that should be globally visible across all tenants, similar to instance type catalogs in cloud providers.

### Changes
- **Auth module**: Added `SharedTenancyLogic` implementation for platform-scoped resources
- **Server configuration**: Updated BareMetalInstanceTypes servers to use SharedTenancyLogic
- **Test updates**: Modified tests to expect 'shared' tenant behavior for catalog resources

### Testing
- **Unit tests:** Added comprehensive test suite for SharedTenancyLogic (5 test cases covering all interface methods)
- **Integration tests:** Updated server tests to validate shared tenant annotation behavior
- **Coverage:** 100% coverage for new SharedTenancyLogic implementation

### Acceptance Criteria
- [ ] AC-1: BareMetalInstanceType resources implement proper tenant isolation patterns
- [ ] AC-2: Resources use 'shared' tenant annotation for global visibility across tenants  
- [ ] AC-3: All tenants can list and access BareMetalInstanceType resources
- [ ] AC-4: Cloud provider admins can create BareMetalInstanceType resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared-tenant handling for bare metal instance types.
  * Platform-scoped resources are assigned to the shared tenant.
  * Shared resources are visible alongside tenants accessible to the current user.
  * Administrators can view resources across all tenants.
  * Users without a tenant now default to the shared tenant.

* **Bug Fixes**
  * Improved tenant isolation and visibility across create, view, update, and list operations.
  * Preserved manually supplied resource annotations without adding automatic owner references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->