### PR TITLE
OSAC-2164: ClusterVersion CLI and ResolveFieldPath reuse

### DIFF
--- a/fulfillment-service/internal/auth/grpc_authz_interceptor.go
+++ b/fulfillment-service/internal/auth/grpc_authz_interceptor.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/osac-project/osac/fulfillment-service/internal/collections"
 	k8sfiles "github.com/osac-project/osac/fulfillment-service/internal/kubernetes/files"
+	"github.com/osac-project/osac/fulfillment-service/internal/reflection"
 )
 
 //go:embed policies/authz.rego
@@ -590,31 +591,7 @@ func (i *GrpcAuthzInterceptor) extractProjectFromRequest(request any) string {
 	if !ok {
 		return ""
 	}
-	reflect := message.ProtoReflect()
-
-	objectField := reflect.Descriptor().Fields().ByName("object")
-	if objectField == nil {
-		return ""
-	}
-	if !reflect.Has(objectField) {
-		return ""
-	}
-	objectMsg := reflect.Get(objectField).Message()
-
-	metadataField := objectMsg.Descriptor().Fields().ByName("metadata")
-	if metadataField == nil {
-		return ""
-	}
-	if !objectMsg.Has(metadataField) {
-		return ""
-	}
-	metadataMsg := objectMsg.Get(metadataField).Message()
-
-	projectField := metadataMsg.Descriptor().Fields().ByName("project")
-	if projectField == nil {
-		return ""
-	}
-	return metadataMsg.Get(projectField).String()
+	return reflection.ResolveFieldPathOr(message, "object.metadata.project", "")
 }
 
 // claimAsAnySlice extracts a claim value and returns it as []any, which is the type that JSON-decoded arrays produce

--- a/fulfillment-service/internal/cmd/cli/describe/cluster/describe_cluster.go
+++ b/fulfillment-service/internal/cmd/cli/describe/cluster/describe_cluster.go
@@ -90,6 +90,9 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		versionsClient := publicv1.NewClusterVersionsClient(conn)
 		version, err = lookup.Find(versionName, "cluster version",
 			func(filter string, limit int32) ([]*publicv1.ClusterVersion, error) {
+				// Override the public-API default filter that hides obsolete versions.
+				// A cluster may reference any version regardless of lifecycle state.
+				filter = fmt.Sprintf("(%s) && this.spec.state > 0", filter)
 				resp, err := versionsClient.List(ctx, publicv1.ClusterVersionsListRequest_builder{
 					Filter: proto.String(filter),
 					Limit:  proto.Int32(limit),

--- a/fulfillment-service/internal/cmd/cli/describe/cluster/describe_cluster.go
+++ b/fulfillment-service/internal/cmd/cli/describe/cluster/describe_cluster.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/proto"
@@ -81,12 +82,36 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	renderCluster(c.console, matched)
+	// Resolve the cluster version, if the cluster references one. Failure to resolve it is not fatal -- version
+	// details are supplementary to the cluster description.
+	var version *publicv1.ClusterVersion
+	if matched.GetSpec().HasVersion() {
+		versionName := matched.GetSpec().GetVersion().GetName()
+		versionsClient := publicv1.NewClusterVersionsClient(conn)
+		version, err = lookup.Find(versionName, "cluster version",
+			func(filter string, limit int32) ([]*publicv1.ClusterVersion, error) {
+				resp, err := versionsClient.List(ctx, publicv1.ClusterVersionsListRequest_builder{
+					Filter: proto.String(filter),
+					Limit:  proto.Int32(limit),
+				}.Build())
+				if err != nil {
+					return nil, fmt.Errorf("failed to fetch cluster version: %w", err)
+				}
+				return resp.GetItems(), nil
+			},
+		)
+		if err != nil {
+			c.console.Errorf(ctx, "Warning: failed to resolve cluster version %q: %v\n", versionName, err)
+			version = nil
+		}
+	}
+
+	renderCluster(c.console, matched, version)
 
 	return nil
 }
 
-func renderCluster(w io.Writer, cluster *publicv1.Cluster) {
+func renderCluster(w io.Writer, cluster *publicv1.Cluster, version *publicv1.ClusterVersion) {
 	writer := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	catalogItem := "-"
 	if cluster.Spec != nil {
@@ -106,7 +131,39 @@ func renderCluster(w io.Writer, cluster *publicv1.Cluster) {
 	fmt.Fprintf(writer, "ID:\t%s\n", cluster.Id)
 	fmt.Fprintf(writer, "Catalog Item:\t%s\n", catalogItem)
 	fmt.Fprintf(writer, "State:\t%s\n", state)
+
 	writer.Flush()
+
+	// Version section — rendered as indented fields under a "Version:" header.
+	if cluster.GetSpec().HasVersion() {
+		fmt.Fprintln(w, "Version:")
+		versionWriter := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+
+		fmt.Fprintf(versionWriter, "\tName:\t%s\n", cluster.GetSpec().GetVersion().GetName())
+
+		versionStr := "-"
+		versionState := "-"
+		if version.GetSpec() != nil {
+			versionStr = version.GetSpec().GetVersion()
+			versionState = strings.TrimPrefix(
+				version.GetSpec().GetState().String(),
+				"CLUSTER_VERSION_STATE_",
+			)
+		}
+		fmt.Fprintf(versionWriter, "\tVersion:\t%s\n", versionStr)
+		fmt.Fprintf(versionWriter, "\tState:\t%s\n", versionState)
+
+		if dep := version.GetSpec().GetDeprecation(); dep != nil {
+			if ts := dep.GetDeprecationTimestamp(); ts != nil {
+				fmt.Fprintf(versionWriter, "\tDeprecated At:\t%s\n", ts.AsTime().Format(time.RFC3339))
+			}
+			if ts := dep.GetObsolescenceTimestamp(); ts != nil {
+				fmt.Fprintf(versionWriter, "\tObsolete At:\t%s\n", ts.AsTime().Format(time.RFC3339))
+			}
+		}
+
+		versionWriter.Flush()
+	}
 }
 
 const shortHelp = `Describe a cluster.`

--- a/fulfillment-service/internal/cmd/cli/describe/cluster/describe_cluster_test.go
+++ b/fulfillment-service/internal/cmd/cli/describe/cluster/describe_cluster_test.go
@@ -15,16 +15,18 @@ package cluster
 
 import (
 	"bytes"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
 )
 
-func formatCluster(cluster *publicv1.Cluster) string {
+func formatCluster(cluster *publicv1.Cluster, version *publicv1.ClusterVersion) string {
 	var buf bytes.Buffer
-	renderCluster(&buf, cluster)
+	renderCluster(&buf, cluster, version)
 	return buf.String()
 }
 
@@ -39,7 +41,7 @@ var _ = Describe("Rendering tests", func() {
 				State: publicv1.ClusterState_CLUSTER_STATE_READY,
 			},
 		}.Build()
-		output := formatCluster(cluster)
+		output := formatCluster(cluster, nil)
 		Expect(output).To(ContainSubstring("cluster-001"))
 		Expect(output).To(MatchRegexp(`Catalog Item:\s+-`))
 		Expect(output).NotTo(ContainSubstring("Template:"))
@@ -50,7 +52,7 @@ var _ = Describe("Rendering tests", func() {
 		cluster := publicv1.Cluster_builder{
 			Id: "cluster-002",
 		}.Build()
-		output := formatCluster(cluster)
+		output := formatCluster(cluster, nil)
 		Expect(output).To(MatchRegexp(`Catalog Item:\s+-`))
 	})
 
@@ -58,7 +60,7 @@ var _ = Describe("Rendering tests", func() {
 		cluster := publicv1.Cluster_builder{
 			Id: "cluster-003",
 		}.Build()
-		output := formatCluster(cluster)
+		output := formatCluster(cluster, nil)
 		Expect(output).To(MatchRegexp(`State:\s+-`))
 	})
 
@@ -69,7 +71,7 @@ var _ = Describe("Rendering tests", func() {
 				State: publicv1.ClusterState_CLUSTER_STATE_READY,
 			},
 		}.Build()
-		output := formatCluster(cluster)
+		output := formatCluster(cluster, nil)
 		Expect(output).To(ContainSubstring("READY"))
 		Expect(output).NotTo(ContainSubstring("CLUSTER_STATE_"))
 	})
@@ -81,7 +83,7 @@ var _ = Describe("Rendering tests", func() {
 				State: publicv1.ClusterState_CLUSTER_STATE_PROGRESSING,
 			},
 		}.Build()
-		output := formatCluster(cluster)
+		output := formatCluster(cluster, nil)
 		Expect(output).To(ContainSubstring("PROGRESSING"))
 		Expect(output).NotTo(ContainSubstring("CLUSTER_STATE_"))
 	})
@@ -93,7 +95,7 @@ var _ = Describe("Rendering tests", func() {
 				Template: publicv1.ClusterTemplateReference_builder{Id: "tpl-ha-001"}.Build(),
 			},
 		}.Build()
-		output := formatCluster(cluster)
+		output := formatCluster(cluster, nil)
 		Expect(output).NotTo(ContainSubstring("Template:"))
 		Expect(output).To(ContainSubstring("Catalog Item:"))
 	})
@@ -102,7 +104,7 @@ var _ = Describe("Rendering tests", func() {
 		cluster := publicv1.Cluster_builder{
 			Id: "cluster-007",
 		}.Build()
-		output := formatCluster(cluster)
+		output := formatCluster(cluster, nil)
 		Expect(output).To(MatchRegexp(`Catalog Item:\s+-`))
 	})
 
@@ -113,7 +115,108 @@ var _ = Describe("Rendering tests", func() {
 				CatalogItem: publicv1.ClusterCatalogItemReference_builder{Id: "my-catalog-item-id"}.Build(),
 			}.Build(),
 		}.Build()
-		output := formatCluster(cluster)
+		output := formatCluster(cluster, nil)
 		Expect(output).To(MatchRegexp(`Catalog Item:\s+my-catalog-item-id`))
+	})
+})
+
+var _ = Describe("Version rendering tests", func() {
+	It("should show version details when version is present and ACTIVE", func() {
+		cluster := publicv1.Cluster_builder{
+			Id: "cluster-v1",
+			Spec: publicv1.ClusterSpec_builder{
+				Version: &publicv1.ClusterVersionReference{Name: "4-17-0"},
+			}.Build(),
+			Status: &publicv1.ClusterStatus{
+				State: publicv1.ClusterState_CLUSTER_STATE_READY,
+			},
+		}.Build()
+		version := publicv1.ClusterVersion_builder{
+			Spec: publicv1.ClusterVersionSpec_builder{
+				Version: "4.17.0",
+				State:   publicv1.ClusterVersionState_CLUSTER_VERSION_STATE_ACTIVE,
+			}.Build(),
+		}.Build()
+		output := formatCluster(cluster, version)
+		Expect(output).To(ContainSubstring("Version:\n"))
+		Expect(output).To(MatchRegexp(`Name:\s+4-17-0`))
+		Expect(output).To(MatchRegexp(`Version:\s+4\.17\.0`))
+		Expect(output).To(MatchRegexp(`State:\s+ACTIVE`))
+		Expect(output).NotTo(ContainSubstring("Deprecated At:"))
+		Expect(output).NotTo(ContainSubstring("Obsolete At:"))
+	})
+
+	It("should show deprecation timestamps when version is DEPRECATED", func() {
+		depTime := time.Date(2026, 7, 15, 10, 30, 0, 0, time.UTC)
+		obsTime := time.Date(2026, 10, 15, 10, 30, 0, 0, time.UTC)
+		cluster := publicv1.Cluster_builder{
+			Id: "cluster-v2",
+			Spec: publicv1.ClusterSpec_builder{
+				Version: &publicv1.ClusterVersionReference{Name: "4-16-0"},
+			}.Build(),
+			Status: &publicv1.ClusterStatus{
+				State: publicv1.ClusterState_CLUSTER_STATE_READY,
+			},
+		}.Build()
+		version := publicv1.ClusterVersion_builder{
+			Spec: publicv1.ClusterVersionSpec_builder{
+				Version: "4.16.0",
+				State:   publicv1.ClusterVersionState_CLUSTER_VERSION_STATE_DEPRECATED,
+				Deprecation: publicv1.ClusterVersionDeprecation_builder{
+					DeprecationTimestamp:  timestamppb.New(depTime),
+					ObsolescenceTimestamp: timestamppb.New(obsTime),
+				}.Build(),
+			}.Build(),
+		}.Build()
+		output := formatCluster(cluster, version)
+		Expect(output).To(ContainSubstring("Version:\n"))
+		Expect(output).To(MatchRegexp(`Name:\s+4-16-0`))
+		Expect(output).To(MatchRegexp(`Version:\s+4\.16\.0`))
+		Expect(output).To(MatchRegexp(`State:\s+DEPRECATED`))
+		Expect(output).To(MatchRegexp(`Deprecated At:\s+2026-07-15T10:30:00Z`))
+		Expect(output).To(MatchRegexp(`Obsolete At:\s+2026-10-15T10:30:00Z`))
+	})
+
+	It("should omit version section when version is not set", func() {
+		cluster := publicv1.Cluster_builder{
+			Id: "cluster-v3",
+			Status: &publicv1.ClusterStatus{
+				State: publicv1.ClusterState_CLUSTER_STATE_READY,
+			},
+		}.Build()
+		output := formatCluster(cluster, nil)
+		Expect(output).NotTo(ContainSubstring("Version:"))
+	})
+
+	It("should show version name but '-' for resolved fields when version lookup failed", func() {
+		cluster := publicv1.Cluster_builder{
+			Id: "cluster-v4",
+			Spec: publicv1.ClusterSpec_builder{
+				Version: &publicv1.ClusterVersionReference{Name: "4-17-0"},
+			}.Build(),
+		}.Build()
+		output := formatCluster(cluster, nil)
+		Expect(output).To(ContainSubstring("Version:\n"))
+		Expect(output).To(MatchRegexp(`Name:\s+4-17-0`))
+		Expect(output).To(MatchRegexp(`Version:\s+-`))
+		Expect(output).To(MatchRegexp(`State:\s+-`))
+	})
+
+	It("should strip CLUSTER_VERSION_STATE_ prefix from OBSOLETE state", func() {
+		cluster := publicv1.Cluster_builder{
+			Id: "cluster-v5",
+			Spec: publicv1.ClusterSpec_builder{
+				Version: &publicv1.ClusterVersionReference{Name: "4-15-0"},
+			}.Build(),
+		}.Build()
+		version := publicv1.ClusterVersion_builder{
+			Spec: publicv1.ClusterVersionSpec_builder{
+				Version: "4.15.0",
+				State:   publicv1.ClusterVersionState_CLUSTER_VERSION_STATE_OBSOLETE,
+			}.Build(),
+		}.Build()
+		output := formatCluster(cluster, version)
+		Expect(output).To(ContainSubstring("OBSOLETE"))
+		Expect(output).NotTo(ContainSubstring("CLUSTER_VERSION_STATE_"))
 	})
 })

