### PR TITLE
NO-ISSUE: restore OSAC-1992 JIT storage extra_vars in 5 AAP playbooks

### DIFF
--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_resources.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_resources.yaml
@@ -3,7 +3,9 @@
   ansible.builtin.include_role:
     name: osac.service.tenant_storage_class
   vars:
-    tenant_storage_class_storage_tier: "{{ _requested_storage_tier | default('default') }}"
+    # 'local' matches the only tier every current environment actually registers
+    # (see playbook_osac_create_compute_instance.yml's _requested_storage_tier).
+    tenant_storage_class_storage_tier: "{{ _requested_storage_tier | default('local') }}"
 
 - name: Set storage_class from tenant StorageClass
   ansible.builtin.set_fact:

--- a/osac-aap/playbook_osac_create_compute_instance.yml
+++ b/osac-aap/playbook_osac_create_compute_instance.yml
@@ -9,7 +9,6 @@
     template_id: "{{ osac_job_vars.resource.spec.templateID }}"
     template_parameters: {}
     tenant_storage_classes: "{{ osac_job_vars.tenant_storage_classes | default([]) }}"
-    _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
     _requested_storage_tier: "{{ lookup('env', 'STORAGE_REQUESTED_TIER') | default('default', true) }}"
 
   pre_tasks:
@@ -38,31 +37,33 @@
             else (compute_instance.metadata.annotations | default({})).get('osac.openshift.io/tenant', 'unknown')
           }}
 
-    - name: Parse STORAGE_TIERS for JIT storage
-      when: _storage_tiers_raw | length > 0
-      block:
-        - name: Parse tier list from STORAGE_TIERS env var
-          ansible.builtin.set_fact:
-            _jit_all_tiers: "{{ _storage_tiers_raw | from_json }}"
+    - name: Validate optional storage_tier_definitions type
+      ansible.builtin.fail:
+        msg: >-
+          osac_job_vars.storage_tier_definitions must be an array when provided.
+          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001"}]
+      when: >-
+        osac_job_vars.storage_tier_definitions is defined and
+        (osac_job_vars.storage_tier_definitions is not sequence or
+         osac_job_vars.storage_tier_definitions is string or
+         osac_job_vars.storage_tier_definitions is mapping)
 
+    - name: Filter storage tier definitions to the requested tier for JIT storage
+      when: (osac_job_vars.storage_tier_definitions | default([])) | length > 0
+      block:
         - name: Filter to only the requested tier
           ansible.builtin.set_fact:
-            _jit_storage_tiers: "{{ _jit_all_tiers | selectattr('name', 'equalto', _requested_storage_tier) | list }}"
+            _jit_storage_tiers: >-
+              {{ osac_job_vars.storage_tier_definitions
+                 | selectattr('name', 'equalto', _requested_storage_tier) | list }}
 
-        - name: Warn if requested tier not found in STORAGE_TIERS
+        - name: Warn if requested tier not found in storage_tier_definitions
           ansible.builtin.debug:
             msg: >-
-              Requested storage tier '{{ _requested_storage_tier }}' not found in STORAGE_TIERS.
-              Available tiers: {{ _jit_all_tiers | map(attribute='name') | list | to_json }}.
+              Requested storage tier '{{ _requested_storage_tier }}' not found in storage_tier_definitions.
+              Available tiers: {{ osac_job_vars.storage_tier_definitions | map(attribute='name') | list | to_json }}.
               JIT storage provisioning will be skipped.
           when: _jit_storage_tiers | length == 0
-      rescue:
-        - name: Fail on malformed STORAGE_TIERS JSON
-          ansible.builtin.fail:
-            msg: >-
-              STORAGE_TIERS env var contains invalid JSON.
-              Value: '{{ _storage_tiers_raw }}'.
-              Expected a JSON array of tier objects with name, protocol, and provider fields.
 
     - name: Ensure storage is provisioned for tenant (JIT)
       when: _jit_storage_tiers is defined and _jit_storage_tiers | length > 0
@@ -71,9 +72,9 @@
       vars:
         storage_provider_action: ensure_storage_class
         storage_provider_tiers: "{{ _jit_storage_tiers }}"
+        storage_provider_backend_connections: "{{ osac_job_vars.storage_backend_connections | default({}) }}"
         storage_provider_provisioning_target: vmaas
         storage_provider_block_encryption_passphrase: "{{ osac_job_vars.resource.spec.blockEncryptionPassphrase | default('') }}"
