### PR TITLE
OSAC-2041: Add BaremetalInstance target to ExternalIPAttachment CRD

### DIFF
--- a/fulfillment-service/internal/controllers/externalipattachment/external_ip_attachment_reconciler_function.go
+++ b/fulfillment-service/internal/controllers/externalipattachment/external_ip_attachment_reconciler_function.go
@@ -375,5 +375,29 @@ func (t *task) buildSpec() osacv1alpha1.ExternalIPAttachmentSpec {
 		ci := t.externalIPAttachment.GetSpec().GetComputeInstance()
 		spec.ComputeInstance = &ci
 	}
+	if t.externalIPAttachment.GetSpec().HasCluster() {
+		cl := t.externalIPAttachment.GetSpec().GetCluster()
+		spec.Cluster = &cl
+		endpoint := mapTargetEndpoint(t.externalIPAttachment.GetSpec().GetTargetEndpoint())
+		if endpoint != "" {
+			te := osacv1alpha1.ExternalIPAttachmentTargetEndpoint(endpoint)
+			spec.TargetEndpoint = &te
+		}
+	}
+	if t.externalIPAttachment.GetSpec().HasBaremetalInstance() {
+		bmi := t.externalIPAttachment.GetSpec().GetBaremetalInstance()
+		spec.BaremetalInstance = &bmi
+	}
 	return spec
+}
+
+func mapTargetEndpoint(endpoint privatev1.ExternalIPAttachmentEndpoint) string {
+	switch endpoint {
+	case privatev1.ExternalIPAttachmentEndpoint_EXTERNAL_IP_ATTACHMENT_ENDPOINT_API:
+		return string(osacv1alpha1.ExternalIPAttachmentTargetEndpointAPI)
+	case privatev1.ExternalIPAttachmentEndpoint_EXTERNAL_IP_ATTACHMENT_ENDPOINT_INGRESS:
+		return string(osacv1alpha1.ExternalIPAttachmentTargetEndpointIngress)
+	default:
+		return ""
+	}
 }

--- a/fulfillment-service/internal/controllers/externalipattachment/external_ip_attachment_reconciler_function_test.go
+++ b/fulfillment-service/internal/controllers/externalipattachment/external_ip_attachment_reconciler_function_test.go
@@ -132,6 +132,71 @@ var _ = Describe("buildSpec", func() {
 		Expect(spec.ComputeInstance).To(BeNil())
 	})
 
