### PR TITLE
OSAC-3669: Fix CLI hangs when OAuth token/logout endpoints stall

### DIFF
--- a/fulfillment-service/internal/cmd/cli/logout/logout_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/logout/logout_cmd.go
@@ -217,16 +217,20 @@ const httpRequestTimeout = 30 * time.Second
 
 func (c *runnerContext) httpClient(caPool *x509.CertPool, insecure bool) *http.Client {
 	tlsConfig := &tls.Config{
-		RootCAs: caPool,
+		RootCAs:    caPool,
+		MinVersion: tls.VersionTLS13,
 	}
 	if insecure {
 		tlsConfig.InsecureSkipVerify = true
 	}
+	// Clone http.DefaultTransport rather than starting from a bare struct literal, so proxy
+	// support (Proxy: http.ProxyFromEnvironment), dial/keep-alive timeouts, HTTP/2, and connection
+	// pooling defaults are preserved — only the TLS configuration is overridden.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
 	return &http.Client{
-		Timeout: httpRequestTimeout,
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
+		Timeout:   httpRequestTimeout,
+		Transport: transport,
 	}
 }
 

--- a/fulfillment-service/internal/cmd/cli/logout/logout_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/logout/logout_cmd.go
@@ -22,6 +22,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -140,7 +142,14 @@ func (c *runnerContext) terminateSession(ctx context.Context, cfg *config.Settin
 
 	logoutURL := fmt.Sprintf("%s?%s", metadata.EndSessionEndpoint, params.Encode())
 
-	resp, err := client.Get(logoutURL)
+	// Build the request with the caller's context explicitly rather than using http.Client.Get, which
+	// always issues its request with context.Background() and therefore ignores cancellation and
+	// deadlines set by the caller.
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, logoutURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create end_session_endpoint request: %w", err)
+	}
+	resp, err := client.Do(request)
 	if err != nil {
 		return fmt.Errorf("failed to call end_session_endpoint: %w", err)
 	}
@@ -164,8 +173,15 @@ func (c *runnerContext) refreshForIdToken(ctx context.Context, client *http.Clie
 		form.Set("client_secret", clientSecret)
 	}
 
