### PR TITLE
OSAC-3500: Make osac CLI help colorless by default

### DIFF
--- a/fulfillment-service/internal/cmd/cli/help/help_setup.go
+++ b/fulfillment-service/internal/cmd/cli/help/help_setup.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"embed"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -35,6 +36,26 @@ import (
 //go:embed templates
 var templatesFS embed.FS
 
+const colorFlag = "color"
+
+func colorEnabled(c *cobra.Command) bool {
+	// NO_COLOR always wins (https://no-color.org/), including over FORCE_COLOR and --color.
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+
+	flags := c.Root().PersistentFlags()
+	if flags.Changed(colorFlag) {
+		enabled, err := flags.GetBool(colorFlag)
+		if err == nil {
+			return enabled
+		}
+	}
+
+	// FORCE_COLOR enables color for environment-based callers when the flag is not set.
+	return os.Getenv("FORCE_COLOR") != ""
+}
+
 // Setup configures the given command and all its subcommands to render their help output as styled Markdown.
 func Setup(cmd *cobra.Command) {
 	// Create a silent logger for the templating engine, as help rendering happens before the persistent pre-run
@@ -52,19 +73,22 @@ func Setup(cmd *cobra.Command) {
 		return
 	}
 
+	cmd.PersistentFlags().Bool(
+		colorFlag,
+		false,
+		"Enable colored help output. NO_COLOR and --color=false override FORCE_COLOR.",
+	)
+
 	// Set the help function for the command and all its subcommands. The renderer is created each time the
 	// help is displayed, so that it can adapt to the current terminal width and color capabilities.
 	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
+		// If the output is a terminal, we want to adjust the width of the terminal, but never more than the
+		// maximun width that we consider readable:
 		out := c.OutOrStdout()
-
-		// Determine if the output is a terminal and get its size:
 		var width int
-		isTTY := false
-		file, ok := out.(*os.File)
-		if ok {
+		if file, ok := out.(*os.File); ok {
 			fd := int(file.Fd())
 			if term.IsTerminal(fd) {
-				isTTY = true
 				width, _, err = term.GetSize(fd)
 				if err != nil {
 					c.PrintErrln("Error getting terminal size:", err)
@@ -74,35 +98,34 @@ func Setup(cmd *cobra.Command) {
 		}
 		width = min(width, maxReadableWidth)
 
-		// Select the style based on terminal capabilities. Use colored styles only when the output is
-		// a terminal and the NO_COLOR environment variable is not set (https://no-color.org/).
-		_, noColor := os.LookupEnv("NO_COLOR")
+		// Color is opt-in by default. Enable with --color, FORCE_COLOR, or both; NO_COLOR always wins.
+		useColor := colorEnabled(c)
+
+		// Select the style: detect terminal background and use a colored style only when color is requested,
+		// otherwise use a plain ASCII style that still renders Markdown structure (headings, code spans, etc.)
+		// without ANSI color codes.
 		var style ansi.StyleConfig
-		if isTTY && !noColor {
+		if useColor {
 			if lipgloss.HasDarkBackground(os.Stdin, os.Stdout) {
 				style = styles.DarkStyleConfig
 			} else {
 				style = styles.LightStyleConfig
 			}
 		} else {
-			style = styles.NoTTYStyleConfig
+			style = styles.ASCIIStyleConfig
 		}
 
-		// Regardless of the style, we want to remove the default document margin and leading newline,
-		// so the output is flush with the left edge of the terminal.
+		// Remove the default document margin and leading newline, so the output is flush with the left edge
+		// of the terminal. Also remove heading prefixes and code background/prefix/suffix styling.
 		zero := new(uint)
 		style.Document.Margin = zero
 		style.Document.BlockPrefix = ""
-
-		// We don't want to display the heading prefixes:
+		style.H1.Prefix = ""
 		style.H2.Prefix = ""
 		style.H3.Prefix = ""
 		style.H4.Prefix = ""
 		style.H5.Prefix = ""
 		style.H6.Prefix = ""
-
-		// For code inside paragraphs, we don't want to change the background color or add prefixes
-		// and suffixes:
 		style.Code.BackgroundColor = nil
 		style.Code.Prefix = ""
 		style.Code.Suffix = ""
@@ -130,7 +153,11 @@ func Setup(cmd *cobra.Command) {
 			c.Print(buffer.String())
 			return
 		}
-		_, err = lipgloss.Fprint(out, text)
+		if useColor {
+			_, err = fmt.Fprint(out, text)
+		} else {
+			_, err = lipgloss.Fprint(out, text)
+		}
 		if err != nil {
 			c.PrintErrln("Error writing help output:", err)
 			return

--- a/fulfillment-service/internal/cmd/cli/help/help_setup_test.go
+++ b/fulfillment-service/internal/cmd/cli/help/help_setup_test.go
@@ -27,6 +27,30 @@ import (
 // ansiPattern matches ANSI escape sequences (CSI sequences for colors, styles, etc.).
 var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
 
+// saveAndSetEnv sets an environment variable and registers cleanup to restore its original state.
+func saveAndSetEnv(name, value string) {
+	origVal, wasSet := os.LookupEnv(name)
+	Expect(os.Setenv(name, value)).To(Succeed())
+	DeferCleanup(func() {
+		if wasSet {
+			os.Setenv(name, origVal)
+		} else {
+			os.Unsetenv(name)
+		}
+	})
+}
+
+// saveAndUnsetEnv unsets an environment variable and registers cleanup to restore its original state.
+func saveAndUnsetEnv(name string) {
+	origVal, wasSet := os.LookupEnv(name)
+	os.Unsetenv(name)
+	DeferCleanup(func() {
+		if wasSet {
+			os.Setenv(name, origVal)
+		}
+	})
+}
+
 func newTestCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "test",
@@ -53,6 +77,18 @@ var _ = Describe("Help output", func() {
 	)
 
 	BeforeEach(func() {
+		for _, name := range []string{"NO_COLOR", "FORCE_COLOR"} {
+			origVal, wasSet := os.LookupEnv(name)
+			os.Unsetenv(name)
+			DeferCleanup(func() {
+				if wasSet {
+					os.Setenv(name, origVal)
+				} else {
+					os.Unsetenv(name)
+				}
+			})
+		}
+
 		cmd = newTestCommand()
 		Setup(cmd)
 		output = &bytes.Buffer{}
@@ -95,6 +131,80 @@ var _ = Describe("Help output", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ansiPattern.FindString(output.String())).To(BeEmpty(),
 			"subcommand help output should not contain ANSI escape codes when writing to a non-TTY")
+	})
+
+	It("Emits ANSI escape codes when FORCE_COLOR is set", func() {
+		saveAndSetEnv("FORCE_COLOR", "1")
+		saveAndUnsetEnv("NO_COLOR")
+
+		cmd.SetArgs([]string{"--help"})
+		err := cmd.Execute()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(output.String()).ToNot(BeEmpty())
+		Expect(ansiPattern.FindString(output.String())).ToNot(BeEmpty(),
+			"help output should contain ANSI escape codes when FORCE_COLOR is set")
+	})
+
+	It("Does not emit ANSI escape codes when both FORCE_COLOR and NO_COLOR are set", func() {
+		saveAndSetEnv("FORCE_COLOR", "1")
+		saveAndSetEnv("NO_COLOR", "1")
+
+		cmd.SetArgs([]string{"--help"})
+		err := cmd.Execute()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(output.String()).ToNot(BeEmpty())
+		Expect(ansiPattern.FindString(output.String())).To(BeEmpty(),
+			"help output should not contain ANSI escape codes when NO_COLOR overrides FORCE_COLOR")
+	})
+
+	It("Emits ANSI escape codes when --color is set", func() {
+		cmd.SetArgs([]string{"--color", "--help"})
+		err := cmd.Execute()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(output.String()).ToNot(BeEmpty())
+		Expect(ansiPattern.FindString(output.String())).ToNot(BeEmpty(),
+			"help output should contain ANSI escape codes when --color is set")
+	})
+
+	It("Does not include heading prefixes in plain output", func() {
+		cmd.SetArgs([]string{"--help"})
+		err := cmd.Execute()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(output.String()).ToNot(HavePrefix("# "),
+			"help output should not contain Markdown heading prefix in plain mode")
+	})
+
+	It("Does not emit ANSI escape codes when --color=false", func() {
+		cmd.SetArgs([]string{"--color=false", "--help"})
+		err := cmd.Execute()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(output.String()).ToNot(BeEmpty())
+		Expect(ansiPattern.FindString(output.String())).To(BeEmpty(),
+			"help output should not contain ANSI escape codes when --color=false")
+	})
+
+	It("Does not emit ANSI escape codes when --color=false overrides FORCE_COLOR", func() {
+		saveAndSetEnv("FORCE_COLOR", "1")
+		saveAndUnsetEnv("NO_COLOR")
+
+		cmd.SetArgs([]string{"--color=false", "--help"})
+		err := cmd.Execute()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(output.String()).ToNot(BeEmpty())
+		Expect(ansiPattern.FindString(output.String())).To(BeEmpty(),
+			"help output should not contain ANSI escape codes when --color=false overrides FORCE_COLOR")
+	})
+
+	It("Does not emit ANSI escape codes when NO_COLOR overrides --color", func() {
+		saveAndSetEnv("NO_COLOR", "1")
+		saveAndUnsetEnv("FORCE_COLOR")
+
+		cmd.SetArgs([]string{"--color", "--help"})
+		err := cmd.Execute()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(output.String()).ToNot(BeEmpty())
+		Expect(ansiPattern.FindString(output.String())).To(BeEmpty(),
+			"help output should not contain ANSI escape codes when NO_COLOR overrides --color")
 	})
 })
 


### PR DESCRIPTION
    Color is now opt-in: default rendering uses a plain ASCII style
    regardless of terminal type. Add --color=yes|true to enable styled output;
    
    Clear all heading prefixes (H1-H6) so plain-mode output does not show
    raw Markdown syntax. Defer terminal background detection until color
    is actually enabled. Use fmt.Fprint for colored output and
    lipgloss.Fprint for plain output to avoid leaking ANSI codes.
    
    Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
    Signed-off-by: Alexander Chuzhoy <achuzhoy@redhat.com>