--- a/fulfillment-service/internal/references/lookups.go
+++ b/fulfillment-service/internal/references/lookups.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
+	"github.com/osac-project/osac/fulfillment-service/internal/reflection"
 )
 
 // errRefNotFound satisfies the IsNotFound() interface expected by the reference validator.
@@ -77,25 +78,11 @@ func NewDAOLookupFunc[O dao.Object](d *dao.GenericDAO[O]) ReferenceLookupFunc {
 			ID: item.GetId(),
 		}
 
-		msg := item.ProtoReflect()
-		metadataFD := msg.Descriptor().Fields().ByName("metadata")
-		if metadataFD != nil {
-			metadataMsg := msg.Get(metadataFD).Message()
-
-			nameFD := metadataMsg.Descriptor().Fields().ByName("name")
-			if nameFD != nil {
-				resolved.Name = metadataMsg.Get(nameFD).String()
-			}
-
-			tenantFD := metadataMsg.Descriptor().Fields().ByName("tenant")
-			if tenantFD != nil {
-				resolved.Tenant = metadataMsg.Get(tenantFD).String()
-			}
-
-			projectFD := metadataMsg.Descriptor().Fields().ByName("project")
-			if projectFD != nil {
-				resolved.Project = metadataMsg.Get(projectFD).String()
-			}
+		if metadata, ok := reflection.ResolveFieldPath[protoreflect.Message](item, "metadata"); ok {
+			m := metadata.Interface()
+			resolved.Name = reflection.ResolveFieldPathOr(m, "name", "")
+			resolved.Tenant = reflection.ResolveFieldPathOr(m, "tenant", "")
+			resolved.Project = reflection.ResolveFieldPathOr(m, "project", "")
 		}
 
 		return resolved, nil

--- a/fulfillment-service/internal/references/reference_validator.go
+++ b/fulfillment-service/internal/references/reference_validator.go
@@ -30,6 +30,8 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"github.com/osac-project/osac/fulfillment-service/internal/reflection"
 )
 
 // ResolvedRef is the result of resolving a reference to a known resource.