-	// Send the request to the token endpoint:
-	resp, err := client.PostForm(tokenEndpoint, form)
+	// Build the request with the caller's context explicitly rather than using http.Client.PostForm,
+	// which always issues its request with context.Background() and therefore ignores cancellation
+	// and deadlines set by the caller.
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("failed to create token endpoint request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := client.Do(request)
 	if err != nil {
 		return "", fmt.Errorf("failed to call token endpoint: %w", err)
 	}
@@ -193,6 +209,12 @@ func (c *runnerContext) refreshForIdToken(ctx context.Context, client *http.Clie
 	return tokenResponse.IdToken, nil
 }
 
+// httpRequestTimeout bounds requests made by this client so a stalled connection to the OAuth server
+// fails instead of hanging forever. The caller's context (see terminateSession/refreshForIdToken) is
+// also honored via NewRequestWithContext, but this is a necessary backstop for a bare
+// context.Background() with no deadline of its own.
+const httpRequestTimeout = 30 * time.Second
+
 func (c *runnerContext) httpClient(caPool *x509.CertPool, insecure bool) *http.Client {
 	tlsConfig := &tls.Config{
 		RootCAs: caPool,
@@ -201,6 +223,7 @@ func (c *runnerContext) httpClient(caPool *x509.CertPool, insecure bool) *http.C
 		tlsConfig.InsecureSkipVerify = true
 	}
 	return &http.Client{
+		Timeout: httpRequestTimeout,
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,
 		},

--- a/fulfillment-service/internal/cmd/cli/logout/logout_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/logout/logout_cmd_test.go
@@ -194,17 +194,19 @@ var _ = Describe("Logout command execution", func() {
 		mux := http.NewServeMux()
 		mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]string{
+			err := json.NewEncoder(w).Encode(map[string]string{
 				"issuer":               serverURL,
 				"token_endpoint":       serverURL + "/token",
 				"end_session_endpoint": serverURL + "/logout",
 			})
+			Expect(err).ToNot(HaveOccurred())
 		})
 		mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]string{
+			err := json.NewEncoder(w).Encode(map[string]string{
 				"id_token": "the-id-token",
 			})
+			Expect(err).ToNot(HaveOccurred())
 		})
 		mux.HandleFunc("/logout", func(w http.ResponseWriter, r *http.Request) {
 			<-release

--- a/fulfillment-service/internal/cmd/cli/logout/logout_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/logout/logout_cmd_test.go
@@ -185,9 +185,11 @@ var _ = Describe("Logout command execution", func() {
 	})
 
 	It("Fails promptly instead of hanging when the end-session endpoint never responds", func() {
-		// release unblocks the /logout handler, closed explicitly after the call below returns so
-		// that server.Close() during cleanup doesn't itself block waiting for it to return.
+		// release unblocks the /logout handler. Deferred so it always runs — even if the goroutine
+		// below never completes — so server.Close() during cleanup doesn't itself block waiting for
+		// it to return.
 		release := make(chan struct{})
+		defer close(release)
 		var serverURL string
 		mux := http.NewServeMux()
 		mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
@@ -229,13 +231,24 @@ var _ = Describe("Logout command execution", func() {
 		requestCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
 		defer cancel()
 
+		// Run the call in a goroutine racing a timer, rather than calling it synchronously, so
+		// that a regression fails this spec cleanly instead of hanging the whole test binary:
 		runner := &runnerContext{}
+		done := make(chan error, 1)
 		start := time.Now()
-		err = runner.terminateSession(requestCtx, settings, slog.Default())
-		elapsed := time.Since(start)
-		close(release)
+		go func() {
+			done <- runner.terminateSession(requestCtx, settings, slog.Default())
+		}()
 
-		Expect(err).To(HaveOccurred())
+		var sessionErr error
+		select {
+		case sessionErr = <-done:
+		case <-time.After(5 * time.Second):
+			Fail("terminateSession should fail promptly once the context deadline is reached, not hang forever")
+		}
+		elapsed := time.Since(start)
+
+		Expect(sessionErr).To(HaveOccurred())
 		Expect(elapsed).To(BeNumerically("<", 5*time.Second),
 			"terminateSession should fail promptly once the context deadline is reached, not hang forever")
 	})
@@ -347,9 +360,11 @@ var _ = Describe("refreshForIdToken", func() {
 	})
 
 	It("Fails promptly instead of hanging when the token endpoint never responds", func() {
-		// release unblocks the handler, closed explicitly after the call below returns so that
-		// server.Close() during cleanup doesn't itself block waiting for this handler to return.
+		// release unblocks the handler. Deferred so it always runs — even if the goroutine below
+		// never completes — so server.Close() during cleanup doesn't itself block waiting for this
+		// handler to return.
 		release := make(chan struct{})
+		defer close(release)
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			<-release
 		}))
@@ -362,13 +377,26 @@ var _ = Describe("refreshForIdToken", func() {
 
 		requestCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 		defer cancel()
-		start := time.Now()
-		_, err := runner.refreshForIdToken(requestCtx, client, server.URL,
-			"my-refresh-token", "my-client", "my-secret")
-		elapsed := time.Since(start)
-		close(release)
 
-		Expect(err).To(HaveOccurred())
+		// Run the call in a goroutine racing a timer, rather than calling it synchronously, so
+		// that a regression fails this spec cleanly instead of hanging the whole test binary:
+		done := make(chan error, 1)
+		start := time.Now()
+		go func() {
+			_, refreshErr := runner.refreshForIdToken(requestCtx, client, server.URL,
+				"my-refresh-token", "my-client", "my-secret")
+			done <- refreshErr
+		}()
+
+		var refreshErr error
+		select {
+		case refreshErr = <-done:
+		case <-time.After(5 * time.Second):
+			Fail("refreshForIdToken should fail promptly once the context deadline is reached, not hang forever")
+		}
+		elapsed := time.Since(start)
+
+		Expect(refreshErr).To(HaveOccurred())
 		Expect(elapsed).To(BeNumerically("<", 5*time.Second),
 			"refreshForIdToken should fail promptly once the context deadline is reached, not hang forever")
 	})

--- a/fulfillment-service/internal/cmd/cli/logout/logout_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/logout/logout_cmd_test.go
@@ -183,6 +183,62 @@ var _ = Describe("Logout command execution", func() {
 		Expect(output.String()).To(ContainSubstring("Successfully logged out"))
 		Expect(settings.Address()).To(BeEmpty())
 	})
+
+	It("Fails promptly instead of hanging when the end-session endpoint never responds", func() {
+		// release unblocks the /logout handler, closed explicitly after the call below returns so
+		// that server.Close() during cleanup doesn't itself block waiting for it to return.
+		release := make(chan struct{})
+		var serverURL string
+		mux := http.NewServeMux()
+		mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{
+				"issuer":               serverURL,
+				"token_endpoint":       serverURL + "/token",
+				"end_session_endpoint": serverURL + "/logout",
+			})
+		})
+		mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{
+				"id_token": "the-id-token",
+			})
+		})
+		mux.HandleFunc("/logout", func(w http.ResponseWriter, r *http.Request) {
+			<-release
+		})
+		server := httptest.NewServer(mux)
+		DeferCleanup(server.Close)
+		serverURL = server.URL
+
+		ctx, settings := setupContext()
+		settings.SetAddress("localhost:8000")
+		settings.SetIssuer(server.URL)
+		settings.SetAccessToken("my-access-token")
+		settings.SetRefreshToken("my-refresh-token")
+		settings.SetTokenExpiry(time.Now().Add(1 * time.Hour))
+		settings.SetFlow("code")
+		settings.SetClientId("test-client")
+		settings.SetClientSecret("test-secret")
+		settings.SetScopes([]string{"openid"})
+		err := settings.Save(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		err = settings.Load(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		requestCtx, cancel := context.WithTimeout(ctx, 1*time.Second)
+		defer cancel()
+
+		runner := &runnerContext{}
+		start := time.Now()
+		err = runner.terminateSession(requestCtx, settings, slog.Default())
+		elapsed := time.Since(start)
+		close(release)
+
+		Expect(err).To(HaveOccurred())
+		Expect(elapsed).To(BeNumerically("<", 5*time.Second),
+			"terminateSession should fail promptly once the context deadline is reached, not hang forever")
+	})
 })
 
 var _ = Describe("refreshForIdToken", func() {
@@ -288,6 +344,33 @@ var _ = Describe("refreshForIdToken", func() {
 		)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("failed to call token endpoint"))
+	})
+
+	It("Fails promptly instead of hanging when the token endpoint never responds", func() {
+		// release unblocks the handler, closed explicitly after the call below returns so that
+		// server.Close() during cleanup doesn't itself block waiting for this handler to return.
+		release := make(chan struct{})
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			<-release
+		}))
+		DeferCleanup(server.Close)
+
+		// Use the runner's real client constructor rather than an injected test client, since the
+		// defect is the combination of that constructor's lack of a timeout with PostForm ignoring
+		// the caller's context:
+		client := runner.httpClient(nil, false)
+
+		requestCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+		start := time.Now()
+		_, err := runner.refreshForIdToken(requestCtx, client, server.URL,
+			"my-refresh-token", "my-client", "my-secret")
+		elapsed := time.Since(start)
+		close(release)
+
+		Expect(err).To(HaveOccurred())
+		Expect(elapsed).To(BeNumerically("<", 5*time.Second),
+			"refreshForIdToken should fail promptly once the context deadline is reached, not hang forever")
 	})
 })
 