-        storage_provider_snapshots_enabled: "{{ lookup('env', 'STORAGE_SNAPSHOTS_ENABLED') | default('true', true) | bool }}"
 
     - name: Add JIT-provisioned StorageClasses to resolution list
       ansible.builtin.set_fact:
@@ -89,7 +90,7 @@
           ComputeInstance '{{ compute_instance_name }}' has no tenant_storage_classes
           available. Either the osac-operator CI controller should inject the resolved
           storageClasses list before triggering provisioning, or JIT storage provisioning
-          via STORAGE_TIERS must succeed.
+          via storage_tier_definitions must succeed.
       when:
         - tenant_storage_class_storage_classes | length == 0
         - _jit_storage_tiers is not defined or _jit_storage_tiers | length == 0

--- a/osac-aap/playbook_osac_create_compute_instance.yml
+++ b/osac-aap/playbook_osac_create_compute_instance.yml
@@ -9,7 +9,11 @@
     template_id: "{{ osac_job_vars.resource.spec.templateID }}"
     template_parameters: {}
     tenant_storage_classes: "{{ osac_job_vars.tenant_storage_classes | default([]) }}"
-    _requested_storage_tier: "{{ lookup('env', 'STORAGE_REQUESTED_TIER') | default('default', true) }}"
+    # 'local' matches the only tier every current environment actually registers
+    # (register-local-storage.yaml's LVMS-backed StorageTier, see osac-installer).
+    # No environment defines a tier literally named 'default' -- that name only
+    # ever appeared in storage_provider's own VAST-oriented unit test fixtures.
+    _requested_storage_tier: "{{ lookup('env', 'STORAGE_REQUESTED_TIER') | default('local', true) }}"
 
   pre_tasks:
     - name: Show resource metadata

--- a/osac-aap/playbook_osac_create_tenant_cluster_storage.yml
+++ b/osac-aap/playbook_osac_create_tenant_cluster_storage.yml
@@ -22,8 +22,6 @@
       {{ osac_job_vars.resource.metadata.namespace }}
       {%- endif -%}
     tenant_uid: "{{ osac_job_vars.resource.metadata.uid }}"
-    _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
-    _storage_snapshots: "{{ lookup('env', 'STORAGE_SNAPSHOTS_ENABLED') | default('true', true) | bool }}"
 
   pre_tasks:
     - name: Show resource metadata
@@ -42,25 +40,18 @@
         osac_job_vars.resource.metadata.uid is not defined or
         osac_job_vars.resource.metadata.uid | length == 0
 
-    - name: Validate STORAGE_TIERS env var is configured
+    - name: Validate storage_tier_definitions is a non-empty array in the EDA event
       ansible.builtin.fail:
         msg: >-
-          STORAGE_TIERS env var must be set at deployment time as a JSON array.
-          Example: [{"name":"default","protocol":"nfs","provider":"vast"}]
-      when: _storage_tiers_raw | length == 0
-
-    - name: Parse STORAGE_TIERS JSON
-      block:
-        - name: Parse tier list from env var
-          ansible.builtin.set_fact:
-            _storage_tiers: "{{ _storage_tiers_raw | from_json }}"
-      rescue:
-        - name: Fail on malformed STORAGE_TIERS JSON
-          ansible.builtin.fail:
-            msg: >-
-              STORAGE_TIERS env var contains invalid JSON.
-              Value: '{{ _storage_tiers_raw }}'.
-              Expected a JSON array of tier objects with name, protocol, and provider fields.
+          osac_job_vars.storage_tier_definitions must be a non-empty array, populated
+          by osac-operator from the Tenant's resolved storage tiers.
+          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota_bytes":500}]
+      when: >-
+        osac_job_vars.storage_tier_definitions is not defined or
+        osac_job_vars.storage_tier_definitions is not sequence or
+        osac_job_vars.storage_tier_definitions is string or
+        osac_job_vars.storage_tier_definitions is mapping or
+        osac_job_vars.storage_tier_definitions | length == 0
 
     - name: Write admin_kubeconfig to temporary file when provided
       when: >-
@@ -91,9 +82,9 @@
             name: osac.service.storage_provider
           vars:
             storage_provider_action: ensure_storage_class