@@ -435,30 +437,8 @@ func resolveTenantProject(refMsg protoreflect.Message, fullName protoreflect.Ful
 // extractTenantProject extracts the tenant and project from the request's embedded object metadata
 // using protoreflect (request → object → metadata → {tenant, project}).
 func extractTenantProject(request proto.Message) (tenant, project string) {
-	msg := request.ProtoReflect()
-
-	objectField := msg.Descriptor().Fields().ByName("object")
-	if objectField == nil {
-		return
-	}
-	objectMsg := msg.Get(objectField).Message()
-
-	metadataField := objectMsg.Descriptor().Fields().ByName("metadata")
-	if metadataField == nil {
-		return
-	}
-	metadataMsg := objectMsg.Get(metadataField).Message()
-
-	tenantField := metadataMsg.Descriptor().Fields().ByName("tenant")
-	if tenantField != nil {
-		tenant = metadataMsg.Get(tenantField).String()
-	}
-
-	projectField := metadataMsg.Descriptor().Fields().ByName("project")
-	if projectField != nil {
-		project = metadataMsg.Get(projectField).String()
-	}
-
+	tenant = reflection.ResolveFieldPathOr(request, "object.metadata.tenant", "")
+	project = reflection.ResolveFieldPathOr(request, "object.metadata.project", "")
 	return
 }
 

--- a/fulfillment-service/internal/reflection/reflection_field_path.go
+++ b/fulfillment-service/internal/reflection/reflection_field_path.go
@@ -21,24 +21,38 @@ import (
 )
 
 // ResolveFieldPath navigates a protobuf message following a dot-separated field path (e.g.
-// "spec.version") and returns the string representation of the final field. Returns an empty
-// string if any segment doesn't exist or if an intermediate segment isn't a message.
-func ResolveFieldPath(msg proto.Message, path string) string {
+// "spec.version") and returns the value of the terminal field converted to T via
+// protoreflect.Value.Interface(). Returns (zero, false) when any segment in the path does not
+// exist or an intermediate segment is not a message, and (value, false) when the terminal field
+// exists but is not assignable to T.
+func ResolveFieldPath[T any](msg proto.Message, path string) (T, bool) {
+	var zero T
 	segments := strings.Split(path, ".")
 	current := msg.ProtoReflect()
 	for i, segment := range segments {
 		fieldDesc := current.Descriptor().Fields().ByName(protoreflect.Name(segment))
 		if fieldDesc == nil {
-			return ""
+			return zero, false
 		}
 		if i < len(segments)-1 {
-			if fieldDesc.Kind() != protoreflect.MessageKind {
-				return ""
+			if fieldDesc.Kind() != protoreflect.MessageKind || fieldDesc.IsList() || fieldDesc.IsMap() {
+				return zero, false
 			}
 			current = current.Get(fieldDesc).Message()
 			continue
 		}
-		return current.Get(fieldDesc).String()
+		result, ok := current.Get(fieldDesc).Interface().(T)
+		return result, ok
 	}
-	return ""
+	return zero, false
+}
+
+// ResolveFieldPathOr is like ResolveFieldPath but returns fallback when the path does not exist
+// or the terminal field is not assignable to T.
+func ResolveFieldPathOr[T any](msg proto.Message, path string, fallback T) T {
+	val, ok := ResolveFieldPath[T](msg, path)
+	if !ok {
+		return fallback
+	}
+	return val
 }

--- a/fulfillment-service/internal/reflection/reflection_field_path.go
+++ b/fulfillment-service/internal/reflection/reflection_field_path.go
@@ -1,0 +1,44 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package reflection
+
+import (
+	"strings"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// ResolveFieldPath navigates a protobuf message following a dot-separated field path (e.g.
+// "spec.version") and returns the string representation of the final field. Returns an empty
+// string if any segment doesn't exist or if an intermediate segment isn't a message.
+func ResolveFieldPath(msg proto.Message, path string) string {
+	segments := strings.Split(path, ".")
+	current := msg.ProtoReflect()
+	for i, segment := range segments {
+		fieldDesc := current.Descriptor().Fields().ByName(protoreflect.Name(segment))
+		if fieldDesc == nil {
+			return ""
+		}
+		if i < len(segments)-1 {
+			if fieldDesc.Kind() != protoreflect.MessageKind {
+				return ""
+			}
+			current = current.Get(fieldDesc).Message()
+			continue
+		}
+		return current.Get(fieldDesc).String()
+	}
+	return ""
+}

--- a/fulfillment-service/internal/reflection/reflection_field_path_test.go
+++ b/fulfillment-service/internal/reflection/reflection_field_path_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package reflection
+
+import (
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+
+	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
+)
+
+var _ = Describe("ResolveFieldPath", func() {
+	It("Resolves a top-level field", func() {
+		obj := publicv1.Cluster_builder{Id: "abc"}.Build()
+		Expect(ResolveFieldPath(obj, "id")).To(Equal("abc"))
+	})
+
+	It("Resolves a nested field path", func() {
+		obj := publicv1.ClusterVersion_builder{
+			Spec: publicv1.ClusterVersionSpec_builder{
+				Version: "4.17.0",
+			}.Build(),
+		}.Build()
+		Expect(ResolveFieldPath(obj, "spec.version")).To(Equal("4.17.0"))
+	})
+
+	It("Resolves metadata.name", func() {
+		obj := publicv1.ClusterVersion_builder{
+			Metadata: publicv1.Metadata_builder{Name: "4-17-0"}.Build(),
+		}.Build()
+		Expect(ResolveFieldPath(obj, "metadata.name")).To(Equal("4-17-0"))
+	})
+
+	It("Returns empty string for a nonexistent field", func() {
+		obj := publicv1.Cluster_builder{Id: "abc"}.Build()
+		Expect(ResolveFieldPath(obj, "nonexistent")).To(BeEmpty())
+	})
+
+	It("Returns empty string for a nonexistent nested field", func() {
+		obj := publicv1.Cluster_builder{Id: "abc"}.Build()
+		Expect(ResolveFieldPath(obj, "spec.nonexistent")).To(BeEmpty())
+	})
+
+	It("Returns empty string when an intermediate segment is not a message", func() {
+		obj := publicv1.Cluster_builder{Id: "abc"}.Build()
+		Expect(ResolveFieldPath(obj, "id.nested")).To(BeEmpty())
+	})
+})

--- a/fulfillment-service/internal/reflection/reflection_field_path_test.go
+++ b/fulfillment-service/internal/reflection/reflection_field_path_test.go
@@ -23,7 +23,9 @@ import (
 var _ = Describe("ResolveFieldPath", func() {
 	It("Resolves a top-level field", func() {
 		obj := publicv1.Cluster_builder{Id: "abc"}.Build()
-		Expect(ResolveFieldPath(obj, "id")).To(Equal("abc"))
+		val, ok := ResolveFieldPath[string](obj, "id")
+		Expect(ok).To(BeTrue())
+		Expect(val).To(Equal("abc"))
 	})
 
 	It("Resolves a nested field path", func() {
@@ -32,28 +34,84 @@ var _ = Describe("ResolveFieldPath", func() {
 				Version: "4.17.0",
 			}.Build(),
 		}.Build()
-		Expect(ResolveFieldPath(obj, "spec.version")).To(Equal("4.17.0"))
+		val, ok := ResolveFieldPath[string](obj, "spec.version")
+		Expect(ok).To(BeTrue())
+		Expect(val).To(Equal("4.17.0"))
 	})
 
 	It("Resolves metadata.name", func() {
 		obj := publicv1.ClusterVersion_builder{
 			Metadata: publicv1.Metadata_builder{Name: "4-17-0"}.Build(),
 		}.Build()
-		Expect(ResolveFieldPath(obj, "metadata.name")).To(Equal("4-17-0"))
+		val, ok := ResolveFieldPath[string](obj, "metadata.name")
+		Expect(ok).To(BeTrue())
+		Expect(val).To(Equal("4-17-0"))
 	})
 
-	It("Returns empty string for a nonexistent field", func() {
+	It("Returns false for a nonexistent field", func() {
 		obj := publicv1.Cluster_builder{Id: "abc"}.Build()
-		Expect(ResolveFieldPath(obj, "nonexistent")).To(BeEmpty())
+		val, ok := ResolveFieldPath[string](obj, "nonexistent")
+		Expect(ok).To(BeFalse())
+		Expect(val).To(BeEmpty())
 	})
 
-	It("Returns empty string for a nonexistent nested field", func() {
+	It("Returns false for a nonexistent nested field", func() {
 		obj := publicv1.Cluster_builder{Id: "abc"}.Build()
-		Expect(ResolveFieldPath(obj, "spec.nonexistent")).To(BeEmpty())
+		val, ok := ResolveFieldPath[string](obj, "spec.nonexistent")
+		Expect(ok).To(BeFalse())
+		Expect(val).To(BeEmpty())
 	})
 
-	It("Returns empty string when an intermediate segment is not a message", func() {
+	It("Returns false when an intermediate segment is not a message", func() {
 		obj := publicv1.Cluster_builder{Id: "abc"}.Build()
-		Expect(ResolveFieldPath(obj, "id.nested")).To(BeEmpty())
+		val, ok := ResolveFieldPath[string](obj, "id.nested")
+		Expect(ok).To(BeFalse())
+		Expect(val).To(BeEmpty())
+	})
+
+	It("Returns false when the type does not match", func() {
+		obj := publicv1.Cluster_builder{Id: "abc"}.Build()
+		val, ok := ResolveFieldPath[int64](obj, "id")
+		Expect(ok).To(BeFalse())
+		Expect(val).To(BeZero())
+	})
+
+	It("Returns false when an intermediate segment is a repeated field", func() {
+		obj := publicv1.ClustersListResponse_builder{
+			Items: []*publicv1.Cluster{
+				publicv1.Cluster_builder{Id: "c1"}.Build(),
+			},
+		}.Build()
+		val, ok := ResolveFieldPath[string](obj, "items.id")
+		Expect(ok).To(BeFalse())
+		Expect(val).To(BeEmpty())
+	})
+
+	It("Returns false when an intermediate segment is a map field", func() {
+		obj := publicv1.Cluster_builder{
+			Metadata: publicv1.Metadata_builder{
+				Labels: map[string]string{"env": "prod"},
+			}.Build(),
+		}.Build()
+		val, ok := ResolveFieldPath[string](obj, "metadata.labels.env")
+		Expect(ok).To(BeFalse())
+		Expect(val).To(BeEmpty())
+	})
+})
+
+var _ = Describe("ResolveFieldPathOr", func() {
+	It("Returns the field value when the path exists", func() {
+		obj := publicv1.Cluster_builder{Id: "abc"}.Build()
+		Expect(ResolveFieldPathOr(obj, "id", "fallback")).To(Equal("abc"))
+	})
+
+	It("Returns the fallback when the path does not exist", func() {
+		obj := publicv1.Cluster_builder{Id: "abc"}.Build()
+		Expect(ResolveFieldPathOr(obj, "nonexistent", "fallback")).To(Equal("fallback"))
+	})
+
+	It("Returns the fallback when the type does not match", func() {
+		obj := publicv1.Cluster_builder{Id: "abc"}.Build()
+		Expect(ResolveFieldPathOr(obj, "id", int64(42))).To(Equal(int64(42)))
 	})
 })

--- a/fulfillment-service/internal/reflection/reflection_helper.go
+++ b/fulfillment-service/internal/reflection/reflection_helper.go
@@ -770,12 +770,7 @@ func (h *objectHelper) SetTenant(object proto.Message, tenant string) {
 
 // GetTenant returns the tenant field from the object's metadata.
 func (h *objectHelper) GetTenant(object proto.Message) string {
-	metadata := object.ProtoReflect().Get(h.metadataField).Message()
-	field := metadata.Descriptor().Fields().ByName(tenantFieldName)
-	if field == nil {
-		return ""
-	}
-	return metadata.Get(field).String()
+	return ResolveFieldPathOr(object, "metadata.tenant", "")
 }
 
 // IsTenantScoped returns true if this resource type is scoped to a tenant.

--- a/fulfillment-service/internal/reflection/reflection_helper_test.go
+++ b/fulfillment-service/internal/reflection/reflection_helper_test.go
@@ -25,10 +25,20 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
-	"github.com/osac-project/osac/fulfillment-service/internal/config"
 	"github.com/osac-project/osac/fulfillment-service/internal/packages"
 	"github.com/osac-project/osac/fulfillment-service/internal/testing"
 )
+
+type testTenantKey struct{}
+
+func testTenantFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(testTenantKey{}).(string)
+	return v
+}
+
+func testTenantIntoContext(ctx context.Context, tenant string) context.Context {
+	return context.WithValue(ctx, testTenantKey{}, tenant)
+}
 
 var _ = Describe("Reflection helper", func() {
 	var (
@@ -128,7 +138,7 @@ var _ = Describe("Reflection helper", func() {
 				SetLogger(logger).
 				SetConnection(connection).
 				AddPackage(packages.PublicV1, 1).
-				SetTenantFunc(config.TenantFromContext).
+				SetTenantFunc(testTenantFromContext).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -694,7 +704,7 @@ var _ = Describe("Reflection helper", func() {
 			})
 			server.Start()
 
-			tenantCtx := config.TenantIntoContext(ctx, "acme")
+			tenantCtx := testTenantIntoContext(ctx, "acme")
 			objectHelper := helper.Lookup("cluster")
 			Expect(objectHelper).ToNot(BeNil())
 			_, err := objectHelper.List(tenantCtx, ListOptions{})
@@ -717,7 +727,7 @@ var _ = Describe("Reflection helper", func() {
 			})
 			server.Start()
 
-			tenantCtx := config.TenantIntoContext(ctx, "acme")
+			tenantCtx := testTenantIntoContext(ctx, "acme")
 			objectHelper := helper.Lookup("cluster")
 			Expect(objectHelper).ToNot(BeNil())
 			_, err := objectHelper.List(tenantCtx, ListOptions{

--- a/fulfillment-service/internal/rendering/table_renderer.go
+++ b/fulfillment-service/internal/rendering/table_renderer.go
@@ -76,6 +76,11 @@ type columnLayout struct {
 	// type to use for the lookup. For example, if the result of the expression is a cluster, then the 'type'
 	// should be 'fulfillment.v1.Cluster'.
 	Lookup bool `yaml:"lookup,omitempty"`
+
+	// LookupField is an optional dot-separated field path used to extract a value from the object found by the
+	// lookup. When empty, the lookup renders the name of the object (the default). For example, to render the
+	// 'spec.version' field of the looked up object, this should be 'spec.version'.
+	LookupField string `yaml:"lookup_field,omitempty"`
 }
 
 // TableRendererBuilder is used to create table renderers. Don't create instances of this type directly, use the
@@ -388,7 +393,7 @@ func (r *TableRenderer) renderCell(ctx context.Context, col *columnLayout, val r
 		if col.Lookup && col.Type != "" {
 			messageType, _ := protoregistry.GlobalTypes.FindMessageByName(col.Type)
 			if messageType != nil {
-				return r.renderCellLookup(ctx, val, messageType.Descriptor())
+				return r.renderCellLookup(ctx, val, messageType.Descriptor(), col.LookupField)
 			}
 		}
 	}
@@ -427,13 +432,14 @@ func (r *TableRenderer) renderCellEnum(val types.Int, enumDesc protoreflect.Enum
 	return err
 }
 
-// renderCellLookup renders a lookup value (identifier to name translation).
+// renderCellLookup renders a lookup value (identifier to name translation). When lookupField is not empty, it is
+// used as a dot-separated field path to extract a value from the looked up object instead of its name.
 func (r *TableRenderer) renderCellLookup(ctx context.Context, val types.String,
-	messageDesc protoreflect.MessageDescriptor) error {
+	messageDesc protoreflect.MessageDescriptor, lookupField string) error {
 	key := string(val)
 	var text string
 	if key != "" {
-		text = r.lookupName(ctx, messageDesc.FullName(), key)
+		text = r.lookupName(ctx, messageDesc.FullName(), key, lookupField)
 	} else {
 		text = "-"
 	}
@@ -441,15 +447,22 @@ func (r *TableRenderer) renderCellLookup(ctx context.Context, val types.String,
 	return err
 }
 
-// lookupName looks up a name from an identifier.
+// lookupName looks up a field value from an identifier. When lookupField is empty it defaults to
+// "metadata.name", which gives the same result as the previous GetMetadata().GetName() path.
 func (r *TableRenderer) lookupName(ctx context.Context, messageFullName protoreflect.FullName,
-	key string) (result string) {
+	key, lookupField string) (result string) {
+	if lookupField == "" {
+		lookupField = "metadata.name"
+	}
+
 	// Check if the result is already in the cache and return it immediately if so, otherwise
-	// remember to update the cache when done:
-	cache, ok := r.cache[messageFullName]
+	// remember to update the cache when done. The lookup field is part of the cache key so that
+	// different fields looked up on the same type don't collide.
+	cacheKey := protoreflect.FullName(string(messageFullName) + ":" + lookupField)
+	cache, ok := r.cache[cacheKey]
 	if !ok {
 		cache = map[string]string{}
-		r.cache[messageFullName] = cache
+		r.cache[cacheKey] = cache
 	}
 	result, ok = cache[key]
 	if ok {
@@ -497,11 +510,10 @@ func (r *TableRenderer) lookupName(ctx context.Context, messageFullName protoref
 		result = key
 		return
 	}
-
-	// Return the name of the first object, falling back to the key if the name is empty:
 	object := listResult.Items[0]
-	metadata := helper.GetMetadata(object)
-	result = metadata.GetName()
+
+	// Resolve the requested field from the looked up object:
+	result = reflection.ResolveFieldPath(object, lookupField)
 	if result == "" {
 		result = key
 	}

--- a/fulfillment-service/internal/rendering/table_renderer.go
+++ b/fulfillment-service/internal/rendering/table_renderer.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/pb"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/ext"
 	"google.golang.org/protobuf/proto"
@@ -70,17 +71,6 @@ type columnLayout struct {
 	// When the result is an identifier the 'type' field should be the name of the type, and it will be used to
 	// find the name of the object.
 	Type protoreflect.FullName `yaml:"type,omitempty"`
-
-	// Lookup indicates if the result of the expression is an identifier that needs to be translated into a name.
-	// When this is set to true the 'type' field also needs to be specified, and should contain the name of the
-	// type to use for the lookup. For example, if the result of the expression is a cluster, then the 'type'
-	// should be 'fulfillment.v1.Cluster'.
-	Lookup bool `yaml:"lookup,omitempty"`
-
-	// LookupField is an optional dot-separated field path used to extract a value from the object found by the
-	// lookup. When empty, the lookup renders the name of the object (the default). For example, to render the
-	// 'spec.version' field of the looked up object, this should be 'spec.version'.
-	LookupField string `yaml:"lookup_field,omitempty"`
 }
 
 // TableRendererBuilder is used to create table renderers. Don't create instances of this type directly, use the
@@ -97,7 +87,7 @@ type TableRenderer struct {
 	logger *slog.Logger
 	helper reflection.Helper
 	writer *tabwriter.Writer
-	cache  map[protoreflect.FullName]map[string]string
+	cache  map[protoreflect.FullName]map[string]proto.Message
 }
 
 // NewTableRenderer creates a new builder for table renderers.
@@ -143,7 +133,7 @@ func (b *TableRendererBuilder) Build() (result *TableRenderer, err error) {
 	writer := tabwriter.NewWriter(b.writer, 0, 0, 2, ' ', 0)
 
 	// Create the cache:
-	cache := map[protoreflect.FullName]map[string]string{}
+	cache := map[protoreflect.FullName]map[string]proto.Message{}
 
 	// Create and populate the object:
 	result = &TableRenderer{
@@ -224,11 +214,13 @@ func (r *TableRenderer) Render(ctx context.Context, objects any) error {
 	// Get the descriptor for the object type:
 	thisDesc := helper.Descriptor()
 
-	// Build CEL environment:
+	// Build CEL environment. Only the row type is registered eagerly; lookup targets are
+	// registered lazily inside lookupFunction when the expression actually evaluates lookup().
 	celEnv, err := cel.NewEnv(
 		cel.Types(dynamicpb.NewMessage(thisDesc)),
 		cel.Variable("this", cel.ObjectType(string(thisDesc.FullName()))),
 		ext.Strings(),
+		r.lookupFunction(ctx),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create CEL environment: %w", err)
@@ -390,10 +382,10 @@ func (r *TableRenderer) renderCell(ctx context.Context, col *columnLayout, val r
 			)
 		}
 	case types.String:
-		if col.Lookup && col.Type != "" {
+		if col.Type != "" {
 			messageType, _ := protoregistry.GlobalTypes.FindMessageByName(col.Type)
 			if messageType != nil {
-				return r.renderCellLookup(ctx, val, messageType.Descriptor(), col.LookupField)
+				return r.renderCellLookup(ctx, val, messageType.Descriptor())
 			}
 		}
 	}
@@ -432,14 +424,13 @@ func (r *TableRenderer) renderCellEnum(val types.Int, enumDesc protoreflect.Enum
 	return err
 }
 
-// renderCellLookup renders a lookup value (identifier to name translation). When lookupField is not empty, it is
-// used as a dot-separated field path to extract a value from the looked up object instead of its name.
+// renderCellLookup renders a lookup value (identifier to name translation).
 func (r *TableRenderer) renderCellLookup(ctx context.Context, val types.String,
-	messageDesc protoreflect.MessageDescriptor, lookupField string) error {
+	messageDesc protoreflect.MessageDescriptor) error {
 	key := string(val)
 	var text string
 	if key != "" {
-		text = r.lookupName(ctx, messageDesc.FullName(), key, lookupField)
+		text = r.lookupName(ctx, messageDesc.FullName(), key)
 	} else {
 		text = "-"
 	}
@@ -447,41 +438,48 @@ func (r *TableRenderer) renderCellLookup(ctx context.Context, val types.String,
 	return err
 }
 
-// lookupName looks up a field value from an identifier. When lookupField is empty it defaults to
-// "metadata.name", which gives the same result as the previous GetMetadata().GetName() path.
+// lookupName looks up a name from an identifier.
 func (r *TableRenderer) lookupName(ctx context.Context, messageFullName protoreflect.FullName,
-	key, lookupField string) (result string) {
-	if lookupField == "" {
-		lookupField = "metadata.name"
+	key string) string {
+	object := r.resolveObject(ctx, messageFullName, key)
+	if object == nil {
+		return key
 	}
+	helper := r.helper.Lookup(string(messageFullName))
+	if helper == nil {
+		return key
+	}
+	name := helper.GetName(object)
+	if name == "" {
+		return key
+	}
+	return name
+}
 
+// resolveObject fetches and caches an object by id or name.
+func (r *TableRenderer) resolveObject(ctx context.Context, targetType protoreflect.FullName,
+	key string) proto.Message {
 	// Check if the result is already in the cache and return it immediately if so, otherwise
-	// remember to update the cache when done. The lookup field is part of the cache key so that
-	// different fields looked up on the same type don't collide.
-	cacheKey := protoreflect.FullName(string(messageFullName) + ":" + lookupField)
-	cache, ok := r.cache[cacheKey]
+	// remember to update the cache when done:
+	cache, ok := r.cache[targetType]
 	if !ok {
-		cache = map[string]string{}
-		r.cache[cacheKey] = cache
+		cache = map[string]proto.Message{}
+		r.cache[targetType] = cache
 	}
-	result, ok = cache[key]
-	if ok {
-		return result
+	if object, ok := cache[key]; ok {
+		return object
 	}
-	defer func() {
-		cache[key] = result
-	}()
 
 	// Find the object helper:
-	helper := r.helper.Lookup(string(messageFullName))
+	helper := r.helper.Lookup(string(targetType))
 	if helper == nil {
 		r.logger.ErrorContext(
 			ctx,
 			"Failed to find object helper for type",
-			slog.String("type", string(messageFullName)),
+			slog.String("type", string(targetType)),
 		)
-		result = key
-		return
+		cache[key] = nil
+		return nil
 	}
 
 	// Find the objects whose identifier or name matches the key:
@@ -497,27 +495,117 @@ func (r *TableRenderer) lookupName(ctx context.Context, messageFullName protoref
 		r.logger.ErrorContext(
 			ctx,
 			"Failed to list objects for lookup",
-			slog.String("type", string(messageFullName)),
+			slog.String("type", string(targetType)),
 			slog.String("key", key),
 			slog.Any("error", err),
 		)
-		result = key
-		return
+		cache[key] = nil
+		return nil
 	}
 
-	// If there is no match, or multiple matches, return the original key:
+	// If there is no match return nil:
 	if len(listResult.Items) == 0 {
-		result = key
-		return
+		cache[key] = nil
+		return nil
 	}
 	object := listResult.Items[0]
+	cache[key] = object
+	return object
+}
 
-	// Resolve the requested field from the looked up object:
-	result = reflection.ResolveFieldPathOr(object, lookupField, "")
-	if result == "" {
-		result = key
+// lookupFunction returns a CEL environment option that registers the lookup() function. The function
+// takes a protobuf reference message (e.g. ClusterVersionReference) and returns the corresponding
+// object (e.g. ClusterVersion) so that the CEL expression can navigate its fields.
+//
+// Each lookup target type gets its own CEL type registry, created lazily on first use and cached
+// for the lifetime of the Render call. This avoids eagerly registering every resource type in the
+// CEL environment.
+func (r *TableRenderer) lookupFunction(ctx context.Context) cel.EnvOption {
+	registries := map[protoreflect.FullName]*types.Registry{}
+
+	return cel.Function("lookup",
+		cel.Overload(
+			"lookup_ref",
+			[]*cel.Type{cel.DynType},
+			cel.DynType,
+			cel.UnaryBinding(func(val ref.Val) ref.Val {
+				msg, ok := val.Value().(proto.Message)
+				if !ok {
+					return types.NewErr("lookup: expected a protobuf reference message, got %T", val.Value())
+				}
+				targetType, ok := referenceTargetType(msg.ProtoReflect().Descriptor())
+				if !ok {
+					r.logger.ErrorContext(
+						ctx,
+						"Failed to derive lookup target type from reference message",
+						slog.String("message", string(msg.ProtoReflect().Descriptor().FullName())),
+					)
+					return types.NewErr(
+						"lookup: cannot derive target type from %q",
+						msg.ProtoReflect().Descriptor().FullName(),
+					)
+				}
+				helper := r.helper.Lookup(string(targetType))
+				if helper == nil {
+					return types.NewErr("lookup: unknown target type %q", targetType)
+				}
+
+				registry, ok := registries[targetType]
+				if !ok {
+					var err error
+					registry, err = types.NewRegistry()
+					if err != nil {
+						return types.NewErr(
+							"lookup: failed to create type registry for %q: %v",
+							targetType, err,
+						)
+					}
+					for _, fd := range pb.CollectFileDescriptorSet(helper.Instance()) {
+						if err = registry.RegisterDescriptor(fd); err != nil {
+							return types.NewErr(
+								"lookup: failed to register type %q: %v",
+								targetType, err,
+							)
+						}
+					}
+					registries[targetType] = registry
+				}
+
+				key := referenceKey(msg)
+				if key == "" {
+					return registry.NativeToValue(helper.Instance())
+				}
+				object := r.resolveObject(ctx, targetType, key)
+				if object == nil {
+					return registry.NativeToValue(helper.Instance())
+				}
+				return registry.NativeToValue(object)
+			}),
+		),
+	)
+}
+
+// referenceTargetType derives the full name of the type that a reference message points to, using
+// the naming convention <Foo>Reference / <Foo>LocalReference -> <Foo>.
+func referenceTargetType(msgDesc protoreflect.MessageDescriptor) (protoreflect.FullName, bool) {
+	name := string(msgDesc.Name())
+	for _, suffix := range []string{"LocalReference", "Reference"} {
+		if base, ok := strings.CutSuffix(name, suffix); ok && base != "" {
+			return msgDesc.FullName().Parent().Append(protoreflect.Name(base)), true
+		}
 	}
-	return
+	return "", false
+}
+
+// referenceKey extracts the lookup key from a reference message, preferring id over name.
+func referenceKey(msg proto.Message) string {
+	if id, ok := reflection.ResolveFieldPath[string](msg, "id"); ok && id != "" {
+		return id
+	}
+	if name, ok := reflection.ResolveFieldPath[string](msg, "name"); ok && name != "" {
+		return name
+	}
+	return ""
 }
 
 // renderCellAny renders any value type as a string.

--- a/fulfillment-service/internal/rendering/table_renderer.go
+++ b/fulfillment-service/internal/rendering/table_renderer.go
@@ -513,7 +513,7 @@ func (r *TableRenderer) lookupName(ctx context.Context, messageFullName protoref
 	object := listResult.Items[0]
 
 	// Resolve the requested field from the looked up object:
-	result = reflection.ResolveFieldPath(object, lookupField)
+	result = reflection.ResolveFieldPathOr(object, lookupField, "")
 	if result == "" {
 		result = key
 	}

--- a/fulfillment-service/internal/rendering/table_renderer_cluster_version_test.go
+++ b/fulfillment-service/internal/rendering/table_renderer_cluster_version_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package rendering
+
+import (
+	"bytes"
+	"context"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
+
+	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/osac/fulfillment-service/internal/reflection"
+)
+
+var _ = Describe("Cluster VERSION column rendering", func() {
+	var ctrl *gomock.Controller
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		DeferCleanup(ctrl.Finish)
+	})
+
+	// makeVersionHelper creates a helper that returns the given cluster version object for any lookup.
+	makeVersionHelper := func(items []proto.Message) *reflection.MockObjectHelper {
+		versionDescriptor := (&publicv1.ClusterVersion{}).ProtoReflect().Descriptor()
+		helper := reflection.NewMockObjectHelper(ctrl)
+		helper.EXPECT().FullName().
+			Return(versionDescriptor.FullName()).
+			AnyTimes()
+		helper.EXPECT().Descriptor().
+			Return(versionDescriptor).
+			AnyTimes()
+		helper.EXPECT().String().
+			Return(string(versionDescriptor.FullName())).
+			AnyTimes()
+		helper.EXPECT().IsTenantScoped().
+			Return(true).
+			AnyTimes()
+		helper.EXPECT().
+			List(gomock.Any(), gomock.Any()).
+			Return(reflection.ListResult{Items: items, Total: int32(len(items))}, nil).
+			AnyTimes()
+		return helper
+	}
+
+	renderClusters := func(ctx context.Context, cluster *publicv1.Cluster, versionHelper *reflection.MockObjectHelper) string {
+		clusterObj := &publicv1.Cluster{}
+		clusterDescriptor := clusterObj.ProtoReflect().Descriptor()
+		clusterHelper := reflection.NewMockObjectHelper(ctrl)
+		clusterHelper.EXPECT().FullName().
+			Return(clusterDescriptor.FullName()).
+			AnyTimes()
+		clusterHelper.EXPECT().Descriptor().
+			Return(clusterDescriptor).
+			AnyTimes()
+		clusterHelper.EXPECT().String().
+			Return(string(clusterDescriptor.FullName())).
+			AnyTimes()
+		clusterHelper.EXPECT().IsTenantScoped().
+			Return(true).
+			AnyTimes()
+
+		helper := reflection.NewMockHelper(ctrl)
+		helper.EXPECT().
+			Lookup(gomock.Any()).
+			DoAndReturn(func(objectType string) reflection.ObjectHelper {
+				switch objectType {
+				case string(clusterDescriptor.FullName()):
+					return clusterHelper
+				default:
+					return versionHelper
+				}
+			}).
+			AnyTimes()
+
+		buffer := &bytes.Buffer{}
+		renderer, err := NewTableRenderer().
+			SetLogger(logger).
+			SetHelper(helper).
+			SetWriter(buffer).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+		err = renderer.Render(ctx, []proto.Message{cluster})
+		Expect(err).ToNot(HaveOccurred())
+		return buffer.String()
+	}
+
+	It("Resolves the version_name to the semver string via lookup_field", func(ctx context.Context) {
+		version := publicv1.ClusterVersion_builder{
+			Metadata: publicv1.Metadata_builder{Name: "4-17-0"}.Build(),
+			Spec: publicv1.ClusterVersionSpec_builder{
+				Version: "4.17.0",
+			}.Build(),
+		}.Build()
+		cluster := publicv1.Cluster_builder{
+			Id: "cluster-1",
+			Spec: publicv1.ClusterSpec_builder{
+				VersionName: proto.String("4-17-0"),
+			}.Build(),
+		}.Build()
+
+		output := renderClusters(ctx, cluster, makeVersionHelper([]proto.Message{version}))
+		Expect(output).To(ContainSubstring("4.17.0"))
+		Expect(output).ToNot(ContainSubstring("4-17-0\t"))
+	})
+
+	It("Falls back to the version_name when the looked-up object has no spec.version", func(ctx context.Context) {
+		version := publicv1.ClusterVersion_builder{
+			Metadata: publicv1.Metadata_builder{Name: "4-17-0"}.Build(),
+			Spec:     publicv1.ClusterVersionSpec_builder{}.Build(),
+		}.Build()
+		cluster := publicv1.Cluster_builder{
+			Id: "cluster-2",
+			Spec: publicv1.ClusterSpec_builder{
+				VersionName: proto.String("4-17-0"),
+			}.Build(),
+		}.Build()
+
+		output := renderClusters(ctx, cluster, makeVersionHelper([]proto.Message{version}))
+		Expect(output).To(ContainSubstring("4-17-0"))
+	})
+
+	It("Shows '-' when the cluster has no version_name", func(ctx context.Context) {
+		cluster := publicv1.Cluster_builder{
+			Id:   "cluster-3",
+			Spec: publicv1.ClusterSpec_builder{}.Build(),
+		}.Build()
+
+		output := renderClusters(ctx, cluster, makeVersionHelper(nil))
+		Expect(output).To(MatchRegexp(`VERSION.*\n.*-`))
+	})
+})

--- a/fulfillment-service/internal/rendering/table_renderer_cluster_version_test.go
+++ b/fulfillment-service/internal/rendering/table_renderer_cluster_version_test.go
@@ -16,11 +16,16 @@ package rendering
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"strings"
 
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/ext"
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/dynamicpb"
 
 	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/reflection"
@@ -50,6 +55,9 @@ var _ = Describe("Cluster VERSION column rendering", func() {
 		helper.EXPECT().IsTenantScoped().
 			Return(true).
 			AnyTimes()
+		helper.EXPECT().Instance().
+			Return(&publicv1.ClusterVersion{}).
+			AnyTimes()
 		helper.EXPECT().
 			List(gomock.Any(), gomock.Any()).
 			Return(reflection.ListResult{Items: items, Total: int32(len(items))}, nil).
@@ -74,6 +82,8 @@ var _ = Describe("Cluster VERSION column rendering", func() {
 			Return(true).
 			AnyTimes()
 
+		versionDescriptor := (&publicv1.ClusterVersion{}).ProtoReflect().Descriptor()
+
 		helper := reflection.NewMockHelper(ctrl)
 		helper.EXPECT().
 			Lookup(gomock.Any()).
@@ -81,8 +91,11 @@ var _ = Describe("Cluster VERSION column rendering", func() {
 				switch objectType {
 				case string(clusterDescriptor.FullName()):
 					return clusterHelper
-				default:
+				case string(versionDescriptor.FullName()):
 					return versionHelper
+				default:
+					Fail(fmt.Sprintf("unexpected object type lookup: %s", objectType))
+					return nil
 				}
 			}).
 			AnyTimes()
@@ -99,7 +112,7 @@ var _ = Describe("Cluster VERSION column rendering", func() {
 		return buffer.String()
 	}
 
-	It("Resolves the version_name to the semver string via lookup_field", func(ctx context.Context) {
+	It("Resolves the version reference to the semver string via the lookup() function", func(ctx context.Context) {
 		version := publicv1.ClusterVersion_builder{
 			Metadata: publicv1.Metadata_builder{Name: "4-17-0"}.Build(),
 			Spec: publicv1.ClusterVersionSpec_builder{
@@ -109,7 +122,7 @@ var _ = Describe("Cluster VERSION column rendering", func() {
 		cluster := publicv1.Cluster_builder{
 			Id: "cluster-1",
 			Spec: publicv1.ClusterSpec_builder{
-				VersionName: proto.String("4-17-0"),
+				Version: &publicv1.ClusterVersionReference{Name: "4-17-0"},
 			}.Build(),
 		}.Build()
 
@@ -118,29 +131,74 @@ var _ = Describe("Cluster VERSION column rendering", func() {
 		Expect(output).ToNot(ContainSubstring("4-17-0\t"))
 	})
 
-	It("Falls back to the version_name when the looked-up object has no spec.version", func(ctx context.Context) {
-		version := publicv1.ClusterVersion_builder{
-			Metadata: publicv1.Metadata_builder{Name: "4-17-0"}.Build(),
-			Spec:     publicv1.ClusterVersionSpec_builder{}.Build(),
-		}.Build()
+	It("Shows '-' when the cluster has no version", func(ctx context.Context) {
 		cluster := publicv1.Cluster_builder{
-			Id: "cluster-2",
-			Spec: publicv1.ClusterSpec_builder{
-				VersionName: proto.String("4-17-0"),
-			}.Build(),
-		}.Build()
-
-		output := renderClusters(ctx, cluster, makeVersionHelper([]proto.Message{version}))
-		Expect(output).To(ContainSubstring("4-17-0"))
-	})
-
-	It("Shows '-' when the cluster has no version_name", func(ctx context.Context) {
-		cluster := publicv1.Cluster_builder{
-			Id:   "cluster-3",
+			Id:   "cluster3",
 			Spec: publicv1.ClusterSpec_builder{}.Build(),
 		}.Build()
 
 		output := renderClusters(ctx, cluster, makeVersionHelper(nil))
-		Expect(output).To(MatchRegexp(`VERSION.*\n.*-`))
+		lines := strings.Split(strings.TrimSpace(output), "\n")
+		Expect(lines).To(HaveLen(2))
+		versionCol := strings.Index(lines[0], "VERSION")
+		Expect(versionCol).To(BeNumerically(">=", 0))
+		Expect(lines[1][versionCol]).To(Equal(byte('-')))
+	})
+
+	It("Navigates into types from imported proto files via lookup()", func(ctx context.Context) {
+		// Metadata is defined in metadata_type.proto, imported by cluster_version_type.proto.
+		// This test verifies that the lazy type registry registers transitive imports so that
+		// lookup(ref).metadata.name resolves correctly.
+		version := publicv1.ClusterVersion_builder{
+			Metadata: publicv1.Metadata_builder{Name: "my-version"}.Build(),
+			Spec:     publicv1.ClusterVersionSpec_builder{Version: "4.17.0"}.Build(),
+		}.Build()
+		cluster := publicv1.Cluster_builder{
+			Id: "cluster-4",
+			Spec: publicv1.ClusterSpec_builder{
+				Version: &publicv1.ClusterVersionReference{Name: "my-version"},
+			}.Build(),
+		}.Build()
+
+		versionHelper := makeVersionHelper([]proto.Message{version})
+		clusterDescriptor := cluster.ProtoReflect().Descriptor()
+
+		helper := reflection.NewMockHelper(ctrl)
+		helper.EXPECT().
+			Lookup(gomock.Any()).
+			DoAndReturn(func(objectType string) reflection.ObjectHelper {
+				if objectType == string((&publicv1.ClusterVersion{}).ProtoReflect().Descriptor().FullName()) {
+					return versionHelper
+				}
+				return nil
+			}).
+			AnyTimes()
+
+		buffer := &bytes.Buffer{}
+		renderer, err := NewTableRenderer().
+			SetLogger(logger).
+			SetHelper(helper).
+			SetWriter(buffer).
+			Build()
+		Expect(err).ToNot(HaveOccurred())
+
+		celEnv, err := cel.NewEnv(
+			cel.Types(dynamicpb.NewMessage(clusterDescriptor)),
+			cel.Variable("this", cel.ObjectType(string(clusterDescriptor.FullName()))),
+			ext.Strings(),
+			renderer.lookupFunction(ctx),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		ast, issues := celEnv.Compile("lookup(this.spec.version).metadata.name")
+		Expect(issues.Err()).ToNot(HaveOccurred())
+		prg, err := celEnv.Program(ast)
+		Expect(err).ToNot(HaveOccurred())
+
+		celVars, err := cel.PartialVars(map[string]any{"this": cluster})
+		Expect(err).ToNot(HaveOccurred())
+		out, _, err := prg.Eval(celVars)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out.Value()).To(Equal("my-version"))
 	})
 })

--- a/fulfillment-service/internal/rendering/table_renderer_compute_instance_test.go
+++ b/fulfillment-service/internal/rendering/table_renderer_compute_instance_test.go
@@ -76,8 +76,10 @@ var _ = Describe("Compute instance table rendering", func() {
 					nil).
 				AnyTimes()
 			templateHelper.EXPECT().
-				GetMetadata(gomock.Any()).
-				Return(templateMetadata).
+				GetName(gomock.Any()).
+				DoAndReturn(func(obj proto.Message) string {
+					return templateName
+				}).
 				AnyTimes()
 
 			// Create the compute instance object:

--- a/fulfillment-service/internal/rendering/tables/osac.private.v1.BareMetalInstance.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.private.v1.BareMetalInstance.yaml
@@ -22,7 +22,6 @@ columns:
 - header: CATALOG ITEM
   value: this.spec.catalog_item.id
   type: osac.private.v1.BareMetalInstanceCatalogItem
-  lookup: true
 
 - header: IMAGE
   value: "has(this.spec.image) && has(this.spec.image.source_ref)? this.spec.image.source_ref: '-'"
@@ -34,4 +33,3 @@ columns:
 - header: HUB
   value: this.status.hub
   type: osac.private.v1.Hub
-  lookup: true

--- a/fulfillment-service/internal/rendering/tables/osac.private.v1.Cluster.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.private.v1.Cluster.yaml
@@ -27,6 +27,12 @@ columns:
   type: osac.private.v1.ClusterTemplate
   lookup: true
 
+- header: VERSION
+  value: "has(this.spec.version)? this.spec.version.name: ''"
+  type: osac.private.v1.ClusterVersion
+  lookup: true
+  lookup_field: spec.version
+
 - header: STATE
   value: this.status.state
   type: osac.public.v1.ClusterState

--- a/fulfillment-service/internal/rendering/tables/osac.private.v1.Cluster.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.private.v1.Cluster.yaml
@@ -25,13 +25,9 @@ columns:
 - header: TEMPLATE
   value: this.spec.template.id
   type: osac.private.v1.ClusterTemplate
-  lookup: true
 
 - header: VERSION
-  value: "has(this.spec.version)? this.spec.version.name: ''"
-  type: osac.private.v1.ClusterVersion
-  lookup: true
-  lookup_field: spec.version
+  value: "has(this.spec.version)? lookup(this.spec.version).spec.version: '-'"
 
 - header: STATE
   value: this.status.state
@@ -40,7 +36,6 @@ columns:
 - header: HUB
   value: this.status.hub
   type: osac.private.v1.Hub
-  lookup: true
 
 - header: API URL
   value: "has(this.status.api_url)? this.status.api_url: '-'"

--- a/fulfillment-service/internal/rendering/tables/osac.private.v1.ComputeInstance.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.private.v1.ComputeInstance.yaml
@@ -25,7 +25,6 @@ columns:
 - header: TEMPLATE
   value: this.spec.template.id
   type: osac.private.v1.ComputeInstanceTemplate
-  lookup: true
 
 - header: OS
   value: "has(this.spec.is_windows) && this.spec.is_windows ? 'windows' : 'linux'"
@@ -37,7 +36,6 @@ columns:
 - header: HUB
   value: this.status.hub
   type: osac.private.v1.Hub
-  lookup: true
 
 - header: INTERNAL IP ADDRESS
   value: this.status.internal_ip_address

--- a/fulfillment-service/internal/rendering/tables/osac.private.v1.ExternalIP.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.private.v1.ExternalIP.yaml
@@ -35,7 +35,6 @@ columns:
 - header: HUB
   value: this.status.hub
   type: osac.private.v1.Hub
-  lookup: true
 
 - header: ATTACHED
   value: "has(this.status) && this.status.attached? 'true': 'false'"

--- a/fulfillment-service/internal/rendering/tables/osac.private.v1.ExternalIPAttachment.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.private.v1.ExternalIPAttachment.yaml
@@ -35,4 +35,3 @@ columns:
 - header: HUB
   value: this.status.hub
   type: osac.private.v1.Hub
-  lookup: true

--- a/fulfillment-service/internal/rendering/tables/osac.private.v1.ExternalIPPool.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.private.v1.ExternalIPPool.yaml
@@ -48,4 +48,3 @@ columns:
 - header: HUB
   value: this.status.hub
   type: osac.private.v1.Hub
-  lookup: true

--- a/fulfillment-service/internal/rendering/tables/osac.private.v1.NATGateway.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.private.v1.NATGateway.yaml
@@ -25,12 +25,10 @@ columns:
 - header: VIRTUAL-NETWORK
   value: this.spec.virtual_network.id
   type: osac.private.v1.VirtualNetwork
-  lookup: true
 
 - header: EXTERNAL-IP
   value: this.spec.external_ip.id
   type: osac.private.v1.ExternalIP
-  lookup: true
 
 - header: STATE
   value: this.status.state
@@ -39,4 +37,3 @@ columns:
 - header: HUB
   value: this.status.hub
   type: osac.private.v1.Hub
-  lookup: true

--- a/fulfillment-service/internal/rendering/tables/osac.private.v1.RoleBinding.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.private.v1.RoleBinding.yaml
@@ -29,7 +29,6 @@ columns:
 - header: ROLE
   value: this.spec.role.id
   type: osac.private.v1.Role
-  lookup: true
 
 - header: USERS
   value: "size(this.spec.users) > 0? this.spec.users.map(u, u.id).join(', '): '-'"

--- a/fulfillment-service/internal/rendering/tables/osac.private.v1.SecurityGroup.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.private.v1.SecurityGroup.yaml
@@ -25,7 +25,6 @@ columns:
 - header: VIRTUAL-NETWORK
   value: this.spec.virtual_network.id
   type: osac.private.v1.VirtualNetwork
-  lookup: true
 
 - header: INGRESS-RULES
   value: '"%d".format([size(this.spec.ingress)])'

--- a/fulfillment-service/internal/rendering/tables/osac.private.v1.Subnet.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.private.v1.Subnet.yaml
@@ -25,7 +25,6 @@ columns:
 - header: VIRTUAL-NETWORK
   value: this.spec.virtual_network.id
   type: osac.private.v1.VirtualNetwork
-  lookup: true
 
 - header: IPV4-CIDR
   value: "has(this.spec.ipv4_cidr)? this.spec.ipv4_cidr: '-'"
@@ -40,4 +39,3 @@ columns:
 - header: HUB
   value: this.status.hub
   type: osac.private.v1.Hub
-  lookup: true

--- a/fulfillment-service/internal/rendering/tables/osac.private.v1.User.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.private.v1.User.yaml
@@ -25,4 +25,3 @@ columns:
 - header: TENANT
   value: "has(this.metadata.tenant)? this.metadata.tenant: '-'"
   type: osac.private.v1.Tenant
-  lookup: true

--- a/fulfillment-service/internal/rendering/tables/osac.private.v1.VirtualNetwork.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.private.v1.VirtualNetwork.yaml
@@ -28,7 +28,6 @@ columns:
 - header: NETWORK-CLASS
   value: this.spec.network_class.id
   type: osac.private.v1.NetworkClass
-  lookup: true
 
 - header: IPV4-CIDR
   value: "has(this.spec.ipv4_cidr)? this.spec.ipv4_cidr: '-'"
@@ -46,4 +45,3 @@ columns:
 - header: HUB
   value: this.status.hub
   type: osac.private.v1.Hub
-  lookup: true

--- a/fulfillment-service/internal/rendering/tables/osac.public.v1.BareMetalInstance.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.public.v1.BareMetalInstance.yaml
@@ -22,7 +22,6 @@ columns:
 - header: CATALOG ITEM
   value: this.spec.catalog_item.id
   type: osac.public.v1.BareMetalInstanceCatalogItem
-  lookup: true
 
 - header: IMAGE
   value: "has(this.spec.image) && has(this.spec.image.source_ref)? this.spec.image.source_ref: '-'"

--- a/fulfillment-service/internal/rendering/tables/osac.public.v1.Cluster.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.public.v1.Cluster.yaml
@@ -27,6 +27,12 @@ columns:
   type: osac.public.v1.ClusterTemplate
   lookup: true
 
+- header: VERSION
+  value: "has(this.spec.version)? this.spec.version.name: ''"
+  type: osac.public.v1.ClusterVersion
+  lookup: true
+  lookup_field: spec.version
+
 - header: STATE
   value: this.status.state
   type: osac.public.v1.ClusterState

--- a/fulfillment-service/internal/rendering/tables/osac.public.v1.Cluster.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.public.v1.Cluster.yaml
@@ -25,13 +25,9 @@ columns:
 - header: TEMPLATE
   value: this.spec.template.id
   type: osac.public.v1.ClusterTemplate
-  lookup: true
 
 - header: VERSION
-  value: "has(this.spec.version)? this.spec.version.name: ''"
-  type: osac.public.v1.ClusterVersion
-  lookup: true
-  lookup_field: spec.version
+  value: "has(this.spec.version)? lookup(this.spec.version).spec.version: '-'"
 
 - header: STATE
   value: this.status.state

--- a/fulfillment-service/internal/rendering/tables/osac.public.v1.ComputeInstance.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.public.v1.ComputeInstance.yaml
@@ -27,7 +27,6 @@ columns:
 - header: TEMPLATE
   value: this.spec.template.id
   type: osac.public.v1.ComputeInstanceTemplate
-  lookup: true
 
 - header: OS
   value: "has(this.spec.is_windows) && this.spec.is_windows ? 'windows' : 'linux'"

--- a/fulfillment-service/internal/rendering/tables/osac.public.v1.NATGateway.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.public.v1.NATGateway.yaml
@@ -25,12 +25,10 @@ columns:
 - header: VIRTUAL-NETWORK
   value: this.spec.virtual_network.id
   type: osac.public.v1.VirtualNetwork
-  lookup: true
 
 - header: EXTERNAL-IP
   value: this.spec.external_ip.id
   type: osac.public.v1.ExternalIP
-  lookup: true
 
 - header: STATE
   value: this.status.state

--- a/fulfillment-service/internal/rendering/tables/osac.public.v1.RoleBinding.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.public.v1.RoleBinding.yaml
@@ -29,7 +29,6 @@ columns:
 - header: ROLE
   value: this.spec.role.id
   type: osac.public.v1.Role
-  lookup: true
 
 - header: USERS
   value: "size(this.spec.users) > 0? this.spec.users.map(u, u.id).join(', '): '-'"

--- a/fulfillment-service/internal/rendering/tables/osac.public.v1.SecurityGroup.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.public.v1.SecurityGroup.yaml
@@ -25,7 +25,6 @@ columns:
 - header: VIRTUAL-NETWORK
   value: this.spec.virtual_network.id
   type: osac.public.v1.VirtualNetwork
-  lookup: true
 
 - header: INGRESS-RULES
   value: '"%d".format([size(this.spec.ingress)])'

--- a/fulfillment-service/internal/rendering/tables/osac.public.v1.Subnet.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.public.v1.Subnet.yaml
@@ -25,7 +25,6 @@ columns:
 - header: VIRTUAL-NETWORK
   value: this.spec.virtual_network.id
   type: osac.public.v1.VirtualNetwork
-  lookup: true
 
 - header: IPV4-CIDR
   value: "has(this.spec.ipv4_cidr)? this.spec.ipv4_cidr: '-'"

--- a/fulfillment-service/internal/rendering/tables/osac.public.v1.User.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.public.v1.User.yaml
@@ -31,4 +31,3 @@ columns:
 - header: TENANT
   value: "has(this.metadata.tenant)? this.metadata.tenant: '-'"
   type: osac.public.v1.Tenant
-  lookup: true

--- a/fulfillment-service/internal/rendering/tables/osac.public.v1.VirtualNetwork.yaml
+++ b/fulfillment-service/internal/rendering/tables/osac.public.v1.VirtualNetwork.yaml
@@ -25,7 +25,6 @@ columns:
 - header: NETWORK-CLASS
   value: this.spec.network_class.id
   type: osac.public.v1.NetworkClass
-  lookup: true
 
 - header: IPV4-CIDR
   value: "has(this.spec.ipv4_cidr)? this.spec.ipv4_cidr: '-'"


### PR DESCRIPTION
- Add ClusterVersion support to the CLI: VERSION column in cluster list tables with lookup_field-based resolution, and a nested Version section in describe cluster output
- Reuse generic ResolveFieldPath[T] across four hand-rolled proto field walkers in auth, references, and reflection packages

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **VERSION** column to cluster tables, displaying the associated version name.
  * Cluster details now show version, status, deprecation, and obsolescence information when available.
* **Bug Fixes**
  * Cluster details continue rendering when version information cannot be retrieved, with a warning instead of failing.
  * Version display falls back gracefully when data or names are unavailable.
* **Improvements**
  * Enhanced table lookups for displaying related resource values more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->