### PR TITLE
OSAC-3289: deploy vendor CSI controllers via csi-backends Helm chart

### DIFF
--- a/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/defaults/main.yaml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/defaults/main.yaml
@@ -1,0 +1,16 @@
+---
+# csi-backends Helm chart — deploys vendor CSI controllers on the hub cluster.
+# Shared across all storage providers. Each provider is enabled/disabled
+# based on the tier list passed to the storage_provider role.
+#
+# Default: OCI registry. For local development or CI, override via the
+# OSAC_CSI_BACKENDS_CHART_REF env var (e.g., path to the local chart).
+# Gated by storage_provider_csi_backends_enabled (default true).
+storage_provider_csi_backends_enabled: true
+storage_provider_csi_backends_chart_ref: >-
+  {{ lookup('env', 'OSAC_CSI_BACKENDS_CHART_REF')
+     | default('oci://ghcr.io/osac-project/charts/csi-backends', true) }}
+# Leave unset to install the latest version. Set to pin (e.g., "0.1.0").
+storage_provider_csi_backends_chart_version: ""
+storage_provider_csi_backends_release_name: "osac-csi-backends"
+storage_provider_csi_backends_namespace: "osac-csi-backends"

--- a/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tasks/ensure_csi_backends.yaml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tasks/ensure_csi_backends.yaml
@@ -1,0 +1,71 @@
+---
+# Deploys vendor CSI controllers on the hub cluster using the csi-backends
+# Helm chart. Enables each vendor whose provider name appears in the tier
+# list. Runs once during setup, before individual provider roles are
+# dispatched — so the chart values reflect all configured vendors, not
+# just the first one.
+#
+# Uses helm upgrade --install (kubernetes.core.helm state=present) so
+# re-runs add newly configured vendors without clobbering existing ones.
+#
+# Requires (from caller):
+#   _unique_providers — list of provider names from the tier list
+
+- name: Build csi-backends chart values from provider list
+  ansible.builtin.set_fact:
+    _csi_backends_values:
+      namespace: "{{ storage_provider_csi_backends_namespace }}"
+      vast:
+        enabled: "{{ 'vast' in _unique_providers }}"
+      trident:
+        enabled: "{{ 'trident' in _unique_providers }}"
+      pure:
+        enabled: "{{ 'pure' in _unique_providers }}"
+
+- name: Check if any vendor controller is needed
+  ansible.builtin.set_fact:
+    _csi_backends_any_enabled: >-
+      {{ 'vast' in _unique_providers
+         or 'trident' in _unique_providers
+         or 'pure' in _unique_providers }}
+
+- name: Install or upgrade csi-backends Helm chart
+  when:
+    - _csi_backends_any_enabled | bool
+    - storage_provider_csi_backends_enabled | default(true) | bool
+  kubernetes.core.helm:
+    name: "{{ storage_provider_csi_backends_release_name }}"
+    chart_ref: "{{ storage_provider_csi_backends_chart_ref }}"
+    chart_version: "{{ storage_provider_csi_backends_chart_version | default(omit, true) }}"
+    release_namespace: "{{ storage_provider_csi_backends_namespace }}"
+    create_namespace: true
+    release_state: present
+    release_values: "{{ _csi_backends_values }}"
+
+- name: Wait for enabled vendor controller deployments
+  when:
+    - _csi_backends_any_enabled | bool
+    - storage_provider_csi_backends_enabled | default(true) | bool
+  kubernetes.core.k8s_info:
+    api_version: apps/v1
+    kind: Deployment
+    name: "{{ item }}-csi-controller"
+    namespace: "{{ storage_provider_csi_backends_namespace }}"
+  register: _csi_backends_deploy
+  retries: 30
+  delay: 10
+  until: >-
+    _csi_backends_deploy.resources | length > 0
+    and (_csi_backends_deploy.resources[0].status.availableReplicas | default(0) | int) > 0
+  loop: "{{ _unique_providers | intersect(['vast', 'trident', 'pure']) }}"
+  loop_control:
+    label: "{{ item }}-csi-controller"
+
+- name: Log vendor controller status
+  when:
+    - _csi_backends_any_enabled | bool
+    - storage_provider_csi_backends_enabled | default(true) | bool
+  ansible.builtin.debug:
+    msg: >-
+      Vendor CSI controllers deployed in namespace {{ storage_provider_csi_backends_namespace }}:
+      {{ _unique_providers | intersect(['vast', 'trident', 'pure']) | join(', ') }}