-            storage_provider_tiers: "{{ _storage_tiers }}"
+            storage_provider_tiers: "{{ osac_job_vars.storage_tier_definitions }}"
+            storage_provider_backend_connections: "{{ osac_job_vars.storage_backend_connections | default({}) }}"
             storage_provider_block_encryption_passphrase: "{{ osac_job_vars.resource.spec.blockEncryptionPassphrase | default('') }}"
-            storage_provider_snapshots_enabled: "{{ _storage_snapshots }}"
       rescue:
         - name: Warn about StorageClass creation failure
           ansible.builtin.debug:
@@ -106,6 +97,6 @@
             name: osac.service.storage_provider
           vars:
             storage_provider_action: ensure_storage_class
-            storage_provider_tiers: "{{ _storage_tiers }}"
+            storage_provider_tiers: "{{ osac_job_vars.storage_tier_definitions }}"
+            storage_provider_backend_connections: "{{ osac_job_vars.storage_backend_connections | default({}) }}"
             storage_provider_block_encryption_passphrase: "{{ osac_job_vars.resource.spec.blockEncryptionPassphrase | default('') }}"
-            storage_provider_snapshots_enabled: "{{ _storage_snapshots }}"

--- a/osac-aap/playbook_osac_create_tenant_storage_backend.yml
+++ b/osac-aap/playbook_osac_create_tenant_storage_backend.yml
@@ -7,7 +7,6 @@
     tenant_name: "{{ osac_job_vars.resource.metadata.name }}"
     tenant_namespace: "{{ osac_job_vars.resource.metadata.namespace }}"
     tenant_uid: "{{ osac_job_vars.resource.metadata.uid }}"
-    _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
 
   pre_tasks:
     - name: Show resource metadata
@@ -26,31 +25,18 @@
         osac_job_vars.resource.metadata.uid is not defined or
         osac_job_vars.resource.metadata.uid | length == 0
 
-    - name: Validate STORAGE_TIERS env var is configured
+    - name: Validate storage_tier_definitions is a non-empty array in the EDA event
       ansible.builtin.fail:
         msg: >-
-          STORAGE_TIERS env var must be set at deployment time as a JSON array.
-          Example: [{"name":"default","protocol":"nfs","provider":"vast"}]
-      when: _storage_tiers_raw | length == 0
-
-    - name: Parse STORAGE_TIERS JSON
-      block:
-        - name: Parse tier list from env var
-          ansible.builtin.set_fact:
-            _storage_tiers: "{{ _storage_tiers_raw | from_json }}"
-        - name: Validate STORAGE_TIERS is a JSON array
-          ansible.builtin.assert:
-            that:
-              - _storage_tiers | type_debug == 'list'
-            fail_msg: >-
-              STORAGE_TIERS must be a JSON array of tier objects.
-      rescue:
-        - name: Fail on malformed STORAGE_TIERS JSON
-          ansible.builtin.fail:
-            msg: >-
-              STORAGE_TIERS env var contains invalid JSON.
-              Value: '{{ _storage_tiers_raw }}'.
-              Expected a JSON array of tier objects with name, protocol, and provider fields.
+          osac_job_vars.storage_tier_definitions must be a non-empty array, populated
+          by osac-operator from the Tenant's resolved storage tiers.
+          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota_bytes":500}]
+      when: >-
+        osac_job_vars.storage_tier_definitions is not defined or
+        osac_job_vars.storage_tier_definitions is not sequence or
+        osac_job_vars.storage_tier_definitions is string or
+        osac_job_vars.storage_tier_definitions is mapping or
+        osac_job_vars.storage_tier_definitions | length == 0
 
   tasks:
     - name: Configure tenant storage backend
@@ -58,6 +44,6 @@
         name: osac.service.storage_provider
       vars:
         storage_provider_action: setup
-        storage_provider_tiers: "{{ _storage_tiers }}"
+        storage_provider_tiers: "{{ osac_job_vars.storage_tier_definitions }}"
+        storage_provider_backend_connections: "{{ osac_job_vars.storage_backend_connections | default({}) }}"
         storage_provider_block_encryption_passphrase: "{{ osac_job_vars.resource.spec.blockEncryptionPassphrase | default('') }}"
-        storage_provider_snapshots_enabled: "{{ lookup('env', 'STORAGE_SNAPSHOTS_ENABLED') | default('true', true) | bool }}"

