### PR TITLE
OSAC-3680: add create subcommand and table rendering for HostType resource

### DIFF
--- a/fulfillment-service/internal/cmd/cli/create/create_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/create_cmd.go
@@ -38,6 +38,7 @@ import (
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/computeinstancecatalogitem"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/externalip"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/externalipattachment"
+	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/hosttype"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/hub"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/instancetype"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/natgateway"
@@ -71,6 +72,7 @@ func Cmd() *cobra.Command {
 	result.AddCommand(computeinstancecatalogitem.Cmd())
 	result.AddCommand(externalip.Cmd())
 	result.AddCommand(externalipattachment.Cmd())
+	result.AddCommand(help.MarkPrivateAPI(hosttype.Cmd()))
 	result.AddCommand(help.MarkPrivateAPI(hub.Cmd()))
 	result.AddCommand(help.MarkPrivateAPI(instancetype.Cmd()))
 	result.AddCommand(natgateway.Cmd())

--- a/fulfillment-service/internal/cmd/cli/create/create_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/create/create_cmd_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/clusterversion"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/computeinstance"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/computeinstancecatalogitem"
+	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/hosttype"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/hub"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/securitygroup"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/subnet"
@@ -47,6 +48,7 @@ var _ = Describe("Create command", func() {
 		Entry("clusterversion", clusterversion.Cmd, (*privatev1.ClusterVersion)(nil)),
 		Entry("computeinstance", computeinstance.Cmd, (*publicv1.ComputeInstance)(nil)),
 		Entry("computeinstancecatalogitem", computeinstancecatalogitem.Cmd, (*publicv1.ComputeInstanceCatalogItem)(nil)),
+		Entry("hosttype", hosttype.Cmd, (*privatev1.HostType)(nil)),
 		Entry("hub", hub.Cmd, (*privatev1.Hub)(nil)),
 		Entry("virtualnetwork", virtualnetwork.Cmd, (*publicv1.VirtualNetwork)(nil)),
 		Entry("subnet", subnet.Cmd, (*publicv1.Subnet)(nil)),
@@ -63,7 +65,7 @@ var _ = Describe("Create command", func() {
 				subcommandNames = append(subcommandNames, subcmd.Name())
 			}
 
-			Expect(subcommandNames).To(ContainElements("baremetalinstancecatalogitem", "cluster", "clustercatalogitem", "clusterversion", "computeinstance", "computeinstancecatalogitem", "hub", "virtualnetwork", "subnet", "securitygroup"))
+			Expect(subcommandNames).To(ContainElements("baremetalinstancecatalogitem", "cluster", "clustercatalogitem", "clusterversion", "computeinstance", "computeinstancecatalogitem", "hosttype", "hub", "virtualnetwork", "subnet", "securitygroup"))
 		})
 	})
 
@@ -71,7 +73,7 @@ var _ = Describe("Create command", func() {
 		It("should annotate private-API subcommands", func() {
 			cmd := Cmd()
 			privateNames := map[string]bool{
-				"hub": true, "instancetype": true, "clusterversion": true,
+				"hosttype": true, "hub": true, "instancetype": true, "clusterversion": true,
 				"storagebackend": true, "storagetier": true,
 			}
 			for _, sub := range cmd.Commands() {

--- a/fulfillment-service/internal/cmd/cli/create/hosttype/create_hosttype_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/hosttype/create_hosttype_cmd.go
@@ -1,0 +1,143 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package hosttype
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+
+	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/osac/fulfillment-service/internal/config"
+	"github.com/osac-project/osac/fulfillment-service/internal/terminal"
+)
+
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:                   "hosttype",
+		Aliases:               []string{string(proto.MessageName((*privatev1.HostType)(nil)))},
+		Short:                 shortHelp,
+		Long:                  longHelp,
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.NoArgs,
+		RunE:                  runner.run,
+	}
+	flags := result.Flags()
+	flags.StringVar(
+		&runner.name,
+		"name",
+		"",
+		nameFlagHelp,
+	)
+	flags.StringVar(
+		&runner.title,
+		"title",
+		"",
+		titleFlagHelp,
+	)
+	flags.StringVar(
+		&runner.description,
+		"description",
+		"",
+		descriptionFlagHelp,
+	)
+	return result
+}
+
+type runnerContext struct {
+	console     *terminal.Console
+	name        string
+	title       string
+	description string
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	c.console = terminal.ConsoleFromContext(ctx)
+
+	cfg := config.SettingsFromContext(ctx)
+	if !cfg.Armed() {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	if c.name == "" {
+		return fmt.Errorf("name is required")
+	}
+
+	conn, err := cfg.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	client := privatev1.NewHostTypesClient(conn)
+
+	hostType := privatev1.HostType_builder{
+		Id: c.name,
+		Metadata: privatev1.Metadata_builder{
+			Name: c.name,
+		}.Build(),
+		Title:       c.title,
+		Description: c.description,
+	}.Build()
+
+	response, err := client.Create(ctx, privatev1.HostTypesCreateRequest_builder{
+		Object: hostType,
+	}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to create host type: %w", err)
+	}
+
+	c.console.Infof(ctx, "Created host type '%s'.\n", response.GetObject().GetId())
+
+	return nil
+}
+
+const shortHelp = `Create a host type`
+
+const longHelp = `
+Create a host type.
+
+A host type describes a set of hosts that share characteristics such as CPU, memory, and GPU
+configuration. For example, {{ bt }}acme_1tb{{ bt }} for hosts with 1 TiB of RAM, or
+{{ bt }}ibm_mi300x{{ bt }} for hosts with MI300X GPUs.
+
+Host types must be registered before creating cluster orders that reference them.
+
+To create a host type:
+
+{{ bt 3 }}shell
+{{ binary }} create hosttype --name dgx --title 'NVIDIA DGX' --description 'DGX H100 host'
+{{ bt 3 }}
+
+To add network interfaces to a host type, use {{ bt }}osac create -f{{ bt }} with a YAML or JSON
+file instead.
+`
+
+const nameFlagHelp = `
+_NAME_ - Name of the host type. Must be a unique identifier (e.g., {{ bt }}dgx{{ bt }},
+{{ bt }}fc430{{ bt }}).
+`
+
+const titleFlagHelp = `
+_TITLE_ - Human friendly short description of the host type, suitable for displaying in a single
+line on a UI or CLI.
+`
+
+const descriptionFlagHelp = `
+_DESCRIPTION_ - Human friendly long description of the host type, using Markdown format.
+`

--- a/fulfillment-service/internal/cmd/cli/create/hosttype/create_hosttype_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/create/hosttype/create_hosttype_cmd_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package hosttype
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Create hosttype flag registration", func() {
+	It("should create command without error", func() {
+		cmd := Cmd()
+		Expect(cmd).NotTo(BeNil())
+		Expect(cmd.Use).To(Equal("hosttype"))
+	})
+
+	It("should register --name flag", func() {
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		flag := cmd.Flags().Lookup("name")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Usage).To(ContainSubstring("Name"))
+	})
+
+	It("should register --title flag", func() {
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		flag := cmd.Flags().Lookup("title")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Usage).To(ContainSubstring("TITLE"))
+	})
+
+	It("should register --description flag", func() {
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		flag := cmd.Flags().Lookup("description")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Usage).To(ContainSubstring("description"))
+	})
+})