--- a/fulfillment-service/internal/oauth/oauth_token_source.go
+++ b/fulfillment-service/internal/oauth/oauth_token_source.go
@@ -431,16 +431,20 @@ func (b *TokenSourceBuilder) resolveDefaults() (cfg resolvedConfig, err error) {
 	cfg.httpClient = b.httpClient
 	if cfg.httpClient == nil {
 		tlsConfig := &tls.Config{
-			RootCAs: cfg.caPool,
+			RootCAs:    cfg.caPool,
+			MinVersion: tls.VersionTLS13,
 		}
 		if b.insecure {
 			tlsConfig.InsecureSkipVerify = true
 		}
+		// Clone http.DefaultTransport rather than starting from a bare struct literal, so proxy
+		// support (Proxy: http.ProxyFromEnvironment), dial/keep-alive timeouts, HTTP/2, and
+		// connection pooling defaults are preserved — only the TLS configuration is overridden.
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = tlsConfig
 		cfg.httpClient = &http.Client{
-			Timeout: httpRequestTimeout,
-			Transport: &http.Transport{
-				TLSClientConfig: tlsConfig,
-			},
+			Timeout:   httpRequestTimeout,
+			Transport: transport,
 		}
 	}
 

--- a/fulfillment-service/internal/oauth/oauth_token_source.go
+++ b/fulfillment-service/internal/oauth/oauth_token_source.go
@@ -29,6 +29,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -420,19 +421,27 @@ func (b *TokenSourceBuilder) resolveDefaults() (cfg resolvedConfig, err error) {
 		}
 	}
 
