### PR TITLE
OSAC-3676: Auto-inject default subnet when creating ComputeInstance without network_attachments

### DIFF
--- a/fulfillment-service/internal/servers/private_compute_instances_server.go
+++ b/fulfillment-service/internal/servers/private_compute_instances_server.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -191,8 +192,124 @@ func (s *PrivateComputeInstancesServer) Get(ctx context.Context,
 	return
 }
 
+func (s *PrivateComputeInstancesServer) findDefaultSubnet(ctx context.Context) (*privatev1.Subnet, error) {
+	filter := fmt.Sprintf("this.metadata.labels[\"%s\"] == \"true\" && has(this.spec.ipv4_cidr)", defaultLabel)
+	listResponse, err := s.subnetsDao.List().
+		SetFilter(filter).
+		Do(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var items []*privatev1.Subnet
+	for _, subnet := range listResponse.GetItems() {
+		if subnet.GetMetadata().HasDeletionTimestamp() {
+			continue
+		}
+		if subnet.GetStatus().GetState() != privatev1.SubnetState_SUBNET_STATE_READY {
+			continue
+		}
+		items = append(items, subnet)
+	}
+	if len(items) == 0 {
+		return nil, nil
+	}
+	sort.Slice(items, func(i, j int) bool {
+		ti := items[i].GetMetadata().GetCreationTimestamp().AsTime()
+		tj := items[j].GetMetadata().GetCreationTimestamp().AsTime()
+		return ti.After(tj)
+	})
+	if len(items) > 1 {
+		s.logger.WarnContext(ctx, "multiple default Subnets found, using newest",
+			slog.Int("count", len(items)),
+		)
+	}
+	return items[0], nil
+}
+
+func (s *PrivateComputeInstancesServer) findDefaultSecurityGroup(ctx context.Context, virtualNetworkID string) (*privatev1.SecurityGroup, error) {
+	filter := fmt.Sprintf("this.metadata.labels[\"%s\"] == \"true\"", defaultLabel)
+	listResponse, err := s.securityGroupsDao.List().
+		SetFilter(filter).
+		Do(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var items []*privatev1.SecurityGroup
+	for _, sg := range listResponse.GetItems() {
+		if sg.GetMetadata().HasDeletionTimestamp() {
+			continue
+		}
+		if sg.GetStatus().GetState() != privatev1.SecurityGroupState_SECURITY_GROUP_STATE_READY {
+			continue
+		}
+		if refKey(sg.GetSpec().GetVirtualNetwork()) != virtualNetworkID {
+			continue
+		}
+		items = append(items, sg)
+	}
+	if len(items) == 0 {
+		return nil, nil
+	}
+	sort.Slice(items, func(i, j int) bool {
+		ti := items[i].GetMetadata().GetCreationTimestamp().AsTime()
+		tj := items[j].GetMetadata().GetCreationTimestamp().AsTime()
+		return ti.After(tj)
+	})
+	if len(items) > 1 {
+		s.logger.WarnContext(ctx, "multiple default SecurityGroups found, using newest",
+			slog.Int("count", len(items)),
+		)
+	}
+	return items[0], nil
+}
+
+func (s *PrivateComputeInstancesServer) injectDefaultNetworkAttachments(ctx context.Context, spec *privatev1.ComputeInstanceSpec) error {
+	subnet, err := s.findDefaultSubnet(ctx)
+	if err != nil {
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to look up default subnet: %v", err)
+	}
+	if subnet == nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"spec.network_attachments: at least one network attachment is required for new compute instances")
+	}
+
+	attachment := privatev1.NetworkAttachment_builder{
+		Subnet: privatev1.SubnetLocalReference_builder{Id: subnet.GetId()}.Build(),
+	}.Build()
+
+	virtualNetworkID := refKey(subnet.GetSpec().GetVirtualNetwork())
+	sg, err := s.findDefaultSecurityGroup(ctx, virtualNetworkID)
+	if err != nil {
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to look up default security group: %v", err)
+	}
+	if sg != nil {
+		attachment.SetSecurityGroups([]*privatev1.SecurityGroupLocalReference{
+			privatev1.SecurityGroupLocalReference_builder{Id: sg.GetId()}.Build(),
+		})
+	}
+
+	spec.SetNetworkAttachments([]*privatev1.NetworkAttachment{attachment})
+
+	attrs := []slog.Attr{
+		slog.String("subnet_id", subnet.GetId()),
+	}
+	if sg != nil {
+		attrs = append(attrs, slog.String("security_group_id", sg.GetId()))
+	}
+	s.logger.LogAttrs(ctx, slog.LevelInfo, "auto-injected default network attachments", attrs...)
+	return nil
+}
+
 func (s *PrivateComputeInstancesServer) Create(ctx context.Context,
 	request *privatev1.ComputeInstancesCreateRequest) (response *privatev1.ComputeInstancesCreateResponse, err error) {
+	// Auto-inject default network attachments if none provided:
+	if len(request.GetObject().GetSpec().GetNetworkAttachments()) == 0 {
+		err = s.injectDefaultNetworkAttachments(ctx, request.GetObject().GetSpec())
+		if err != nil {
+			return
+		}
+	}
+
 	// Validate tenant isolation for network references:
 	err = s.validateNetworkReferencesTenancy(ctx, request.GetObject())
 	if err != nil {
@@ -202,13 +319,6 @@ func (s *PrivateComputeInstancesServer) Create(ctx context.Context,
 	// Validate network references state (exists, READY):
 	err = s.validateNetworkReferencesState(ctx, request.GetObject())
 	if err != nil {
-		return
-	}
-
-	// Require network_attachments for new VMs (no pod network for new VMs):
-	if len(request.GetObject().GetSpec().GetNetworkAttachments()) == 0 {
-		err = grpcstatus.Errorf(grpccodes.InvalidArgument,
-			"spec.network_attachments: at least one network attachment is required for new compute instances")
 		return
 	}
 

--- a/fulfillment-service/internal/servers/private_compute_instances_server_test.go
+++ b/fulfillment-service/internal/servers/private_compute_instances_server_test.go
@@ -1641,7 +1641,7 @@ var _ = Describe("Private compute instances server", func() {
 		})
 
 		Context("Required network fields", func() {
-			It("Should reject when network_attachments is missing", func() {
+			It("Should reject when network_attachments is missing and no default subnet exists", func() {
 				vm := privatev1.ComputeInstance_builder{
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: template.GetId()}.Build(),
@@ -1658,6 +1658,163 @@ var _ = Describe("Private compute instances server", func() {
 				Expect(ok).To(BeTrue())
 				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
 				Expect(status.Message()).To(ContainSubstring("network_attachments"))
+				Expect(status.Message()).To(ContainSubstring("at least one network attachment is required"))
+			})
+
+			It("Should auto-inject default subnet and security group when network_attachments is empty", func() {
+				defaultSubnetDao, err := dao.NewGenericDAO[*privatev1.Subnet]().
+					SetLogger(logger).
+					SetTenancyLogic(tenancy).
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+
+				defaultSubnet := privatev1.Subnet_builder{
+					Metadata: privatev1.Metadata_builder{
+						Tenant: auth.SharedTenant,
+						Labels: map[string]string{
+							"osac.openshift.io/default": "true",
+						},
+					}.Build(),
+					Spec: privatev1.SubnetSpec_builder{
+						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: virtualNetwork.GetId()}.Build(),
+						Ipv4Cidr:       new("10.0.1.0/24"),
+					}.Build(),
+					Status: privatev1.SubnetStatus_builder{
+						State: privatev1.SubnetState_SUBNET_STATE_READY,
+					}.Build(),
+				}.Build()
+
+				subnetResponse, err := defaultSubnetDao.Create().SetObject(defaultSubnet).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				defaultSGDao, err := dao.NewGenericDAO[*privatev1.SecurityGroup]().
+					SetLogger(logger).
+					SetTenancyLogic(tenancy).
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+
+				defaultSG := privatev1.SecurityGroup_builder{
+					Metadata: privatev1.Metadata_builder{
+						Tenant: auth.SharedTenant,
+						Labels: map[string]string{
+							"osac.openshift.io/default": "true",
+						},
+					}.Build(),
+					Spec: privatev1.SecurityGroupSpec_builder{
+						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: virtualNetwork.GetId()}.Build(),
+					}.Build(),
+					Status: privatev1.SecurityGroupStatus_builder{
+						State: privatev1.SecurityGroupState_SECURITY_GROUP_STATE_READY,
+					}.Build(),
+				}.Build()
+
+				sgResponse, err := defaultSGDao.Create().SetObject(defaultSG).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				vm := privatev1.ComputeInstance_builder{
+					Spec: privatev1.ComputeInstanceSpec_builder{
+						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: template.GetId()}.Build(),
+					}.Build(),
+				}.Build()
+
+				request := &privatev1.ComputeInstancesCreateRequest{}
+				request.SetObject(vm)
+
+				response, err := server.Create(ctx, request)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+				attachments := response.GetObject().GetSpec().GetNetworkAttachments()
+				Expect(attachments).To(HaveLen(1))
+				Expect(attachments[0].GetSubnet().GetId()).To(Equal(subnetResponse.GetObject().GetId()))
+				Expect(attachments[0].GetSecurityGroups()).To(HaveLen(1))
+				Expect(attachments[0].GetSecurityGroups()[0].GetId()).To(Equal(sgResponse.GetObject().GetId()))
+			})
+
+			It("Should auto-inject default subnet without security group when no default SG exists", func() {
+				defaultSubnetDao, err := dao.NewGenericDAO[*privatev1.Subnet]().
+					SetLogger(logger).
+					SetTenancyLogic(tenancy).
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+
+				defaultSubnet := privatev1.Subnet_builder{
+					Metadata: privatev1.Metadata_builder{
+						Tenant: auth.SharedTenant,
+						Labels: map[string]string{
+							"osac.openshift.io/default": "true",
+						},
+					}.Build(),
+					Spec: privatev1.SubnetSpec_builder{
+						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: virtualNetwork.GetId()}.Build(),
+						Ipv4Cidr:       new("10.0.1.0/24"),
+					}.Build(),
+					Status: privatev1.SubnetStatus_builder{
+						State: privatev1.SubnetState_SUBNET_STATE_READY,
+					}.Build(),
+				}.Build()
+
+				subnetResponse, err := defaultSubnetDao.Create().SetObject(defaultSubnet).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				vm := privatev1.ComputeInstance_builder{
+					Spec: privatev1.ComputeInstanceSpec_builder{
+						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: template.GetId()}.Build(),
+					}.Build(),
+				}.Build()
+
+				request := &privatev1.ComputeInstancesCreateRequest{}
+				request.SetObject(vm)
+
+				response, err := server.Create(ctx, request)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response).ToNot(BeNil())
+				attachments := response.GetObject().GetSpec().GetNetworkAttachments()
+				Expect(attachments).To(HaveLen(1))
+				Expect(attachments[0].GetSubnet().GetId()).To(Equal(subnetResponse.GetObject().GetId()))
+				Expect(attachments[0].GetSecurityGroups()).To(BeEmpty())
+			})
+
+			It("Should not auto-inject when default subnet is not READY", func() {
+				defaultSubnetDao, err := dao.NewGenericDAO[*privatev1.Subnet]().
+					SetLogger(logger).
+					SetTenancyLogic(tenancy).
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+
+				defaultSubnet := privatev1.Subnet_builder{
+					Metadata: privatev1.Metadata_builder{
+						Tenant: auth.SharedTenant,
+						Labels: map[string]string{
+							"osac.openshift.io/default": "true",
+						},
+					}.Build(),
+					Spec: privatev1.SubnetSpec_builder{
+						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: virtualNetwork.GetId()}.Build(),
+						Ipv4Cidr:       new("10.0.1.0/24"),
+					}.Build(),
+					Status: privatev1.SubnetStatus_builder{
+						State: privatev1.SubnetState_SUBNET_STATE_PENDING,
+					}.Build(),
+				}.Build()
+
+				_, err = defaultSubnetDao.Create().SetObject(defaultSubnet).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				vm := privatev1.ComputeInstance_builder{
+					Spec: privatev1.ComputeInstanceSpec_builder{
+						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: template.GetId()}.Build(),
+					}.Build(),
+				}.Build()
+
+				request := &privatev1.ComputeInstancesCreateRequest{}
+				request.SetObject(vm)
+
+				response, err := server.Create(ctx, request)
+				Expect(err).To(HaveOccurred())
+				Expect(response).To(BeNil())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
 				Expect(status.Message()).To(ContainSubstring("at least one network attachment is required"))
 			})
 


### PR DESCRIPTION


When network_attachments is empty on ComputeInstance creation, look up the tenant's default IPv4 subnet and security group (labeled osac.openshift.io/default) and auto-inject them, matching AWS EC2 behavior. Falls back to the original InvalidArgument error when no default subnet exists.