--- a/fulfillment-service/internal/cmd/cli/create/hosttype/create_hosttype_suite_test.go
+++ b/fulfillment-service/internal/cmd/cli/create/hosttype/create_hosttype_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package hosttype
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCreateHosttype(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Create hosttype command")
+}

--- a/fulfillment-service/internal/rendering/tables/osac.private.v1.HostType.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.private.v1.HostType.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2026 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: TITLE
+  value: "has(this.title) && this.title != ''? this.title: '-'"
+
+- header: DESCRIPTION
+  value: "has(this.description) && this.description != ''? this.description: '-'"

--- a/fulfillment-service/internal/rendering/tables/osac.public.v1.HostType.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.public.v1.HostType.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2026 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+columns:
+
+- header: ID
+  value: this.id
+
+- header: NAME
+  value: "has(this.metadata.name)? this.metadata.name: '-'"
+
+- header: TITLE
+  value: "has(this.title) && this.title != ''? this.title: '-'"
+
+- header: DESCRIPTION
+  value: "has(this.description) && this.description != ''? this.description: '-'"


### PR DESCRIPTION
## Summary
- Add `osac create hosttype` CLI subcommand with `--name`, `--title`, and `--description` flags, following the existing `create hub` pattern
- Mark `create hosttype` as private API via `help.MarkPrivateAPI()` so it is hidden from non-admin `--help` output (consistent with other private-API subcommands like hub, instancetype, clusterversion, storagebackend, storagetier)
- Add table rendering YAMLs for HostType (public and private) so `osac get hosttypes` displays meaningful columns (ID, NAME, TITLE, DESCRIPTION) instead of generic fallback columns
- Add hosttype to the `create_cmd_test.go` alias table, subcommand list, and private-API annotation assertions
- Network interfaces are not exposed as CLI flags due to their nested structure — use `osac create -f` with YAML/JSON for host types with interfaces

## Output

Before (generic fallback):
```
ID     DELETING  NAME
dgx    -         -
fc430  -         -
```

After (with table rendering):
```
ID     DELETING  NAME  TITLE       DESCRIPTION
dgx    -         -     NVIDIA DGX  NVIDIA DGX bare metal node
fc430  -         -     Dell FC430  Dell PowerEdge FC430 bare metal node
```

```
$ osac create hosttype --name test-ht --title 'Test Host Type' --description 'Temporary host type for CLI testing'
$ osac get hosttypes
     ID       DELETING  NAME     TITLE           DESCRIPTION
     dgx      -         -        NVIDIA DGX      NVIDIA DGX bare metal node
     fc430    -         -        Dell FC430      Dell PowerEdge FC430 bare metal node
     test-ht  -         test-ht  Test Host Type  Temporary host type for CLI testing
```
```
$ osac delete hosttype test-ht
  Deleted hosttype 'test-ht'.
```

## Jira
https://redhat.atlassian.net/browse/OSAC-3680

## Test plan
- [x] `osac create hosttype --help` shows correct usage and flags
- [x] `osac get hosttypes` displays proper columns with new rendering
- [x] Unit tests pass (13/13 create, 4/4 hosttype)
- [x] Private-API annotation test verifies hosttype is marked as private
- [x] `go build ./...` succeeds
- [ ] E2E: create and delete a host type against a live cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a private CLI command to create host types.
  * Supports configuring a host type’s name, title, and description.
  * Added command usage guidance and validation for required input.
  * Added table output displaying host type IDs, names, titles, and descriptions.

* **Tests**
  * Added coverage for command registration, usage, and supported flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->