-	// Create HTTP client with optional insecure TLS configuration:
+	// Create the HTTP client with optional insecure TLS configuration. If the caller explicitly
+	// supplied a client, trust that it is already configured correctly and use it as-is — don't
+	// overwrite its transport. Otherwise build a fresh client rather than reusing and mutating the
+	// shared http.DefaultClient, and give it a bounded per-request timeout: sendForm sends requests
+	// built with the caller's context, but a client with no Timeout combined with a Transport that
+	// has no dial/handshake/response timeouts would still hang forever if the context is never
+	// canceled (e.g. a bare context.Background()).
 	cfg.httpClient = b.httpClient
 	if cfg.httpClient == nil {
-		cfg.httpClient = http.DefaultClient
-	}
-	tlsConfig := &tls.Config{
-		RootCAs: cfg.caPool,
-	}
-	if b.insecure {
-		tlsConfig.InsecureSkipVerify = true
-	}
-	cfg.httpClient.Transport = &http.Transport{
-		TLSClientConfig: tlsConfig,
+		tlsConfig := &tls.Config{
+			RootCAs: cfg.caPool,
+		}
+		if b.insecure {
+			tlsConfig.InsecureSkipVerify = true
+		}
+		cfg.httpClient = &http.Client{
+			Timeout: httpRequestTimeout,
+			Transport: &http.Transport{
+				TLSClientConfig: tlsConfig,
+			},
+		}
 	}
 
 	// Set the default open function:
@@ -744,7 +753,15 @@ func (s *TokenSource) sendForm(ctx context.Context, endpoint string, form any, r
 	if err != nil {
 		return err
 	}
-	response, err := s.httpClient.PostForm(endpoint, values)
+	// Build the request with the caller's context explicitly rather than using http.Client.PostForm,
+	// which always issues its request with context.Background() and therefore ignores cancellation
+	// and deadlines set by the caller.
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(values.Encode()))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	response, err := s.httpClient.Do(request)
 	if err != nil {
 		return err
 	}
@@ -874,6 +891,11 @@ func (s *TokenSource) Invalidate(ctx context.Context) error {
 // defaultRedirectUri is the default redirect URI to use for the authorization code flow. It binds to localhost with
 // a dynamically allocated port.
 const defaultRedirectUri = "http://localhost:0"
+
+// httpRequestTimeout is the timeout applied to the HTTP client built when the caller doesn't supply their own via
+// SetHttpClient. It bounds discovery and token-endpoint requests so a stalled connection to the authorization server
+// fails instead of hanging forever.
+const httpRequestTimeout = 30 * time.Second
 
 // defaultScopes is the list of scopes that will be requested by default if the server supports them and the user
 // doesn't explicitly set scopes.

--- a/fulfillment-service/internal/oauth/oauth_token_source_test.go
+++ b/fulfillment-service/internal/oauth/oauth_token_source_test.go
@@ -1035,11 +1035,11 @@ var _ = Describe("Token source", func() {
 				},
 			),
 		)
-		// release unblocks the handler. It is closed explicitly right after the request below
-		// returns (success or failure) rather than relying on the server noticing the client gave
-		// up, which isn't guaranteed to happen promptly — so that server.Close() during cleanup
-		// doesn't itself block waiting for this handler to return.
+		// release unblocks the handler. Deferred so it always runs — even if the goroutine below
+		// never completes — so server.Close() during cleanup doesn't itself block waiting for this
+		// handler to return.
 		release := make(chan struct{})
+		defer close(release)
 		server.RouteToHandler(
 			http.MethodPost,
 			"/token",
@@ -1061,15 +1061,27 @@ var _ = Describe("Token source", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Request a token with a context that has a short deadline. If the request honors the
-		// context, it fails quickly once the deadline is reached instead of hanging forever:
+		// context, it fails quickly once the deadline is reached instead of hanging forever. Run it
+		// in a goroutine racing a timer, rather than calling it synchronously, so that a regression
+		// fails this spec cleanly instead of hanging the whole test binary:
 		requestCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 		defer cancel()
+		done := make(chan error, 1)
 		start := time.Now()
-		_, err = source.Token(requestCtx)
-		elapsed := time.Since(start)
-		close(release)
+		go func() {
+			_, tokenErr := source.Token(requestCtx)
+			done <- tokenErr
+		}()
 
-		Expect(err).To(HaveOccurred())
+		var tokenErr error
+		select {
+		case tokenErr = <-done:
+		case <-time.After(5 * time.Second):
+			Fail("Token() should fail promptly once the context deadline is reached, not hang forever")
+		}
+		elapsed := time.Since(start)
+
+		Expect(tokenErr).To(HaveOccurred())
 		Expect(elapsed).To(BeNumerically("<", 5*time.Second),
 			"Token() should fail promptly once the context deadline is reached, not hang forever")
 	})

