### PR TITLE
NO-ISSUE: fix - preserve billing context through transient states and treat DELETING as billing-ending

### DIFF
--- a/osac-metering/metering-service/internal/events/compute_instance.go
+++ b/osac-metering/metering-service/internal/events/compute_instance.go
@@ -121,9 +121,9 @@ func (m *computeInstanceMapper) resolveUpdatedEventType(previousState string) (s
 		return "osac.resource.resumed.v1", nil
 	case currentState == "RUNNING":
 		return "osac.resource.started.v1", nil
-	case currentState == "STOPPED" || currentState == "PAUSED" || currentState == "FAILED":
+	case currentState == "STOPPED" || currentState == "PAUSED" || currentState == "FAILED" || currentState == "DELETING":
 		return "osac.resource.suspended.v1", nil
-	case currentState == "STOPPING" || currentState == "STARTING" || currentState == "DELETING":
+	case currentState == "STOPPING" || currentState == "STARTING":
 		return "", ErrTransientState
 	case currentState == "UNSPECIFIED":
 		return "osac.resource.updated.v1", nil

--- a/osac-metering/metering-service/internal/events/compute_instance.go
+++ b/osac-metering/metering-service/internal/events/compute_instance.go
@@ -107,24 +107,28 @@ func (m *computeInstanceMapper) CloudEventType(eventType privatev1.EventType, pr
 	case privatev1.EventType_EVENT_TYPE_OBJECT_DELETED:
 		return "osac.resource.deleted.v1", nil
 	case privatev1.EventType_EVENT_TYPE_OBJECT_UPDATED:
-		return m.resolveUpdatedEventType(previousState), nil
+		return m.resolveUpdatedEventType(previousState)
 	default:
 		return "", fmt.Errorf("unsupported event type: %v", eventType)
 	}
 }
 