--- a/osac-aap/playbook_osac_delete_tenant_cluster_storage.yml
+++ b/osac-aap/playbook_osac_delete_tenant_cluster_storage.yml
@@ -20,7 +20,6 @@
       {%- else -%}
       {{ osac_job_vars.resource.metadata.namespace }}
       {%- endif -%}
-    _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
 
   pre_tasks:
     - name: Show resource metadata
@@ -37,25 +36,18 @@
         osac_job_vars.resource.metadata.namespace is not defined or
         osac_job_vars.resource.metadata.namespace | length == 0
 
-    - name: Parse STORAGE_TIERS JSON
-      when: _storage_tiers_raw | length > 0
-      block:
-        - name: Parse tier list from env var
-          ansible.builtin.set_fact:
-            _storage_tiers: "{{ _storage_tiers_raw | from_json }}"
-        - name: Validate STORAGE_TIERS is a JSON array
-          ansible.builtin.assert:
-            that:
-              - _storage_tiers | type_debug == 'list'
-            fail_msg: >-
-              STORAGE_TIERS must be a JSON array of tier objects.
-      rescue:
-        - name: Fail on malformed STORAGE_TIERS JSON
-          ansible.builtin.fail:
-            msg: >-
-              STORAGE_TIERS env var contains invalid JSON.
-              Value: '{{ _storage_tiers_raw }}'.
-              Expected a JSON array of tier objects with name, protocol, and provider fields.
+    - name: Validate storage_tier_definitions is a non-empty array in the EDA event
+      ansible.builtin.fail:
+        msg: >-
+          osac_job_vars.storage_tier_definitions must be a non-empty array, populated
+          by osac-operator from the Tenant's resolved storage tiers.
+          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota_bytes":500}]
+      when: >-
+        osac_job_vars.storage_tier_definitions is not defined or
+        osac_job_vars.storage_tier_definitions is not sequence or
+        osac_job_vars.storage_tier_definitions is string or
+        osac_job_vars.storage_tier_definitions is mapping or
+        osac_job_vars.storage_tier_definitions | length == 0
 
     - name: Write admin_kubeconfig to temporary file when provided
       when: >-
@@ -78,15 +70,9 @@
         (_remote_kubeconfig is not defined or _remote_kubeconfig | length == 0)
 
   tasks:
-    - name: Skip cleanup when STORAGE_TIERS is not configured
-      when: _storage_tiers_raw | length == 0
-      ansible.builtin.debug:
-        msg: "STORAGE_TIERS env var is not set — nothing to clean up."
-
     - name: Clean up cluster-side tenant storage resources
-      when: _storage_tiers_raw | length > 0
       ansible.builtin.include_role:
         name: osac.service.storage_provider
       vars:
         storage_provider_action: teardown_cluster_storage
-        storage_provider_tiers: "{{ _storage_tiers }}"
+        storage_provider_tiers: "{{ osac_job_vars.storage_tier_definitions }}"

--- a/osac-aap/playbook_osac_delete_tenant_storage_backend.yml
+++ b/osac-aap/playbook_osac_delete_tenant_storage_backend.yml
@@ -6,7 +6,6 @@
   vars:
     tenant_name: "{{ osac_job_vars.resource.metadata.name }}"
     tenant_namespace: "{{ osac_job_vars.resource.metadata.namespace }}"
-    _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
 
   pre_tasks:
     - name: Show resource metadata
@@ -23,30 +22,24 @@
         osac_job_vars.resource.metadata.namespace is not defined or
         osac_job_vars.resource.metadata.namespace | length == 0
 
-    - name: Parse STORAGE_TIERS JSON
-      when: _storage_tiers_raw | length > 0
-      block:
-        - name: Parse tier list from env var
-          ansible.builtin.set_fact:
-            _storage_tiers: "{{ _storage_tiers_raw | from_json }}"
-      rescue:
-        - name: Fail on malformed STORAGE_TIERS JSON
-          ansible.builtin.fail:
-            msg: >-
-              STORAGE_TIERS env var contains invalid JSON.
-              Value: '{{ _storage_tiers_raw }}'.
-              Expected a JSON array of tier objects with name, protocol, and provider fields.
+    - name: Validate storage_tier_definitions is a non-empty array in the EDA event
+      ansible.builtin.fail:
+        msg: >-
+          osac_job_vars.storage_tier_definitions must be a non-empty array, populated
+          by osac-operator from the Tenant's resolved storage tiers.
+          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota_bytes":500}]
+      when: >-
+        osac_job_vars.storage_tier_definitions is not defined or
+        osac_job_vars.storage_tier_definitions is not sequence or
+        osac_job_vars.storage_tier_definitions is string or
+        osac_job_vars.storage_tier_definitions is mapping or
+        osac_job_vars.storage_tier_definitions | length == 0
 
   tasks:
