### PR TITLE
OSAC-2964: Openbao it setup

### DIFF
--- a/fulfillment-service/charts/service/templates/grpc-server/deployment.yaml
+++ b/fulfillment-service/charts/service/templates/grpc-server/deployment.yaml
@@ -131,6 +131,11 @@ spec:
         - --token-encryption-crt=/etc/fulfillment-token-encryption/tls.crt
         - --token-issuer={{ include "fulfillment-api.tokenIssuerUrl" . }}
         - --metrics-listener-address=0.0.0.0:8002
+        {{ if .Values.vault.endpoint }}
+        - --vault-endpoint={{ .Values.vault.endpoint }}
+        - --vault-namespace={{ .Values.vault.namespace }}
+        - --vault-kv-mount-path={{ .Values.vault.kvMountPath }}
+        {{ end }}
         ports:
         - name: grpc
           containerPort: 8000

--- a/fulfillment-service/charts/service/values.yaml
+++ b/fulfillment-service/charts/service/values.yaml
@@ -183,3 +183,17 @@ idp:
   #
   # This parameter is mandatory.
   credentials:
+
+# Vault-compatible secret store configuration.
+# When the endpoint is set, the service verifies connectivity to the vault at startup.
+# When empty, Vault integration is disabled.
+vault:
+
+  # Vault API endpoint URL (e.g., http://openbao.openbao.svc.cluster.local:8200).
+  endpoint: ""
+
+  # Parent namespace path within the Vault-compatible store.
+  namespace: osac
+
+  # KV v2 secret engine mount path within tenant namespaces.
+  kvMountPath: secret

--- a/fulfillment-service/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -54,6 +54,7 @@ import (
 	"github.com/osac-project/osac/fulfillment-service/internal/servers"
 	shtdwn "github.com/osac-project/osac/fulfillment-service/internal/shutdown"
 	"github.com/osac-project/osac/fulfillment-service/internal/validation"
+	"github.com/osac-project/osac/fulfillment-service/internal/vault"
 )
 
 // userIDResolver implements auth.UserIDResolver by querying the users DAO.
@@ -182,6 +183,24 @@ func Cmd() *cobra.Command {
 		},
 		emergencyServiceAccountsFlagHelp,
 	)
+	flags.StringVar(
+		&runner.args.vaultEndpoint,
+		"vault-endpoint",
+		"",
+		vaultEndpointFlagHelp,
+	)
+	flags.StringVar(
+		&runner.args.vaultNamespace,
+		"vault-namespace",
+		"osac",
+		vaultNamespaceFlagHelp,
+	)
+	flags.StringVar(
+		&runner.args.vaultKVMountPath,
+		"vault-kv-mount-path",
+		"secret",
+		vaultKVMountPathFlagHelp,
+	)
 	network.AddGrpcKeepaliveFlags(flags)
 	return command
 }
@@ -201,6 +220,9 @@ type runnerContext struct {
 		tokenEncryptionCrt       string
 		tokenIssuer              string
 		emergencyServiceAccounts []string
+		vaultEndpoint            string
+		vaultNamespace           string
+		vaultKVMountPath         string
 	}
 }
 
@@ -1091,6 +1113,25 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 	}
 	privatev1.RegisterStorageBackendsServer(grpcServer, privateStorageBackendsServer)
 
+	// Perform vault health check if configured:
+	if c.args.vaultEndpoint != "" {
+		c.logger.InfoContext(ctx, "Performing vault health check")
+		healthChecker, healthErr := vault.NewHealthChecker().
+			SetLogger(c.logger).
+			SetAddress(c.args.vaultEndpoint).
+			SetCaPool(caPool).
+			Build()
+		if healthErr != nil {
+			c.logger.ErrorContext(ctx, "Failed to create Vault health checker",
+				slog.String("error", healthErr.Error()),
+			)
+		} else if healthErr = healthChecker.Check(ctx); healthErr != nil {
+			c.logger.ErrorContext(ctx, "Vault health check failed",
+				slog.String("error", healthErr.Error()),
+			)
+		}
+	}
+
 	// Create the private secrets server:
 	c.logger.InfoContext(ctx, "Creating private secrets server")
 	privateSecretsServer, err := servers.NewPrivateSecretsServer().
