### PR TITLE
OSAC-3611: replace release_image with version_name in cluster templates

### DIFF
--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/meta/osac.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/meta/osac.yaml
@@ -14,7 +14,7 @@ default_node_request:
 allowed_resource_classes: []
 
 spec_defaults:
-  release_image: "quay.io/openshift-release-dev/ocp-release:4.20.0-multi"
+  version_name: "4.20.0"
 
 parameters:
   - name: enable_maas

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_small_nico/meta/osac.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_small_nico/meta/osac.yaml
@@ -20,7 +20,7 @@ default_node_request:
 allowed_resource_classes: []
 
 spec_defaults:
-  release_image: "quay.io/openshift-release-dev/ocp-release:4.20.0-multi"
+  version_name: "4.20.0"
 
 parameters:
   - name: pull_secret

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_ci_small/meta/osac.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_ci_small/meta/osac.yaml
@@ -12,7 +12,7 @@ default_node_request:
 allowed_resource_classes: []
 
 spec_defaults:
-  release_image: "quay.io/openshift-release-dev/ocp-release:4.17.0-multi"
+  version_name: "4.17.0"
 
 parameters:
   - name: pull_secret

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_small/meta/osac.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_small/meta/osac.yaml
@@ -12,4 +12,4 @@ default_node_request:
 allowed_resource_classes: []
 
 spec_defaults:
-  release_image: "quay.io/openshift-release-dev/ocp-release:4.22.0-multi"
+  version_name: "4.22.0"


### PR DESCRIPTION
## Summary

PR #84 ([OSAC-2162](https://redhat.atlassian.net/browse/OSAC-2162)) removed `release_image` from `ClusterTemplateSpecDefaults` proto and replaced it with `version_name`. PR #103 ([OSAC-692](https://redhat.atlassian.net/browse/OSAC-692)) added `release_image` to `spec_defaults` in 4 cluster templates, unaware of the removal. Both PRs passed CI independently but crossed in flight — all E2E CI broken on main since 2026-08-04 16:57 UTC.

Replaces `spec_defaults.release_image` with `spec_defaults.version_name` in all 4 affected templates, extracting the semver version from the release image URL.

## Affected templates

- `ocp_small`: `4.22.0`
- `ocp_ci_small`: `4.17.0`
- `ocp_4_20_small_nico`: `4.20.0`
- `ocp_4_20_ai_maas`: `4.20.0`

## Test plan

- [ ] `publish-templates` AAP hook job succeeds (currently fails on every E2E run)
- [ ] E2E vmaas-full-install passes the install phase

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated default OpenShift versions for AI and small cluster deployments.
  * AI MaaS and small Nico deployments now default to OpenShift 4.20.0.
  * CI small deployments now default to OpenShift 4.17.0.
  * Standard small deployments now default to OpenShift 4.22.0.
  * Cluster setup now selects releases by version, simplifying and standardizing deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->