-func (m *computeInstanceMapper) resolveUpdatedEventType(previousState string) string {
+func (m *computeInstanceMapper) resolveUpdatedEventType(previousState string) (string, error) {
 	currentState := m.CurrentState()
 
 	switch {
 	case currentState == "RUNNING" && (previousState == "STOPPED" || previousState == "PAUSED"):
-		return "osac.resource.resumed.v1"
+		return "osac.resource.resumed.v1", nil
 	case currentState == "RUNNING":
-		return "osac.resource.started.v1"
+		return "osac.resource.started.v1", nil
 	case currentState == "STOPPED" || currentState == "PAUSED" || currentState == "FAILED":
-		return "osac.resource.suspended.v1"
+		return "osac.resource.suspended.v1", nil
+	case currentState == "STOPPING" || currentState == "STARTING" || currentState == "DELETING":
+		return "", ErrTransientState
+	case currentState == "UNSPECIFIED":
+		return "osac.resource.updated.v1", nil
 	default:
-		return "osac.resource.updated.v1"
+		return "", fmt.Errorf("unexpected compute instance state transition: %s -> %s", previousState, currentState)
 	}
 }
 

--- a/osac-metering/metering-service/internal/events/mapper.go
+++ b/osac-metering/metering-service/internal/events/mapper.go
@@ -10,7 +10,10 @@ import (
 	privatev1 "github.com/osac-project/osac-metering/internal/api/osac/private/v1"
 )
 
-var ErrDataQuality = errors.New("data quality")
+var (
+	ErrDataQuality    = errors.New("data quality")
+	ErrTransientState = errors.New("transient state: update projection only, no CloudEvent")
+)
 
 // ResourceMapper extracts metering data from a resource-specific Event payload.
 // Each OSAC resource type (ComputeInstance, ClusterOrder, etc.) implements this.

--- a/osac-metering/metering-service/internal/events/mapper_test.go
+++ b/osac-metering/metering-service/internal/events/mapper_test.go
@@ -124,21 +124,7 @@ var _ = Describe("MapWatchEvent", func() {
 			Expect(ce.Type()).To(Equal("osac.resource.suspended.v1"))
 		})
 
-		It("maps OBJECT_UPDATED with STARTING state to osac.resource.updated.v1", func() {
-			ci.Status.State = privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_STARTING
-
-			event := &privatev1.Event{
-				Id:      "evt-2",
-				Type:    privatev1.EventType_EVENT_TYPE_OBJECT_UPDATED,
-				Payload: &privatev1.Event_ComputeInstance{ComputeInstance: ci},
-			}
-
-			ce, err := mapEvent(event, &events.StateContext{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ce.Type()).To(Equal("osac.resource.updated.v1"))
-		})
-
-		It("maps OBJECT_UPDATED with STOPPING state to osac.resource.updated.v1", func() {
+		It("returns ErrTransientState for STOPPING state", func() {
 			ci.Status.State = privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_STOPPING
 
 			event := &privatev1.Event{
@@ -147,9 +133,37 @@ var _ = Describe("MapWatchEvent", func() {
 				Payload: &privatev1.Event_ComputeInstance{ComputeInstance: ci},
 			}
 
-			ce, err := mapEvent(event, &events.StateContext{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ce.Type()).To(Equal("osac.resource.updated.v1"))
+			_, err := mapEvent(event, &events.StateContext{})
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, events.ErrTransientState)).To(BeTrue())
+		})
+
+		It("returns ErrTransientState for STARTING state", func() {
+			ci.Status.State = privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_STARTING
+
+			event := &privatev1.Event{
+				Id:      "evt-starting",
+				Type:    privatev1.EventType_EVENT_TYPE_OBJECT_UPDATED,
+				Payload: &privatev1.Event_ComputeInstance{ComputeInstance: ci},
+			}
+
+			_, err := mapEvent(event, &events.StateContext{})
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, events.ErrTransientState)).To(BeTrue())
+		})
+
+		It("returns ErrTransientState for DELETING state", func() {
+			ci.Status.State = privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_DELETING
+
+			event := &privatev1.Event{
+				Id:      "evt-deleting",
+				Type:    privatev1.EventType_EVENT_TYPE_OBJECT_UPDATED,
+				Payload: &privatev1.Event_ComputeInstance{ComputeInstance: ci},
+			}
+
+			_, err := mapEvent(event, &events.StateContext{})
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, events.ErrTransientState)).To(BeTrue())
 		})
 
 		It("maps STOPPED→RUNNING to osac.resource.resumed.v1 with state context", func() {
@@ -227,20 +241,6 @@ var _ = Describe("MapWatchEvent", func() {
 			Expect(ce.Type()).To(Equal("osac.resource.started.v1"))
 		})
 
-		It("maps DELETING to osac.resource.updated.v1", func() {
-			ci.Status.State = privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_DELETING
-
-			event := &privatev1.Event{
-				Id:      "evt-deleting",
-				Type:    privatev1.EventType_EVENT_TYPE_OBJECT_UPDATED,
-				Payload: &privatev1.Event_ComputeInstance{ComputeInstance: ci},
-			}
-
-			ce, err := mapEvent(event, &events.StateContext{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ce.Type()).To(Equal("osac.resource.updated.v1"))
-		})
-
 		It("maps UNSPECIFIED to osac.resource.updated.v1", func() {
 			ci.Status.State = privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_UNSPECIFIED
 
@@ -253,6 +253,21 @@ var _ = Describe("MapWatchEvent", func() {
 			ce, err := mapEvent(event, &events.StateContext{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ce.Type()).To(Equal("osac.resource.updated.v1"))
+		})
+
+		It("returns error for unknown state (default branch)", func() {
+			ci.Status.State = privatev1.ComputeInstanceState(9999)
+
+			event := &privatev1.Event{
+				Id:      "evt-unknown-state",
+				Type:    privatev1.EventType_EVENT_TYPE_OBJECT_UPDATED,
+				Payload: &privatev1.Event_ComputeInstance{ComputeInstance: ci},
+			}
+
+			_, err := mapEvent(event, &events.StateContext{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unexpected compute instance state transition"))
+			Expect(errors.Is(err, events.ErrTransientState)).To(BeFalse())
 		})
 
 		It("maps RUNNING→STOPPED with duration to osac.resource.suspended.v1", func() {

--- a/osac-metering/metering-service/internal/events/mapper_test.go
+++ b/osac-metering/metering-service/internal/events/mapper_test.go
@@ -152,7 +152,7 @@ var _ = Describe("MapWatchEvent", func() {
 			Expect(errors.Is(err, events.ErrTransientState)).To(BeTrue())
 		})
 
-		It("returns ErrTransientState for DELETING state", func() {
+		It("maps DELETING to osac.resource.suspended.v1", func() {
 			ci.Status.State = privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_DELETING
 
 			event := &privatev1.Event{
@@ -161,9 +161,10 @@ var _ = Describe("MapWatchEvent", func() {
 				Payload: &privatev1.Event_ComputeInstance{ComputeInstance: ci},
 			}
 
-			_, err := mapEvent(event, &events.StateContext{})
-			Expect(err).To(HaveOccurred())
-			Expect(errors.Is(err, events.ErrTransientState)).To(BeTrue())
+			stateCtx := &events.StateContext{PreviousState: "RUNNING"}
+			ce, err := mapEvent(event, stateCtx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ce.Type()).To(Equal("osac.resource.suspended.v1"))
 		})
 
 		It("maps STOPPED→RUNNING to osac.resource.resumed.v1 with state context", func() {

--- a/osac-metering/metering-service/internal/reconciliation/correction.go
+++ b/osac-metering/metering-service/internal/reconciliation/correction.go
@@ -61,7 +61,7 @@ func correctionDescription(reason CorrectionReason) string {
 	case MissedDeletion:
 		return "Resource found in metering projection but missing from fulfillment-service"
 	default:
-		return string(reason)
+		return fmt.Sprintf("unknown correction reason: %s", reason)
 	}
 }
 

--- a/osac-metering/metering-service/internal/watch/consumer.go
+++ b/osac-metering/metering-service/internal/watch/consumer.go
@@ -188,9 +188,9 @@ func (c *Consumer) handleEvent(ctx context.Context, event *privatev1.Event) erro
 }
 
 // handleTransientState updates the projection's CurrentState and
-// FulfillmentVersion for transient states (STOPPING, STARTING, DELETING)
-// without changing billing fields or emitting a CloudEvent. This preserves
-// the billing context (IsBillable, BillableSince) so that the subsequent
+// FulfillmentVersion for transient states (STOPPING, STARTING) without
+// changing billing fields or emitting a CloudEvent. This preserves the
+// billing context (IsBillable, BillableSince) so that the subsequent
 // final state transition (e.g., STOPPED) can compute duration_seconds
 // correctly on the suspended.v1 event.
 func (c *Consumer) handleTransientState(

--- a/osac-metering/metering-service/internal/watch/consumer.go
+++ b/osac-metering/metering-service/internal/watch/consumer.go
@@ -151,7 +151,7 @@ func (c *Consumer) handleEvent(ctx context.Context, event *privatev1.Event) erro
 	ce, err := events.MapWatchEvent(event, mapper, stateCtx)
 	if err != nil {
 		if errors.Is(err, events.ErrTransientState) {
-			return c.handleTransientState(ctx, mapper, existing, version, currentState, transitionTime)
+			return c.handleTransientState(ctx, mapper, existing, version, transitionTime)
 		}
 		return err
 	}
@@ -187,26 +187,22 @@ func (c *Consumer) handleEvent(ctx context.Context, event *privatev1.Event) erro
 	return nil
 }
 
-// handleTransientState updates the projection's CurrentState and
-// FulfillmentVersion for transient states (STOPPING, STARTING) without
-// changing billing fields or emitting a CloudEvent. This preserves the
-// billing context (IsBillable, BillableSince) so that the subsequent
-// final state transition (e.g., STOPPED) can compute duration_seconds
-// correctly on the suspended.v1 event.
+// handleTransientState updates only FulfillmentVersion and TransitionTime
+// for transient states (STOPPING, STARTING) without changing CurrentState,
+// billing fields, or emitting a CloudEvent. The projection keeps
+// CurrentState=RUNNING so the subsequent final state (e.g., STOPPED)
+// sees previous_state=RUNNING and computes duration_seconds correctly.
 func (c *Consumer) handleTransientState(
 	ctx context.Context,
 	mapper events.ResourceMapper,
 	existing *projection.ResourceState,
 	version int32,
-	currentState string,
 	transitionTime time.Time,
 ) error {
 	if existing == nil {
 		return nil
 	}
 
-	existing.PreviousState = existing.CurrentState
-	existing.CurrentState = currentState
 	existing.FulfillmentVersion = version
 	existing.TransitionTime = transitionTime.UTC()
 
@@ -214,14 +210,14 @@ func (c *Consumer) handleTransientState(
 	if err != nil {
 		if errors.Is(err, projection.ErrStaleVersion) {
 			c.logger.Info("stale version during transient state update, skipping",
-				"resource_id", mapper.ResourceID(), "state", currentState)
+				"resource_id", mapper.ResourceID())
 			return nil
 		}
 		return fmt.Errorf("upserting transient state for %s: %w", mapper.ResourceID(), err)
 	}
 
 	c.logger.V(1).Info("transient state updated (no CloudEvent)",
-		"resource_id", mapper.ResourceID(), "state", currentState)
+		"resource_id", mapper.ResourceID())
 	return nil
 }
 

--- a/osac-metering/metering-service/internal/watch/consumer.go
+++ b/osac-metering/metering-service/internal/watch/consumer.go
@@ -150,6 +150,9 @@ func (c *Consumer) handleEvent(ctx context.Context, event *privatev1.Event) erro
 
 	ce, err := events.MapWatchEvent(event, mapper, stateCtx)
 	if err != nil {
+		if errors.Is(err, events.ErrTransientState) {
+			return c.handleTransientState(ctx, mapper, existing, version, currentState, transitionTime)
+		}
 		return err
 	}
 
@@ -181,6 +184,44 @@ func (c *Consumer) handleEvent(ctx context.Context, event *privatev1.Event) erro
 		return err
 	}
 
+	return nil
+}
+
+// handleTransientState updates the projection's CurrentState and
+// FulfillmentVersion for transient states (STOPPING, STARTING, DELETING)
+// without changing billing fields or emitting a CloudEvent. This preserves
+// the billing context (IsBillable, BillableSince) so that the subsequent
+// final state transition (e.g., STOPPED) can compute duration_seconds
+// correctly on the suspended.v1 event.
+func (c *Consumer) handleTransientState(
+	ctx context.Context,
+	mapper events.ResourceMapper,
+	existing *projection.ResourceState,
+	version int32,
+	currentState string,
+	transitionTime time.Time,
+) error {
+	if existing == nil {
+		return nil
+	}
+
+	existing.PreviousState = existing.CurrentState
+	existing.CurrentState = currentState
+	existing.FulfillmentVersion = version
+	existing.TransitionTime = transitionTime.UTC()
+
+	err := c.store.Upsert(ctx, *existing)
+	if err != nil {
+		if errors.Is(err, projection.ErrStaleVersion) {
+			c.logger.Info("stale version during transient state update, skipping",
+				"resource_id", mapper.ResourceID(), "state", currentState)
+			return nil
+		}
+		return fmt.Errorf("upserting transient state for %s: %w", mapper.ResourceID(), err)
+	}
+
+	c.logger.V(1).Info("transient state updated (no CloudEvent)",
+		"resource_id", mapper.ResourceID(), "state", currentState)
 	return nil
 }
 

--- a/osac-metering/metering-service/internal/watch/consumer_test.go
+++ b/osac-metering/metering-service/internal/watch/consumer_test.go
@@ -710,6 +710,76 @@ var _ = Describe("Consumer", func() {
 			Expect(updated.BillableSince.After(originalStart)).To(BeTrue())
 		})
 
+		It("preserves billing context through RUNNING→STOPPING→STOPPED sequence", func() {
+			store := newMockStore()
+			now := time.Now().Add(-1 * time.Hour).UTC().Truncate(time.Microsecond)
+			store.states["vm-stop-seq"] = projection.ResourceState{
+				ResourceID:         "vm-stop-seq",
+				ResourceType:       "compute_instance",
+				TenantID:           "tenant-1",
+				CurrentState:       "RUNNING",
+				IsBillable:         true,
+				BillableSince:      &now,
+				FulfillmentVersion: 1,
+				BillingDimensions:  map[string]any{},
+				TransitionTime:     now,
+			}
+
+			// Two events: RUNNING→STOPPING, then STOPPING→STOPPED
+			ciStopping := makeComputeInstance("vm-stop-seq", "tenant-1")
+			ciStopping.Status.State = privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_STOPPING
+			ciStopping.Metadata.Version = 2
+
+			ciStopped := makeComputeInstance("vm-stop-seq", "tenant-1")
+			ciStopped.Status.State = privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_STOPPED
+			ciStopped.Metadata.Version = 3
+
+			stream := &mockWatchStream{
+				responses: []*privatev1.EventsWatchResponse{
+					makeResponse(&privatev1.Event{
+						Id:      "evt-stopping",
+						Type:    privatev1.EventType_EVENT_TYPE_OBJECT_UPDATED,
+						Payload: &privatev1.Event_ComputeInstance{ComputeInstance: ciStopping},
+					}),
+					makeResponse(&privatev1.Event{
+						Id:      "evt-stopped",
+						Type:    privatev1.EventType_EVENT_TYPE_OBJECT_UPDATED,
+						Payload: &privatev1.Event_ComputeInstance{ComputeInstance: ciStopped},
+					}),
+				},
+			}
+			client.results = []mockStreamResult{{stream: stream}}
+
+			pub := &mockPublisher{published: make([]cloudevents.Event, 0, 1), cancelFunc: cancel}
+			consumer := newConsumerWithStore(pub, store)
+
+			err := consumer.Run(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			pub.mu.Lock()
+			defer pub.mu.Unlock()
+
+			// STOPPING is transient — no CloudEvent published for it.
+			// Only suspended.v1 for STOPPED should be published.
+			Expect(pub.published).To(HaveLen(1))
+			Expect(pub.published[0].Type()).To(Equal("osac.resource.suspended.v1"))
+
+			// suspended.v1 should have duration_seconds > 0 because
+			// billing context (IsBillable, BillableSince) was preserved
+			// through the transient STOPPING state.
+			var data map[string]any
+			Expect(json.Unmarshal(pub.published[0].Data(), &data)).To(Succeed())
+			Expect(data["previous_state"]).To(Equal("STOPPING"))
+			Expect(data["duration_seconds"]).ToNot(BeNil())
+			Expect(data["duration_seconds"]).To(BeNumerically(">", 0))
+
+			// Projection should show STOPPED, non-billable
+			store.mu.Lock()
+			defer store.mu.Unlock()
+			Expect(store.states["vm-stop-seq"].CurrentState).To(Equal("STOPPED"))
+			Expect(store.states["vm-stop-seq"].IsBillable).To(BeFalse())
+		})
+
 		It("upserts projection for first-seen resource", func() {
 			store := newMockStore()
 			stream := &mockWatchStream{

--- a/osac-metering/metering-service/internal/watch/consumer_test.go
+++ b/osac-metering/metering-service/internal/watch/consumer_test.go
@@ -712,26 +712,31 @@ var _ = Describe("Consumer", func() {
 
 		It("preserves billing context through RUNNING→STOPPING→STOPPED sequence", func() {
 			store := newMockStore()
-			now := time.Now().Add(-1 * time.Hour).UTC().Truncate(time.Microsecond)
+			billableStart := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
 			store.states["vm-stop-seq"] = projection.ResourceState{
 				ResourceID:         "vm-stop-seq",
 				ResourceType:       "compute_instance",
 				TenantID:           "tenant-1",
 				CurrentState:       "RUNNING",
 				IsBillable:         true,
-				BillableSince:      &now,
+				BillableSince:      &billableStart,
 				FulfillmentVersion: 1,
 				BillingDimensions:  map[string]any{},
-				TransitionTime:     now,
+				TransitionTime:     billableStart,
 			}
 
 			// Two events: RUNNING→STOPPING, then STOPPING→STOPPED
+			stoppingTime := billableStart.Add(30 * time.Minute)
+			stoppedTime := billableStart.Add(1 * time.Hour)
+
 			ciStopping := makeComputeInstance("vm-stop-seq", "tenant-1")
 			ciStopping.Status.State = privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_STOPPING
+			ciStopping.Status.StateTransitionTime = timestamppb.New(stoppingTime)
 			ciStopping.Metadata.Version = 2
 
 			ciStopped := makeComputeInstance("vm-stop-seq", "tenant-1")
 			ciStopped.Status.State = privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_STOPPED
+			ciStopped.Status.StateTransitionTime = timestamppb.New(stoppedTime)
 			ciStopped.Metadata.Version = 3
 
 			stream := &mockWatchStream{
@@ -764,14 +769,13 @@ var _ = Describe("Consumer", func() {
 			Expect(pub.published).To(HaveLen(1))
 			Expect(pub.published[0].Type()).To(Equal("osac.resource.suspended.v1"))
 
-			// suspended.v1 should have duration_seconds > 0 because
-			// billing context (IsBillable, BillableSince) was preserved
-			// through the transient STOPPING state.
+			// suspended.v1 should have duration_seconds = 3600 (1 hour from
+			// BillableSince to STOPPED transition time), proving billing context
+			// was preserved through STOPPING, not reset to STOPPING time.
 			var data map[string]any
 			Expect(json.Unmarshal(pub.published[0].Data(), &data)).To(Succeed())
 			Expect(data["previous_state"]).To(Equal("STOPPING"))
-			Expect(data["duration_seconds"]).ToNot(BeNil())
-			Expect(data["duration_seconds"]).To(BeNumerically(">", 0))
+			Expect(data["duration_seconds"]).To(BeNumerically("~", 3600.0, 0.1))
 
 			// Projection should show STOPPED, non-billable
 			store.mu.Lock()

--- a/osac-metering/metering-service/internal/watch/consumer_test.go
+++ b/osac-metering/metering-service/internal/watch/consumer_test.go
@@ -774,7 +774,7 @@ var _ = Describe("Consumer", func() {
 			// was preserved through STOPPING, not reset to STOPPING time.
 			var data map[string]any
 			Expect(json.Unmarshal(pub.published[0].Data(), &data)).To(Succeed())
-			Expect(data["previous_state"]).To(Equal("STOPPING"))
+			Expect(data["previous_state"]).To(Equal("RUNNING"))
 			Expect(data["duration_seconds"]).To(BeNumerically("~", 3600.0, 0.1))
 
 			// Projection should show STOPPED, non-billable


### PR DESCRIPTION
## Summary

Fixes a billing data integrity bug where transient states (STOPPING,
STARTING) destroyed billing context, causing `suspended.v1` events to
have `null` `duration_seconds` and wrong `previous_state`.

## Bug

When a RUNNING VM is stopped, the state machine goes:
RUNNING → STOPPING → STOPPED

The Watch Consumer emitted:
1. `updated.v1` for STOPPING — overwrote `IsBillable=false`, `BillableSince=nil`
2. `suspended.v1` for STOPPED — `duration_seconds=null`, `previous_state=STOPPING`

The design doc (line 341) says `suspended.v1` should carry
`duration_seconds` for billing closure. Adapters watching for
`suspended.v1` to close billing intervals got no duration.

## Root cause

`resolveUpdatedEventType` mapped STOPPING to `updated.v1`. The
projection update overwrote `IsBillable=false` and `BillableSince=nil`.
When STOPPED arrived, billing context was gone.

## Fix

STOPPING and STARTING now return `ErrTransientState`. The Watch
Consumer catches this and updates only `FulfillmentVersion` +
`TransitionTime` in the projection — `CurrentState`, `IsBillable`,
and `BillableSince` are all preserved. No CloudEvent is published.

When the final state arrives (STOPPED), the projection still shows
`CurrentState=RUNNING`, so `suspended.v1` has `previous_state=RUNNING`
and correct `duration_seconds`. This matches the design exactly.

DELETING emits `suspended.v1` (billing closure), same as
STOPPED/PAUSED/FAILED — it is a billing-ending state, not transient.

Unknown states return an error (fail fast). All supported state
transitions are explicit in the switch.

## Before/After

| Transition | Before | After |
|-----------|--------|-------|
| RUNNING→STOPPING | `updated.v1` (destroyed billing context) | No event (projection: version+time only) |
| STOPPING→STOPPED | `suspended.v1` (duration=null, prev=STOPPING) | `suspended.v1` (duration=3600, prev=RUNNING) |
| RUNNING→DELETING | `updated.v1` (consumed billing context) | `suspended.v1` (duration=3600, billing closed) |
| Unknown state | `updated.v1` (silent) | Error (fail fast) |

## Test plan

- [x] `ginkgo run -r internal` — 127 specs pass
- [x] RUNNING→STOPPING→STOPPED: no event for STOPPING,
  `suspended.v1` has `previous_state=RUNNING` and `duration_seconds ≈ 3600`
  (fixed timestamps prove BillableSince preserved, not reset)
- [x] STOPPING/STARTING return `ErrTransientState`
- [x] DELETING emits `suspended.v1`
- [x] Unknown state (proto value 9999) returns error, not `ErrTransientState`
- [x] Pre-commit passes

## References

- Design doc line 341: "`suspended.v1` — Billing interval closes with exact `duration_seconds`"
- Design doc line 416: "STOPPING → STOPPED → `osac.resource.suspended.v1`"
- E2E test failure: osac-project/osac-test-infra#301

Assisted-by: Claude Code <noreply@anthropic.com>