--- a/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tasks/ensure_csi_backends.yaml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tasks/ensure_csi_backends.yaml
@@ -1,71 +1,133 @@
 ---
 # Deploys vendor CSI controllers on the hub cluster using the csi-backends
-# Helm chart. Enables each vendor whose provider name appears in the tier
-# list. Runs once during setup, before individual provider roles are
-# dispatched — so the chart values reflect all configured vendors, not
-# just the first one.
+# Helm chart, enabling each vendor whose controller is needed on the hub.
 #
-# Uses helm upgrade --install (kubernetes.core.helm state=present) so
-# re-runs add newly configured vendors without clobbering existing ones.
+# WHY THIS IS CUMULATIVE (do not "simplify" back to enabled: <v> in _unique_providers):
+# The csi-backends release is a single, hub-wide (platform) resource, but this
+# task runs once PER TENANT — setup.yaml is invoked by
+# playbook_osac_create_tenant_storage_backend.yml with _unique_providers derived
+# from *that tenant's* resolved storage tiers, i.e. a per-tenant subset. A plain
+# `helm upgrade` replaces the release's values wholesale (it does not merge with
+# the previous release), so setting a vendor's enabled flag straight from
+# _unique_providers would flip other vendors to enabled: false and tear down a
+# controller a different tenant still relies on (e.g. onboarding a trident-only
+# tenant would uninstall the vast controller a vast tenant depends on).
 #
-# Requires (from caller):
-#   _unique_providers — list of provider names from the tier list
+# To prevent that, enablement here only ever GROWS: a vendor is enabled if this
+# tenant needs it OR its controller Deployment already exists on the hub. Disabling
+# a vendor is a separate, deliberate teardown — never a side effect of onboarding
+# another tenant.
+#
+# The whole thing is one block gated on storage_provider_csi_backends_enabled so
+# that when it is disabled (e.g. the storage_provider unit tests, which have no
+# cluster) every task here — including the cluster reads — is skipped and the
+# facts these tasks set are never referenced.
+#
+# Requires (from caller / main.yaml):
+#   _unique_providers — list of provider names from this tenant's tier list
 
-- name: Build csi-backends chart values from provider list
-  ansible.builtin.set_fact:
-    _csi_backends_values:
-      namespace: "{{ storage_provider_csi_backends_namespace }}"
-      vast:
-        enabled: "{{ 'vast' in _unique_providers }}"
-      trident:
-        enabled: "{{ 'trident' in _unique_providers }}"
-      pure:
-        enabled: "{{ 'pure' in _unique_providers }}"
+- name: Ensure vendor CSI controllers are deployed on the hub (cumulative across tenants)
+  when: storage_provider_csi_backends_enabled | default(true) | bool
+  block:
+    - name: Discover vendor controllers already deployed on the hub
+      kubernetes.core.k8s_info:
+        api_version: apps/v1
+        kind: Deployment
+        namespace: "{{ storage_provider_csi_backends_namespace }}"
+      register: _csi_backends_existing
 
-- name: Check if any vendor controller is needed
-  ansible.builtin.set_fact:
-    _csi_backends_any_enabled: >-
-      {{ 'vast' in _unique_providers
-         or 'trident' in _unique_providers
-         or 'pure' in _unique_providers }}
+    - name: Compute this tenant's vendors and the controllers already present
+      ansible.builtin.set_fact:
+        # Vendors this tenant's tiers require, bounded to the chart-managed vendor set.
+        _this_tenant_vendors: "{{ _unique_providers | intersect(['vast', 'trident', 'pure']) }}"
+        # Names of vendor controller Deployments that already exist in the namespace.
+        _existing_controller_names: >-
+          {{ (_csi_backends_existing.resources | default([]))
+             | map(attribute='metadata.name') | list }}
 
