### PR TITLE
NO-ISSUE: Restore e2e-caas-netris-full-install as on-demand only

### DIFF
--- a/.github/workflows/e2e-caas-netris-full-install.yml
+++ b/.github/workflows/e2e-caas-netris-full-install.yml
@@ -73,6 +73,10 @@ jobs:
           {"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},
           {"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"}
         ]
+      # Pass author_association for fork PR authorization (empty for non-fork PRs)
+      fork-pr-author-association: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association || '' }}
+      fork-pr-author: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.user.login || '' }}
+      pr-number: ${{ github.event.pull_request.number }}
 
   e2e:
     if: always()

--- a/.github/workflows/e2e-caas-netris-full-install.yml
+++ b/.github/workflows/e2e-caas-netris-full-install.yml
@@ -1,0 +1,89 @@
+---
+name: E2E CaaS Netris Full Install
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+  schedule:
+    - cron: "53 6 * * *"
+  workflow_dispatch:
+    inputs:
+      test-infra-ref:
+        description: "Branch/ref of osac-test-infra"
+        required: false
+        default: "main"
+
+concurrency:
+  group: e2e-caas-netris-full-install-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      should-run: ${{ github.event_name != 'pull_request' || (steps.filter.outputs.code == 'true' && github.run_attempt != '1') }}
+    steps:
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '**'
+              - '!**/OWNERS'
+              - '!**/LICENSE'
+              - '!**/*.md'
+              - '!**/docs/**'
+
+      # This suite doesn't run automatically on a PR's first check run --
+      # only on explicit re-run (github.run_attempt != '1' above), since it
+      # provisions a real ephemeral EC2 box and running it on every PR isn't
+      # warranted. To run it for real: comment `/test e2e-caas-netris-full-install`
+      # on the PR, or click "Re-run this job" on this check in the GitHub UI.
+      - if: github.event_name == 'pull_request' && github.run_attempt == '1'
+        run: |
+          echo "e2e-caas-netris-full-install does not run automatically on PRs."
+          echo "To run it: comment '/test e2e-caas-netris-full-install' on this PR, or re-run this job from the GitHub UI."
+
+  # Provisions an ephemeral EC2 c5n.metal box, deploys the full Netris
+  # Spectrum-X simulated lab + OCP SNO (from snapshot) + OSAC (fresh Helm
+  # install with PR component images), and runs the CaaS test suite.
+  #
+  # All component images are built from this PR's code on the EC2 box and
+  # loaded onto the SNO node via oc debug + podman load.
+  e2e-caas-netris-full-install:
+    needs: changes
+    if: needs.changes.outputs.should-run == 'true'
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-caas-netris-full-install.yml@main
+    with:
+      osac-repo: ${{ github.event.pull_request.head.repo.clone_url || format('https://github.com/{0}.git', github.repository) }}
+      osac-branch: ${{ github.event.pull_request.head.ref || github.ref_name }}
+      test-infra-repository: osac-project/osac-test-infra
+      components: >-
+        [
+          {"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","imageKey":"service.images.service"},
+          {"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","imageKey":"operator.image.repository"},
+          {"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},
+          {"repo":"${{ github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"}
+        ]
+
+  e2e:
+    if: always()
+    needs: [changes, e2e-caas-netris-full-install]
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "Upstream job results:"
+          echo "  changes: ${{ needs.changes.result }}"
+          echo "  e2e-caas-netris-full-install: ${{ needs.e2e-caas-netris-full-install.result }}"
+          echo ""
+          echo "One or more upstream jobs failed or were cancelled."
+          exit 1


### PR DESCRIPTION
## Summary

PR #110 ([OSAC-2801](https://redhat.atlassian.net/browse/OSAC-2801)) added e2e-caas-netris-full-install.yml (provisions an ephemeral EC2 c5n.metal box, runs a full Netris Spectrum-X simulated lab + OCP SNO + OSAC install, then the CaaS suite), auto-triggered on every PR. It started failing on every PR -- including totally unrelated ones -- with `gh: Resource not accessible by personal access token (HTTP 403)` when registering the ephemeral EC2 instance as a JIT GitHub Actions runner. That's a separate, still-open token/permissions problem, not addressed by this PR. #166 reverted the whole workflow rather than leave every PR red.

This restores the original file (`git show 4416ff26:.github/workflows/e2e-caas-netris-full-install.yml`) verbatim, with exactly one substantive change: the `changes` job's `should-run` output now also requires `github.run_attempt != '1'` on `pull_request` events, so the suite is skipped (not run) on a PR's automatic first check run. `schedule`/`workflow_dispatch`/`merge_group` triggers are untouched -- those always run for real. Also adds a log step (pull_request + attempt 1 only) explaining how to actually trigger it.

**Why this works with zero shared-code changes**: `github.run_attempt` is `1` for a workflow's original run and `2+` for each `gh run rerun`. `osac-test-infra`'s existing shared `slash-command-handler.yml` (untouched) already finds an existing PR-triggered run for a given workflow at the PR's current head SHA and reruns it on `/test <workflow>` -- that's exactly attempt 2+. Keeping `on: pull_request` means there's always a run for the handler to find and rerun; no new trigger mechanism, and zero effect on e2e-bmaas/e2e-vmaas/e2e-caas-full-install's own `/test` commands (their own workflows and the shared handler are both unmodified).

## Test plan

- [x] YAML parses, `yamllint --strict`, `actionlint`, full `pre-commit run` all pass
- [ ] This PR's own check list shows `E2E CaaS Netris Full Install` completing quickly as skipped on the initial push (not running, not red) -- proves the JIT-runner-403 path is no longer hit automatically
- [ ] Comment `/test e2e-caas-netris-full-install` on this PR and confirm the existing slash-command handler finds and reruns the same check (not a new one), and that attempt 2 actually starts the real job (reaches EC2 provisioning) -- expected to still hit the separate JIT-runner-403 issue at that point, which is out of scope here; this only proves it's on-demand now, not that the suite passes end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated end-to-end coverage for the full-install suite.
  * Tests now run on pull requests, merge queues, scheduled daily runs, and on demand.
  * Added safeguards to report and fail the workflow when test execution is unsuccessful or cancelled.
  * Coverage includes validation of key application components during complete installation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->