### PR TITLE
OSAC-3668: grant osac-operator networkclasses RBAC for hub-access escalation

### DIFF
--- a/bare-metal-fulfillment-operator/charts/operator-crds/templates/osac.openshift.io_baremetalinstances.yaml
+++ b/bare-metal-fulfillment-operator/charts/operator-crds/templates/osac.openshift.io_baremetalinstances.yaml
@@ -323,6 +323,13 @@ spec:
                       - Canceled
                       - Unknown
                       type: string
+                    target:
+                      description: |-
+                        Target identifies which manager this job was dispatched to, for resources
+                        that provision through multiple managers concurrently (e.g. a Subnet
+                        dispatching to both a fabric manager and a k8s manager). Empty for
+                        resources with a single provisioning target.
+                      type: string
                     timestamp:
                       description: Timestamp when this job was created/triggered
                       format: date-time

--- a/bare-metal-fulfillment-operator/charts/operator-crds/templates/osac.openshift.io_baremetalpools.yaml
+++ b/bare-metal-fulfillment-operator/charts/operator-crds/templates/osac.openshift.io_baremetalpools.yaml
@@ -242,6 +242,13 @@ spec:
                       - Canceled
                       - Unknown
                       type: string
+                    target:
+                      description: |-
+                        Target identifies which manager this job was dispatched to, for resources
+                        that provision through multiple managers concurrently (e.g. a Subnet
+                        dispatching to both a fabric manager and a k8s manager). Empty for
+                        resources with a single provisioning target.
+                      type: string
                     timestamp:
                       description: Timestamp when this job was created/triggered
                       format: date-time

--- a/bare-metal-fulfillment-operator/charts/operator/templates/clusterrole.yaml
+++ b/bare-metal-fulfillment-operator/charts/operator/templates/clusterrole.yaml
@@ -45,3 +45,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - osac.openshift.io
+  resources:
+  - networkclasses
+  - subnets
+  verbs:
+  - get
+  - list
+  - watch

--- a/bare-metal-fulfillment-operator/config/crd/bases/osac.openshift.io_baremetalinstances.yaml
+++ b/bare-metal-fulfillment-operator/config/crd/bases/osac.openshift.io_baremetalinstances.yaml
@@ -322,6 +322,13 @@ spec:
                       - Canceled
                       - Unknown
                       type: string
+                    target:
+                      description: |-
+                        Target identifies which manager this job was dispatched to, for resources
+                        that provision through multiple managers concurrently (e.g. a Subnet
+                        dispatching to both a fabric manager and a k8s manager). Empty for
+                        resources with a single provisioning target.
+                      type: string
                     timestamp:
                       description: Timestamp when this job was created/triggered
                       format: date-time

--- a/bare-metal-fulfillment-operator/config/crd/bases/osac.openshift.io_baremetalpools.yaml
+++ b/bare-metal-fulfillment-operator/config/crd/bases/osac.openshift.io_baremetalpools.yaml
@@ -241,6 +241,13 @@ spec:
                       - Canceled
                       - Unknown
                       type: string
+                    target:
+                      description: |-
+                        Target identifies which manager this job was dispatched to, for resources
+                        that provision through multiple managers concurrently (e.g. a Subnet
+                        dispatching to both a fabric manager and a k8s manager). Empty for
+                        resources with a single provisioning target.
+                      type: string
                     timestamp:
                       description: Timestamp when this job was created/triggered
                       format: date-time

--- a/bare-metal-fulfillment-operator/config/rbac/role.yaml
+++ b/bare-metal-fulfillment-operator/config/rbac/role.yaml
@@ -43,3 +43,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - osac.openshift.io
+  resources:
+  - networkclasses
+  - subnets
+  verbs:
+  - get
+  - list
+  - watch

--- a/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_controller.go
+++ b/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_controller.go
@@ -98,6 +98,8 @@ func NewBareMetalInstanceReconciler(
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=baremetalinstances/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=baremetalinstances/finalizers,verbs=update
 // +kubebuilder:rbac:groups=metal3.io,resources=baremetalhosts,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=subnets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=networkclasses,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the pool closer to the desired state.

--- a/osac-installer/charts/osac/templates/hub-access.yaml
+++ b/osac-installer/charts/osac/templates/hub-access.yaml
@@ -65,6 +65,15 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - subnets
+      - networkclasses
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/osac-operator/charts/operator/templates/clusterrole.yaml
+++ b/osac-operator/charts/operator/templates/clusterrole.yaml
@@ -119,6 +119,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - osac.openshift.io
+  resources:
+  - networkclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/osac-operator/config/rbac/role.yaml
+++ b/osac-operator/config/rbac/role.yaml
@@ -141,6 +141,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - osac.openshift.io
+  resources:
+  - networkclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/osac-operator/internal/controller/clusterorder_controller.go
+++ b/osac-operator/internal/controller/clusterorder_controller.go
@@ -116,6 +116,8 @@ func NewClusterOrderReconciler(
 // +kubebuilder:rbac:groups="",resources=namespaces;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=hypershift.openshift.io,resources=hostedclusters;nodepools,verbs=get;list;watch
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=subnets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=networkclasses,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
## [OSAC-3668](https://redhat.atlassian.net/browse/OSAC-3668): Grant osac-operator networkclasses RBAC for hub-access escalation

**Jira:** https://redhat.atlassian.net/browse/OSAC-3668
**Fixes regression from:** [OSAC-2352](https://redhat.atlassian.net/browse/OSAC-2352) / #111

### Root cause

[OSAC-2352](https://redhat.atlassian.net/browse/OSAC-2352) added `subnets` and `networkclasses` read rules to the `hub-access-hosted-clusters` ClusterRole but did not grant the osac-operator SA matching `networkclasses` permissions. The osac-operator creates per-ClusterOrder RoleBindings referencing that ClusterRole ([OSAC-1121](https://redhat.atlassian.net/browse/OSAC-1121)). Kubernetes RBAC escalation prevention blocked the binding — the operator SA cannot grant permissions it does not hold. Result: ClusterOrder stuck with no phase, no HostedCluster created.

### Fix

- **osac-operator**: add `networkclasses` get/list/watch kubebuilder RBAC marker to `clusterorder_controller.go`, regenerate `config/rbac/role.yaml`, update Helm chart clusterrole
- **bare-metal-fulfillment-operator**: re-apply reverted [OSAC-2352](https://redhat.atlassian.net/browse/OSAC-2352) `subnets`/`networkclasses` markers + regenerated manifests
- **osac-installer**: re-apply reverted [OSAC-2352](https://redhat.atlassian.net/browse/OSAC-2352) `subnets`/`networkclasses` rules to `hub-access-hosted-clusters` ClusterRole

### Testing

- `make lint` — 0 issues (both operators)
- `make test` — all pass (both operators)
- `helm lint` — pass (osac-installer)
- CaaS E2E should now succeed — operator can create hub-access RoleBinding without escalation denial

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Expanded platform access controls to support read-only discovery of network classes and subnets.
  * Improved operator and hosted-cluster integration with network configuration resources.
  * Controllers can now monitor network classes and subnet availability for provisioning workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->