@@ -1695,4 +1736,17 @@ const emergencyServiceAccountsFlagHelp = `
 _NAMES_ - Comma-separated list of Kubernetes service account names that are allowed to access the private API with
 administrator permissions. These are intended only for emergency situations, for example when the regular authentication
 mechanisms are not working. The service accounts are expected to be in the namespace where the service is deployed.
+`
+
+const vaultEndpointFlagHelp = `
+_URL_ - Vault API endpoint URL.
+`
+
+const vaultNamespaceFlagHelp = `
+_NAMESPACE_ - Parent namespace path within the Vault-compatible
+store. Tenant namespaces are created as children of this namespace.
+`
+
+const vaultKVMountPathFlagHelp = `
+_PATH_ - KV v2 secret engine mount path within tenant namespaces.
 `

--- a/fulfillment-service/internal/vault/vault_health.go
+++ b/fulfillment-service/internal/vault/vault_health.go
@@ -1,0 +1,107 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package vault
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	vaultapi "github.com/hashicorp/vault/api"
+)
+
+type HealthCheckerBuilder struct {
+	logger  *slog.Logger
+	address string
+	caPool  *x509.CertPool
+}
+
+type HealthChecker struct {
+	logger *slog.Logger
+	client *vaultapi.Client
+}
+
+func NewHealthChecker() *HealthCheckerBuilder {
+	return &HealthCheckerBuilder{}
+}
+
+func (b *HealthCheckerBuilder) SetLogger(value *slog.Logger) *HealthCheckerBuilder {
+	b.logger = value
+	return b
+}
+
+func (b *HealthCheckerBuilder) SetAddress(value string) *HealthCheckerBuilder {
+	b.address = value
+	return b
+}
+
+func (b *HealthCheckerBuilder) SetCaPool(value *x509.CertPool) *HealthCheckerBuilder {
+	b.caPool = value
+	return b
+}
+
+func (b *HealthCheckerBuilder) Build() (result *HealthChecker, err error) {
+	if b.logger == nil {
+		err = errors.New("logger is mandatory")
+		return
+	}
+	if b.address == "" {
+		err = errors.New("address is mandatory")
+		return
+	}
+	config := vaultapi.DefaultConfig()
+	config.Address = b.address
+
+	if b.caPool != nil {
+		transport, ok := config.HttpClient.Transport.(*http.Transport)
+		if !ok {
+			err = errors.New("unexpected transport type from vault default config")
+			return
+		}
+		cloned := transport.Clone()
+		cloned.TLSClientConfig.RootCAs = b.caPool
+		config.HttpClient.Transport = cloned
+	}
+
+	client, clientErr := vaultapi.NewClient(config)
+	if clientErr != nil {
+		err = fmt.Errorf("failed to create vault client: %w", clientErr)
+		return
+	}
+	result = &HealthChecker{
+		logger: b.logger,
+		client: client,
+	}
+	return
+}
+
+func (c *HealthChecker) Check(ctx context.Context) error {
+	health, err := c.client.Sys().HealthWithContext(ctx)
+	if err != nil {
+		return fmt.Errorf("vault health request failed: %w", err)
+	}
+	if !health.Initialized {
+		return fmt.Errorf("vault is not initialized")
+	}
+	if health.Sealed {
+		return fmt.Errorf("vault is sealed")
+	}
+	c.logger.InfoContext(ctx, "Vault health check passed",
+		slog.String("version", health.Version),
+	)
+	return nil
+}

--- a/fulfillment-service/it/charts/README.md
+++ b/fulfillment-service/it/charts/README.md
@@ -12,4 +12,5 @@ For production PostgreSQL, deploy an in-cluster database via an operator
 |-------|---------|
 | `postgres/` | Single-replica PostgreSQL with TLS for integration tests |
 | `keycloak/` | Keycloak instance for integration tests |
+| `openbao/` | OpenBao secret store (dev mode) for integration tests |
 | `prometheus/` | Prometheus monitoring stack for integration tests |

--- a/fulfillment-service/it/charts/openbao/Chart.yaml
+++ b/fulfillment-service/it/charts/openbao/Chart.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2026 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+apiVersion: v2
+name: openbao
+description: A Helm chart for OpenBao for use in OSAC development and testing environments (not for production)
+type: application
+version: 0.0.0
+appVersion: "2.5"