-- name: Install or upgrade csi-backends Helm chart
-  when:
-    - _csi_backends_any_enabled | bool
-    - storage_provider_csi_backends_enabled | default(true) | bool
-  kubernetes.core.helm:
-    name: "{{ storage_provider_csi_backends_release_name }}"
-    chart_ref: "{{ storage_provider_csi_backends_chart_ref }}"
-    chart_version: "{{ storage_provider_csi_backends_chart_version | default(omit, true) }}"
-    release_namespace: "{{ storage_provider_csi_backends_namespace }}"
-    create_namespace: true
-    release_state: present
-    release_values: "{{ _csi_backends_values }}"
+    - name: Compute cumulative vendor enablement set (this tenant's vendors ∪ already-deployed)
+      ansible.builtin.set_fact:
+        # A vendor stays/gets enabled if THIS tenant needs it OR its controller already
+        # exists — the union is what keeps a per-tenant run from clobbering others.
+        _csi_backends_enabled_vendors: >-
+          {{
+            (['vast'] if ('vast' in _this_tenant_vendors
+                          or 'vast-csi-controller' in _existing_controller_names) else [])
+            + (['trident'] if ('trident' in _this_tenant_vendors
+                               or 'trident-csi-controller' in _existing_controller_names) else [])
+            + (['pure'] if ('pure' in _this_tenant_vendors
+                            or 'pure-csi-controller' in _existing_controller_names) else [])
+          }}
 
-- name: Wait for enabled vendor controller deployments
-  when:
-    - _csi_backends_any_enabled | bool
-    - storage_provider_csi_backends_enabled | default(true) | bool
-  kubernetes.core.k8s_info:
-    api_version: apps/v1
-    kind: Deployment
-    name: "{{ item }}-csi-controller"
-    namespace: "{{ storage_provider_csi_backends_namespace }}"
-  register: _csi_backends_deploy
-  retries: 30
-  delay: 10
-  until: >-
-    _csi_backends_deploy.resources | length > 0
-    and (_csi_backends_deploy.resources[0].status.availableReplicas | default(0) | int) > 0
-  loop: "{{ _unique_providers | intersect(['vast', 'trident', 'pure']) }}"
-  loop_control:
-    label: "{{ item }}-csi-controller"
+    - name: Build csi-backends chart values from the cumulative vendor set
+      ansible.builtin.set_fact:
+        _csi_backends_values:
+          namespace: "{{ storage_provider_csi_backends_namespace }}"
+          vast:
+            enabled: "{{ 'vast' in _csi_backends_enabled_vendors }}"
+          trident:
+            enabled: "{{ 'trident' in _csi_backends_enabled_vendors }}"
+          pure:
+            enabled: "{{ 'pure' in _csi_backends_enabled_vendors }}"
+        _csi_backends_any_enabled: "{{ _csi_backends_enabled_vendors | length > 0 }}"
 
-- name: Log vendor controller status
-  when:
-    - _csi_backends_any_enabled | bool
-    - storage_provider_csi_backends_enabled | default(true) | bool
-  ansible.builtin.debug:
-    msg: >-
-      Vendor CSI controllers deployed in namespace {{ storage_provider_csi_backends_namespace }}:
-      {{ _unique_providers | intersect(['vast', 'trident', 'pure']) | join(', ') }}
+    - name: Ensure csi-backends namespace exists with privileged Pod Security labels
+      # Vendor CSI controllers require privileged Pod Security Admission (trident runs
+      # runAsNonRoot: false; vast/pure declare no securityContext). The chart no longer
+      # ships a Namespace template, and helm's create_namespace only creates a bare,
+      # unlabeled namespace — under the default restricted PSA that would reject the
+      # vendor pods. Create the namespace here with the required labels (idempotent, so
+      # it also patches the labels onto a namespace a prior create_namespace run left
+      # bare), then install the chart into it with create_namespace: false below.
+      when: _csi_backends_any_enabled | bool
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: "{{ storage_provider_csi_backends_namespace }}"
+            labels:
+              pod-security.kubernetes.io/enforce: privileged
+              pod-security.kubernetes.io/warn: privileged
+
+    - name: Install or upgrade csi-backends Helm chart
+      when: _csi_backends_any_enabled | bool
+      kubernetes.core.helm:
+        name: "{{ storage_provider_csi_backends_release_name }}"
+        chart_ref: "{{ storage_provider_csi_backends_chart_ref }}"
+        chart_version: "{{ storage_provider_csi_backends_chart_version | default(omit, true) }}"
+        release_namespace: "{{ storage_provider_csi_backends_namespace }}"
+        # Namespace is created above with the required PSA labels; do not let helm
+        # create a bare, unlabeled one.
+        create_namespace: false
+        release_state: present
+        release_values: "{{ _csi_backends_values }}"
+
+    - name: Wait for enabled vendor controller deployments
+      when: _csi_backends_any_enabled | bool
+      kubernetes.core.k8s_info:
+        api_version: apps/v1
+        kind: Deployment
+        name: "{{ item }}-csi-controller"
+        namespace: "{{ storage_provider_csi_backends_namespace }}"
+      register: _csi_backends_deploy
+      retries: 30
+      delay: 10
+      until: >-
+        _csi_backends_deploy.resources | length > 0
+        and (_csi_backends_deploy.resources[0].status.availableReplicas | default(0) | int) > 0
+      # Wait on the full enabled set (not just this tenant's vendors): the upgrade
+      # re-renders the shared release, so confirm every controller it should be running
+      # is healthy afterwards.
+      loop: "{{ _csi_backends_enabled_vendors }}"
+      loop_control:
+        label: "{{ item }}-csi-controller"
+
+    - name: Log vendor controller status
+      when: _csi_backends_any_enabled | bool
+      ansible.builtin.debug:
+        msg: >-
+          Vendor CSI controllers running in namespace {{ storage_provider_csi_backends_namespace }}:
+          {{ _csi_backends_enabled_vendors | join(', ') }}
+          (this tenant needs: {{ _this_tenant_vendors | join(', ') | default('none', true) }})

--- a/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tasks/setup.yaml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/storage_provider/tasks/setup.yaml
@@ -7,6 +7,9 @@
   ansible.builtin.set_fact:
     _all_tenant_configs: {}
 
+- name: Deploy vendor CSI controllers on hub
+  ansible.builtin.include_tasks: ensure_csi_backends.yaml
+
 - name: Dispatch setup to each provider
   block:
     - name: Run setup per provider

--- a/osac-aap/tests/integration/run_tests.sh
+++ b/osac-aap/tests/integration/run_tests.sh
@@ -163,7 +163,7 @@ echo ""
 # everything after it.
 STORAGE_PROVIDER_UNIT_TEST="${SCRIPT_DIR}/../../collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml"
 
-if ansible-playbook "${STORAGE_PROVIDER_UNIT_TEST}" -v; then
+if ansible-playbook "${STORAGE_PROVIDER_UNIT_TEST}" -v -e storage_provider_csi_backends_enabled=false; then
   echo "  ✓ storage_provider unit tests (part 1) passed"
   PASSED+=("storage_provider_unit_tests:part1")
 else
@@ -173,7 +173,7 @@ fi
 
 part2_log="${SCRIPT_DIR}/.storage_provider_unit_part2.log"
 if ansible-playbook --start-at-task "Attempt with invalid action 'destroy' (expected to fail)" \
-  "${STORAGE_PROVIDER_UNIT_TEST}" -v > "${part2_log}" 2>&1 \
+  "${STORAGE_PROVIDER_UNIT_TEST}" -v -e storage_provider_csi_backends_enabled=false > "${part2_log}" 2>&1 \
   && grep -q 'ok=[1-9]' "${part2_log}"; then
   echo "  ✓ storage_provider unit tests (part 2) passed"
   PASSED+=("storage_provider_unit_tests:part2")

--- a/osac-aap/tests/integration/setup_test_env.sh
+++ b/osac-aap/tests/integration/setup_test_env.sh
@@ -168,11 +168,16 @@ CSIEOF
   # playbook or role (OSAC-1992 moved credential/tier input to
   # storage_provider_backend_connections/storage_provider_tiers extra_vars, set directly
   # by each test target) -- only VIP pool and TLS settings remain relevant here.
-  cat > "${SCRIPT_DIR}/.storage_env" <<'ENVEOF'
+  # Resolve the csi-backends chart path from the repo root — integration tests
+  # run playbooks from test subdirectories, not the top-level osac-aap/ dir,
+  # so the playbook_dir-based default doesn't resolve correctly.
+  REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+  cat > "${SCRIPT_DIR}/.storage_env" <<ENVEOF
 export VAST_VIP_POOL_NAME="osac-test-pool"
 export VAST_VIP_POOL_IP_RANGES='[["10.0.0.10","10.0.0.50"]]'
 export VAST_VIP_POOL_SUBNET_CIDR="24"
 export VAST_VALIDATE_CERTS="false"
+export OSAC_CSI_BACKENDS_CHART_REF="${REPO_ROOT}/../osac-csi-driver/charts/csi-backends"
 ENVEOF
 fi
 

--- a/osac-csi-driver/charts/csi-backends/README.md
+++ b/osac-csi-driver/charts/csi-backends/README.md
@@ -93,6 +93,82 @@ pure:
     nodePluginNamespace: "<namespace-where-node-plugin-runs>"
 ```
 
+## Provisioning volumes through a vendor controller
+
+The Deployments this chart creates expose each vendor's **raw CSI gRPC API** on
+port 50051. Nothing calls them yet: the OSAC CSI meta-driver's controller plugin
+never talks to vendor drivers directly (it delegates to the fulfillment-service
+Volume API), and volume-level tier/backend resolution — which picks the vendor
+for a given request — does not exist yet.
+
+The future caller is the **osac-operator Volume reconciler**. It reconciles
+`Volume` CRs by calling `VendorProvisioner.CreateVolume`. That interface has no
+production implementation yet: the reconciler is currently constructed with a
+`nil` provisioner and skips provisioning (a mock, `MockVendorProvisioner`, is
+used only in tests). Wiring the real vendor CSI client is the follow-up. See
+`../../../osac-operator/internal/controller/volume_controller.go`
+(the `VendorProvisioner` interface and `VendorCreateVolumeRequest`/`Response`
+structs). The real implementation will dial the vendor Deployment created here
+(`<vendor>-csi-controller:50051`) and issue a CSI `CreateVolume` RPC.
+
+This section documents the wire contract that implementation must emit, verified
+against the VAST controller this chart deploys.
+
+Note the CSI-level fields below (`parameters.*`, `secrets.*`, `fs_type`) are
+**not** on today's `VendorCreateVolumeRequest`, which carries only `Name`,
+`Backend`, `SizeGiB`, and `AccessMode`. Wiring the real client means either
+extending that struct or sourcing these values from the resolved `Backend`/tier
+config; the mapping notes below point at the closest existing field where one
+exists.
+
+### VAST `CreateVolume` contract (verified)
+
+A CSI `CreateVolume` request that successfully provisions on VAST:
+
+| Field | Value | Notes |
+|-------|-------|-------|
+| `name` | volume name | maps to `VendorCreateVolumeRequest.Name` |
+| `capacity_range.required_bytes` | size in bytes | from `SizeGiB` (convert GiB → bytes) |
+| `volume_capabilities[0].mount.fs_type` | **empty string** | NFS view — no filesystem is formatted; NFS is the transport. The driver **rejects** `fs_type=nfs` and only accepts `ext4`/`ext3`/`xfs` when `fs_type` is set at all, so leave it empty |
+| `volume_capabilities[0].access_mode.mode` | `MULTI_NODE_MULTI_WRITER` | NFS shared access; maps to `AccessMode` |
+| `parameters.root_export` | e.g. `/k8s` | export root under which the view path is created |
+| `parameters.view_policy` | **a uniquely-named per-tenant view policy** | see multi-tenancy note below |
+| `parameters.vip_pool_name` | e.g. `osac-shared` | VIP pool serving the NFS mount |
+| `secrets.username` / `secrets.password` | VMS management credentials | the same credentials held in the `vast-credentials` secret above — passed **per-request** as CSI secrets |
+| `secrets.endpoint` | VMS host | **required** in secrets whenever credentials are in secrets; the `X_CSI_VMS_HOST` env fallback does **not** apply to per-request credentials |
+| `secrets.tenant` | *(omit)* | only for the tenant-scoped-auth model — see below |
+
+`Backend` in `VendorCreateVolumeRequest` selects **which** vendor Deployment to
+dial (it is resolved by fulfillment-service tier resolution before the `Volume`
+CR is created); the fields above are what the operator sends **to** that vendor.
+
+### Multi-tenancy: one credential, many VAST tenants
+
+Verified: a **single** VMS credential (a cluster admin) provisions isolated
+volumes across different VAST tenants by selecting a **uniquely-named per-tenant
+view policy** per request. The VAST driver resolves `view_policy` by name, and
+each view policy carries the `tenant_id` that scopes where the resulting view and
+quota land. A shared policy name (e.g. `default`) is ambiguous across tenants and
+fails with `Too many viewpolicys found`.
+
+Verification run — the same `<vms-username>`/`<vms-password>` credential created:
+
+| Volume | VAST tenant | view | quota |
+|--------|-------------|------|-------|
+| `csi-rgolan-test-1-vol1` | `rgolan-test-1` (tenant_id 118) | 72 | 36 |
+| `csi-rgolan-test-2-vol1` | `rgolan-test-2` (tenant_id 119) | 73 | 37 |
+
+**Prerequisite for each tenant:** create a uniquely-named VMS view policy bound
+to that tenant's `tenant_id` before provisioning volumes for it. This is the
+mapping the operator (or an out-of-band tenant-onboarding step) must establish
+so that a per-tenant `view_policy` name exists to pass in `parameters`.
+
+There is an **alternative** VAST model: setting the `tenant` CSI secret sends an
+`X-Tenant-Name` header for tenant-scoped authentication. That path requires
+**tenant-admin** credentials (a cluster-admin credential is rejected with
+`Authentication failure` at `/api/v1/token/`), so it is *not* used by the
+cluster-admin + per-tenant-view-policy model above. Pick one model; do not mix.
+
 ## Registry authentication
 
 If vendor images require private registry access (e.g. `registry.connect.redhat.com`

--- a/osac-csi-driver/charts/csi-backends/templates/namespace.yaml
+++ b/osac-csi-driver/charts/csi-backends/templates/namespace.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.namespace }}
-  labels:
-    {{- include "csi-backends.labels" . | nindent 4 }}
-    pod-security.kubernetes.io/enforce: privileged
-    pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
## [OSAC-3289](https://redhat.atlassian.net/browse/OSAC-3289): deploy vendor CSI controllers via csi-backends Helm chart

**Jira:** https://redhat.atlassian.net/browse/OSAC-3289

### Summary

Deploys the vendor CSI controllers on the hub cluster during storage
backend setup (Stage 1). The `csi-backends` Helm chart is installed via
`kubernetes.core.helm` in the shared `storage_provider` service role,
before the per-vendor roles are dispatched. Each vendor (VAST, Trident,
Pure) is enabled or disabled in a single release.

Because that release is a single hub-wide resource but `storage_provider`
setup runs **once per tenant** (with a per-tenant provider subset), and
`helm upgrade` replaces release values wholesale rather than merging,
enablement is computed **cumulatively** — the union of this tenant's
vendors and the controllers already running on the hub — so onboarding one
tenant never tears down a controller another tenant relies on.

The chart README also documents the verified VAST `CreateVolume` wire
contract and the single-credential multi-tenant provisioning model, for
the future osac-operator Volume reconciler that will call the vendor
controllers deployed here.

Runs alongside the existing OLM-based CSI operator installation — no
breaking changes.

### Changes

- **New task — `storage_provider/tasks/ensure_csi_backends.yaml`:**
  installs/upgrades the csi-backends Helm chart via `kubernetes.core.helm`.
  - Computes vendor enablement as the **union** of this tenant's vendors
    (`_unique_providers`) and vendor controllers already deployed on the
    hub, so per-tenant runs only ever grow the enabled set — fixes the
    per-tenant clobber where a helm upgrade for one tenant would disable
    another tenant's controller.
  - Creates the `osac-csi-backends` namespace with **privileged Pod
    Security Admission** labels before installing (`create_namespace: false`)
    — vendor controllers need privileged PSA (e.g. Trident runs
    `runAsNonRoot: false`) and are rejected under the default restricted PSA.
  - Waits for each enabled vendor controller Deployment to become available.
  - The whole task is one `block` gated on
    `storage_provider_csi_backends_enabled`, so the unit-test path (no
    cluster) skips every task and never evaluates the cluster facts.
- **New defaults — `storage_provider/defaults/main.yaml`:** shared chart
  config (`storage_provider_csi_backends_*`). Chart ref defaults to the OCI
  registry (`oci://ghcr.io/osac-project/charts/csi-backends`), overridable
  via the `OSAC_CSI_BACKENDS_CHART_REF` env var (used by the integration
  tests to point at the local chart).
- **Wiring:** called from `storage_provider/tasks/setup.yaml` before the
  per-provider dispatch loop.
- **Chart — removed `csi-backends/templates/namespace.yaml`:** the
  namespace (with its privileged PSA labels) is now created by the Ansible
  task above, so the chart no longer ships its own Namespace template.
- **Docs — `csi-backends/README.md`:** documents the verified VAST
  `CreateVolume` contract (parameters/secrets/capabilities) and the single
  cluster-admin credential + per-tenant view-policy multi-tenancy model,
  cross-referenced to the osac-operator `VendorProvisioner` interface that
  will consume it.
- **Tests:** run the `storage_provider` unit tests with
  `storage_provider_csi_backends_enabled=false` (no cluster), and point the
  integration-test env at the local chart via `OSAC_CSI_BACKENDS_CHART_REF`.

### Testing

- **ansible-lint:** `ensure_csi_backends.yaml` passes the production profile
- **yamllint `--strict`:** passes
- **Pre-commit hooks:** pass on all commits
- **Cumulative enablement:** verified by evaluating the union expression
  across scenarios — single vendor; a second vendor onboarding while
  another is already deployed (the prior clobber case, now preserving the
  first); a no-vendor tenant; three vendors; an unrelated deployment — all
  correct.
- **kind-dev:** the initial single-vendor chart deployment was verified on a
  local kind cluster (VAST controller Running, Service on 50051, idempotent).
- **OpenShift:** the initial deployment was verified on a real OpenShift
  cluster (SCC from PR #219 grants privileged access for the node DaemonSet).
- **VAST multi-tenancy:** verified experimentally — the same VMS
  cluster-admin credential provisioned isolated volumes for two tenants via
  uniquely-named per-tenant view policies (documented in the README).
- Note: the cumulative-enablement and privileged-PSA namespace changes have
  not been re-run end-to-end on a live multi-tenant cluster; they are
  covered by lint plus the logic verification above.

### Depends on

- [PR #219](https://github.com/osac-project/osac/pull/219) (merged) — E2E
  enablement, `| lower` fix for chart helpers, OpenShift SCC for the CSI
  node DaemonSet

### Acceptance Criteria

- [x] Vendor CSI controller deployed as a Deployment in `osac-csi-backends` namespace
- [x] Service reachable at `vast-csi-controller.osac-csi-backends.svc.cluster.local`
- [x] Idempotent: deploy if not running, upgrade if values changed, skip if healthy
- [x] One-time per backend, not per-tenant
- [x] Multi-vendor safe: onboarding a tenant with a new provider doesn't clobber another tenant's controller

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic deployment and upgrades of CSI backend controllers for configured storage providers.
  - Added options to enable or disable CSI backend handling and customize the chart reference, version, release name, and namespace.
  - Added readiness checks to confirm vendor storage controllers are available before provider setup continues.

- **Tests**
  - Updated the storage test environment to use the local CSI backends chart.
  - Updated dispatcher tests to run with CSI backend deployment disabled where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