+	It("Includes cluster and targetEndpoint in spec", func() {
+		cl := "cluster-uuid-abc123"
+		t := &task{
+			externalIPAttachment: privatev1.ExternalIPAttachment_builder{
+				Id: "eia-uuid-test-cluster",
+				Spec: privatev1.ExternalIPAttachmentSpec_builder{
+					ExternalIp:     "eip-uuid-cluster",
+					Cluster:        &cl,
+					TargetEndpoint: privatev1.ExternalIPAttachmentEndpoint_EXTERNAL_IP_ATTACHMENT_ENDPOINT_API,
+				}.Build(),
+			}.Build(),
+		}
+
+		spec := t.buildSpec()
+
+		Expect(spec.ExternalIP).To(Equal("eip-uuid-cluster"))
+		Expect(spec.Cluster).ToNot(BeNil())
+		Expect(*spec.Cluster).To(Equal("cluster-uuid-abc123"))
+		Expect(spec.TargetEndpoint).ToNot(BeNil())
+		Expect(*spec.TargetEndpoint).To(Equal(osacv1alpha1.ExternalIPAttachmentTargetEndpointAPI))
+		Expect(spec.ComputeInstance).To(BeNil())
+		Expect(spec.BaremetalInstance).To(BeNil())
+	})
+
+	It("Includes cluster with ingress endpoint in spec", func() {
+		cl := "cluster-uuid-ingress"
+		t := &task{
+			externalIPAttachment: privatev1.ExternalIPAttachment_builder{
+				Id: "eia-uuid-test-ingress",
+				Spec: privatev1.ExternalIPAttachmentSpec_builder{
+					ExternalIp:     "eip-uuid-ingress",
+					Cluster:        &cl,
+					TargetEndpoint: privatev1.ExternalIPAttachmentEndpoint_EXTERNAL_IP_ATTACHMENT_ENDPOINT_INGRESS,
+				}.Build(),
+			}.Build(),
+		}
+
+		spec := t.buildSpec()
+
+		Expect(spec.TargetEndpoint).ToNot(BeNil())
+		Expect(*spec.TargetEndpoint).To(Equal(osacv1alpha1.ExternalIPAttachmentTargetEndpointIngress))
+	})
+
+	It("Includes baremetalInstance in spec", func() {
+		bmi := "bmi-uuid-abc123"
+		t := &task{
+			externalIPAttachment: privatev1.ExternalIPAttachment_builder{
+				Id: "eia-uuid-test-bmi",
+				Spec: privatev1.ExternalIPAttachmentSpec_builder{
+					ExternalIp:        "eip-uuid-bmi",
+					BaremetalInstance: &bmi,
+				}.Build(),
+			}.Build(),
+		}
+
+		spec := t.buildSpec()
+
+		Expect(spec.ExternalIP).To(Equal("eip-uuid-bmi"))
+		Expect(spec.BaremetalInstance).ToNot(BeNil())
+		Expect(*spec.BaremetalInstance).To(Equal("bmi-uuid-abc123"))
+		Expect(spec.ComputeInstance).To(BeNil())
+		Expect(spec.Cluster).To(BeNil())
+		Expect(spec.TargetEndpoint).To(BeNil())
+	})
+
 	It("Does not include status fields", func() {
 		ci := "ci-uuid-xyz"
 		t := &task{

--- a/osac-operator/api/v1alpha1/externalipattachment_types.go
+++ b/osac-operator/api/v1alpha1/externalipattachment_types.go
@@ -33,9 +33,10 @@ const (
 // The entire spec is immutable after creation: to change the target, delete
 // the attachment and create a new one.
 // +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec is immutable after creation"
-// +kubebuilder:validation:XValidation:rule="(has(self.computeInstance) ? 1 : 0) + (has(self.cluster) ? 1 : 0) <= 1",message="at most one target field may be set"
+// +kubebuilder:validation:XValidation:rule="(has(self.computeInstance) ? 1 : 0) + (has(self.cluster) ? 1 : 0) + (has(self.baremetalInstance) ? 1 : 0) == 1",message="exactly one target field must be set"
 // +kubebuilder:validation:XValidation:rule="!has(self.cluster) || has(self.targetEndpoint)",message="targetEndpoint is required when cluster is set"
 // +kubebuilder:validation:XValidation:rule="!has(self.computeInstance) || !has(self.targetEndpoint)",message="targetEndpoint must not be set when computeInstance is set"
+// +kubebuilder:validation:XValidation:rule="!has(self.baremetalInstance) || !has(self.targetEndpoint)",message="targetEndpoint must not be set when baremetalInstance is set"
 type ExternalIPAttachmentSpec struct {
 	// ExternalIP is the name of the ExternalIP resource to attach.
 	// +kubebuilder:validation:Required
@@ -43,19 +44,25 @@ type ExternalIPAttachmentSpec struct {
 	ExternalIP string `json:"externalIP"`
 
 	// ComputeInstance is the UUID of the ComputeInstance to attach to.
-	// Exactly one target field (computeInstance or cluster) must be set.
+	// Exactly one target field (computeInstance, cluster, or baremetalInstance) must be set.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:MinLength=1
 	ComputeInstance *string `json:"computeInstance,omitempty"`
 
 	// Cluster is the UUID of the ClusterOrder to attach to.
-	// Exactly one target field (computeInstance or cluster) must be set.
+	// Exactly one target field (computeInstance, cluster, or baremetalInstance) must be set.
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:MinLength=1
 	Cluster *string `json:"cluster,omitempty"`
 
+	// BaremetalInstance is the UUID of the BareMetalInstance to attach to.
+	// Exactly one target field (computeInstance, cluster, or baremetalInstance) must be set.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MinLength=1
+	BaremetalInstance *string `json:"baremetalInstance,omitempty"`
+
 	// TargetEndpoint specifies which cluster endpoint receives the DNAT rule.
-	// Required when cluster is set; must not be set when computeInstance is set.
+	// Required when cluster is set; must not be set when computeInstance or baremetalInstance is set.
 	// +kubebuilder:validation:Optional
 	TargetEndpoint *ExternalIPAttachmentTargetEndpoint `json:"targetEndpoint,omitempty"`
 }
@@ -104,6 +111,7 @@ type ExternalIPAttachmentStatus struct {
 // +kubebuilder:printcolumn:name="ExternalIP",type=string,JSONPath=`.spec.externalIP`
 // +kubebuilder:printcolumn:name="ComputeInstance",type=string,JSONPath=`.spec.computeInstance`
 // +kubebuilder:printcolumn:name="Cluster",type=string,JSONPath=`.spec.cluster`
+// +kubebuilder:printcolumn:name="BaremetalInstance",type=string,JSONPath=`.spec.baremetalInstance`,priority=1
 // +kubebuilder:printcolumn:name="TargetEndpoint",type=string,JSONPath=`.spec.targetEndpoint`,priority=1
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`

--- a/osac-operator/api/v1alpha1/externalipattachment_types_test.go
+++ b/osac-operator/api/v1alpha1/externalipattachment_types_test.go
@@ -37,6 +37,21 @@ var _ = Describe("ExternalIPAttachmentSpec", func() {
 		Expect(*spec.ComputeInstance).To(Equal("my-instance"))
 	})
 
+	It("should accept a spec with baremetalInstance target", func() {
+		bmi := "my-bmi"
+		spec := v1alpha1.ExternalIPAttachmentSpec{
+			ExternalIP:       "my-public-ip",
+			BaremetalInstance: &bmi,
+		}
+
+		Expect(spec.ExternalIP).To(Equal("my-public-ip"))
+		Expect(spec.BaremetalInstance).ToNot(BeNil())
+		Expect(*spec.BaremetalInstance).To(Equal("my-bmi"))
+		Expect(spec.ComputeInstance).To(BeNil())
+		Expect(spec.Cluster).To(BeNil())
+		Expect(spec.TargetEndpoint).To(BeNil())
+	})
+
 	It("should accept a minimal spec without optional target", func() {
 		spec := v1alpha1.ExternalIPAttachmentSpec{
 			ExternalIP: "my-public-ip",

--- a/osac-operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/osac-operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -455,6 +455,11 @@ func (in *ExternalIPAttachmentSpec) DeepCopyInto(out *ExternalIPAttachmentSpec) 
 		*out = new(string)
 		**out = **in
 	}
+	if in.BaremetalInstance != nil {
+		in, out := &in.BaremetalInstance, &out.BaremetalInstance
+		*out = new(string)
+		**out = **in
+	}
 	if in.TargetEndpoint != nil {
 		in, out := &in.TargetEndpoint, &out.TargetEndpoint
 		*out = new(ExternalIPAttachmentTargetEndpoint)

--- a/osac-operator/charts/operator-crds/templates/osac.openshift.io_externalipattachments.yaml
+++ b/osac-operator/charts/operator-crds/templates/osac.openshift.io_externalipattachments.yaml
@@ -28,6 +28,10 @@ spec:
     - jsonPath: .spec.cluster
       name: Cluster
       type: string
+    - jsonPath: .spec.baremetalInstance
+      name: BaremetalInstance
+      priority: 1
+      type: string
     - jsonPath: .spec.targetEndpoint
       name: TargetEndpoint
       priority: 1
@@ -64,16 +68,22 @@ spec:
           spec:
             description: spec defines the desired state of ExternalIPAttachment
             properties:
+              baremetalInstance:
+                description: |-
+                  BaremetalInstance is the UUID of the BareMetalInstance to attach to.
+                  Exactly one target field (computeInstance, cluster, or baremetalInstance) must be set.
+                minLength: 1
+                type: string
               cluster:
                 description: |-
                   Cluster is the UUID of the ClusterOrder to attach to.
-                  Exactly one target field (computeInstance or cluster) must be set.
+                  Exactly one target field (computeInstance, cluster, or baremetalInstance) must be set.
                 minLength: 1
                 type: string
               computeInstance:
                 description: |-
                   ComputeInstance is the UUID of the ComputeInstance to attach to.
-                  Exactly one target field (computeInstance or cluster) must be set.
+                  Exactly one target field (computeInstance, cluster, or baremetalInstance) must be set.
                 minLength: 1
                 type: string
               externalIP:
@@ -84,7 +94,7 @@ spec:
               targetEndpoint:
                 description: |-
                   TargetEndpoint specifies which cluster endpoint receives the DNAT rule.
-                  Required when cluster is set; must not be set when computeInstance is set.
+                  Required when cluster is set; must not be set when computeInstance or baremetalInstance is set.
                 enum:
                 - API
                 - Ingress
@@ -95,13 +105,15 @@ spec:
             x-kubernetes-validations:
             - message: spec is immutable after creation
               rule: self == oldSelf
-            - message: at most one target field may be set
+            - message: exactly one target field must be set
               rule: '(has(self.computeInstance) ? 1 : 0) + (has(self.cluster) ? 1
-                : 0) <= 1'
+                : 0) + (has(self.baremetalInstance) ? 1 : 0) == 1'
             - message: targetEndpoint is required when cluster is set
               rule: '!has(self.cluster) || has(self.targetEndpoint)'
             - message: targetEndpoint must not be set when computeInstance is set
               rule: '!has(self.computeInstance) || !has(self.targetEndpoint)'
+            - message: targetEndpoint must not be set when baremetalInstance is set
+              rule: '!has(self.baremetalInstance) || !has(self.targetEndpoint)'
           status:
             description: status defines the observed state of ExternalIPAttachment
             properties:

--- a/osac-operator/cmd/main.go
+++ b/osac-operator/cmd/main.go
@@ -472,6 +472,7 @@ func setupNetworkingControllers(
 	networkingNamespace := os.Getenv(envNetworkingNamespace)
 	computeInstanceNamespace := os.Getenv(envComputeInstanceNamespace)
 	clusterOrderNamespace := os.Getenv(envClusterOrderNamespace)
+	bareMetalInstanceNamespace := os.Getenv(envBareMetalInstanceNamespace)
 
 	aapURL := os.Getenv(envAAPURL)
 	aapToken := os.Getenv(envAAPToken)
@@ -526,7 +527,8 @@ func setupNetworkingControllers(
 		return err
 	}
 	if err := setupExternalIPAttachmentControllers(
-		mgr, localMgr, grpcConn, networkingNamespace, computeInstanceNamespace, clusterOrderNamespace,
+		mgr, localMgr, grpcConn,
+		networkingNamespace, computeInstanceNamespace, clusterOrderNamespace, bareMetalInstanceNamespace,
 		externalIPAttachmentProvider, statusPollInterval, maxJobHistory, targetCluster,
 	); err != nil {
 		return err
@@ -643,12 +645,13 @@ func setupExternalIPControllers(
 
 func setupExternalIPAttachmentControllers(
 	mgr mcmanager.Manager, localMgr ctrl.Manager, grpcConn *grpc.ClientConn,
-	networkingNamespace string, computeInstanceNamespace string, clusterOrderNamespace string,
+	networkingNamespace, computeInstanceNamespace, clusterOrderNamespace, baremetalInstanceNamespace string,
 	provider provisioning.ProvisioningProvider,
 	statusPollInterval time.Duration, maxJobHistory int, targetCluster multicluster.ClusterName,
 ) error {
 	if err := controller.NewExternalIPAttachmentReconciler(
-		mgr, networkingNamespace, computeInstanceNamespace, clusterOrderNamespace,
+		mgr, networkingNamespace, computeInstanceNamespace,
+		clusterOrderNamespace, baremetalInstanceNamespace,
 		provider, statusPollInterval, maxJobHistory, targetCluster,
 	).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("externalipattachment controller: %w", err)

--- a/osac-operator/config/crd/bases/osac.openshift.io_externalipattachments.yaml
+++ b/osac-operator/config/crd/bases/osac.openshift.io_externalipattachments.yaml
@@ -26,6 +26,10 @@ spec:
     - jsonPath: .spec.cluster
       name: Cluster
       type: string
+    - jsonPath: .spec.baremetalInstance
+      name: BaremetalInstance
+      priority: 1
+      type: string
     - jsonPath: .spec.targetEndpoint
       name: TargetEndpoint
       priority: 1
@@ -62,16 +66,22 @@ spec:
           spec:
             description: spec defines the desired state of ExternalIPAttachment
             properties:
+              baremetalInstance:
+                description: |-
+                  BaremetalInstance is the UUID of the BareMetalInstance to attach to.
+                  Exactly one target field (computeInstance, cluster, or baremetalInstance) must be set.
+                minLength: 1
+                type: string
               cluster:
                 description: |-
                   Cluster is the UUID of the ClusterOrder to attach to.
-                  Exactly one target field (computeInstance or cluster) must be set.
+                  Exactly one target field (computeInstance, cluster, or baremetalInstance) must be set.
                 minLength: 1
                 type: string
               computeInstance:
                 description: |-
                   ComputeInstance is the UUID of the ComputeInstance to attach to.
-                  Exactly one target field (computeInstance or cluster) must be set.
+                  Exactly one target field (computeInstance, cluster, or baremetalInstance) must be set.
                 minLength: 1
                 type: string
               externalIP:
@@ -82,7 +92,7 @@ spec:
               targetEndpoint:
                 description: |-
                   TargetEndpoint specifies which cluster endpoint receives the DNAT rule.
-                  Required when cluster is set; must not be set when computeInstance is set.
+                  Required when cluster is set; must not be set when computeInstance or baremetalInstance is set.
                 enum:
                 - API
                 - Ingress
@@ -93,13 +103,15 @@ spec:
             x-kubernetes-validations:
             - message: spec is immutable after creation
               rule: self == oldSelf
-            - message: at most one target field may be set
+            - message: exactly one target field must be set
               rule: '(has(self.computeInstance) ? 1 : 0) + (has(self.cluster) ? 1
-                : 0) <= 1'
+                : 0) + (has(self.baremetalInstance) ? 1 : 0) == 1'
             - message: targetEndpoint is required when cluster is set
               rule: '!has(self.cluster) || has(self.targetEndpoint)'
             - message: targetEndpoint must not be set when computeInstance is set
               rule: '!has(self.computeInstance) || !has(self.targetEndpoint)'
+            - message: targetEndpoint must not be set when baremetalInstance is set
+              rule: '!has(self.baremetalInstance) || !has(self.targetEndpoint)'
           status:
             description: status defines the observed state of ExternalIPAttachment
             properties:

--- a/osac-operator/config/rbac/role.yaml
+++ b/osac-operator/config/rbac/role.yaml
@@ -83,6 +83,7 @@ rules:
   verbs:
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/osac-operator/internal/controller/externalipattachment_controller.go
+++ b/osac-operator/internal/controller/externalipattachment_controller.go
@@ -35,6 +35,7 @@ import (
 
 	"k8s.io/utils/ptr"
 
+	bmfov1alpha1 "github.com/osac-project/osac/bare-metal-fulfillment-operator/api/v1alpha1"
 	"github.com/osac-project/osac/osac-operator/api/v1alpha1"
 	"github.com/osac-project/osac/osac-operator/pkg/provisioning"
 )
@@ -54,16 +55,17 @@ const (
 // auto-delete the ExternalIPAttachment when the target CI is deleted.
 type ExternalIPAttachmentReconciler struct {
 	client.Client
-	APIReader                client.Reader
-	Scheme                   *runtime.Scheme
-	mgr                      mcmanager.Manager
-	NetworkingNamespace      string
-	ComputeInstanceNamespace string
-	ClusterOrderNamespace    string
-	ProvisioningProvider     provisioning.ProvisioningProvider
-	StatusPollInterval       time.Duration
-	MaxJobHistory            int
-	targetCluster            mc.ClusterName
+	APIReader                  client.Reader
+	Scheme                     *runtime.Scheme
+	mgr                        mcmanager.Manager
+	NetworkingNamespace        string
+	ComputeInstanceNamespace   string
+	ClusterOrderNamespace      string
+	BaremetalInstanceNamespace string
+	ProvisioningProvider       provisioning.ProvisioningProvider
+	StatusPollInterval         time.Duration
+	MaxJobHistory              int
+	targetCluster              mc.ClusterName
 }
 
 // NewExternalIPAttachmentReconciler creates a new reconciler for ExternalIPAttachment resources.
@@ -72,6 +74,7 @@ func NewExternalIPAttachmentReconciler(
 	networkingNamespace string,
 	computeInstanceNamespace string,
 	clusterOrderNamespace string,
+	baremetalInstanceNamespace string,
 	provisioningProvider provisioning.ProvisioningProvider,
 	statusPollInterval time.Duration,
 	maxJobHistory int,
@@ -92,18 +95,22 @@ func NewExternalIPAttachmentReconciler(
 	if clusterOrderNamespace == "" {
 		clusterOrderNamespace = defaultClusterOrderNamespace
 	}
+	if baremetalInstanceNamespace == "" {
+		baremetalInstanceNamespace = DefaultBareMetalInstanceNamespace
+	}
 	return &ExternalIPAttachmentReconciler{
-		Client:                   mgr.GetLocalManager().GetClient(),
-		APIReader:                mgr.GetLocalManager().GetAPIReader(),
-		Scheme:                   mgr.GetLocalManager().GetScheme(),
-		mgr:                      mgr,
-		NetworkingNamespace:      networkingNamespace,
-		ComputeInstanceNamespace: computeInstanceNamespace,
-		ClusterOrderNamespace:    clusterOrderNamespace,
-		ProvisioningProvider:     provisioningProvider,
-		StatusPollInterval:       statusPollInterval,
-		MaxJobHistory:            maxJobHistory,
-		targetCluster:            targetCluster,
+		Client:                     mgr.GetLocalManager().GetClient(),
+		APIReader:                  mgr.GetLocalManager().GetAPIReader(),
+		Scheme:                     mgr.GetLocalManager().GetScheme(),
+		mgr:                        mgr,
+		NetworkingNamespace:        networkingNamespace,
+		ComputeInstanceNamespace:   computeInstanceNamespace,
+		ClusterOrderNamespace:      clusterOrderNamespace,
+		BaremetalInstanceNamespace: baremetalInstanceNamespace,
+		ProvisioningProvider:       provisioningProvider,
+		StatusPollInterval:         statusPollInterval,
+		MaxJobHistory:              maxJobHistory,
+		targetCluster:              targetCluster,
 	}
 }
 
@@ -112,6 +119,8 @@ func NewExternalIPAttachmentReconciler(
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=externalipattachments/finalizers,verbs=update
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=clusterorders,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=clusterorders/finalizers,verbs=update
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=baremetalinstances,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=baremetalinstances/finalizers,verbs=update
 
 // Reconcile handles create/update/delete for a ExternalIPAttachment CR.
 func (r *ExternalIPAttachmentReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
@@ -213,39 +222,13 @@ func (r *ExternalIPAttachmentReconciler) handleUpdate(ctx context.Context, attac
 		return result, err
 	}
 
-	// Sync annotations
-	needsUpdate := false
-	if attachment.Annotations == nil {
-		attachment.Annotations = make(map[string]string)
+	// Resolve target BareMetalInstance
+	_, result, err = r.resolveBaremetalInstance(ctx, attachment)
+	if err != nil || result.RequeueAfter > 0 {
+		return result, err
 	}
 
-	if attachment.Annotations[osacImplementationStrategyAnnotation] != implementationStrategy {
-		attachment.Annotations[osacImplementationStrategyAnnotation] = implementationStrategy
-		needsUpdate = true
-	}
-	if attachment.Annotations[osacExternalIPPoolNameAnnotation] != pool.Name {
-		attachment.Annotations[osacExternalIPPoolNameAnnotation] = pool.Name
-		needsUpdate = true
-	}
-	if attachment.Annotations[osacExternalIPNameAnnotation] != externalIP.Name {
-		attachment.Annotations[osacExternalIPNameAnnotation] = externalIP.Name
-		needsUpdate = true
-	}
-	if ci != nil && ci.Status.VirtualMachineReference != nil {
-		targetNamespace := ci.Status.VirtualMachineReference.Namespace
-		if attachment.Annotations[osacExternalIPTargetNamespaceAnnotation] != targetNamespace {
-			attachment.Annotations[osacExternalIPTargetNamespaceAnnotation] = targetNamespace
-			needsUpdate = true
-		}
-	}
-	if co != nil {
-		targetIP := r.resolveClusterEndpoint(co, attachment)
-		if targetIP != "" && attachment.Annotations[osacExternalIPTargetIPAnnotation] != targetIP {
-			attachment.Annotations[osacExternalIPTargetIPAnnotation] = targetIP
-			needsUpdate = true
-		}
-	}
-
+	needsUpdate := r.syncAnnotations(attachment, pool, externalIP, implementationStrategy, ci, co)
 	if needsUpdate {
 		if err := r.Update(ctx, attachment); err != nil {
 			return ctrl.Result{}, err
@@ -278,6 +261,48 @@ func (r *ExternalIPAttachmentReconciler) handleUpdate(ctx context.Context, attac
 	}
 
 	return r.handleProvisioning(ctx, attachment, externalIP, ci)
+}
+
+func (r *ExternalIPAttachmentReconciler) syncAnnotations(
+	attachment *v1alpha1.ExternalIPAttachment,
+	pool *v1alpha1.ExternalIPPool,
+	externalIP *v1alpha1.ExternalIP,
+	implementationStrategy string,
+	ci *v1alpha1.ComputeInstance,
+	co *v1alpha1.ClusterOrder,
+) bool {
+	if attachment.Annotations == nil {
+		attachment.Annotations = make(map[string]string)
+	}
+
+	needsUpdate := false
+	if attachment.Annotations[osacImplementationStrategyAnnotation] != implementationStrategy {
+		attachment.Annotations[osacImplementationStrategyAnnotation] = implementationStrategy
+		needsUpdate = true
+	}
+	if attachment.Annotations[osacExternalIPPoolNameAnnotation] != pool.Name {
+		attachment.Annotations[osacExternalIPPoolNameAnnotation] = pool.Name
+		needsUpdate = true
+	}
+	if attachment.Annotations[osacExternalIPNameAnnotation] != externalIP.Name {
+		attachment.Annotations[osacExternalIPNameAnnotation] = externalIP.Name
+		needsUpdate = true
+	}
+	if ci != nil && ci.Status.VirtualMachineReference != nil {
+		targetNamespace := ci.Status.VirtualMachineReference.Namespace
+		if attachment.Annotations[osacExternalIPTargetNamespaceAnnotation] != targetNamespace {
+			attachment.Annotations[osacExternalIPTargetNamespaceAnnotation] = targetNamespace
+			needsUpdate = true
+		}
+	}
+	if co != nil {
+		targetIP := r.resolveClusterEndpoint(co, attachment)
+		if targetIP != "" && attachment.Annotations[osacExternalIPTargetIPAnnotation] != targetIP {
+			attachment.Annotations[osacExternalIPTargetIPAnnotation] = targetIP
+			needsUpdate = true
+		}
+	}
+	return needsUpdate
 }
 
 // resolveComputeInstance looks up the target ComputeInstance by UUID label, handles
@@ -397,6 +422,50 @@ func (r *ExternalIPAttachmentReconciler) resolveClusterEndpoint(
 	default:
 		return ""
 	}
+}
+
+// resolveBaremetalInstance looks up the target BareMetalInstance by UUID label, handles
+// auto-detach if the BMI is being deleted, and adds the detach finalizer.
+// Returns nil BMI (with no requeue) when spec.baremetalInstance is not set.
+func (r *ExternalIPAttachmentReconciler) resolveBaremetalInstance(
+	ctx context.Context,
+	attachment *v1alpha1.ExternalIPAttachment,
+) (*bmfov1alpha1.BareMetalInstance, ctrl.Result, error) {
+	if attachment.Spec.BaremetalInstance == nil {
+		return nil, ctrl.Result{}, nil
+	}
+
+	log := ctrllog.FromContext(ctx)
+
+	bmiList := &bmfov1alpha1.BareMetalInstanceList{}
+	if err := r.List(ctx, bmiList,
+		client.InNamespace(r.BaremetalInstanceNamespace),
+		client.MatchingLabels{osacBareMetalInstanceIDLabel: *attachment.Spec.BaremetalInstance},
+	); err != nil {
+		return nil, ctrl.Result{}, err
+	}
+	if len(bmiList.Items) == 0 {
+		log.Info("BareMetalInstance not found, requeueing", "baremetalInstanceUUID", *attachment.Spec.BaremetalInstance)
+		return nil, ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
+	}
+	bmi := &bmiList.Items[0]
+
+	if !bmi.DeletionTimestamp.IsZero() {
+		log.Info("auto-detaching: BareMetalInstance is being deleted", "baremetalInstance", bmi.Name)
+		if err := r.Delete(ctx, attachment); err != nil {
+			return nil, ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+		return nil, ctrl.Result{RequeueAfter: time.Second}, nil
+	}
+
+	if controllerutil.AddFinalizer(bmi, osacExternalIPDetachFinalizer) {
+		log.Info("adding externalip-detach finalizer to BareMetalInstance", "baremetalInstance", bmi.Name)
+		if err := r.Update(ctx, bmi); err != nil {
+			return nil, ctrl.Result{}, err
+		}
+	}
+
+	return bmi, ctrl.Result{}, nil
 }
 
 func (r *ExternalIPAttachmentReconciler) handleProvisioning(
@@ -588,6 +657,14 @@ func (r *ExternalIPAttachmentReconciler) onDeprovisionSuccess(ctx context.Contex
 		}
 	}
 
+	// Remove BareMetalInstance detach finalizer
+	if attachment.Spec.BaremetalInstance != nil {
+		bmiUUID := *attachment.Spec.BaremetalInstance
+		if err := r.maybeRemoveBMIDetachFinalizer(ctx, bmiUUID, attachment.Name); err != nil {
+			return fmt.Errorf("failed to remove BareMetalInstance detach finalizer: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -681,6 +758,86 @@ func (r *ExternalIPAttachmentReconciler) maybeRemoveCODetachFinalizer(ctx contex
 		}
 		return nil
 	})
+}
+
+// maybeRemoveBMIDetachFinalizer removes the externalip-detach finalizer from the
+// BareMetalInstance if no other ExternalIPAttachments still reference it.
+func (r *ExternalIPAttachmentReconciler) maybeRemoveBMIDetachFinalizer(ctx context.Context, bmiUUID string, excludeAttachment string) error {
+	log := ctrllog.FromContext(ctx)
+
+	attachments := &v1alpha1.ExternalIPAttachmentList{}
+	if err := r.List(ctx, attachments, client.InNamespace(r.NetworkingNamespace)); err != nil {
+		return err
+	}
+	for i := range attachments.Items {
+		if attachments.Items[i].Name == excludeAttachment {
+			continue
+		}
+		if attachments.Items[i].Spec.BaremetalInstance != nil && *attachments.Items[i].Spec.BaremetalInstance == bmiUUID {
+			log.Info("other ExternalIPAttachments still reference BareMetalInstance, keeping finalizer",
+				"baremetalInstanceUUID", bmiUUID,
+				"attachment", attachments.Items[i].Name)
+			return nil
+		}
+	}
+
+	log.Info("no more references, removing BareMetalInstance detach finalizer", "baremetalInstanceUUID", bmiUUID)
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		bmiList := &bmfov1alpha1.BareMetalInstanceList{}
+		if err := r.List(ctx, bmiList,
+			client.InNamespace(r.BaremetalInstanceNamespace),
+			client.MatchingLabels{osacBareMetalInstanceIDLabel: bmiUUID},
+		); err != nil {
+			return err
+		}
+		if len(bmiList.Items) == 0 {
+			return nil
+		}
+		bmi := &bmiList.Items[0]
+
+		if controllerutil.RemoveFinalizer(bmi, osacExternalIPDetachFinalizer) {
+			return r.Update(ctx, bmi)
+		}
+		return nil
+	})
+}
+
+// mapBaremetalInstanceToExternalIPAttachments maps a BareMetalInstance change to all
+// ExternalIPAttachments that reference it, so the controller can react to
+// BMI deletion.
+func (r *ExternalIPAttachmentReconciler) mapBaremetalInstanceToExternalIPAttachments(ctx context.Context, obj client.Object) []reconcile.Request {
+	log := ctrllog.FromContext(ctx)
+
+	bmiUUID, exists := obj.GetLabels()[osacBareMetalInstanceIDLabel]
+	if !exists {
+		return nil
+	}
+
+	attachments := &v1alpha1.ExternalIPAttachmentList{}
+	if err := r.List(ctx, attachments, client.InNamespace(r.NetworkingNamespace)); err != nil {
+		log.Error(err, "failed to list ExternalIPAttachments for BareMetalInstance watch")
+		return nil
+	}
+
+	var requests []reconcile.Request
+	for i := range attachments.Items {
+		if attachments.Items[i].Spec.BaremetalInstance != nil && *attachments.Items[i].Spec.BaremetalInstance == bmiUUID {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: client.ObjectKeyFromObject(&attachments.Items[i]),
+			})
+		}
+	}
+
+	if len(requests) > 0 {
+		log.Info("mapped BareMetalInstance change to ExternalIPAttachments",
+			"baremetalInstance", obj.GetName(),
+			"baremetalInstanceUUID", bmiUUID,
+			"attachmentCount", len(requests),
+		)
+	}
+
+	return requests
 }
 
 // mapClusterOrderToExternalIPAttachments maps a ClusterOrder change to all
@@ -799,6 +956,13 @@ func (r *ExternalIPAttachmentReconciler) SetupWithManager(mgr mcmanager.Manager)
 			&v1alpha1.ClusterOrder{},
 			mchandler.EnqueueRequestsFromMapFunc(r.mapClusterOrderToExternalIPAttachments),
 			mcbuilder.WithPredicates(NamespacePredicate(r.ClusterOrderNamespace)),
+			mcbuilder.WithEngageWithLocalCluster(true),
+			mcbuilder.WithEngageWithProviderClusters(false),
+		).
+		Watches(
+			&bmfov1alpha1.BareMetalInstance{},
+			mchandler.EnqueueRequestsFromMapFunc(r.mapBaremetalInstanceToExternalIPAttachments),
+			mcbuilder.WithPredicates(BareMetalInstanceNamespacePredicate(r.BaremetalInstanceNamespace)),
 			mcbuilder.WithEngageWithLocalCluster(true),
 			mcbuilder.WithEngageWithProviderClusters(false),
 		).

--- a/osac-operator/internal/controller/externalipattachment_controller_test.go
+++ b/osac-operator/internal/controller/externalipattachment_controller_test.go
@@ -35,26 +35,30 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
+	bmfov1alpha1 "github.com/osac-project/osac/bare-metal-fulfillment-operator/api/v1alpha1"
 	osacv1alpha1 "github.com/osac-project/osac/osac-operator/api/v1alpha1"
 	"github.com/osac-project/osac/osac-operator/pkg/provisioning"
 )
 
 var _ = Describe("ExternalIPAttachmentReconciler", func() {
 	const (
-		testNetworkingNamespace      = "test-networking"
-		testComputeInstanceNamespace = "test-ci"
-		testClusterOrderNamespace    = "test-orders"
-		testPoolUUID                 = "pool-uuid-123"
-		testExternalIPUUID           = "pip-uuid-789"
-		testCIUUID                   = "ci-uuid-456"
-		testCIName                   = "test-ci-1"
-		testCOUUID                   = "co-uuid-789"
-		testCOName                   = "test-cluster-1"
-		testAPIEndpoint              = "10.0.0.100"
-		testIngressEndpoint          = "10.0.0.200"
-		testExternalIPName           = "test-pip"
-		testAttachmentName           = "test-attachment"
-		testVMNamespace              = "subnet-abc123"
+		testNetworkingNamespace        = "test-networking"
+		testComputeInstanceNamespace   = "test-ci"
+		testClusterOrderNamespace      = "test-orders"
+		testBaremetalInstanceNamespace = "test-bmi"
+		testPoolUUID                   = "pool-uuid-123"
+		testExternalIPUUID             = "pip-uuid-789"
+		testCIUUID                     = "ci-uuid-456"
+		testCIName                     = "test-ci-1"
+		testCOUUID                     = "co-uuid-789"
+		testCOName                     = "test-cluster-1"
+		testBMIUUID                    = "bmi-uuid-101"
+		testBMIName                    = "test-bmi-1"
+		testAPIEndpoint                = "10.0.0.100"
+		testIngressEndpoint            = "10.0.0.200"
+		testExternalIPName             = "test-pip"
+		testAttachmentName             = "test-attachment"
+		testVMNamespace                = "subnet-abc123"
 	)
 
 	var (
@@ -79,6 +83,7 @@ var _ = Describe("ExternalIPAttachmentReconciler", func() {
 				&osacv1alpha1.ExternalIP{},
 				&osacv1alpha1.ComputeInstance{},
 				&osacv1alpha1.ClusterOrder{},
+				&bmfov1alpha1.BareMetalInstance{},
 			).
 			Build()
 	}
@@ -87,6 +92,7 @@ var _ = Describe("ExternalIPAttachmentReconciler", func() {
 		testCtx = context.TODO()
 		testScheme = runtime.NewScheme()
 		Expect(osacv1alpha1.AddToScheme(testScheme)).To(Succeed())
+		Expect(bmfov1alpha1.AddToScheme(testScheme)).To(Succeed())
 		Expect(scheme.AddToScheme(testScheme)).To(Succeed())
 
 		pool = &osacv1alpha1.ExternalIPPool{
@@ -151,15 +157,16 @@ var _ = Describe("ExternalIPAttachmentReconciler", func() {
 
 	setupReconciler := func(c client.Client) {
 		reconciler = &ExternalIPAttachmentReconciler{
-			Client:                   c,
-			APIReader:                c,
-			Scheme:                   testScheme,
-			NetworkingNamespace:      testNetworkingNamespace,
-			ComputeInstanceNamespace: testComputeInstanceNamespace,
-			ClusterOrderNamespace:    testClusterOrderNamespace,
-			ProvisioningProvider:     mockProvider,
-			StatusPollInterval:       1 * time.Second,
-			MaxJobHistory:            10,
+			Client:                     c,
+			APIReader:                  c,
+			Scheme:                     testScheme,
+			NetworkingNamespace:        testNetworkingNamespace,
+			ComputeInstanceNamespace:   testComputeInstanceNamespace,
+			ClusterOrderNamespace:      testClusterOrderNamespace,
+			BaremetalInstanceNamespace: testBaremetalInstanceNamespace,
+			ProvisioningProvider:       mockProvider,
+			StatusPollInterval:         1 * time.Second,
+			MaxJobHistory:              10,
 		}
 	}
 
@@ -1226,6 +1233,196 @@ var _ = Describe("ExternalIPAttachmentReconciler", func() {
 			updatedPIP := &osacv1alpha1.ExternalIP{}
 			Expect(fakeClient.Get(testCtx, client.ObjectKeyFromObject(publicIP), updatedPIP)).To(Succeed())
 			Expect(updatedPIP.Status.Attached).To(BeFalse())
+		})
+	})
+
+	// --- BareMetalInstance target tests ---
+
+	Context("BareMetalInstance target resolution", func() {
+		var (
+			bmi           *bmfov1alpha1.BareMetalInstance
+			bmiAttachment *osacv1alpha1.ExternalIPAttachment
+			bmiKey        types.NamespacedName
+		)
+
+		BeforeEach(func() {
+			bmi = &bmfov1alpha1.BareMetalInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testBMIName,
+					Namespace: testBaremetalInstanceNamespace,
+					Labels: map[string]string{
+						osacBareMetalInstanceIDLabel: testBMIUUID,
+					},
+				},
+				Spec: bmfov1alpha1.BareMetalInstanceSpec{
+					HostType:       "compute",
+					ExternalHostID: "ext-host-1",
+				},
+			}
+
+			bmiAttachment = &osacv1alpha1.ExternalIPAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bmi-attachment",
+					Namespace: testNetworkingNamespace,
+				},
+				Spec: osacv1alpha1.ExternalIPAttachmentSpec{
+					ExternalIP:        testExternalIPUUID,
+					BaremetalInstance: ptr.To(testBMIUUID),
+				},
+			}
+
+			bmiKey = types.NamespacedName{
+				Name: "bmi-attachment", Namespace: testNetworkingNamespace,
+			}
+		})
+
+		bmiReconcileOnce := func() (ctrl.Result, error) {
+			return reconciler.Reconcile(testCtx, mcreconcile.Request{
+				Request: ctrl.Request{NamespacedName: bmiKey},
+			})
+		}
+
+		It("should requeue when BareMetalInstance not found", func() {
+			fakeClient = buildClient(bmiAttachment, publicIP, pool)
+			setupReconciler(fakeClient)
+
+			_, _ = bmiReconcileOnce() // finalizer
+
+			result, err := bmiReconcileOnce()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(defaultPreconditionRequeueInterval))
+		})
+
+		It("should add detach finalizer to BareMetalInstance", func() {
+			fakeClient = buildClient(bmiAttachment, publicIP, pool, bmi)
+			setupReconciler(fakeClient)
+
+			mockProvider.getProvisionStatusFunc = func(
+				ctx context.Context, resource client.Object, jobID string,
+			) (provisioning.ProvisionStatus, error) {
+				return provisioning.ProvisionStatus{
+					JobID: jobID, State: osacv1alpha1.JobStateRunning, Message: "running",
+				}, nil
+			}
+
+			_, _ = bmiReconcileOnce() // finalizer
+			_, _ = bmiReconcileOnce() // resolve + annotations
+
+			updatedBMI := &bmfov1alpha1.BareMetalInstance{}
+			Expect(fakeClient.Get(testCtx, client.ObjectKeyFromObject(bmi), updatedBMI)).To(Succeed())
+			Expect(updatedBMI.Finalizers).To(ContainElement(osacExternalIPDetachFinalizer))
+		})
+
+		It("should trigger delete when BareMetalInstance is being deleted", func() {
+			deletingBMI := bmi.DeepCopy()
+			now := metav1.Now()
+			deletingBMI.DeletionTimestamp = &now
+			deletingBMI.Finalizers = []string{osacExternalIPDetachFinalizer}
+
+			bmiAttachment.Finalizers = []string{osacExternalIPAttachmentFinalizer}
+			fakeClient = buildClient(bmiAttachment, publicIP, pool, bmi)
+			setupReconciler(fakeClient)
+
+			fetchedBMI := &bmfov1alpha1.BareMetalInstance{}
+			Expect(fakeClient.Get(testCtx, client.ObjectKeyFromObject(bmi), fetchedBMI)).To(Succeed())
+			fetchedBMI.Finalizers = []string{osacExternalIPDetachFinalizer}
+			Expect(fakeClient.Update(testCtx, fetchedBMI)).To(Succeed())
+
+			requests := reconciler.mapBaremetalInstanceToExternalIPAttachments(testCtx, bmi)
+			Expect(requests).To(HaveLen(1))
+		})
+
+		It("should map BareMetalInstance changes to attachment reconcile requests", func() {
+			fakeClient = buildClient(bmiAttachment, publicIP, pool, bmi)
+			setupReconciler(fakeClient)
+
+			requests := reconciler.mapBaremetalInstanceToExternalIPAttachments(testCtx, bmi)
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].NamespacedName).To(Equal(bmiKey))
+		})
+
+		It("should not map BareMetalInstance changes to unrelated attachments", func() {
+			fakeClient = buildClient(attachment, publicIP, pool, bmi)
+			setupReconciler(fakeClient)
+
+			requests := reconciler.mapBaremetalInstanceToExternalIPAttachments(testCtx, bmi)
+			Expect(requests).To(BeEmpty())
+		})
+	})
+
+	Context("BareMetalInstance detach finalizer cleanup", func() {
+		var bmi *bmfov1alpha1.BareMetalInstance
+
+		BeforeEach(func() {
+			bmi = &bmfov1alpha1.BareMetalInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testBMIName,
+					Namespace: testBaremetalInstanceNamespace,
+					Labels: map[string]string{
+						osacBareMetalInstanceIDLabel: testBMIUUID,
+					},
+				},
+				Spec: bmfov1alpha1.BareMetalInstanceSpec{
+					HostType:       "compute",
+					ExternalHostID: "ext-host-1",
+				},
+			}
+		})
+
+		It("should remove detach finalizer when no other attachments reference the BMI", func() {
+			bmi.Finalizers = []string{osacExternalIPDetachFinalizer}
+			excluded := &osacv1alpha1.ExternalIPAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "excluded-attachment",
+					Namespace: testNetworkingNamespace,
+				},
+				Spec: osacv1alpha1.ExternalIPAttachmentSpec{
+					ExternalIP:        "excluded-pip",
+					BaremetalInstance: ptr.To(testBMIUUID),
+				},
+			}
+			fakeClient = buildClient(bmi, excluded)
+			setupReconciler(fakeClient)
+
+			err := reconciler.maybeRemoveBMIDetachFinalizer(testCtx, testBMIUUID, "excluded-attachment")
+			Expect(err).NotTo(HaveOccurred())
+
+			updatedBMI := &bmfov1alpha1.BareMetalInstance{}
+			Expect(fakeClient.Get(testCtx, client.ObjectKeyFromObject(bmi), updatedBMI)).To(Succeed())
+			Expect(updatedBMI.Finalizers).NotTo(ContainElement(osacExternalIPDetachFinalizer))
+		})
+
+		It("should keep detach finalizer when other attachments reference the BMI", func() {
+			excluded := &osacv1alpha1.ExternalIPAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "excluded-attachment",
+					Namespace: testNetworkingNamespace,
+				},
+				Spec: osacv1alpha1.ExternalIPAttachmentSpec{
+					ExternalIP:        "excluded-pip",
+					BaremetalInstance: ptr.To(testBMIUUID),
+				},
+			}
+			other := &osacv1alpha1.ExternalIPAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-bmi-attachment",
+					Namespace: testNetworkingNamespace,
+				},
+				Spec: osacv1alpha1.ExternalIPAttachmentSpec{
+					ExternalIP:        "other-pip",
+					BaremetalInstance: ptr.To(testBMIUUID),
+				},
+			}
+			bmi.Finalizers = []string{osacExternalIPDetachFinalizer}
+			fakeClient = buildClient(bmi, excluded, other)
+			setupReconciler(fakeClient)
+
+			err := reconciler.maybeRemoveBMIDetachFinalizer(testCtx, testBMIUUID, "excluded-attachment")
+			Expect(err).NotTo(HaveOccurred())
+
+			updatedBMI := &bmfov1alpha1.BareMetalInstance{}
+			Expect(fakeClient.Get(testCtx, client.ObjectKeyFromObject(bmi), updatedBMI)).To(Succeed())
+			Expect(updatedBMI.Finalizers).To(ContainElement(osacExternalIPDetachFinalizer))
 		})
 	})
 })


### PR DESCRIPTION
Add baremetalInstance as a third target type alongside computeInstance and cluster. Update CEL validation to enforce exactly one target and block targetEndpoint for non-cluster targets. Add controller resolution, auto-detach on BMI deletion, finalizer management, and BareMetalInstance watch. Fix fulfillment-service buildSpec() to map cluster and baremetalInstance targets to the CRD.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External IP attachments can now target bare-metal instances.
  * Added visibility of bare-metal targets in attachment listings.
  * Attachments automatically track bare-metal instance changes and detach when instances are deleted.
* **Validation**
  * Exactly one target—compute instance, cluster, or bare-metal instance—must be selected.
  * Cluster targets require an endpoint; compute and bare-metal targets cannot specify one.
* **Improvements**
  * Cluster endpoints are mapped to the appropriate Kubernetes endpoint types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->