--- a/fulfillment-service/it/charts/openbao/README.md
+++ b/fulfillment-service/it/charts/openbao/README.md
@@ -1,0 +1,16 @@
+# OpenBao integration test chart
+
+Deploys [OpenBao](https://openbao.org) in dev mode as a Vault-compatible secret store for
+integration testing. Dev mode runs auto-unsealed with in-memory storage and a configurable root
+token.
+
+This chart is for **integration testing only** and must not be used for production installations.
+
+## Configuration
+
+| Value | Description | Default |
+|-------|-------------|---------|
+| `images.openbao` | Container image | `ghcr.io/openbao/openbao:2.5` |
+| `dev.rootToken` | Root token for authentication | (must be set) |
+| `dev.listenAddress` | API listen address | `0.0.0.0:8200` |
+| `caBundle.configMap` | ConfigMap with trusted CA bundle (`bundle.pem` key) | (optional) |

--- a/fulfillment-service/it/charts/openbao/templates/pod.yaml
+++ b/fulfillment-service/it/charts/openbao/templates/pod.yaml
@@ -1,0 +1,64 @@
+{{/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: openbao
+  labels:
+    app: openbao
+spec:
+  {{ if .Values.caBundle.configMap }}
+  volumes:
+  - name: ca-bundle
+    configMap:
+      name: {{ .Values.caBundle.configMap }}
+  {{ end }}
+  containers:
+  - name: server
+    image: "{{ .Values.images.openbao }}"
+    imagePullPolicy: IfNotPresent
+    command:
+    - bao
+    - server
+    - -dev
+    - -dev-root-token-id={{ required "dev.rootToken must be set" .Values.dev.rootToken }}
+    - -dev-listen-address={{ .Values.dev.listenAddress }}
+    {{ if .Values.caBundle.configMap }}
+    env:
+    - name: BAO_CACERT
+      value: /etc/openbao/ca/bundle.pem
+    volumeMounts:
+    - name: ca-bundle
+      mountPath: /etc/openbao/ca
+      readOnly: true
+    {{ end }}
+    ports:
+    - name: api
+      protocol: TCP
+      containerPort: 8200
+    readinessProbe:
+      httpGet:
+        path: /v1/sys/health
+        port: api
+        scheme: HTTP
+      initialDelaySeconds: 5
+      periodSeconds: 5
+    livenessProbe:
+      httpGet:
+        path: /v1/sys/health
+        port: api
+        scheme: HTTP
+      initialDelaySeconds: 10
+      periodSeconds: 10

--- a/fulfillment-service/it/charts/openbao/templates/service.yaml
+++ b/fulfillment-service/it/charts/openbao/templates/service.yaml
@@ -1,0 +1,25 @@
+{{/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+*/}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: openbao
+spec:
+  selector:
+    app: openbao
+  ports:
+  - name: api
+    port: 8200
+    targetPort: api

--- a/fulfillment-service/it/charts/openbao/values.yaml
+++ b/fulfillment-service/it/charts/openbao/values.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2026 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+# Image configuration:
+images:
+  openbao: ghcr.io/openbao/openbao:2.6.1
+
+# Dev mode configuration:
+dev:
+  # Root token for authenticating to OpenBao in dev mode. Must be set.
+  rootToken:
+  # Listen address. Must be 0.0.0.0 for in-cluster access (dev mode defaults to 127.0.0.1).
+  listenAddress: "0.0.0.0:8200"
+
+# Trusted CA certificates bundle used by OpenBao to verify TLS connections to other services (e.g., Keycloak OIDC
+# discovery). It must be the name of a ConfigMap that contains trusted CA certificates in PEM format under the key
+# `bundle.pem`. If not set, OpenBao uses the system trust store.
+caBundle:
+  configMap:

--- a/fulfillment-service/it/it_tool.go
+++ b/fulfillment-service/it/it_tool.go
@@ -367,6 +367,18 @@ func (t *Tool) Setup(ctx context.Context) error {
 		return err
 	}
 
+	// Install OpenBao:
+	err = t.deployOpenBao(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Configure OpenBao (create parent namespace):
+	err = t.configureOpenBao(ctx)
+	if err != nil {
+		return err
+	}
+
 	// Create the service database resources:
 	err = t.createServiceDatabaseResources(ctx)
 	if err != nil {
@@ -1385,6 +1397,93 @@ func (t *Tool) deployPostgres(ctx context.Context) error {
 	return nil
 }
 
+// deployOpenBao installs the OpenBao chart in dev mode as a Vault-compatible secret store.
+func (t *Tool) deployOpenBao(ctx context.Context) error {
+	t.logger.DebugContext(ctx, "Installing OpenBao chart")
+
+	valuesData := map[string]any{
+		"dev": map[string]any{
+			"rootToken":     t.secret,
+			"listenAddress": "0.0.0.0:8200",
+		},
+		"caBundle": map[string]any{
+			"configMap": "ca-bundle",
+		},
+	}
+	valuesBytes, err := yaml.Marshal(valuesData)
+	if err != nil {
+		return fmt.Errorf("failed to marshal OpenBao values to YAML: %w", err)
+	}
+
+	valuesFile := filepath.Join(t.tmpDir, "openbao-values.yaml")
+	err = os.WriteFile(valuesFile, valuesBytes, 0400)
+	if err != nil {
+		return fmt.Errorf("failed to write OpenBao values to file: %w", err)
+	}
+
+	installCmd, err := testing.NewCommand().
+		SetLogger(t.logger).
+		SetHome(t.projectDir).
+		SetDir(t.projectDir).
+		SetName(helmCmd).
+		SetArgs(
+			"upgrade",
+			"--install",
+			"openbao",
+			"it/charts/openbao",
+			"--kubeconfig", t.kcFile,
+			"--namespace", "openbao",
+			"--create-namespace",
+			"--values", valuesFile,
+			"--wait",
+		).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create OpenBao install command: %w", err)
+	}
+	if err = installCmd.Execute(ctx); err != nil {
+		return fmt.Errorf("failed to install OpenBao: %w", err)
+	}
+	return nil
+}
+
+// configureOpenBao sets up the parent namespace in the OpenBao secret store using kubectl exec to run the bao CLI
+// inside the pod.
+func (t *Tool) configureOpenBao(ctx context.Context) error {
+	t.logger.DebugContext(ctx, "Configuring OpenBao")
+
+	cmd, err := testing.NewCommand().
+		SetLogger(t.logger).
+		SetHome(t.projectDir).
+		SetDir(t.projectDir).
+		SetName(kubectlCmd).
+		SetArgs(
+			"exec", "openbao",
+			"--namespace", "openbao",
+			"--kubeconfig", t.kcFile,
+			"--",
+			"env",
+			"BAO_ADDR=http://127.0.0.1:8200",
+			fmt.Sprintf("BAO_TOKEN=%s", t.secret),
+			"bao", "namespace", "create", "osac",
+		).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create command to configure OpenBao: %w", err)
+	}
+	stdout, _, err := cmd.Evaluate(ctx)
+	if err != nil {
+		if strings.Contains(string(stdout), "already exists") {
+			t.logger.DebugContext(ctx, "OpenBao osac namespace already exists")
+		} else {
+			return fmt.Errorf("failed to create osac namespace in OpenBao: %w", err)
+		}
+	}
+
+	t.logger.InfoContext(ctx, "Configured OpenBao with parent namespace")
+	return nil
+}
+
 func (t *Tool) deployService(ctx context.Context, imageRef string) error {
 	// Prepare the values:
 	externalHostname, _, err := net.SplitHostPort(externalServiceAddr)
@@ -1495,6 +1594,11 @@ func (t *Tool) deployService(ctx context.Context, imageRef string) error {
 					},
 				},
 			},
+		},
+		"vault": map[string]any{
+			"endpoint":    fmt.Sprintf("http://%s", openbaoAddr),
+			"namespace":   "osac",
+			"kvMountPath": "secret",
 		},
 	}
 	valuesBytes, err := yaml.Marshal(valuesData)
@@ -2125,6 +2229,7 @@ func (t *Tool) waitForRestGatewayReady(ctx context.Context) error {
 			)
 			return err
 		}