--- a/fulfillment-service/internal/oauth/oauth_token_source_test.go
+++ b/fulfillment-service/internal/oauth/oauth_token_source_test.go
@@ -1007,4 +1007,70 @@ var _ = Describe("Token source", func() {
 		// Verify that no scopes were requested:
 		Expect(requestedScopes).To(BeEmpty())
 	})
+
+	It("Fails promptly instead of hanging when the token endpoint never responds", func() {
+		// Create a server whose token endpoint accepts the request but never writes a response,
+		// simulating a stalled connection to the OAuth server. This isn't reachable using the
+		// standard ghttp handlers used by the other tests in this file, which always respond
+		// immediately.
+		server, caFile := testing.MakeTCPTLSServer()
+		DeferCleanup(server.Close)
+		DeferCleanup(func() {
+			err := os.Remove(caFile)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		caPool, err := network.NewCertPool().
+			SetLogger(logger).
+			AddFile(caFile).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		server.RouteToHandler(
+			http.MethodGet,
+			"/.well-known/oauth-authorization-server",
+			RespondWithJSONEncoded(
+				http.StatusOK,
+				&ServerMetadata{
+					Issuer:        server.URL(),
+					TokenEndpoint: fmt.Sprintf("%s/token", server.URL()),
+				},
+			),
+		)
+		// release unblocks the handler. It is closed explicitly right after the request below
+		// returns (success or failure) rather than relying on the server noticing the client gave
+		// up, which isn't guaranteed to happen promptly — so that server.Close() during cleanup
+		// doesn't itself block waiting for this handler to return.
+		release := make(chan struct{})
+		server.RouteToHandler(
+			http.MethodPost,
+			"/token",
+			func(w http.ResponseWriter, r *http.Request) {
+				<-release
+			},
+		)
+
+		// Create the source:
+		source, err := NewTokenSource().
+			SetLogger(logger).
+			SetIssuer(server.URL()).
+			SetStore(store).
+			SetFlow(CredentialsFlow).
+			SetClientId("my_client").
+			SetClientSecret("my_secret").
+			SetCaPool(caPool).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Request a token with a context that has a short deadline. If the request honors the
+		// context, it fails quickly once the deadline is reached instead of hanging forever:
+		requestCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		defer cancel()
+		start := time.Now()
+		_, err = source.Token(requestCtx)
+		elapsed := time.Since(start)
+		close(release)
+
+		Expect(err).To(HaveOccurred())
+		Expect(elapsed).To(BeNumerically("<", 5*time.Second),
+			"Token() should fail promptly once the context deadline is reached, not hang forever")
+	})
 })


### PR DESCRIPTION
## Summary
- `sendForm()` (login/token refresh) and `logout_cmd.go`'s `terminateSession`/`refreshForIdToken` all sent requests via `http.Client.PostForm`/`.Get`, which build their request with `context.Background()` internally, so the caller's context could never cancel a stalled request; combined with falling back to an unbounded-timeout client, any stall talking to the OAuth server hung the CLI forever
- Requests are now built explicitly with `http.NewRequestWithContext` so the caller's context is honored, and a bounded 30s timeout is set on every client constructed by this code instead of relying on an unbounded default
- Audited the rest of the `osac` mono-repo (osac-operator, osac-csi-driver, bare-metal-fulfillment-operator, and the rest of fulfillment-service) for the same pattern — no other instances found; server-side JWKS/API-client code already builds context-aware requests correctly
- Adds regression tests for all three fixed call sites that point their respective endpoint at a handler that never responds and assert the call fails promptly once the context deadline is reached

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - OAuth token requests now honor caller-provided cancellation and deadlines.
  - Requests to unresponsive token endpoints fail promptly instead of hanging indefinitely.
  - Logout and token-refresh requests now stop promptly when cancelled or when deadlines expire.
  - Requests without a deadline use a 30-second timeout.
  - Form requests explicitly provide the expected content type.
  - TLS connections now require TLS 1.3 or later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->