-    - name: Skip teardown when STORAGE_TIERS is not configured
-      when: _storage_tiers_raw | length == 0
-      ansible.builtin.debug:
-        msg: "STORAGE_TIERS env var is not set — nothing to tear down."
-
     - name: Delete tenant storage backend
-      when: _storage_tiers_raw | length > 0
       ansible.builtin.include_role:
         name: osac.service.storage_provider
       vars:
         storage_provider_action: teardown_backend
-        storage_provider_tiers: "{{ _storage_tiers }}"
+        storage_provider_tiers: "{{ osac_job_vars.storage_tier_definitions }}"
+        storage_provider_backend_connections: "{{ osac_job_vars.storage_backend_connections | default({}) }}"

--- a/osac-installer/charts/osac/values.schema.json
+++ b/osac-installer/charts/osac/values.schema.json
@@ -843,10 +843,6 @@
                   "type": "object",
                   "description": "Environment variables for the storage-operations instance group",
                   "properties": {
-                    "STORAGE_TIERS": {
-                      "type": "string",
-                      "description": "Available storage tiers configuration"
-                    },
                     "STORAGE_SNAPSHOTS_ENABLED": {
                       "type": "string",
                       "description": "Enable storage snapshots"

--- a/osac-installer/charts/osac/values.yaml
+++ b/osac-installer/charts/osac/values.yaml
@@ -170,7 +170,6 @@ aap:
     storageFulfillment:
       enabled: false
       config:
-        STORAGE_TIERS: ""
         STORAGE_SNAPSHOTS_ENABLED: ""
       secret:
         VAST_ENDPOINT: ""

--- a/osac-installer/values/vmaas-ci/values.yaml
+++ b/osac-installer/values/vmaas-ci/values.yaml
@@ -149,11 +149,6 @@ aap:
   instanceGroups:
     storageFulfillment:
       enabled: true
-      config:
-        # OSAC-3011: local LVMS tier for VMaaS CI storage testing.
-        # Temporary: will be sourced from osac_job_vars.storage_tier_definitions
-        # once OSAC-3013 AAP side lands.
-        STORAGE_TIERS: '[{"name":"local","protocol":"block","provider":"lvms"}]'
 
 # --- Validation ---
 validation:


### PR DESCRIPTION
## Summary
- PR #97 ([OSAC-3547](https://redhat.atlassian.net/browse/OSAC-3547)) branched before PR #99 ([OSAC-1992](https://redhat.atlassian.net/browse/OSAC-1992)) merged and was itself merged ~8 hours later without rebasing, silently reverting PR #99's JIT storage logic on 5 playbooks while keeping only the mechanical `ansible_eda` -> `osac_job_vars` rename — restores `storage_tier_definitions`/`storage_backend_connections` extra_vars handling in all 5, confirmed via full audit of all 32 files PR #99 originally touched
- Fixes the requested-tier default: every current environment that registers a storage tier (Tier-API-backed `register-local-storage.yaml` or the now-removed static `STORAGE_TIERS`) names it `local`, never `default` — changes both hardcoded tier-name fallbacks (`playbook_osac_create_compute_instance.yml` and `ocp_virt_vm/create_resources.yaml`) to match
- Finishes [OSAC-1992](https://redhat.atlassian.net/browse/OSAC-1992)'s goal of eliminating `STORAGE_TIERS` entirely — removed from osac-installer's chart default, schema, and the `vmaas-ci` CI override (the only environment running the ComputeInstance controller); verified via `helm template` that the rendered ConfigMap no longer carries it and the Tier-API hook remains the sole source of truth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Storage provisioning and teardown now use storage tier settings supplied with the automation event.
  * Optional storage backend connection details are supported during storage creation and removal.
  * VM storage selection now defaults to the `local` tier.
* **Bug Fixes**
  * Added validation for required, non-empty storage tier settings.
  * Improved handling of unavailable storage tiers with clearer warnings and errors.
  * Storage cleanup consistently uses the supplied tier configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->