+		_, _ = io.Copy(io.Discard, response.Body)
 		response.Body.Close()
 		if response.StatusCode != http.StatusOK {
 			err = fmt.Errorf("REST gateway returned status %d", response.StatusCode)
@@ -2506,6 +2611,7 @@ const (
 	keycloakAddr        = "keycloak.keycloak.svc.cluster.local:8000"
 	externalServiceAddr = "fulfillment-api.osac.svc.cluster.local:8000"
 	internalServiceAddr = "fulfillment-internal-api.osac.svc.cluster.local:8000"
+	openbaoAddr         = "openbao.openbao.svc.cluster.local:8200"
 )
 
 // Names of the database-related Kubernetes resources.

--- a/kind-dev/setup.sh
+++ b/kind-dev/setup.sh
@@ -737,6 +737,67 @@ EOF
   log "External TLSRoutes created"
 }
 
+install_openbao() {
+  local chart_dir="${REPO_ROOT}/fulfillment-service/it/charts/openbao"
+  if [[ ! -d "$chart_dir" ]]; then
+    err "OpenBao chart not found at ${chart_dir}"
+    return 1
+  fi
+
+  log "Installing OpenBao..."
+  helm upgrade --install openbao \
+    "${chart_dir}" \
+    --namespace openbao \
+    --create-namespace \
+    --set "dev.rootToken=dev-root-token" \
+    --set "caBundle.configMap=ca-bundle" \
+    --wait --timeout 2m
+
+  log "OpenBao installed"
+}
+
+configure_openbao() {
+  log "Configuring OpenBao (creating parent namespace)..."
+
+  local openbao_token="dev-root-token"
+
+  kubectl port-forward svc/openbao 8200:8200 -n openbao &
+  local pf_pid=$!
+
+  cleanup_port_forward() {
+    kill "${pf_pid}" 2>/dev/null || true
+    wait "${pf_pid}" 2>/dev/null || true
+  }
+
+  local attempts=0
+  while ! curl -sf http://localhost:8200/v1/sys/health >/dev/null 2>&1; do
+    attempts=$((attempts + 1))
+    if [[ $attempts -ge 30 ]]; then
+      err "OpenBao port-forward did not become reachable"
+      cleanup_port_forward
+      return 1
+    fi
+    sleep 1
+  done
+
+  local status
+  status=$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+    http://localhost:8200/v1/sys/namespaces/osac \
+    -H "X-Vault-Token: ${openbao_token}")
+
+  case "$status" in
+    200|204) log "Created 'osac' namespace in OpenBao" ;;
+    400)     log "OpenBao 'osac' namespace already exists (idempotent)" ;;
+    *)       err "Failed to create 'osac' namespace in OpenBao (HTTP ${status})"
+             cleanup_port_forward
+             return 1 ;;
+  esac
+
+  cleanup_port_forward
+
+  log "OpenBao configured"
+}
+
 create_controller_credentials() {
   log "Creating controller credentials..."
 
@@ -1511,6 +1572,8 @@ main() {
   install_postgres
   create_database_resources
   install_keycloak
+  install_openbao
+  configure_openbao
   create_controller_credentials
 
   if [[ "$SKIP_OSAC" == "true" ]]; then

--- a/kind-dev/teardown.sh
+++ b/kind-dev/teardown.sh
@@ -34,6 +34,7 @@ if [[ "$KEEP_DATA" == "true" ]]; then
   export KUBECONFIG="${KC_FILE}"
 
   helm uninstall osac -n osac 2>/dev/null || true
+  helm uninstall openbao -n openbao 2>/dev/null || true
   helm uninstall keycloak -n keycloak 2>/dev/null || true
   helm uninstall postgres -n osac 2>/dev/null || true
 

--- a/kind-dev/values-kind.yaml
+++ b/kind-dev/values-kind.yaml
@@ -92,6 +92,10 @@ service:
               param: sslrootcert
   log:
     level: debug
+  vault:
+    endpoint: "http://openbao.openbao.svc.cluster.local:8200"
+    namespace: osac
+    kvMountPath: secret
 
 # --- AAP (disabled for kind) ---
 aap:


### PR DESCRIPTION
Adds an OpenBao (aka Vault compatible store) installation to our IT and Kind-dev installation options.

Please note that the current implementation of the fulfillment-service tries a health check to the (unauthenticated) health endpoint for the Vault store.  So no auth is setup and the health check is optional, this PR is really just about the IT / dev side of things to get things up and running and a fully featured e2e setup of actually storing the secrets will be another PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added optional Vault/OpenBao-backed secret storage for the fulfillment service.
- Added startup health checks with trusted CA support and detection of unavailable or sealed secret stores.
- Added OpenBao setup for local development and integration testing, including namespaces and KV storage.

## Documentation
- Added configuration guidance for OpenBao and secret-store settings.

## Bug Fixes
- Improved readiness checks and development environment cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->