### PR TITLE
OSAC-3263: Require metadata during object creation

### DIFF
--- a/fulfillment-service/internal/servers/baremetal_instance_catalog_items_server_test.go
+++ b/fulfillment-service/internal/servers/baremetal_instance_catalog_items_server_test.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc/codes"
@@ -76,6 +77,9 @@ var _ = Describe("Bare metal instance catalog items server", func() {
 					Description: "My description.",
 					Template:    publicv1.BareMetalInstanceTemplateReference_builder{Id: "my-bmi-template-id"}.Build(),
 					Published:   true,
+					Metadata: publicv1.Metadata_builder{
+						Name: "test-bmi-catalog-item",
+					}.Build(),
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -104,6 +108,9 @@ var _ = Describe("Bare metal instance catalog items server", func() {
 						Title:     fmt.Sprintf("Published item %d", i),
 						Template:  publicv1.BareMetalInstanceTemplateReference_builder{Id: "my-bmi-template-id"}.Build(),
 						Published: true,
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("published-item-%d", i),
+						}.Build(),
 					}.Build(),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
@@ -113,6 +120,9 @@ var _ = Describe("Bare metal instance catalog items server", func() {
 					Title:     "Unpublished item",
 					Template:  publicv1.BareMetalInstanceTemplateReference_builder{Id: "my-bmi-template-id"}.Build(),
 					Published: false,
+					Metadata: publicv1.Metadata_builder{
+						Name: "unpublished-item",
+					}.Build(),
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -141,6 +151,9 @@ var _ = Describe("Bare metal instance catalog items server", func() {
 					Title:     "Published item",
 					Template:  publicv1.BareMetalInstanceTemplateReference_builder{Id: "my-bmi-template-id"}.Build(),
 					Published: true,
+					Metadata: publicv1.Metadata_builder{
+						Name: "published-item",
+					}.Build(),
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -159,6 +172,9 @@ var _ = Describe("Bare metal instance catalog items server", func() {
 					Title:     "Unpublished item",
 					Template:  publicv1.BareMetalInstanceTemplateReference_builder{Id: "my-bmi-template-id"}.Build(),
 					Published: false,
+					Metadata: publicv1.Metadata_builder{
+						Name: "unpublished-item-get",
+					}.Build(),
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -179,6 +195,9 @@ var _ = Describe("Bare metal instance catalog items server", func() {
 					Title:     "Original title",
 					Template:  publicv1.BareMetalInstanceTemplateReference_builder{Id: "my-bmi-template-id"}.Build(),
 					Published: true,
+					Metadata: publicv1.Metadata_builder{
+						Name: "original-item",
+					}.Build(),
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -190,6 +209,9 @@ var _ = Describe("Bare metal instance catalog items server", func() {
 					Title:     "Updated title",
 					Template:  publicv1.BareMetalInstanceTemplateReference_builder{Id: "my-bmi-template-id"}.Build(),
 					Published: true,
+					Metadata: publicv1.Metadata_builder{
+						Name: "test-bmi-catalog-item-update",
+					}.Build(),
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -220,6 +242,9 @@ var _ = Describe("Bare metal instance catalog items server", func() {
 					Title:     "Item to delete",
 					Template:  publicv1.BareMetalInstanceTemplateReference_builder{Id: "my-bmi-template-id"}.Build(),
 					Published: true,
+					Metadata: publicv1.Metadata_builder{
+						Name: "item-to-delete",
+					}.Build(),
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -245,6 +270,9 @@ var _ = Describe("Bare metal instance catalog items server", func() {
 					Title:     "Referenced item",
 					Template:  publicv1.BareMetalInstanceTemplateReference_builder{Id: "my-bmi-template-id"}.Build(),
 					Published: true,
+					Metadata: publicv1.Metadata_builder{
+						Name: "referenced-item",
+					}.Build(),
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
@@ -258,6 +286,9 @@ var _ = Describe("Bare metal instance catalog items server", func() {
 			Expect(err).ToNot(HaveOccurred())
 			_, err = instancesServer.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catalogItemID}.Build(),
 					}.Build(),

--- a/fulfillment-service/internal/servers/baremetal_instance_templates_server_test.go
+++ b/fulfillment-service/internal/servers/baremetal_instance_templates_server_test.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -80,6 +81,9 @@ var _ = Describe("Bare metal instance templates server", func() {
 			for i := range count {
 				_, err := privateServer.Create(ctx, privatev1.BareMetalInstanceTemplatesCreateRequest_builder{
 					Object: privatev1.BareMetalInstanceTemplate_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title: fmt.Sprintf("Template %d", i),
 					}.Build(),
 				}.Build())
@@ -94,6 +98,9 @@ var _ = Describe("Bare metal instance templates server", func() {
 		It("Gets object", func() {
 			createResponse, err := privateServer.Create(ctx, privatev1.BareMetalInstanceTemplatesCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceTemplate_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My template",
 					Description: "A test template.",
 				}.Build(),

--- a/fulfillment-service/internal/servers/baremetal_instances_server_test.go
+++ b/fulfillment-service/internal/servers/baremetal_instances_server_test.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc/codes"
@@ -75,6 +76,9 @@ var _ = Describe("Bare metal instances server", func() {
 			Expect(err).ToNot(HaveOccurred())
 			catalogResp, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Test catalog item",
 					Template:  privatev1.BareMetalInstanceTemplateReference_builder{Id: "test-template"}.Build(),
 					Published: true,

--- a/fulfillment-service/internal/servers/cluster_catalog_items_server_test.go
+++ b/fulfillment-service/internal/servers/cluster_catalog_items_server_test.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc/codes"
@@ -76,6 +77,9 @@ var _ = Describe("Cluster catalog items server", func() {
 		It("Creates object", func() {
 			response, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My cluster catalog item",
 					Description: "My description.",
 					Template:    publicv1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
@@ -97,6 +101,9 @@ var _ = Describe("Cluster catalog items server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 					Object: publicv1.ClusterCatalogItem_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:     fmt.Sprintf("Catalog item %d", i),
 						Template:  publicv1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 						Published: true,
@@ -116,6 +123,9 @@ var _ = Describe("Cluster catalog items server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 					Object: publicv1.ClusterCatalogItem_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:     fmt.Sprintf("Catalog item %d", i),
 						Template:  publicv1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 						Published: true,
@@ -137,6 +147,9 @@ var _ = Describe("Cluster catalog items server", func() {
 			for i := range count {
 				response, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 					Object: publicv1.ClusterCatalogItem_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:     fmt.Sprintf("Catalog item %d", i),
 						Template:  publicv1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 						Published: true,
@@ -159,6 +172,9 @@ var _ = Describe("Cluster catalog items server", func() {
 		It("List excludes unpublished objects", func() {
 			_, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Published item",
 					Template:  publicv1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					Published: true,
@@ -168,6 +184,9 @@ var _ = Describe("Cluster catalog items server", func() {
 
 			_, err = server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Unpublished item",
 					Template:  publicv1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					Published: false,
@@ -184,6 +203,9 @@ var _ = Describe("Cluster catalog items server", func() {
 		It("List with user filter excludes unpublished objects", func() {
 			publishedResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Target published",
 					Template:  publicv1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					Published: true,
@@ -193,6 +215,9 @@ var _ = Describe("Cluster catalog items server", func() {
 
 			_, err = server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Other published",
 					Template:  publicv1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					Published: true,
@@ -202,6 +227,9 @@ var _ = Describe("Cluster catalog items server", func() {
 
 			unpublishedResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Target unpublished",
 					Template:  publicv1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					Published: false,
@@ -222,6 +250,9 @@ var _ = Describe("Cluster catalog items server", func() {
 		It("Get returns unpublished item when caller has a referencing cluster", func() {
 			createResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Unpublished item",
 					Template:  publicv1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					Published: false,
@@ -260,6 +291,9 @@ var _ = Describe("Cluster catalog items server", func() {
 		It("Get returns not found for unpublished object", func() {
 			createResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Unpublished item",
 					Template:  publicv1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					Published: false,
@@ -277,6 +311,9 @@ var _ = Describe("Cluster catalog items server", func() {
 		It("Get object", func() {
 			createResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My catalog item",
 					Description: "My description.",
 					Template:    publicv1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
@@ -295,6 +332,9 @@ var _ = Describe("Cluster catalog items server", func() {
 		It("Update object", func() {
 			createResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "Original title",
 					Description: "Original description.",
 					Template:    publicv1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
@@ -328,6 +368,9 @@ var _ = Describe("Cluster catalog items server", func() {
 		It("Delete object", func() {
 			createResponse, err := server.Create(ctx, publicv1.ClusterCatalogItemsCreateRequest_builder{
 				Object: publicv1.ClusterCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "My catalog item",
 					Template:  publicv1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					Published: true,

--- a/fulfillment-service/internal/servers/cluster_templates_server_test.go
+++ b/fulfillment-service/internal/servers/cluster_templates_server_test.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
@@ -83,6 +84,9 @@ var _ = Describe("Cluster templates server", func() {
 		It("Creates object", func() {
 			response, err := server.Create(ctx, publicv1.ClusterTemplatesCreateRequest_builder{
 				Object: publicv1.ClusterTemplate_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Id:          "my_template",
 					Title:       "My template",
 					Description: "My template is *nice*",
@@ -101,6 +105,9 @@ var _ = Describe("Cluster templates server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, publicv1.ClusterTemplatesCreateRequest_builder{
 					Object: publicv1.ClusterTemplate_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Id:          fmt.Sprintf("my_template_%d", i),
 						Title:       fmt.Sprintf("My template %d", i),
 						Description: fmt.Sprintf("My template is *nice* %d", i),
@@ -125,6 +132,9 @@ var _ = Describe("Cluster templates server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, publicv1.ClusterTemplatesCreateRequest_builder{
 					Object: publicv1.ClusterTemplate_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Id:          fmt.Sprintf("my_template_%d", i),
 						Title:       fmt.Sprintf("My template %d", i),
 						Description: fmt.Sprintf("My template is *nice* %d", i),
@@ -147,6 +157,9 @@ var _ = Describe("Cluster templates server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, publicv1.ClusterTemplatesCreateRequest_builder{
 					Object: publicv1.ClusterTemplate_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Id:          fmt.Sprintf("my_template_%d", i),
 						Title:       fmt.Sprintf("My template %d", i),
 						Description: fmt.Sprintf("My template is *nice* %d", i),
@@ -171,6 +184,9 @@ var _ = Describe("Cluster templates server", func() {
 			for i := range count {
 				response, err := server.Create(ctx, publicv1.ClusterTemplatesCreateRequest_builder{
 					Object: publicv1.ClusterTemplate_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Id:          fmt.Sprintf("my_template_%d", i),
 						Title:       fmt.Sprintf("My template %d", i),
 						Description: fmt.Sprintf("My template is *nice* %d", i),
@@ -195,6 +211,9 @@ var _ = Describe("Cluster templates server", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, publicv1.ClusterTemplatesCreateRequest_builder{
 				Object: publicv1.ClusterTemplate_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Id:          "my_template",
 					Title:       "My template",
 					Description: "My template is *nice*",
@@ -214,6 +233,9 @@ var _ = Describe("Cluster templates server", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, publicv1.ClusterTemplatesCreateRequest_builder{
 				Object: publicv1.ClusterTemplate_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Id:          "my_template",
 					Title:       "My template",
 					Description: "My template is *nice*",
@@ -247,6 +269,9 @@ var _ = Describe("Cluster templates server", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, publicv1.ClusterTemplatesCreateRequest_builder{
 				Object: publicv1.ClusterTemplate_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Id:          "my_template",
 					Title:       "My template",
 					Description: "My template is *nice*",

--- a/fulfillment-service/internal/servers/clusters_server_test.go
+++ b/fulfillment-service/internal/servers/clusters_server_test.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
@@ -278,6 +279,9 @@ var _ = Describe("Clusters server", func() {
 		It("Creates object", func() {
 			response, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template: publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 					}.Build(),
@@ -292,7 +296,11 @@ var _ = Describe("Clusters server", func() {
 
 		It("Doesn't create object without template", func() {
 			response, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
-				Object: publicv1.Cluster_builder{}.Build(),
+				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
+				}.Build(),
 			}.Build())
 			Expect(err).To(HaveOccurred())
 			Expect(response).To(BeNil())
@@ -305,6 +313,9 @@ var _ = Describe("Clusters server", func() {
 		It("Takes default node sets from template", func() {
 			response, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template: publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 					}.Build(),
@@ -326,6 +337,9 @@ var _ = Describe("Clusters server", func() {
 		It("Rejects node set that isn't in the template", func() {
 			response, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template: publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 						NodeSets: map[string]*publicv1.ClusterNodeSet{
@@ -351,6 +365,9 @@ var _ = Describe("Clusters server", func() {
 		It("Rejects node set with host type that isn't in the template", func() {
 			response, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template: publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 						NodeSets: map[string]*publicv1.ClusterNodeSet{
@@ -376,6 +393,9 @@ var _ = Describe("Clusters server", func() {
 		It("Rejects node set with zero size", func() {
 			response, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template: publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 						NodeSets: map[string]*publicv1.ClusterNodeSet{
@@ -399,6 +419,9 @@ var _ = Describe("Clusters server", func() {
 		It("Rejects node set with negative size", func() {
 			response, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template: publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 						NodeSets: map[string]*publicv1.ClusterNodeSet{
@@ -422,6 +445,9 @@ var _ = Describe("Clusters server", func() {
 		It("Accepts node set with explicit size", func() {
 			response, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template: publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 						NodeSets: map[string]*publicv1.ClusterNodeSet{
@@ -443,6 +469,9 @@ var _ = Describe("Clusters server", func() {
 		It("Accepts multiple node sets with explicit size", func() {
 			response, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template: publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 						NodeSets: map[string]*publicv1.ClusterNodeSet{
@@ -470,6 +499,9 @@ var _ = Describe("Clusters server", func() {
 		It("Merges explicit size for one node set with size for another node set from the template", func() {
 			response, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template: publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 						NodeSets: map[string]*publicv1.ClusterNodeSet{
@@ -496,6 +528,9 @@ var _ = Describe("Clusters server", func() {
 				ctx,
 				publicv1.ClustersCreateRequest_builder{
 					Object: publicv1.Cluster_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: publicv1.ClusterSpec_builder{
 							Template: publicv1.ClusterTemplateReference_builder{Id: "my_deleted_template"}.Build(),
 						}.Build(),
@@ -515,6 +550,9 @@ var _ = Describe("Clusters server", func() {
 		It("Doesn't create object if there are missing required template parameters", func() {
 			response, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template: publicv1.ClusterTemplateReference_builder{Id: "my_with_parameters"}.Build(),
 					}.Build(),
@@ -533,6 +571,9 @@ var _ = Describe("Clusters server", func() {
 		It("Doesn't create object if one parameter doesn't exist in the template", func() {
 			response, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template: publicv1.ClusterTemplateReference_builder{Id: "my_with_parameters"}.Build(),
 						TemplateParameters: map[string]*anypb.Any{
@@ -555,6 +596,9 @@ var _ = Describe("Clusters server", func() {
 		It("Doesn't create object if two parameters don't exist in the template", func() {
 			response, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template: publicv1.ClusterTemplateReference_builder{Id: "my_with_parameters"}.Build(),
 						TemplateParameters: map[string]*anypb.Any{
@@ -578,6 +622,9 @@ var _ = Describe("Clusters server", func() {
 		It("Doesn't create object if parameter type doesn't match the template", func() {
 			response, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template: publicv1.ClusterTemplateReference_builder{Id: "my_with_parameters"}.Build(),
 						TemplateParameters: map[string]*anypb.Any{
@@ -601,6 +648,9 @@ var _ = Describe("Clusters server", func() {
 		It("Takes default values of parameters from the template", func() {
 			response, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template: publicv1.ClusterTemplateReference_builder{Id: "my_with_parameters"}.Build(),
 						TemplateParameters: map[string]*anypb.Any{
@@ -631,6 +681,9 @@ var _ = Describe("Clusters server", func() {
 		It("Allows overriding of default values of template parameters", func() {
 			response, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template: publicv1.ClusterTemplateReference_builder{Id: "my_with_parameters"}.Build(),
 						TemplateParameters: map[string]*anypb.Any{
@@ -657,6 +710,9 @@ var _ = Describe("Clusters server", func() {
 			for range count {
 				_, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 					Object: publicv1.Cluster_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: publicv1.ClusterSpec_builder{
 							Template: publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 						}.Build(),
@@ -679,6 +735,9 @@ var _ = Describe("Clusters server", func() {
 			for range count {
 				_, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 					Object: publicv1.Cluster_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: publicv1.ClusterSpec_builder{
 							Template: publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 						}.Build(),
@@ -701,6 +760,9 @@ var _ = Describe("Clusters server", func() {
 			for range count {
 				_, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 					Object: publicv1.Cluster_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: publicv1.ClusterSpec_builder{
 							Template: publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 						}.Build(),
@@ -724,6 +786,9 @@ var _ = Describe("Clusters server", func() {
 			for range count {
 				response, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 					Object: publicv1.Cluster_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: publicv1.ClusterSpec_builder{
 							Template: publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 						}.Build(),
@@ -748,6 +813,9 @@ var _ = Describe("Clusters server", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template: publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 					}.Build(),
@@ -979,6 +1047,9 @@ var _ = Describe("Clusters server", func() {
 			// Try to create an object with status:
 			createResponse, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template: publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 					}.Build(),
@@ -1624,6 +1695,9 @@ var _ = Describe("Clusters server", func() {
 			pullSecret := "my-secret-pull-secret"
 			response, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template:   publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 						PullSecret: &pullSecret,
@@ -1638,6 +1712,9 @@ var _ = Describe("Clusters server", func() {
 			pullSecret := "my-secret-pull-secret"
 			createResponse, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template:   publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 						PullSecret: &pullSecret,
@@ -1657,6 +1734,9 @@ var _ = Describe("Clusters server", func() {
 			pullSecret := "my-secret-pull-secret"
 			_, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template:   publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 						PullSecret: &pullSecret,
@@ -1696,6 +1776,9 @@ var _ = Describe("Clusters server", func() {
 			versionName := "4-18-0"
 			createResponse, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template:     publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 						PullSecret:   &pullSecret,
@@ -1728,6 +1811,9 @@ var _ = Describe("Clusters server", func() {
 		It("Does not redact pull_secret when not set", func() {
 			response, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template: publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 					}.Build(),
@@ -1785,6 +1871,9 @@ var _ = Describe("Clusters server", func() {
 			invalidCIDR := "not-a-cidr"
 			_, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template: publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 						Network: publicv1.ClusterNetwork_builder{
@@ -1805,6 +1894,9 @@ var _ = Describe("Clusters server", func() {
 			invalidCIDR := "999.999.999.999/99"
 			_, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template: publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 						Network: publicv1.ClusterNetwork_builder{
@@ -1826,6 +1918,9 @@ var _ = Describe("Clusters server", func() {
 			serviceCIDR := "172.30.0.0/16"
 			response, err := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 				Object: publicv1.Cluster_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.ClusterSpec_builder{
 						Template: publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 						Network: publicv1.ClusterNetwork_builder{
@@ -1906,6 +2001,9 @@ var _ = Describe("Clusters server", func() {
 			It("Returns resolved cluster without persisting", func() {
 				response, err := server.Create(dryRunCtx(), publicv1.ClustersCreateRequest_builder{
 					Object: publicv1.Cluster_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: publicv1.ClusterSpec_builder{
 							Template: publicv1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
 						}.Build(),
@@ -1923,6 +2021,9 @@ var _ = Describe("Clusters server", func() {
 			It("Returns same error as real creation for invalid template", func() {
 				_, realErr := server.Create(ctx, publicv1.ClustersCreateRequest_builder{
 					Object: publicv1.Cluster_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: publicv1.ClusterSpec_builder{
 							Template: publicv1.ClusterTemplateReference_builder{Id: "non-existent"}.Build(),
 						}.Build(),
@@ -1932,6 +2033,9 @@ var _ = Describe("Clusters server", func() {
 
 				_, dryRunErr := server.Create(dryRunCtx(), publicv1.ClustersCreateRequest_builder{
 					Object: publicv1.Cluster_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: publicv1.ClusterSpec_builder{
 							Template: publicv1.ClusterTemplateReference_builder{Id: "non-existent"}.Build(),
 						}.Build(),

--- a/fulfillment-service/internal/servers/compute_instance_catalog_items_server_test.go
+++ b/fulfillment-service/internal/servers/compute_instance_catalog_items_server_test.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc/codes"
@@ -76,6 +77,9 @@ var _ = Describe("Compute instance catalog items server", func() {
 		It("Creates object", func() {
 			response, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My CI catalog item",
 					Description: "My description.",
 					Template:    publicv1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
@@ -97,6 +101,9 @@ var _ = Describe("Compute instance catalog items server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 					Object: publicv1.ComputeInstanceCatalogItem_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:     fmt.Sprintf("CI catalog item %d", i),
 						Template:  publicv1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 						Published: true,
@@ -116,6 +123,9 @@ var _ = Describe("Compute instance catalog items server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 					Object: publicv1.ComputeInstanceCatalogItem_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:     fmt.Sprintf("CI catalog item %d", i),
 						Template:  publicv1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 						Published: true,
@@ -137,6 +147,9 @@ var _ = Describe("Compute instance catalog items server", func() {
 			for i := range count {
 				response, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 					Object: publicv1.ComputeInstanceCatalogItem_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:     fmt.Sprintf("CI catalog item %d", i),
 						Template:  publicv1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 						Published: true,
@@ -159,6 +172,9 @@ var _ = Describe("Compute instance catalog items server", func() {
 		It("List excludes unpublished objects", func() {
 			_, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Published item",
 					Template:  publicv1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 					Published: true,
@@ -168,6 +184,9 @@ var _ = Describe("Compute instance catalog items server", func() {
 
 			_, err = server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Unpublished item",
 					Template:  publicv1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 					Published: false,
@@ -184,6 +203,9 @@ var _ = Describe("Compute instance catalog items server", func() {
 		It("List with user filter excludes unpublished objects", func() {
 			publishedResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Target published",
 					Template:  publicv1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 					Published: true,
@@ -193,6 +215,9 @@ var _ = Describe("Compute instance catalog items server", func() {
 
 			_, err = server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Other published",
 					Template:  publicv1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 					Published: true,
@@ -202,6 +227,9 @@ var _ = Describe("Compute instance catalog items server", func() {
 
 			unpublishedResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Target unpublished",
 					Template:  publicv1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 					Published: false,
@@ -222,6 +250,9 @@ var _ = Describe("Compute instance catalog items server", func() {
 		It("Get returns unpublished item when caller has a referencing compute instance", func() {
 			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Unpublished item",
 					Template:  publicv1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 					Published: false,
@@ -260,6 +291,9 @@ var _ = Describe("Compute instance catalog items server", func() {
 		It("Get returns not found for unpublished object", func() {
 			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Unpublished item",
 					Template:  publicv1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 					Published: false,
@@ -277,6 +311,9 @@ var _ = Describe("Compute instance catalog items server", func() {
 		It("Get object", func() {
 			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My CI catalog item",
 					Description: "My description.",
 					Template:    publicv1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
@@ -295,6 +332,9 @@ var _ = Describe("Compute instance catalog items server", func() {
 		It("Update object", func() {
 			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "Original title",
 					Description: "Original description.",
 					Template:    publicv1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
@@ -328,6 +368,9 @@ var _ = Describe("Compute instance catalog items server", func() {
 		It("Delete object", func() {
 			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: publicv1.ComputeInstanceCatalogItem_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "My CI catalog item",
 					Template:  publicv1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 					Published: true,

--- a/fulfillment-service/internal/servers/compute_instance_templates_server_test.go
+++ b/fulfillment-service/internal/servers/compute_instance_templates_server_test.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
@@ -84,6 +85,9 @@ var _ = Describe("Compute instance templates server", func() {
 		It("Creates object", func() {
 			response, err := server.Create(ctx, publicv1.ComputeInstanceTemplatesCreateRequest_builder{
 				Object: publicv1.ComputeInstanceTemplate_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My title",
 					Description: "My description.",
 				}.Build(),
@@ -100,6 +104,9 @@ var _ = Describe("Compute instance templates server", func() {
 		It("Creates object with parameters", func() {
 			response, err := server.Create(ctx, publicv1.ComputeInstanceTemplatesCreateRequest_builder{
 				Object: publicv1.ComputeInstanceTemplate_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My title",
 					Description: "My description.",
 					Parameters: []*publicv1.ComputeInstanceTemplateParameterDefinition{
@@ -141,6 +148,9 @@ var _ = Describe("Compute instance templates server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, publicv1.ComputeInstanceTemplatesCreateRequest_builder{
 					Object: publicv1.ComputeInstanceTemplate_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:       fmt.Sprintf("My title %d", i),
 						Description: fmt.Sprintf("My description %d.", i),
 					}.Build(),
@@ -162,6 +172,9 @@ var _ = Describe("Compute instance templates server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, publicv1.ComputeInstanceTemplatesCreateRequest_builder{
 					Object: publicv1.ComputeInstanceTemplate_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:       fmt.Sprintf("My title %d", i),
 						Description: fmt.Sprintf("My description %d.", i),
 					}.Build(),
@@ -185,6 +198,9 @@ var _ = Describe("Compute instance templates server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, publicv1.ComputeInstanceTemplatesCreateRequest_builder{
 					Object: publicv1.ComputeInstanceTemplate_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:       fmt.Sprintf("My title %d", i),
 						Description: fmt.Sprintf("My description %d.", i),
 					}.Build(),
@@ -206,6 +222,9 @@ var _ = Describe("Compute instance templates server", func() {
 			// Create an object:
 			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceTemplatesCreateRequest_builder{
 				Object: publicv1.ComputeInstanceTemplate_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My title",
 					Description: "My description.",
 				}.Build(),
@@ -234,6 +253,9 @@ var _ = Describe("Compute instance templates server", func() {
 			// Create an object:
 			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceTemplatesCreateRequest_builder{
 				Object: publicv1.ComputeInstanceTemplate_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My title",
 					Description: "My description.",
 				}.Build(),
@@ -269,6 +291,9 @@ var _ = Describe("Compute instance templates server", func() {
 			// Create an object with parameters:
 			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceTemplatesCreateRequest_builder{
 				Object: publicv1.ComputeInstanceTemplate_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My title",
 					Description: "My description.",
 					Parameters: []*publicv1.ComputeInstanceTemplateParameterDefinition{
@@ -324,6 +349,9 @@ var _ = Describe("Compute instance templates server", func() {
 			// Create an object:
 			createResponse, err := server.Create(ctx, publicv1.ComputeInstanceTemplatesCreateRequest_builder{
 				Object: publicv1.ComputeInstanceTemplate_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My title",
 					Description: "My description.",
 				}.Build(),

--- a/fulfillment-service/internal/servers/external_ip_attachments_server_test.go
+++ b/fulfillment-service/internal/servers/external_ip_attachments_server_test.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
@@ -177,6 +178,9 @@ var _ = Describe("External IP attachments server", func() {
 			createResponse, err := externalIPAttachmentsServer.Create(ctx,
 				publicv1.ExternalIPAttachmentsCreateRequest_builder{
 					Object: publicv1.ExternalIPAttachment_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: publicv1.ExternalIPAttachmentSpec_builder{
 							ExternalIp:     publicv1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 							Cluster:        publicv1.ClusterLocalReference_builder{Id: cluster.GetId()}.Build(),
@@ -207,6 +211,9 @@ var _ = Describe("External IP attachments server", func() {
 			createResponse, err := externalIPAttachmentsServer.Create(ctx,
 				publicv1.ExternalIPAttachmentsCreateRequest_builder{
 					Object: publicv1.ExternalIPAttachment_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: publicv1.ExternalIPAttachmentSpec_builder{
 							ExternalIp:        publicv1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 							BaremetalInstance: publicv1.BareMetalInstanceLocalReference_builder{Id: bmi.GetId()}.Build(),

--- a/fulfillment-service/internal/servers/generic_server.go
+++ b/fulfillment-service/internal/servers/generic_server.go
@@ -540,13 +540,14 @@ func (s *GenericServer[O]) prepareForCreate(ctx context.Context, request any) (O
 	requestObject := requestMsg.GetObject()
 	if s.isNil(requestObject) {
 		requestObject = proto.Clone(s.template).(O)
-	} else {
-		requestMetadata := s.getMetadata(requestObject)
-		if requestMetadata != nil {
-			if err := s.validateMetadata(ctx, requestMetadata); err != nil {
-				return nilObject, err
-			}
-		}
+	}
+
+	requestMetadata := s.getMetadata(requestObject)
+	if requestMetadata == nil {
+		return nilObject, grpcstatus.Errorf(grpccodes.InvalidArgument, "metadata is required")
+	}
+	if err := s.validateMetadata(ctx, requestMetadata); err != nil {
+		return nilObject, err
 	}
 
 	assignedCreator, err := s.determineAssignedCreator(ctx)

--- a/fulfillment-service/internal/servers/host_types_server_test.go
+++ b/fulfillment-service/internal/servers/host_types_server_test.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
@@ -82,7 +83,11 @@ var _ = Describe("Host types server", func() {
 
 		It("Creates object", func() {
 			response, err := server.Create(ctx, publicv1.HostTypesCreateRequest_builder{
-				Object: publicv1.HostType_builder{}.Build(),
+				Object: publicv1.HostType_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
+				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(response).ToNot(BeNil())
@@ -111,6 +116,9 @@ var _ = Describe("Host types server", func() {
 			}
 			createResponse, err := server.Create(ctx, publicv1.HostTypesCreateRequest_builder{
 				Object: publicv1.HostType_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:      "BM host type",
 					Interfaces: interfaces,
 				}.Build(),
@@ -135,6 +143,9 @@ var _ = Describe("Host types server", func() {
 		It("Creates object without interfaces", func() {
 			createResponse, err := server.Create(ctx, publicv1.HostTypesCreateRequest_builder{
 				Object: publicv1.HostType_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title: "VM host type",
 				}.Build(),
 			}.Build())
@@ -146,6 +157,9 @@ var _ = Describe("Host types server", func() {
 		It("Updates object interfaces", func() {
 			createResponse, err := server.Create(ctx, publicv1.HostTypesCreateRequest_builder{
 				Object: publicv1.HostType_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title: "BM host type",
 				}.Build(),
 			}.Build())
@@ -183,7 +197,11 @@ var _ = Describe("Host types server", func() {
 			const count = 10
 			for range count {
 				_, err := server.Create(ctx, publicv1.HostTypesCreateRequest_builder{
-					Object: publicv1.HostType_builder{}.Build(),
+					Object: publicv1.HostType_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
+					}.Build(),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 			}
@@ -201,7 +219,11 @@ var _ = Describe("Host types server", func() {
 			const count = 10
 			for range count {
 				_, err := server.Create(ctx, publicv1.HostTypesCreateRequest_builder{
-					Object: publicv1.HostType_builder{}.Build(),
+					Object: publicv1.HostType_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
+					}.Build(),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 			}
@@ -219,7 +241,11 @@ var _ = Describe("Host types server", func() {
 			const count = 10
 			for range count {
 				_, err := server.Create(ctx, publicv1.HostTypesCreateRequest_builder{
-					Object: publicv1.HostType_builder{}.Build(),
+					Object: publicv1.HostType_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
+					}.Build(),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 			}
@@ -238,7 +264,11 @@ var _ = Describe("Host types server", func() {
 			var objects []*publicv1.HostType
 			for range count {
 				response, err := server.Create(ctx, publicv1.HostTypesCreateRequest_builder{
-					Object: publicv1.HostType_builder{}.Build(),
+					Object: publicv1.HostType_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
+					}.Build(),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
 				objects = append(objects, response.GetObject())
@@ -258,7 +288,11 @@ var _ = Describe("Host types server", func() {
 		It("Get object", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, publicv1.HostTypesCreateRequest_builder{
-				Object: publicv1.HostType_builder{}.Build(),
+				Object: publicv1.HostType_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
+				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 
@@ -274,6 +308,9 @@ var _ = Describe("Host types server", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, publicv1.HostTypesCreateRequest_builder{
 				Object: publicv1.HostType_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My title",
 					Description: "My description.",
 				}.Build(),
@@ -305,7 +342,11 @@ var _ = Describe("Host types server", func() {
 		It("Delete object", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, publicv1.HostTypesCreateRequest_builder{
-				Object: publicv1.HostType_builder{}.Build(),
+				Object: publicv1.HostType_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
+				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 			object := createResponse.GetObject()

--- a/fulfillment-service/internal/servers/private_baremetal_instance_catalog_items_server_test.go
+++ b/fulfillment-service/internal/servers/private_baremetal_instance_catalog_items_server_test.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
@@ -85,6 +86,9 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 		It("Creates object", func() {
 			response, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My catalog item",
 					Description: "A test catalog item.",
 					Template:    privatev1.BareMetalInstanceTemplateReference_builder{Id: "my-template-id"}.Build(),
@@ -106,6 +110,9 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 					Object: privatev1.BareMetalInstanceCatalogItem_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:    fmt.Sprintf("Catalog item %d", i),
 						Template: privatev1.BareMetalInstanceTemplateReference_builder{Id: "my-template-id"}.Build(),
 					}.Build(),
@@ -121,6 +128,9 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 		It("Updates object", func() {
 			createResponse, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:    "Original title",
 					Template: privatev1.BareMetalInstanceTemplateReference_builder{Id: "my-template-id"}.Build(),
 				}.Build(),
@@ -167,6 +177,9 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 		It("Blocks delete when referenced by a bare metal instance", func() {
 			createResponse, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Referenced catalog item",
 					Template:  privatev1.BareMetalInstanceTemplateReference_builder{Id: "my-template-id"}.Build(),
 					Published: true,
@@ -206,6 +219,9 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 		It("Creates object with field definitions", func() {
 			response, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:    "Catalog item with fields",
 					Template: privatev1.BareMetalInstanceTemplateReference_builder{Id: "my-template-id"}.Build(),
 					FieldDefinitions: []*privatev1.FieldDefinition{
@@ -225,6 +241,9 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 		It("Rejects non-editable field definition without default value", func() {
 			_, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:    "Bad catalog item",
 					Template: privatev1.BareMetalInstanceTemplateReference_builder{Id: "my-template-id"}.Build(),
 					FieldDefinitions: []*privatev1.FieldDefinition{
@@ -246,6 +265,9 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 		It("Accepts non-editable field definition with default value", func() {
 			response, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:    "Good catalog item",
 					Template: privatev1.BareMetalInstanceTemplateReference_builder{Id: "my-template-id"}.Build(),
 					FieldDefinitions: []*privatev1.FieldDefinition{
@@ -271,6 +293,9 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 		It("Accepts editable field definition without default value", func() {
 			response, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:    "Editable no default",
 					Template: privatev1.BareMetalInstanceTemplateReference_builder{Id: "my-template-id"}.Build(),
 					FieldDefinitions: []*privatev1.FieldDefinition{
@@ -295,6 +320,9 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 		It("Rejects non-editable field definition without default when not first in list", func() {
 			_, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:    "Bad catalog item",
 					Template: privatev1.BareMetalInstanceTemplateReference_builder{Id: "my-template-id"}.Build(),
 					FieldDefinitions: []*privatev1.FieldDefinition{
@@ -319,6 +347,9 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 		It("Rejects field definition with invalid validation_schema JSON", func() {
 			_, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:    "Bad schema catalog item",
 					Template: privatev1.BareMetalInstanceTemplateReference_builder{Id: "my-template-id"}.Build(),
 					FieldDefinitions: []*privatev1.FieldDefinition{
@@ -341,6 +372,9 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 		It("Accepts field definition with valid validation_schema JSON", func() {
 			response, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:    "Valid schema catalog item",
 					Template: privatev1.BareMetalInstanceTemplateReference_builder{Id: "my-template-id"}.Build(),
 					FieldDefinitions: []*privatev1.FieldDefinition{
@@ -366,6 +400,9 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 		It("Rejects update that introduces non-editable field without default", func() {
 			createResponse, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:    "Valid catalog item",
 					Template: privatev1.BareMetalInstanceTemplateReference_builder{Id: "my-template-id"}.Build(),
 				}.Build(),
@@ -404,6 +441,9 @@ var _ = Describe("Private bare metal instance catalog items server", func() {
 		It("Rejects update that introduces invalid validation_schema", func() {
 			createResponse, err := server.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:    "Valid catalog item",
 					Template: privatev1.BareMetalInstanceTemplateReference_builder{Id: "my-template-id"}.Build(),
 				}.Build(),

--- a/fulfillment-service/internal/servers/private_baremetal_instance_templates_server_test.go
+++ b/fulfillment-service/internal/servers/private_baremetal_instance_templates_server_test.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
@@ -80,7 +81,10 @@ var _ = Describe("Private bare metal instance templates server", func() {
 		It("Creates object", func() {
 			response, err := server.Create(ctx, privatev1.BareMetalInstanceTemplatesCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceTemplate_builder{
-					Id:          "test_template_create",
+					Id: "test_template_create",
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My template",
 					Description: "A test template.",
 				}.Build(),
@@ -98,7 +102,10 @@ var _ = Describe("Private bare metal instance templates server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, privatev1.BareMetalInstanceTemplatesCreateRequest_builder{
 					Object: privatev1.BareMetalInstanceTemplate_builder{
-						Id:    fmt.Sprintf("test_template_list_%d", i),
+						Id: fmt.Sprintf("test_template_list_%d", i),
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title: fmt.Sprintf("Template %d", i),
 					}.Build(),
 				}.Build())
@@ -113,7 +120,10 @@ var _ = Describe("Private bare metal instance templates server", func() {
 		It("Gets object", func() {
 			createResponse, err := server.Create(ctx, privatev1.BareMetalInstanceTemplatesCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceTemplate_builder{
-					Id:    "test_template_get",
+					Id: "test_template_get",
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title: "My template",
 				}.Build(),
 			}.Build())
@@ -130,7 +140,10 @@ var _ = Describe("Private bare metal instance templates server", func() {
 		It("Updates object", func() {
 			createResponse, err := server.Create(ctx, privatev1.BareMetalInstanceTemplatesCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceTemplate_builder{
-					Id:          "test_template_update",
+					Id: "test_template_update",
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "Original title",
 					Description: "Original description.",
 				}.Build(),
@@ -153,7 +166,10 @@ var _ = Describe("Private bare metal instance templates server", func() {
 		It("Rejects update when ID does not match required pattern", func() {
 			createResponse, err := server.Create(ctx, privatev1.BareMetalInstanceTemplatesCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceTemplate_builder{
-					Id:    "0192a3b4-5678-7def-9012-abcdef345678",
+					Id: "0192a3b4-5678-7def-9012-abcdef345678",
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title: "My template",
 				}.Build(),
 			}.Build())
@@ -197,7 +213,10 @@ var _ = Describe("Private bare metal instance templates server", func() {
 		It("Signals object", func() {
 			createResponse, err := server.Create(ctx, privatev1.BareMetalInstanceTemplatesCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceTemplate_builder{
-					Id:    "test_template_signal",
+					Id: "test_template_signal",
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title: "My template",
 				}.Build(),
 			}.Build())

--- a/fulfillment-service/internal/servers/private_baremetal_instances_server_test.go
+++ b/fulfillment-service/internal/servers/private_baremetal_instances_server_test.go
@@ -14,9 +14,11 @@ language governing permissions and limitations under the License.
 package servers
 
 import (
+	"fmt"
 	"strings"
 
 	"buf.build/go/protovalidate"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -103,6 +105,9 @@ var _ = Describe("Private bare metal instances server", func() {
 			// Create a published catalog item for use in tests.
 			catalogResp, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Test catalog item",
 					Template:  privatev1.BareMetalInstanceTemplateReference_builder{Id: "test-template"}.Build(),
 					Published: true,
@@ -137,6 +142,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		createCatalogItemWithTemplate := func(templateID string) string {
 			catalogResp, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Catalog with template params",
 					Template:  privatev1.BareMetalInstanceTemplateReference_builder{Id: templateID}.Build(),
 					Published: true,
@@ -149,6 +157,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Creates object with minimal spec", func() {
 			response, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catalogItemID}.Build(),
 					}.Build(),
@@ -162,6 +173,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Creates object with valid SSH key", func() {
 			response, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem:  privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catalogItemID}.Build(),
 						SshPublicKey: new(testSSHPublicKey),
@@ -175,6 +189,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Rejects nonexistent catalog item", func() {
 			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: "does-not-exist"}.Build(),
 					}.Build(),
@@ -210,6 +227,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			_, err = server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: "my-named-catalog-item"}.Build(),
 					}.Build(),
@@ -225,6 +245,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Rejects unpublished catalog item", func() {
 			unpubResp, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Unpublished item",
 					Template:  privatev1.BareMetalInstanceTemplateReference_builder{Id: "test-template"}.Build(),
 					Published: false,
@@ -235,6 +258,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			_, err = server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: unpubID}.Build(),
 					}.Build(),
@@ -252,6 +278,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Rejects invalid SSH key at create time", func() {
 			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem:  privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catalogItemID}.Build(),
 						SshPublicKey: new("not-a-valid-ssh-key"),
@@ -269,6 +298,9 @@ var _ = Describe("Private bare metal instances server", func() {
 			bigData := strings.Repeat("x", bareMetalInstanceUserDataMaxBytes+1)
 			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catalogItemID}.Build(),
 						UserData:    new(bigData),
@@ -287,6 +319,9 @@ var _ = Describe("Private bare metal instances server", func() {
 			exactData := strings.Repeat("x", bareMetalInstanceUserDataMaxBytes)
 			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catalogItemID}.Build(),
 						UserData:    new(exactData),
@@ -312,6 +347,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			secondResp, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Second catalog item",
 					Template:  privatev1.BareMetalInstanceTemplateReference_builder{Id: "test-template"}.Build(),
 					Published: true,
@@ -452,6 +490,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Creates object with image and persists it", func() {
 			createResponse, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catalogItemID}.Build(),
 						Image: privatev1.BareMetalInstanceImage_builder{
@@ -478,6 +519,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Rejects image with missing source_type", func() {
 			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catalogItemID}.Build(),
 						Image: privatev1.BareMetalInstanceImage_builder{
@@ -496,6 +540,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Rejects image with missing source_ref", func() {
 			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catalogItemID}.Build(),
 						Image: privatev1.BareMetalInstanceImage_builder{
@@ -539,6 +586,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			catResp, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Catalog with image default",
 					Template:  privatev1.BareMetalInstanceTemplateReference_builder{Id: "image-default-template"}.Build(),
 					Published: true,
@@ -549,6 +599,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			createResponse, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catID}.Build(),
 					}.Build(),
@@ -588,6 +641,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			catResp, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Catalog with image default override",
 					Template:  privatev1.BareMetalInstanceTemplateReference_builder{Id: "image-override-template"}.Build(),
 					Published: true,
@@ -598,6 +654,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			createResponse, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catID}.Build(),
 						Image: privatev1.BareMetalInstanceImage_builder{
@@ -641,6 +700,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			catResp, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Catalog with partial merge",
 					Template:  privatev1.BareMetalInstanceTemplateReference_builder{Id: "image-partial-merge-template"}.Build(),
 					Published: true,
@@ -651,6 +713,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			createResponse, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catID}.Build(),
 						Image: privatev1.BareMetalInstanceImage_builder{
@@ -758,6 +823,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Signals object", func() {
 			createResponse, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catalogItemID}.Build(),
 					}.Build(),
@@ -786,6 +854,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			response, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem:        privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catID}.Build(),
 						TemplateParameters: map[string]*anypb.Any{"os_version": osParam},
@@ -811,6 +882,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			response, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem:        privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catID}.Build(),
 						TemplateParameters: map[string]*anypb.Any{"os_version": osParam},
@@ -839,6 +913,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			_, err = server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catID}.Build(),
 						TemplateParameters: map[string]*anypb.Any{
@@ -864,6 +941,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem:        privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catID}.Build(),
 						TemplateParameters: map[string]*anypb.Any{},
@@ -889,6 +969,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			_, err = server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem:        privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catID}.Build(),
 						TemplateParameters: map[string]*anypb.Any{"os_version": wrongType},
@@ -992,6 +1075,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			comboCatResp, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Catalog with both constraints",
 					Template:  privatev1.BareMetalInstanceTemplateReference_builder{Id: "combo-template"}.Build(),
 					Published: true,
@@ -1016,6 +1102,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			response, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem:        privatev1.BareMetalInstanceCatalogItemReference_builder{Id: comboCatID}.Build(),
 						TemplateParameters: map[string]*anypb.Any{"os_version": osParam},
@@ -1034,6 +1123,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			catResp, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Override + template params",
 					Template:  privatev1.BareMetalInstanceTemplateReference_builder{Id: "override-combo-template"}.Build(),
 					Published: true,
@@ -1059,6 +1151,9 @@ var _ = Describe("Private bare metal instances server", func() {
 			userKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIUserProvidedKeyThatShouldBeOverridden user@test"
 			_, err = server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem:        privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catID}.Build(),
 						SshPublicKey:       &userKey,
@@ -1080,6 +1175,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			catResp, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Editable + template params",
 					Template:  privatev1.BareMetalInstanceTemplateReference_builder{Id: "editable-combo-template"}.Build(),
 					Published: true,
@@ -1103,6 +1201,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			response, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem:        privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catID}.Build(),
 						SshPublicKey:       new(testSSHPublicKey),
@@ -1122,6 +1223,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			catResp, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "FD fail + valid TP",
 					Template:  privatev1.BareMetalInstanceTemplateReference_builder{Id: "fd-fail-template"}.Build(),
 					Published: true,
@@ -1145,6 +1249,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			_, err = server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem:        privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catID}.Build(),
 						TemplateParameters: map[string]*anypb.Any{"os_version": osParam},
@@ -1165,6 +1272,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			catResp, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Valid FD + TP fail",
 					Template:  privatev1.BareMetalInstanceTemplateReference_builder{Id: "tp-fail-template"}.Build(),
 					Published: true,
@@ -1182,6 +1292,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			_, err = server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem:        privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catID}.Build(),
 						TemplateParameters: map[string]*anypb.Any{},
@@ -1198,6 +1311,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Creates object with auto_external_ip_attachment and persists it", func() {
 			response, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem:              privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catalogItemID}.Build(),
 						AutoExternalIpAttachment: true,
@@ -1250,6 +1366,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Rejects template_parameters when catalog item has no template", func() {
 			noTemplateResp, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "No template item",
 					Published: true,
 				}.Build(),
@@ -1262,6 +1381,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			_, err = server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem:        privatev1.BareMetalInstanceCatalogItemReference_builder{Id: noTemplateCatID}.Build(),
 						TemplateParameters: map[string]*anypb.Any{"os_version": osParam},
@@ -1354,6 +1476,9 @@ var _ = Describe("Private bare metal instances server", func() {
 			// Create catalog items referencing the templates.
 			catResp, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Catalog with HT",
 					Template:  privatev1.BareMetalInstanceTemplateReference_builder{Id: "template-with-ht"}.Build(),
 					Published: true,
@@ -1364,6 +1489,9 @@ var _ = Describe("Private bare metal instances server", func() {
 
 			catResp2, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Catalog no HT",
 					Template:  privatev1.BareMetalInstanceTemplateReference_builder{Id: "template-no-ht"}.Build(),
 					Published: true,
@@ -1376,6 +1504,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Accepts single attachment without interface", func() {
 			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDWithHT}.Build(),
 						NetworkAttachments: []*privatev1.BareMetalNetworkAttachment{
@@ -1392,6 +1523,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Accepts single attachment with valid interface", func() {
 			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDWithHT}.Build(),
 						NetworkAttachments: []*privatev1.BareMetalNetworkAttachment{
@@ -1409,6 +1543,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Accepts multiple attachments with distinct valid interfaces and one primary", func() {
 			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDWithHT}.Build(),
 						NetworkAttachments: []*privatev1.BareMetalNetworkAttachment{
@@ -1431,6 +1568,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Rejects interface not in HostType interfaces list", func() {
 			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDWithHT}.Build(),
 						NetworkAttachments: []*privatev1.BareMetalNetworkAttachment{
@@ -1453,6 +1593,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Rejects duplicate interface across attachments", func() {
 			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDWithHT}.Build(),
 						NetworkAttachments: []*privatev1.BareMetalNetworkAttachment{
@@ -1480,6 +1623,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Rejects interface with lifecycle role", func() {
 			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDWithHT}.Build(),
 						NetworkAttachments: []*privatev1.BareMetalNetworkAttachment{
@@ -1502,6 +1648,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Rejects multiple attachments without explicit interface", func() {
 			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDWithHT}.Build(),
 						NetworkAttachments: []*privatev1.BareMetalNetworkAttachment{
@@ -1526,6 +1675,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Rejects attachment count exceeding available interfaces", func() {
 			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDWithHT}.Build(),
 						NetworkAttachments: []*privatev1.BareMetalNetworkAttachment{
@@ -1547,6 +1699,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Rejects multiple attachments with no primary", func() {
 			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDWithHT}.Build(),
 						NetworkAttachments: []*privatev1.BareMetalNetworkAttachment{
@@ -1572,6 +1727,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Rejects multiple attachments with more than one primary", func() {
 			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDWithHT}.Build(),
 						NetworkAttachments: []*privatev1.BareMetalNetworkAttachment{
@@ -1599,6 +1757,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Skips interface-against-HostType validation when template has no host_type", func() {
 			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDNoHT}.Build(),
 						NetworkAttachments: []*privatev1.BareMetalNetworkAttachment{
@@ -1616,6 +1777,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Still validates structural rules when template has no host_type", func() {
 			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDNoHT}.Build(),
 						NetworkAttachments: []*privatev1.BareMetalNetworkAttachment{
@@ -1642,6 +1806,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Accepts no network attachments", func() {
 			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDWithHT}.Build(),
 					}.Build(),
@@ -1731,6 +1898,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Rejects update that changes array size", func() {
 			createResp, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDWithHT}.Build(),
 						NetworkAttachments: []*privatev1.BareMetalNetworkAttachment{
@@ -1769,6 +1939,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Rejects update that changes subnet", func() {
 			createResp, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDWithHT}.Build(),
 						NetworkAttachments: []*privatev1.BareMetalNetworkAttachment{
@@ -1809,6 +1982,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Rejects update that changes interface", func() {
 			createResp, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDWithHT}.Build(),
 						NetworkAttachments: []*privatev1.BareMetalNetworkAttachment{
@@ -1849,6 +2025,9 @@ var _ = Describe("Private bare metal instances server", func() {
 		It("Rejects update that changes primary", func() {
 			createResp, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDWithHT}.Build(),
 						NetworkAttachments: []*privatev1.BareMetalNetworkAttachment{

--- a/fulfillment-service/internal/servers/private_cluster_catalog_items_server_test.go
+++ b/fulfillment-service/internal/servers/private_cluster_catalog_items_server_test.go
@@ -91,6 +91,9 @@ var _ = Describe("Private cluster catalog items server", func() {
 		It("Creates object", func() {
 			response, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
 				Object: privatev1.ClusterCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Title:       "My cluster catalog item",
 					Description: "My description.",
 					Template:    privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
@@ -114,6 +117,9 @@ var _ = Describe("Private cluster catalog items server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
 					Object: privatev1.ClusterCatalogItem_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Title:       fmt.Sprintf("Catalog item %d", i),
 						Description: fmt.Sprintf("Description %d.", i),
 						Template:    privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
@@ -134,6 +140,9 @@ var _ = Describe("Private cluster catalog items server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
 					Object: privatev1.ClusterCatalogItem_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Title:    fmt.Sprintf("Catalog item %d", i),
 						Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					}.Build(),
@@ -154,6 +163,9 @@ var _ = Describe("Private cluster catalog items server", func() {
 			for i := range count {
 				createResponse, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
 					Object: privatev1.ClusterCatalogItem_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Title:    fmt.Sprintf("Catalog item %d", i),
 						Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					}.Build(),
@@ -183,6 +195,9 @@ var _ = Describe("Private cluster catalog items server", func() {
 		It("Get object", func() {
 			createResponse, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
 				Object: privatev1.ClusterCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Title:       "My catalog item",
 					Description: "My description.",
 					Template:    privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
@@ -287,6 +302,9 @@ var _ = Describe("Private cluster catalog items server", func() {
 		It("Creates object with field definitions and round-trips them", func() {
 			response, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
 				Object: privatev1.ClusterCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Title:    "Catalog item with fields",
 					Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					FieldDefinitions: []*privatev1.FieldDefinition{
@@ -364,6 +382,9 @@ var _ = Describe("Private cluster catalog items server", func() {
 		It("Blocks delete when referenced by a cluster", func() {
 			createResponse, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
 				Object: privatev1.ClusterCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Title:     "Referenced catalog item",
 					Template:  privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					Published: true,
@@ -498,6 +519,9 @@ var _ = Describe("Private cluster catalog items server", func() {
 		It("Rejects non-editable field definition without default value", func() {
 			_, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
 				Object: privatev1.ClusterCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Title:    "Bad catalog item",
 					Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					FieldDefinitions: []*privatev1.FieldDefinition{
@@ -519,6 +543,9 @@ var _ = Describe("Private cluster catalog items server", func() {
 		It("Accepts non-editable field definition with default value", func() {
 			response, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
 				Object: privatev1.ClusterCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Title:    "Good catalog item",
 					Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					FieldDefinitions: []*privatev1.FieldDefinition{
@@ -544,6 +571,9 @@ var _ = Describe("Private cluster catalog items server", func() {
 		It("Accepts editable field definition without default value", func() {
 			response, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
 				Object: privatev1.ClusterCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Title:    "Editable no default",
 					Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					FieldDefinitions: []*privatev1.FieldDefinition{
@@ -568,6 +598,9 @@ var _ = Describe("Private cluster catalog items server", func() {
 		It("Rejects non-editable field definition without default when not first in list", func() {
 			_, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
 				Object: privatev1.ClusterCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Title:    "Bad catalog item",
 					Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					FieldDefinitions: []*privatev1.FieldDefinition{
@@ -592,6 +625,9 @@ var _ = Describe("Private cluster catalog items server", func() {
 		It("Rejects field definition with invalid validation_schema JSON", func() {
 			_, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
 				Object: privatev1.ClusterCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Title:    "Bad schema catalog item",
 					Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					FieldDefinitions: []*privatev1.FieldDefinition{
@@ -614,6 +650,9 @@ var _ = Describe("Private cluster catalog items server", func() {
 		It("Accepts field definition with valid validation_schema JSON", func() {
 			response, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
 				Object: privatev1.ClusterCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Title:    "Valid schema catalog item",
 					Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					FieldDefinitions: []*privatev1.FieldDefinition{
@@ -777,6 +816,9 @@ var _ = Describe("Private cluster catalog items server", func() {
 			It("Rejects create with non-existent version_name default in field_definitions", func() {
 				_, err := validatedServer.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
 					Object: privatev1.ClusterCatalogItem_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Title:    "Bad version catalog item",
 						Template: &privatev1.ClusterTemplateReference{Id: "my-template-id"},
 						FieldDefinitions: []*privatev1.FieldDefinition{
@@ -821,6 +863,9 @@ var _ = Describe("Private cluster catalog items server", func() {
 
 				_, err = validatedServer.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
 					Object: privatev1.ClusterCatalogItem_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Title:    "Obsolete version catalog item",
 						Template: &privatev1.ClusterTemplateReference{Id: "my-template-id"},
 						FieldDefinitions: []*privatev1.FieldDefinition{
@@ -842,6 +887,9 @@ var _ = Describe("Private cluster catalog items server", func() {
 			It("Rejects update with non-existent version_name default in field_definitions", func() {
 				createResponse, err := validatedServer.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
 					Object: privatev1.ClusterCatalogItem_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Title:    "Catalog item for update test",
 						Template: &privatev1.ClusterTemplateReference{Id: "my-template-id"},
 					}.Build(),
@@ -873,6 +921,7 @@ var _ = Describe("Private cluster catalog items server", func() {
 		It("Allows empty name without conflict", func() {
 			_, err := server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
 				Object: privatev1.ClusterCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{}.Build(),
 					Title:    "First unnamed item",
 					Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 				}.Build(),
@@ -881,6 +930,7 @@ var _ = Describe("Private cluster catalog items server", func() {
 
 			_, err = server.Create(ctx, privatev1.ClusterCatalogItemsCreateRequest_builder{
 				Object: privatev1.ClusterCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{}.Build(),
 					Title:    "Second unnamed item",
 					Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 				}.Build(),

--- a/fulfillment-service/internal/servers/private_cluster_templates_server_test.go
+++ b/fulfillment-service/internal/servers/private_cluster_templates_server_test.go
@@ -88,6 +88,9 @@ var _ = Describe("Private cluster templates server", func() {
 		It("Creates object", func() {
 			response, err := server.Create(ctx, privatev1.ClusterTemplatesCreateRequest_builder{
 				Object: privatev1.ClusterTemplate_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Title:       "My title",
 					Description: "My description.",
 				}.Build(),
@@ -455,6 +458,9 @@ var _ = Describe("Private cluster templates server", func() {
 			It("Rejects create with non-existent spec_defaults.version_name", func() {
 				_, err := validatedServer.Create(ctx, privatev1.ClusterTemplatesCreateRequest_builder{
 					Object: privatev1.ClusterTemplate_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Title:       "Bad version template",
 						Description: "Template referencing a non-existent version.",
 						SpecDefaults: privatev1.ClusterTemplateSpecDefaults_builder{
@@ -495,6 +501,9 @@ var _ = Describe("Private cluster templates server", func() {
 				// Create a template first:
 				createResponse, err := validatedServer.Create(ctx, privatev1.ClusterTemplatesCreateRequest_builder{
 					Object: privatev1.ClusterTemplate_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Title:       "My template",
 						Description: "Template to update.",
 					}.Build(),

--- a/fulfillment-service/internal/servers/private_clusters_server_test.go
+++ b/fulfillment-service/internal/servers/private_clusters_server_test.go
@@ -251,6 +251,9 @@ var _ = Describe("Private clusters server", func() {
 		It("Creates object", func() {
 			response, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 				Object: privatev1.Cluster_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Spec: privatev1.ClusterSpec_builder{
 						Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					}.Build(),
@@ -270,6 +273,9 @@ var _ = Describe("Private clusters server", func() {
 			// Create the object:
 			response, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 				Object: privatev1.Cluster_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Spec: privatev1.ClusterSpec_builder{
 						Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-name"}.Build(),
 					}.Build(),
@@ -291,6 +297,9 @@ var _ = Describe("Private clusters server", func() {
 		It("Fails when creating object with non-existent template name", func() {
 			_, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 				Object: privatev1.Cluster_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Spec: privatev1.ClusterSpec_builder{
 						Template: privatev1.ClusterTemplateReference_builder{Id: "does-not-exist"}.Build(),
 					}.Build(),
@@ -312,6 +321,9 @@ var _ = Describe("Private clusters server", func() {
 			// Create a cluster specifying the host type by name:
 			response, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 				Object: privatev1.Cluster_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Spec: privatev1.ClusterSpec_builder{
 						Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 						NodeSets: map[string]*privatev1.ClusterNodeSet{
@@ -343,6 +355,9 @@ var _ = Describe("Private clusters server", func() {
 			// Create a cluster specifying the host type by identifier:
 			response, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 				Object: privatev1.Cluster_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Spec: privatev1.ClusterSpec_builder{
 						Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 						NodeSets: map[string]*privatev1.ClusterNodeSet{
@@ -374,6 +389,9 @@ var _ = Describe("Private clusters server", func() {
 			// Create a cluster specifying the template and the host type by name:
 			response, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 				Object: privatev1.Cluster_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Spec: privatev1.ClusterSpec_builder{
 						Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-name"}.Build(),
 						NodeSets: map[string]*privatev1.ClusterNodeSet{
@@ -405,6 +423,9 @@ var _ = Describe("Private clusters server", func() {
 		It("Fails when creating object with non-existent host type name", func() {
 			_, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 				Object: privatev1.Cluster_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Spec: privatev1.ClusterSpec_builder{
 						Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 						NodeSets: map[string]*privatev1.ClusterNodeSet{
@@ -431,6 +452,9 @@ var _ = Describe("Private clusters server", func() {
 		It("Fails when creating object with non-existent node set", func() {
 			_, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 				Object: privatev1.Cluster_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Spec: privatev1.ClusterSpec_builder{
 						Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 						NodeSets: map[string]*privatev1.ClusterNodeSet{
@@ -458,6 +482,9 @@ var _ = Describe("Private clusters server", func() {
 		It("Fails when creating object with host type that doesn't match template", func() {
 			_, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 				Object: privatev1.Cluster_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Spec: privatev1.ClusterSpec_builder{
 						Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 						NodeSets: map[string]*privatev1.ClusterNodeSet{
@@ -488,6 +515,9 @@ var _ = Describe("Private clusters server", func() {
 			_, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 				Object: privatev1.Cluster_builder{
 					Id: id,
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Spec: privatev1.ClusterSpec_builder{
 						Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					}.Build(),
@@ -499,9 +529,13 @@ var _ = Describe("Private clusters server", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Try to create another object with the same identifier:
+			name := fmt.Sprintf("test-%s", uuid.New()[24:32])
 			_, err = server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 				Object: privatev1.Cluster_builder{
 					Id: id,
+					Metadata: privatev1.Metadata_builder{
+						Name: name,
+					}.Build(),
 					Spec: privatev1.ClusterSpec_builder{
 						Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					}.Build(),
@@ -514,7 +548,7 @@ var _ = Describe("Private clusters server", func() {
 			status, ok := grpcstatus.FromError(err)
 			Expect(ok).To(BeTrue())
 			Expect(status.Code()).To(Equal(grpccodes.AlreadyExists))
-			Expect(status.Message()).To(Equal(fmt.Sprintf("object with identifier '%s' already exists", id)))
+			Expect(status.Message()).To(Equal(fmt.Sprintf("object with identifier '%s' and name '%s' already exists", id, name)))
 		})
 
 		It("List objects", func() {
@@ -523,6 +557,9 @@ var _ = Describe("Private clusters server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							Template: privatev1.ClusterTemplateReference_builder{Id: fmt.Sprintf("my-template-id-%d", i)}.Build(),
 						}.Build(),
@@ -548,6 +585,9 @@ var _ = Describe("Private clusters server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							Template: privatev1.ClusterTemplateReference_builder{Id: fmt.Sprintf("my-template-id-%d", i)}.Build(),
 						}.Build(),
@@ -573,6 +613,9 @@ var _ = Describe("Private clusters server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							Template: privatev1.ClusterTemplateReference_builder{Id: fmt.Sprintf("my-template-id-%d", i)}.Build(),
 						}.Build(),
@@ -599,6 +642,9 @@ var _ = Describe("Private clusters server", func() {
 			for i := range count {
 				response, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							Template: privatev1.ClusterTemplateReference_builder{Id: fmt.Sprintf("my-template-id-%d", i)}.Build(),
 						}.Build(),
@@ -626,6 +672,9 @@ var _ = Describe("Private clusters server", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 				Object: privatev1.Cluster_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Spec: privatev1.ClusterSpec_builder{
 						Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					}.Build(),
@@ -766,6 +815,9 @@ var _ = Describe("Private clusters server", func() {
 		It("Rejects creation with duplicate condition", func() {
 			_, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 				Object: privatev1.Cluster_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Spec: privatev1.ClusterSpec_builder{
 						Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 					}.Build(),
@@ -1325,6 +1377,9 @@ var _ = Describe("Private clusters server", func() {
 
 				response, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							CatalogItem: privatev1.ClusterCatalogItemReference_builder{Id: "cat-happy"}.Build(),
 						}.Build(),
@@ -1357,6 +1412,9 @@ var _ = Describe("Private clusters server", func() {
 
 				response, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							CatalogItem: privatev1.ClusterCatalogItemReference_builder{Id: "cat-by-name-name"}.Build(),
 						}.Build(),
@@ -1375,6 +1433,9 @@ var _ = Describe("Private clusters server", func() {
 			It("Fails when catalog item not found", func() {
 				_, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							CatalogItem: privatev1.ClusterCatalogItemReference_builder{Id: "nonexistent"}.Build(),
 						}.Build(),
@@ -1397,6 +1458,9 @@ var _ = Describe("Private clusters server", func() {
 
 				_, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							CatalogItem: privatev1.ClusterCatalogItemReference_builder{Id: "cat-unpublished"}.Build(),
 						}.Build(),
@@ -1417,6 +1481,9 @@ var _ = Describe("Private clusters server", func() {
 			It("Fails when both catalog_item and template are set", func() {
 				_, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							CatalogItem: privatev1.ClusterCatalogItemReference_builder{Id: "any-catalog-item"}.Build(),
 							Template:    privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
@@ -1444,6 +1511,9 @@ var _ = Describe("Private clusters server", func() {
 
 				_, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							CatalogItem: privatev1.ClusterCatalogItemReference_builder{Id: "cat-noneditable"}.Build(),
 							PullSecret:  new("user-secret"),
@@ -1472,6 +1542,9 @@ var _ = Describe("Private clusters server", func() {
 
 					response, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 						Object: privatev1.Cluster_builder{
+							Metadata: privatev1.Metadata_builder{
+								Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+							}.Build(),
 							Spec: privatev1.ClusterSpec_builder{
 								CatalogItem: privatev1.ClusterCatalogItemReference_builder{Id: catID}.Build(),
 								PullSecret:  new(value),
@@ -1507,6 +1580,9 @@ var _ = Describe("Private clusters server", func() {
 
 				response, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							CatalogItem: privatev1.ClusterCatalogItemReference_builder{Id: "cat-default"}.Build(),
 						}.Build(),
@@ -1569,6 +1645,9 @@ var _ = Describe("Private clusters server", func() {
 				// Create a cluster via catalog item without specifying ssh_public_key:
 				response, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							CatalogItem: privatev1.ClusterCatalogItemReference_builder{Id: "cat-with-defaults"}.Build(),
 						}.Build(),
@@ -1655,6 +1734,9 @@ var _ = Describe("Private clusters server", func() {
 				// Create a cluster via catalog item without specifying version_name:
 				response, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							CatalogItem: &privatev1.ClusterCatalogItemReference{Id: "cat-version-pinned"},
 						}.Build(),
@@ -1740,6 +1822,9 @@ var _ = Describe("Private clusters server", func() {
 				// Create a cluster via catalog item without specifying version_name:
 				response, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							CatalogItem: &privatev1.ClusterCatalogItemReference{Id: "cat-fd-override"},
 						}.Build(),
@@ -1800,6 +1885,9 @@ var _ = Describe("Private clusters server", func() {
 				// Create a cluster via catalog item without specifying version_name:
 				response, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							CatalogItem: &privatev1.ClusterCatalogItemReference{Id: "cat-no-version"},
 						}.Build(),
@@ -1830,6 +1918,9 @@ var _ = Describe("Private clusters server", func() {
 
 				_, err = server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							CatalogItem: privatev1.ClusterCatalogItemReference_builder{Id: "cat-no-template"}.Build(),
 						}.Build(),
@@ -1979,6 +2070,9 @@ var _ = Describe("Private clusters server", func() {
 			// Create a cluster with an explicit version_name:
 			createResponse, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 				Object: privatev1.Cluster_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Spec: privatev1.ClusterSpec_builder{
 						Template:    &privatev1.ClusterTemplateReference{Id: "my-template-id"},
 						VersionName: &versionName,
@@ -2016,6 +2110,9 @@ var _ = Describe("Private clusters server", func() {
 			// Create a cluster with an explicit version_name:
 			createResponse, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 				Object: privatev1.Cluster_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Spec: privatev1.ClusterSpec_builder{
 						Template:    &privatev1.ClusterTemplateReference{Id: "my-template-id"},
 						VersionName: &versionName,
@@ -2067,6 +2164,9 @@ var _ = Describe("Private clusters server", func() {
 			// Create a cluster with an explicit version_name:
 			createResponse, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 				Object: privatev1.Cluster_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Spec: privatev1.ClusterSpec_builder{
 						Template:    &privatev1.ClusterTemplateReference{Id: "my-template-id"},
 						VersionName: &versionName,
@@ -2119,6 +2219,9 @@ var _ = Describe("Private clusters server", func() {
 			// Create a cluster with a valid version_name:
 			createResponse, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 				Object: privatev1.Cluster_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+					}.Build(),
 					Spec: privatev1.ClusterSpec_builder{
 						Template:    &privatev1.ClusterTemplateReference{Id: "my-template-id"},
 						VersionName: &versionName,
@@ -2160,6 +2263,9 @@ var _ = Describe("Private clusters server", func() {
 				nonExistent := "does-not-exist"
 				_, err := validatedServer.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							Template:    &privatev1.ClusterTemplateReference{Id: "my-template-id"},
 							VersionName: &nonExistent,
@@ -2194,6 +2300,9 @@ var _ = Describe("Private clusters server", func() {
 				disabledName := "4-18-0-disabled"
 				_, err := validatedServer.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							Template:    &privatev1.ClusterTemplateReference{Id: "my-template-id"},
 							VersionName: &disabledName,
@@ -2229,6 +2338,9 @@ var _ = Describe("Private clusters server", func() {
 				obsoleteName := "4-16-0-obsolete"
 				_, err := validatedServer.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							Template:    &privatev1.ClusterTemplateReference{Id: "my-template-id"},
 							VersionName: &obsoleteName,
@@ -2250,6 +2362,9 @@ var _ = Describe("Private clusters server", func() {
 				// ClusterVersion with name "4-17-0" and is_default=true.
 				response, err := validatedServer.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							Template: &privatev1.ClusterTemplateReference{Id: "my-template-id"},
 						}.Build(),
@@ -2276,6 +2391,9 @@ var _ = Describe("Private clusters server", func() {
 
 				_, err = validatedServer.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							Template: &privatev1.ClusterTemplateReference{Id: "my-template-id"},
 						}.Build(),
@@ -2324,6 +2442,9 @@ var _ = Describe("Private clusters server", func() {
 
 				_, err = validatedServer.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							Template: &privatev1.ClusterTemplateReference{Id: "my-template-id"},
 						}.Build(),
@@ -2372,6 +2493,9 @@ var _ = Describe("Private clusters server", func() {
 
 				_, err = validatedServer.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							Template: &privatev1.ClusterTemplateReference{Id: "my-template-id"},
 						}.Build(),

--- a/fulfillment-service/internal/servers/private_compute_instance_catalog_items_server_test.go
+++ b/fulfillment-service/internal/servers/private_compute_instance_catalog_items_server_test.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
@@ -89,6 +90,9 @@ var _ = Describe("Private compute instance catalog items server", func() {
 		It("Creates object", func() {
 			response, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My CI catalog item",
 					Description: "My description.",
 					Template:    privatev1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
@@ -112,6 +116,9 @@ var _ = Describe("Private compute instance catalog items server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
 					Object: privatev1.ComputeInstanceCatalogItem_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:    fmt.Sprintf("CI catalog item %d", i),
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 					}.Build(),
@@ -131,6 +138,9 @@ var _ = Describe("Private compute instance catalog items server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
 					Object: privatev1.ComputeInstanceCatalogItem_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:    fmt.Sprintf("CI catalog item %d", i),
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 					}.Build(),
@@ -151,6 +161,9 @@ var _ = Describe("Private compute instance catalog items server", func() {
 			for i := range count {
 				createResponse, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
 					Object: privatev1.ComputeInstanceCatalogItem_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:    fmt.Sprintf("CI catalog item %d", i),
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 					}.Build(),
@@ -180,6 +193,9 @@ var _ = Describe("Private compute instance catalog items server", func() {
 		It("Get object", func() {
 			createResponse, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My CI catalog item",
 					Description: "My description.",
 					Template:    privatev1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
@@ -284,6 +300,9 @@ var _ = Describe("Private compute instance catalog items server", func() {
 		It("Creates object with field definitions and round-trips them", func() {
 			response, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:    "CI catalog item with fields",
 					Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 					FieldDefinitions: []*privatev1.FieldDefinition{
@@ -361,6 +380,9 @@ var _ = Describe("Private compute instance catalog items server", func() {
 		It("Blocks delete when referenced by a compute instance", func() {
 			createResponse, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:     "Referenced CI catalog item",
 					Template:  privatev1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 					Published: true,
@@ -495,6 +517,9 @@ var _ = Describe("Private compute instance catalog items server", func() {
 		It("Rejects non-editable field definition without default value", func() {
 			_, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:    "Bad CI catalog item",
 					Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 					FieldDefinitions: []*privatev1.FieldDefinition{
@@ -516,6 +541,9 @@ var _ = Describe("Private compute instance catalog items server", func() {
 		It("Accepts non-editable field definition with default value", func() {
 			response, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:    "Good CI catalog item",
 					Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 					FieldDefinitions: []*privatev1.FieldDefinition{
@@ -541,6 +569,9 @@ var _ = Describe("Private compute instance catalog items server", func() {
 		It("Accepts editable field definition without default value", func() {
 			response, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:    "Editable no default",
 					Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 					FieldDefinitions: []*privatev1.FieldDefinition{
@@ -565,6 +596,9 @@ var _ = Describe("Private compute instance catalog items server", func() {
 		It("Rejects non-editable field definition without default when not first in list", func() {
 			_, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:    "Bad catalog item",
 					Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 					FieldDefinitions: []*privatev1.FieldDefinition{
@@ -589,6 +623,9 @@ var _ = Describe("Private compute instance catalog items server", func() {
 		It("Rejects field definition with invalid validation_schema JSON", func() {
 			_, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:    "Bad schema catalog item",
 					Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 					FieldDefinitions: []*privatev1.FieldDefinition{
@@ -611,6 +648,9 @@ var _ = Describe("Private compute instance catalog items server", func() {
 		It("Accepts field definition with valid validation_schema JSON", func() {
 			response, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:    "Valid schema catalog item",
 					Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 					FieldDefinitions: []*privatev1.FieldDefinition{
@@ -761,6 +801,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 		It("Allows empty name without conflict", func() {
 			_, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{}.Build(),
 					Title:    "First unnamed CI item",
 					Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 				}.Build(),
@@ -769,6 +810,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 
 			_, err = server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
 				Object: privatev1.ComputeInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{}.Build(),
 					Title:    "Second unnamed CI item",
 					Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 				}.Build(),
@@ -831,6 +873,9 @@ var _ = Describe("Private compute instance catalog items server", func() {
 
 				response, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
 					Object: privatev1.ComputeInstanceCatalogItem_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:    "Catalog item with deprecated default",
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 						FieldDefinitions: []*privatev1.FieldDefinition{
@@ -888,6 +933,9 @@ var _ = Describe("Private compute instance catalog items server", func() {
 
 				_, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
 					Object: privatev1.ComputeInstanceCatalogItem_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:    "Catalog item with obsolete default",
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 						FieldDefinitions: []*privatev1.FieldDefinition{
@@ -949,6 +997,9 @@ var _ = Describe("Private compute instance catalog items server", func() {
 
 				response, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
 					Object: privatev1.ComputeInstanceCatalogItem_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:    "Catalog item with active default",
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 						FieldDefinitions: []*privatev1.FieldDefinition{
@@ -967,6 +1018,9 @@ var _ = Describe("Private compute instance catalog items server", func() {
 			It("Rejects Create when field_definitions default references a non-existent instance type", func() {
 				_, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
 					Object: privatev1.ComputeInstanceCatalogItem_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:    "Catalog item with missing type",
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 						FieldDefinitions: []*privatev1.FieldDefinition{
@@ -987,6 +1041,9 @@ var _ = Describe("Private compute instance catalog items server", func() {
 			It("Skips validation when field_definitions has no spec.instance_type path", func() {
 				response, err := server.Create(ctx, privatev1.ComputeInstanceCatalogItemsCreateRequest_builder{
 					Object: privatev1.ComputeInstanceCatalogItem_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:    "Catalog item without instance type field",
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 						FieldDefinitions: []*privatev1.FieldDefinition{

--- a/fulfillment-service/internal/servers/private_compute_instance_templates_server_test.go
+++ b/fulfillment-service/internal/servers/private_compute_instance_templates_server_test.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
@@ -84,6 +85,9 @@ var _ = Describe("Private compute instance templates server", func() {
 		It("Creates object", func() {
 			response, err := server.Create(ctx, privatev1.ComputeInstanceTemplatesCreateRequest_builder{
 				Object: privatev1.ComputeInstanceTemplate_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My title",
 					Description: "My description.",
 				}.Build(),
@@ -100,6 +104,9 @@ var _ = Describe("Private compute instance templates server", func() {
 		It("Creates object with parameters", func() {
 			response, err := server.Create(ctx, privatev1.ComputeInstanceTemplatesCreateRequest_builder{
 				Object: privatev1.ComputeInstanceTemplate_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My title",
 					Description: "My description.",
 					Parameters: []*privatev1.ComputeInstanceTemplateParameterDefinition{
@@ -141,6 +148,9 @@ var _ = Describe("Private compute instance templates server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, privatev1.ComputeInstanceTemplatesCreateRequest_builder{
 					Object: privatev1.ComputeInstanceTemplate_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:       fmt.Sprintf("My title %d", i),
 						Description: fmt.Sprintf("My description %d.", i),
 					}.Build(),
@@ -162,6 +172,9 @@ var _ = Describe("Private compute instance templates server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, privatev1.ComputeInstanceTemplatesCreateRequest_builder{
 					Object: privatev1.ComputeInstanceTemplate_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:       fmt.Sprintf("My title %d", i),
 						Description: fmt.Sprintf("My description %d.", i),
 					}.Build(),
@@ -185,6 +198,9 @@ var _ = Describe("Private compute instance templates server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, privatev1.ComputeInstanceTemplatesCreateRequest_builder{
 					Object: privatev1.ComputeInstanceTemplate_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:       fmt.Sprintf("My title %d", i),
 						Description: fmt.Sprintf("My description %d.", i),
 					}.Build(),
@@ -206,6 +222,9 @@ var _ = Describe("Private compute instance templates server", func() {
 			// Create an object:
 			createResponse, err := server.Create(ctx, privatev1.ComputeInstanceTemplatesCreateRequest_builder{
 				Object: privatev1.ComputeInstanceTemplate_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My title",
 					Description: "My description.",
 				}.Build(),
@@ -330,6 +349,9 @@ var _ = Describe("Private compute instance templates server", func() {
 			// Create an object:
 			createResponse, err := server.Create(ctx, privatev1.ComputeInstanceTemplatesCreateRequest_builder{
 				Object: privatev1.ComputeInstanceTemplate_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My title",
 					Description: "My description.",
 				}.Build(),
@@ -365,12 +387,14 @@ var _ = Describe("Private compute instance templates server", func() {
 			Expect(getResponse).To(BeNil())
 		})
 
-		It("Creates empty object if no object is provided", func() {
+		It("Rejects creation if no object is provided", func() {
 			response, err := server.Create(ctx, privatev1.ComputeInstanceTemplatesCreateRequest_builder{}.Build())
-			Expect(err).ToNot(HaveOccurred())
-			Expect(response).ToNot(BeNil())
-			Expect(response.GetObject()).ToNot(BeNil())
-			Expect(response.GetObject().GetId()).ToNot(BeEmpty())
+			Expect(err).To(HaveOccurred())
+			Expect(response).To(BeNil())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(status.Message()).To(Equal("metadata is required"))
 		})
 
 		It("Handles empty object in update request", func() {
@@ -446,6 +470,9 @@ var _ = Describe("Private compute instance templates server", func() {
 
 				response, err := server.Create(ctx, privatev1.ComputeInstanceTemplatesCreateRequest_builder{
 					Object: privatev1.ComputeInstanceTemplate_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:       "Template with deprecated default",
 						Description: "Template referencing a deprecated instance type.",
 						SpecDefaults: privatev1.ComputeInstanceTemplateSpecDefaults_builder{
@@ -500,6 +527,9 @@ var _ = Describe("Private compute instance templates server", func() {
 
 				response, err := server.Create(ctx, privatev1.ComputeInstanceTemplatesCreateRequest_builder{
 					Object: privatev1.ComputeInstanceTemplate_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:       "Template with obsolete default",
 						Description: "Template referencing an obsolete instance type.",
 						SpecDefaults: privatev1.ComputeInstanceTemplateSpecDefaults_builder{
@@ -558,6 +588,9 @@ var _ = Describe("Private compute instance templates server", func() {
 
 				response, err := server.Create(ctx, privatev1.ComputeInstanceTemplatesCreateRequest_builder{
 					Object: privatev1.ComputeInstanceTemplate_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:       "Template with active default",
 						Description: "Template referencing an active instance type.",
 						SpecDefaults: privatev1.ComputeInstanceTemplateSpecDefaults_builder{
@@ -573,6 +606,9 @@ var _ = Describe("Private compute instance templates server", func() {
 			It("Rejects Create when spec_defaults references a non-existent instance type", func() {
 				response, err := server.Create(ctx, privatev1.ComputeInstanceTemplatesCreateRequest_builder{
 					Object: privatev1.ComputeInstanceTemplate_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:       "Template with missing default",
 						Description: "Template referencing a non-existent instance type.",
 						SpecDefaults: privatev1.ComputeInstanceTemplateSpecDefaults_builder{

--- a/fulfillment-service/internal/servers/private_compute_instances_server_test.go
+++ b/fulfillment-service/internal/servers/private_compute_instances_server_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
@@ -346,6 +347,9 @@ var _ = Describe("Private compute instances server", func() {
 
 			response, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 				Object: privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template:           privatev1.ComputeInstanceTemplateReference_builder{Id: "general.small"}.Build(),
 						TemplateParameters: templateParams,
@@ -378,6 +382,9 @@ var _ = Describe("Private compute instances server", func() {
 
 				_, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 					Object: privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.ComputeInstanceSpec_builder{
 							Template: privatev1.ComputeInstanceTemplateReference_builder{Id: templateID}.Build(),
 							NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -411,6 +418,9 @@ var _ = Describe("Private compute instances server", func() {
 
 				_, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 					Object: privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.ComputeInstanceSpec_builder{
 							Template: privatev1.ComputeInstanceTemplateReference_builder{Id: templateID}.Build(),
 							NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -446,6 +456,9 @@ var _ = Describe("Private compute instances server", func() {
 
 				_, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 					Object: privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.ComputeInstanceSpec_builder{
 							Template: privatev1.ComputeInstanceTemplateReference_builder{Id: templateID}.Build(),
 							NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -479,6 +492,9 @@ var _ = Describe("Private compute instances server", func() {
 			// Create an object:
 			createResponse, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 				Object: privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "general.small"}.Build(),
 						NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -570,6 +586,9 @@ var _ = Describe("Private compute instances server", func() {
 			// Create an object:
 			createResponse, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 				Object: privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "general.small"}.Build(),
 						NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -646,6 +665,9 @@ var _ = Describe("Private compute instances server", func() {
 			// Try to create with non-existent template:
 			response, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 				Object: privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "non-existent-template"}.Build(),
 					}.Build(),
@@ -807,6 +829,9 @@ var _ = Describe("Private compute instances server", func() {
 			// Try to create with empty template ID:
 			response, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 				Object: privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: ""}.Build(),
 					}.Build(),
@@ -826,6 +851,9 @@ var _ = Describe("Private compute instances server", func() {
 			// because template defaults cover all required fields.
 			response, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 				Object: privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "defaults-template"}.Build(),
 						NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -856,6 +884,9 @@ var _ = Describe("Private compute instances server", func() {
 			// Create with user-provided run_strategy (overrides template default):
 			response, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 				Object: privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template:    privatev1.ComputeInstanceTemplateReference_builder{Id: "override-template"}.Build(),
 						RunStrategy: new("Halted"),
@@ -903,6 +934,9 @@ var _ = Describe("Private compute instances server", func() {
 			// Create a compute instance without user-provided spec fields:
 			response, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 				Object: privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "no-defaults-template"}.Build(),
 						NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -948,6 +982,9 @@ var _ = Describe("Private compute instances server", func() {
 			// Create with all required fields provided by user:
 			response, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 				Object: privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template:     privatev1.ComputeInstanceTemplateReference_builder{Id: "bare-template"}.Build(),
 						InstanceType: privatev1.InstanceTypeReference_builder{Id: "standard-4-16"}.Build(),
@@ -999,6 +1036,9 @@ var _ = Describe("Private compute instances server", func() {
 			// User provides the remaining required fields:
 			response, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 				Object: privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "partial-defaults-template"}.Build(),
 						Image: privatev1.ComputeInstanceImage_builder{
@@ -1068,6 +1108,9 @@ var _ = Describe("Private compute instances server", func() {
 
 				response, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 					Object: privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.ComputeInstanceSpec_builder{
 							CatalogItem: privatev1.ComputeInstanceCatalogItemReference_builder{Id: "ci-cat-happy"}.Build(),
 							NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -1092,6 +1135,9 @@ var _ = Describe("Private compute instances server", func() {
 
 				response, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 					Object: privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.ComputeInstanceSpec_builder{
 							CatalogItem: privatev1.ComputeInstanceCatalogItemReference_builder{Id: "ci-cat-byname-name"}.Build(),
 							NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -1112,6 +1158,9 @@ var _ = Describe("Private compute instances server", func() {
 			It("Fails when catalog item not found", func() {
 				_, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 					Object: privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.ComputeInstanceSpec_builder{
 							CatalogItem: privatev1.ComputeInstanceCatalogItemReference_builder{Id: "nonexistent"}.Build(),
 							NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -1136,6 +1185,9 @@ var _ = Describe("Private compute instances server", func() {
 
 				_, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 					Object: privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.ComputeInstanceSpec_builder{
 							CatalogItem: privatev1.ComputeInstanceCatalogItemReference_builder{Id: "ci-cat-unpub"}.Build(),
 							NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -1171,6 +1223,9 @@ var _ = Describe("Private compute instances server", func() {
 
 				_, err = server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 					Object: privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.ComputeInstanceSpec_builder{
 							CatalogItem: privatev1.ComputeInstanceCatalogItemReference_builder{Id: "ci-cat-no-template"}.Build(),
 							NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -1193,6 +1248,9 @@ var _ = Describe("Private compute instances server", func() {
 			It("Fails when both catalog_item and template are set", func() {
 				_, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 					Object: privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.ComputeInstanceSpec_builder{
 							CatalogItem: privatev1.ComputeInstanceCatalogItemReference_builder{Id: "any-catalog-item"}.Build(),
 							Template:    privatev1.ComputeInstanceTemplateReference_builder{Id: "some-template"}.Build(),
@@ -1226,6 +1284,9 @@ var _ = Describe("Private compute instances server", func() {
 
 				_, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 					Object: privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.ComputeInstanceSpec_builder{
 							CatalogItem:  privatev1.ComputeInstanceCatalogItemReference_builder{Id: "ci-cat-nonedit"}.Build(),
 							SshPublicKey: new("user-key"),
@@ -1260,6 +1321,9 @@ var _ = Describe("Private compute instances server", func() {
 
 					response, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 						Object: privatev1.ComputeInstance_builder{
+							Metadata: privatev1.Metadata_builder{
+								Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+							}.Build(),
 							Spec: privatev1.ComputeInstanceSpec_builder{
 								CatalogItem:  privatev1.ComputeInstanceCatalogItemReference_builder{Id: catID}.Build(),
 								SshPublicKey: new(value),
@@ -1301,6 +1365,9 @@ var _ = Describe("Private compute instances server", func() {
 
 				response, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 					Object: privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.ComputeInstanceSpec_builder{
 							CatalogItem: privatev1.ComputeInstanceCatalogItemReference_builder{Id: "ci-cat-dflt"}.Build(),
 							NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -1392,6 +1459,9 @@ var _ = Describe("Private compute instances server", func() {
 
 				_, err = server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 					Object: privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.ComputeInstanceSpec_builder{
 							CatalogItem: privatev1.ComputeInstanceCatalogItemReference_builder{Id: "ci-cat-no-defaults"}.Build(),
 							NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -1461,6 +1531,9 @@ var _ = Describe("Private compute instances server", func() {
 				// Create via catalog item — should fail because instance type doesn't exist:
 				_, err = server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 					Object: privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.ComputeInstanceSpec_builder{
 							CatalogItem: privatev1.ComputeInstanceCatalogItemReference_builder{Id: "ci-cat-with-it"}.Build(),
 							NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -1528,6 +1601,9 @@ var _ = Describe("Private compute instances server", func() {
 				// Create via catalog item — should succeed:
 				response, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
 					Object: privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.ComputeInstanceSpec_builder{
 							CatalogItem: privatev1.ComputeInstanceCatalogItemReference_builder{Id: "ci-cat-valid-it"}.Build(),
 							NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -1655,6 +1731,9 @@ var _ = Describe("Private compute instances server", func() {
 				s2 := createTestSubnet(ctx, virtualNetwork.GetId(), privatev1.SubnetState_SUBNET_STATE_READY)
 
 				vm := privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: template.GetId()}.Build(),
 						NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -1679,6 +1758,9 @@ var _ = Describe("Private compute instances server", func() {
 		Context("Required network fields", func() {
 			It("Should reject when network_attachments is missing and no default subnet exists", func() {
 				vm := privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: template.GetId()}.Build(),
 					}.Build(),
@@ -1706,6 +1788,7 @@ var _ = Describe("Private compute instances server", func() {
 
 				defaultSubnet := privatev1.Subnet_builder{
 					Metadata: privatev1.Metadata_builder{
+						Name:   "test-default-subnet",
 						Tenant: auth.SharedTenant,
 						Labels: map[string]string{
 							"osac.openshift.io/default": "true",
@@ -1731,6 +1814,7 @@ var _ = Describe("Private compute instances server", func() {
 
 				defaultSG := privatev1.SecurityGroup_builder{
 					Metadata: privatev1.Metadata_builder{
+						Name:   "test-default-sg",
 						Tenant: auth.SharedTenant,
 						Labels: map[string]string{
 							"osac.openshift.io/default": "true",
@@ -1748,6 +1832,9 @@ var _ = Describe("Private compute instances server", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				vm := privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: template.GetId()}.Build(),
 					}.Build(),
@@ -1775,6 +1862,7 @@ var _ = Describe("Private compute instances server", func() {
 
 				defaultSubnet := privatev1.Subnet_builder{
 					Metadata: privatev1.Metadata_builder{
+						Name:   "test-default-subnet",
 						Tenant: auth.SharedTenant,
 						Labels: map[string]string{
 							"osac.openshift.io/default": "true",
@@ -1793,6 +1881,9 @@ var _ = Describe("Private compute instances server", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				vm := privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "test-pod-network-vm",
+					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: template.GetId()}.Build(),
 					}.Build(),
@@ -1819,6 +1910,7 @@ var _ = Describe("Private compute instances server", func() {
 
 				defaultSubnet := privatev1.Subnet_builder{
 					Metadata: privatev1.Metadata_builder{
+						Name:   "test-default-subnet",
 						Tenant: auth.SharedTenant,
 						Labels: map[string]string{
 							"osac.openshift.io/default": "true",
@@ -1837,6 +1929,9 @@ var _ = Describe("Private compute instances server", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				vm := privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "pod-network-vm",
+					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: template.GetId()}.Build(),
 					}.Build(),
@@ -1907,6 +2002,9 @@ var _ = Describe("Private compute instances server", func() {
 		Context("NetworkAttachments validation", func() {
 			It("Should reject when subnet not found in network_attachments", func() {
 				vm := privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: template.GetId()}.Build(),
 						NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -1932,6 +2030,9 @@ var _ = Describe("Private compute instances server", func() {
 				subnet := createTestSubnet(ctx, virtualNetwork.GetId(), privatev1.SubnetState_SUBNET_STATE_PENDING)
 
 				vm := privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: template.GetId()}.Build(),
 						NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -1957,6 +2058,9 @@ var _ = Describe("Private compute instances server", func() {
 				subnet := createTestSubnet(ctx, virtualNetwork.GetId(), privatev1.SubnetState_SUBNET_STATE_READY)
 
 				vm := privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: template.GetId()}.Build(),
 						NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -1988,6 +2092,9 @@ var _ = Describe("Private compute instances server", func() {
 				wrongSG := createTestSecurityGroup(ctx, otherVNet.GetId(), privatev1.SecurityGroupState_SECURITY_GROUP_STATE_READY)
 
 				vm := privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: template.GetId()}.Build(),
 						NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -2016,6 +2123,9 @@ var _ = Describe("Private compute instances server", func() {
 				subnet := createTestSubnet(ctx, virtualNetwork.GetId(), privatev1.SubnetState_SUBNET_STATE_READY)
 
 				vm := privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: template.GetId()}.Build(),
 						NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -2042,6 +2152,9 @@ var _ = Describe("Private compute instances server", func() {
 				sg := createTestSecurityGroup(ctx, virtualNetwork.GetId(), privatev1.SecurityGroupState_SECURITY_GROUP_STATE_PENDING)
 
 				vm := privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: template.GetId()}.Build(),
 						NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -2390,6 +2503,9 @@ var _ = Describe("Private compute instances server", func() {
 
 				return privatev1.ComputeInstancesCreateRequest_builder{
 					Object: privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.ComputeInstanceSpec_builder{
 							Template:     privatev1.ComputeInstanceTemplateReference_builder{Id: templateID}.Build(),
 							InstanceType: privatev1.InstanceTypeReference_builder{Id: instanceTypeName}.Build(),

--- a/fulfillment-service/internal/servers/private_external_ip_attachments_server_test.go
+++ b/fulfillment-service/internal/servers/private_external_ip_attachments_server_test.go
@@ -15,7 +15,9 @@ package servers
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
@@ -246,6 +248,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			response, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 						Cluster:        privatev1.ClusterLocalReference_builder{Id: cluster.GetId()}.Build(),
@@ -265,6 +270,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			response, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp:        privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 						BaremetalInstance: privatev1.BareMetalInstanceLocalReference_builder{Id: bmi.GetId()}.Build(),
@@ -287,6 +295,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp:      privatev1.ExternalIPLocalReference_builder{Id: eip1.GetId()}.Build(),
 						ComputeInstance: privatev1.ComputeInstanceLocalReference_builder{Id: ci1.GetId()}.Build(),
@@ -297,6 +308,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			_, err = server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp:      privatev1.ExternalIPLocalReference_builder{Id: eip2.GetId()}.Build(),
 						ComputeInstance: privatev1.ComputeInstanceLocalReference_builder{Id: ci2.GetId()}.Build(),
@@ -381,6 +395,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			createResponse, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp:      privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 						ComputeInstance: privatev1.ComputeInstanceLocalReference_builder{Id: ci.GetId()}.Build(),
@@ -403,6 +420,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			createResponse, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp:      privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 						ComputeInstance: privatev1.ComputeInstanceLocalReference_builder{Id: ci.GetId()}.Build(),
@@ -446,6 +466,9 @@ var _ = Describe("Private external IP attachments server", func() {
 		It("Rejects Create with empty spec.external_ip", func() {
 			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ComputeInstance: privatev1.ComputeInstanceLocalReference_builder{Id: "some-ci"}.Build(),
 					}.Build(),
@@ -461,6 +484,9 @@ var _ = Describe("Private external IP attachments server", func() {
 		It("Rejects Create with no target set", func() {
 			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp: privatev1.ExternalIPLocalReference_builder{Id: "some-ip"}.Build(),
 					}.Build(),
@@ -480,6 +506,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp: privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 						Cluster:    privatev1.ClusterLocalReference_builder{Id: cluster.GetId()}.Build(),
@@ -502,6 +531,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp:      privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 						ComputeInstance: privatev1.ComputeInstanceLocalReference_builder{Id: ci.GetId()}.Build(),
@@ -525,6 +557,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp:      privatev1.ExternalIPLocalReference_builder{Id: "nonexistent-external-ip-id"}.Build(),
 						ComputeInstance: privatev1.ComputeInstanceLocalReference_builder{Id: ci.GetId()}.Build(),
@@ -546,6 +581,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp:      privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 						ComputeInstance: privatev1.ComputeInstanceLocalReference_builder{Id: ci.GetId()}.Build(),
@@ -567,6 +605,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp:      privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 						ComputeInstance: privatev1.ComputeInstanceLocalReference_builder{Id: ci.GetId()}.Build(),
@@ -588,6 +629,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp:      privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 						ComputeInstance: privatev1.ComputeInstanceLocalReference_builder{Id: "nonexistent-ci-id"}.Build(),
@@ -608,6 +652,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 						Cluster:        privatev1.ClusterLocalReference_builder{Id: "nonexistent-cluster-id"}.Build(),
@@ -629,6 +676,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp:        privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 						BaremetalInstance: privatev1.BareMetalInstanceLocalReference_builder{Id: "nonexistent-bmi-id"}.Build(),
@@ -655,6 +705,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp:      privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 						ComputeInstance: privatev1.ComputeInstanceLocalReference_builder{Id: ci1.GetId()}.Build(),
@@ -665,6 +718,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			_, err = server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp:      privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 						ComputeInstance: privatev1.ComputeInstanceLocalReference_builder{Id: ci2.GetId()}.Build(),
@@ -688,6 +744,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp:      privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 						ComputeInstance: privatev1.ComputeInstanceLocalReference_builder{Id: ci1.GetId()}.Build(),
@@ -705,6 +764,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			_, err = server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp:      privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 						ComputeInstance: privatev1.ComputeInstanceLocalReference_builder{Id: ci2.GetId()}.Build(),
@@ -728,6 +790,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			createResponse, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp:      privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 						ComputeInstance: privatev1.ComputeInstanceLocalReference_builder{Id: ci.GetId()}.Build(),
@@ -765,6 +830,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			createResponse, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp:      privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 						ComputeInstance: privatev1.ComputeInstanceLocalReference_builder{Id: ci.GetId()}.Build(),
@@ -805,6 +873,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			_, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp:      privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 						ComputeInstance: privatev1.ComputeInstanceLocalReference_builder{Id: ci.GetId()}.Build(),
@@ -826,6 +897,9 @@ var _ = Describe("Private external IP attachments server", func() {
 
 			createResp, err := server.Create(ctx, privatev1.ExternalIPAttachmentsCreateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPAttachmentSpec_builder{
 						ExternalIp:      privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 						ComputeInstance: privatev1.ComputeInstanceLocalReference_builder{Id: ci.GetId()}.Build(),

--- a/fulfillment-service/internal/servers/private_external_ip_pools_server_test.go
+++ b/fulfillment-service/internal/servers/private_external_ip_pools_server_test.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
@@ -84,6 +85,9 @@ var _ = Describe("Private external IP pools server", func() {
 		It("Creates a pool", func() {
 			response, err := poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
 				Object: privatev1.ExternalIPPool_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPPoolSpec_builder{
 						Cidrs:    []string{"192.168.1.0/24"},
 						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
@@ -123,6 +127,9 @@ var _ = Describe("Private external IP pools server", func() {
 		It("Gets a pool", func() {
 			createResponse, err := poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
 				Object: privatev1.ExternalIPPool_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPPoolSpec_builder{
 						Cidrs:    []string{"192.168.1.0/24"},
 						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
@@ -249,6 +256,9 @@ var _ = Describe("Private external IP pools server", func() {
 		It("Allows deletion when no ExternalIPs reference the pool", func() {
 			createPoolResponse, err := poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
 				Object: privatev1.ExternalIPPool_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.ExternalIPPoolSpec_builder{
 						Cidrs:    []string{"10.1.0.0/24"},
 						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
@@ -282,6 +292,9 @@ var _ = Describe("Private external IP pools server", func() {
 		Context("ip_family validation", func() {
 			It("rejects pool with unspecified ip_family", func() {
 				pool := privatev1.ExternalIPPool_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "test-pool-ip-family",
+					}.Build(),
 					Spec: privatev1.ExternalIPPoolSpec_builder{
 						Cidrs: []string{"192.168.1.0/24"},
 					}.Build(),
@@ -299,6 +312,9 @@ var _ = Describe("Private external IP pools server", func() {
 		Context("CIDRs required", func() {
 			It("rejects pool with no CIDRs", func() {
 				pool := privatev1.ExternalIPPool_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "test-pool-cidrs",
+					}.Build(),
 					Spec: privatev1.ExternalIPPoolSpec_builder{
 						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
 					}.Build(),
@@ -316,6 +332,9 @@ var _ = Describe("Private external IP pools server", func() {
 		Context("CIDR format validation", func() {
 			It("rejects malformed CIDR", func() {
 				pool := privatev1.ExternalIPPool_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "test-pool-cidr-format",
+					}.Build(),
 					Spec: privatev1.ExternalIPPoolSpec_builder{
 						Cidrs:    []string{"not-a-cidr"},
 						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
@@ -334,6 +353,9 @@ var _ = Describe("Private external IP pools server", func() {
 		Context("IP family consistency", func() {
 			It("rejects IPv6 CIDR in an IPv4 pool", func() {
 				pool := privatev1.ExternalIPPool_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "test-pool-ip-family",
+					}.Build(),
 					Spec: privatev1.ExternalIPPoolSpec_builder{
 						Cidrs:    []string{"2001:db8::/64"},
 						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
@@ -350,6 +372,9 @@ var _ = Describe("Private external IP pools server", func() {
 
 			It("canonicalizes non-canonical CIDRs on Create", func() {
 				pool := privatev1.ExternalIPPool_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "test-pool-ip-family",
+					}.Build(),
 					Spec: privatev1.ExternalIPPoolSpec_builder{
 						Cidrs:    []string{"10.0.1.5/24"},
 						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
@@ -395,6 +420,9 @@ var _ = Describe("Private external IP pools server", func() {
 			It("accepts a pool with a non-overlapping CIDR", func() {
 				_, err := poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
 					Object: privatev1.ExternalIPPool_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.ExternalIPPoolSpec_builder{
 							Cidrs:    []string{"10.0.0.0/24"},
 							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
@@ -405,6 +433,9 @@ var _ = Describe("Private external IP pools server", func() {
 
 				_, err = poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
 					Object: privatev1.ExternalIPPool_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.ExternalIPPoolSpec_builder{
 							Cidrs:    []string{"10.0.1.0/24"},
 							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
@@ -418,6 +449,9 @@ var _ = Describe("Private external IP pools server", func() {
 		Context("Intra-pool CIDR overlap detection", func() {
 			It("rejects a pool whose second CIDR is a subset of the first", func() {
 				pool := privatev1.ExternalIPPool_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: "test-pool-intra-pool-overlap",
+					}.Build(),
 					Spec: privatev1.ExternalIPPoolSpec_builder{
 						Cidrs:    []string{"10.0.0.0/24", "10.0.0.0/25"},
 						IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
@@ -437,6 +471,9 @@ var _ = Describe("Private external IP pools server", func() {
 			It("sets status.total to 254 for a /24 IPv4 CIDR", func() {
 				response, err := poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
 					Object: privatev1.ExternalIPPool_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.ExternalIPPoolSpec_builder{
 							Cidrs:    []string{"192.168.1.0/24"},
 							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,
@@ -450,6 +487,9 @@ var _ = Describe("Private external IP pools server", func() {
 			It("sets status.available equal to status.total on a new pool", func() {
 				response, err := poolsServer.Create(ctx, privatev1.ExternalIPPoolsCreateRequest_builder{
 					Object: privatev1.ExternalIPPool_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.ExternalIPPoolSpec_builder{
 							Cidrs:    []string{"10.0.0.0/24"},
 							IpFamily: privatev1.IPFamily_IP_FAMILY_IPV4,

--- a/fulfillment-service/internal/servers/private_host_types_server_test.go
+++ b/fulfillment-service/internal/servers/private_host_types_server_test.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
@@ -84,6 +85,9 @@ var _ = Describe("Private host types server", func() {
 		It("Creates object", func() {
 			response, err := server.Create(ctx, privatev1.HostTypesCreateRequest_builder{
 				Object: privatev1.HostType_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My title",
 					Description: "My description.",
 				}.Build(),
@@ -101,6 +105,9 @@ var _ = Describe("Private host types server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, privatev1.HostTypesCreateRequest_builder{
 					Object: privatev1.HostType_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:       fmt.Sprintf("My title %d", i),
 						Description: fmt.Sprintf("My description %d.", i),
 					}.Build(),
@@ -122,6 +129,9 @@ var _ = Describe("Private host types server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, privatev1.HostTypesCreateRequest_builder{
 					Object: privatev1.HostType_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:       fmt.Sprintf("My title %d", i),
 						Description: fmt.Sprintf("My description %d.", i),
 					}.Build(),
@@ -143,6 +153,9 @@ var _ = Describe("Private host types server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, privatev1.HostTypesCreateRequest_builder{
 					Object: privatev1.HostType_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:       fmt.Sprintf("My title %d", i),
 						Description: fmt.Sprintf("My description %d.", i),
 					}.Build(),
@@ -165,6 +178,9 @@ var _ = Describe("Private host types server", func() {
 			for i := range count {
 				response, err := server.Create(ctx, privatev1.HostTypesCreateRequest_builder{
 					Object: privatev1.HostType_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Title:       fmt.Sprintf("My title %d", i),
 						Description: fmt.Sprintf("My description %d.", i),
 					}.Build(),
@@ -188,6 +204,9 @@ var _ = Describe("Private host types server", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, privatev1.HostTypesCreateRequest_builder{
 				Object: privatev1.HostType_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Title:       "My title",
 					Description: "My description.",
 				}.Build(),

--- a/fulfillment-service/internal/servers/private_hubs_server_test.go
+++ b/fulfillment-service/internal/servers/private_hubs_server_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
@@ -85,6 +86,9 @@ var _ = Describe("Private hubs server", func() {
 		It("Creates object", func() {
 			response, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
 				Object: privatev1.Hub_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.HubSpec_builder{
 						Kubeconfig: []byte("my_config"),
 						Namespace:  "my_ns",
@@ -104,6 +108,9 @@ var _ = Describe("Private hubs server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
 					Object: privatev1.Hub_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.HubSpec_builder{
 							Kubeconfig: []byte(fmt.Sprintf("my_config_%d", i)),
 							Namespace:  fmt.Sprintf("my_ns_%d", i),
@@ -127,6 +134,9 @@ var _ = Describe("Private hubs server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
 					Object: privatev1.Hub_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.HubSpec_builder{
 							Kubeconfig: []byte(fmt.Sprintf("my_config_%d", i)),
 							Namespace:  fmt.Sprintf("my_ns_%d", i),
@@ -150,6 +160,9 @@ var _ = Describe("Private hubs server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
 					Object: privatev1.Hub_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.HubSpec_builder{
 							Kubeconfig: []byte(fmt.Sprintf("my_config_%d", i)),
 							Namespace:  fmt.Sprintf("my_ns_%d", i),
@@ -174,6 +187,9 @@ var _ = Describe("Private hubs server", func() {
 			for i := range count {
 				response, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
 					Object: privatev1.Hub_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: privatev1.HubSpec_builder{
 							Kubeconfig: []byte(fmt.Sprintf("my_config_%d", i)),
 							Namespace:  fmt.Sprintf("my_ns_%d", i),
@@ -199,6 +215,9 @@ var _ = Describe("Private hubs server", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
 				Object: privatev1.Hub_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.HubSpec_builder{
 						Kubeconfig: []byte("my_config"),
 						Namespace:  "my_ns",
@@ -219,6 +238,9 @@ var _ = Describe("Private hubs server", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
 				Object: privatev1.Hub_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.HubSpec_builder{
 						Kubeconfig: []byte("my_config"),
 						Namespace:  "my_ns",
@@ -256,6 +278,7 @@ var _ = Describe("Private hubs server", func() {
 			createResponse, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
 				Object: privatev1.Hub_builder{
 					Metadata: privatev1.Metadata_builder{
+						Name:       "test-hub",
 						Finalizers: []string{"a"},
 					}.Build(),
 					Spec: privatev1.HubSpec_builder{
@@ -308,6 +331,9 @@ var _ = Describe("Private hubs server", func() {
 		response, err := server.Create(
 			ctx, privatev1.HubsCreateRequest_builder{
 				Object: privatev1.Hub_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.HubSpec_builder{
 						Kubeconfig: []byte("my_config"),
 					}.Build(),

--- a/fulfillment-service/internal/servers/private_identity_providers_server_test.go
+++ b/fulfillment-service/internal/servers/private_identity_providers_server_test.go
@@ -278,9 +278,10 @@ var _ = Describe("Private identity providers server", func() {
 			Expect(updateResp.Object.Spec.Title).To(Equal("Updated OIDC Title"))
 		})
 
-		It("Accepts creation of an identity provider without a name", func() {
-			// Identity providers can have empty names (name is not mandatory)
-			response, err := server.Create(ctx, privatev1.IdentityProvidersCreateRequest_builder{
+		It("Creates an identity provider without a name when interceptor is not present", func() {
+			// Name validation is enforced by the protovalidate interceptor, not the server handler.
+			// In unit tests (no interceptor), creating with an empty name succeeds.
+			_, err := server.Create(ctx, privatev1.IdentityProvidersCreateRequest_builder{
 				Object: privatev1.IdentityProvider_builder{
 					Metadata: privatev1.Metadata_builder{
 						Tenant: "my-tenant",
@@ -299,9 +300,6 @@ var _ = Describe("Private identity providers server", func() {
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(response).ToNot(BeNil())
-			// Tenant should be preserved from the request
-			Expect(response.Object.Metadata.Tenant).To(Equal("my-tenant"))
 		})
 
 		It("Rejects update of the name of an identity provider", func() {

--- a/fulfillment-service/internal/servers/private_nat_gateways_server_test.go
+++ b/fulfillment-service/internal/servers/private_nat_gateways_server_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			eip := createAllocatedExternalIP()
 			response, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -167,7 +167,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			eip := createAllocatedExternalIP()
 			response, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -186,7 +186,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			eip := createAllocatedExternalIP()
 			createResponse, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -209,7 +209,7 @@ var _ = Describe("Private NAT gateways server", func() {
 				eip := createAllocatedExternalIP()
 				_, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 					Object: privatev1.NATGateway_builder{
-						Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+						Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
 						Spec: privatev1.NATGatewaySpec_builder{
 							VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vn}.Build(),
 							ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -228,7 +228,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			eip := createAllocatedExternalIP()
 			createResponse, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -251,6 +251,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			createResponse, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
 					Metadata: privatev1.Metadata_builder{
+						Name:       "test-nat-gateway",
 						Finalizers: []string{"test-finalizer"},
 						Tenant:     auth.SharedTenant,
 					}.Build(),
@@ -278,7 +279,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			eip := createAllocatedExternalIP()
 			createResponse, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -317,7 +318,7 @@ var _ = Describe("Private NAT gateways server", func() {
 		It("rejects Create with nil spec", func() {
 			_, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
 				}.Build(),
 			}.Build())
 			Expect(err).To(HaveOccurred())
@@ -329,7 +330,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			eip := createAllocatedExternalIP()
 			_, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						ExternalIp: privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 					}.Build(),
@@ -344,7 +345,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			vnID := createVirtualNetwork()
 			_, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 					}.Build(),
@@ -373,7 +374,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			vnID := createVirtualNetwork()
 			_, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: "nonexistent-id"}.Build(),
@@ -391,7 +392,7 @@ var _ = Describe("Private NAT gateways server", func() {
 				privatev1.ExternalIPState_EXTERNAL_IP_STATE_PENDING, false)
 			_, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -409,7 +410,7 @@ var _ = Describe("Private NAT gateways server", func() {
 				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, true)
 			_, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -440,7 +441,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			eip := createAllocatedExternalIP()
 			createResponse, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -468,7 +469,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			eip := createAllocatedExternalIP()
 			createResponse, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -510,7 +511,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			eip := createAllocatedExternalIP()
 			_, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -530,6 +531,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			createResponse, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
 					Metadata: privatev1.Metadata_builder{
+						Name:       "test-nat-gateway",
 						Finalizers: []string{"test-finalizer"},
 						Tenant:     auth.SharedTenant,
 					}.Build(),
@@ -557,6 +559,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			createResponse, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
 					Metadata: privatev1.Metadata_builder{
+						Name:       "test-nat-gateway",
 						Finalizers: []string{"test-finalizer"},
 						Tenant:     auth.SharedTenant,
 						Labels: map[string]string{

--- a/fulfillment-service/internal/servers/private_secrets_server_test.go
+++ b/fulfillment-service/internal/servers/private_secrets_server_test.go
@@ -294,6 +294,9 @@ var _ = Describe("Private secrets server", func() {
 			It("Create without name fails", func() {
 				_, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
 					Object: privatev1.Secret_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "",
+						}.Build(),
 						Spec: privatev1.SecretSpec_builder{
 							Data: map[string][]byte{
 								"key": []byte("value"),

--- a/fulfillment-service/internal/servers/private_storage_tiers_server_test.go
+++ b/fulfillment-service/internal/servers/private_storage_tiers_server_test.go
@@ -420,6 +420,9 @@ var _ = Describe("Private storage tiers server", func() {
 			It("Create without name fails", func() {
 				_, err := server.Create(ctx, privatev1.StorageTiersCreateRequest_builder{
 					Object: privatev1.StorageTier_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "",
+						}.Build(),
 						Spec: privatev1.StorageTierSpec_builder{
 							Backends: []*privatev1.BackendAssociation{
 								privatev1.BackendAssociation_builder{

--- a/fulfillment-service/internal/servers/private_subnets_server_test.go
+++ b/fulfillment-service/internal/servers/private_subnets_server_test.go
@@ -384,6 +384,7 @@ var _ = Describe("Private subnets server", func() {
 				createResponse, err := server.Create(ctx, privatev1.SubnetsCreateRequest_builder{
 					Object: privatev1.Subnet_builder{
 						Metadata: privatev1.Metadata_builder{
+							Name:   "test-subnet",
 							Tenant: auth.SharedTenant,
 						}.Build(),
 						Spec: privatev1.SubnetSpec_builder{
@@ -1104,6 +1105,7 @@ var _ = Describe("Private subnets server", func() {
 				createResponse, err := server.Create(ctx, privatev1.SubnetsCreateRequest_builder{
 					Object: privatev1.Subnet_builder{
 						Metadata: privatev1.Metadata_builder{
+							Name:   "test-subnet",
 							Tenant: auth.SharedTenant,
 						}.Build(),
 						Spec: privatev1.SubnetSpec_builder{
@@ -1289,6 +1291,7 @@ var _ = Describe("Private subnets server", func() {
 				createResponse, err := server.Create(ctx, privatev1.SubnetsCreateRequest_builder{
 					Object: privatev1.Subnet_builder{
 						Metadata: privatev1.Metadata_builder{
+							Name:   "test-subnet",
 							Tenant: auth.SharedTenant,
 						}.Build(),
 						Spec: privatev1.SubnetSpec_builder{
@@ -1332,6 +1335,7 @@ var _ = Describe("Private subnets server", func() {
 				createResponse, err := server.Create(ctx, privatev1.SubnetsCreateRequest_builder{
 					Object: privatev1.Subnet_builder{
 						Metadata: privatev1.Metadata_builder{
+							Name:   "test-subnet",
 							Tenant: auth.SharedTenant,
 						}.Build(),
 						Spec: privatev1.SubnetSpec_builder{
@@ -1360,6 +1364,7 @@ var _ = Describe("Private subnets server", func() {
 				createResponse, err := server.Create(ctx, privatev1.SubnetsCreateRequest_builder{
 					Object: privatev1.Subnet_builder{
 						Metadata: privatev1.Metadata_builder{
+							Name:   "test-subnet",
 							Tenant: auth.SharedTenant,
 						}.Build(),
 						Spec: privatev1.SubnetSpec_builder{
@@ -1403,6 +1408,7 @@ var _ = Describe("Private subnets server", func() {
 				createResponse, err := server.Create(ctx, privatev1.SubnetsCreateRequest_builder{
 					Object: privatev1.Subnet_builder{
 						Metadata: privatev1.Metadata_builder{
+							Name:   "test-subnet",
 							Tenant: auth.SharedTenant,
 						}.Build(),
 						Spec: privatev1.SubnetSpec_builder{
@@ -1449,6 +1455,7 @@ var _ = Describe("Private subnets server", func() {
 				createResponse, err := server.Create(ctx, privatev1.SubnetsCreateRequest_builder{
 					Object: privatev1.Subnet_builder{
 						Metadata: privatev1.Metadata_builder{
+							Name:   "test-subnet",
 							Tenant: auth.SharedTenant,
 							Labels: map[string]string{
 								"osac.openshift.io/default": "true",

--- a/fulfillment-service/internal/servers/private_virtual_networks_server_test.go
+++ b/fulfillment-service/internal/servers/private_virtual_networks_server_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
@@ -310,6 +311,7 @@ var _ = Describe("Private virtual networks server", func() {
 				createResponse, err := server.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 					Object: privatev1.VirtualNetwork_builder{
 						Metadata: privatev1.Metadata_builder{
+							Name:   "test-virtual-network",
 							Tenant: auth.SharedTenant,
 						}.Build(),
 						Spec: privatev1.VirtualNetworkSpec_builder{
@@ -774,6 +776,7 @@ var _ = Describe("Private virtual networks server", func() {
 				createResponse, err := server.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 					Object: privatev1.VirtualNetwork_builder{
 						Metadata: privatev1.Metadata_builder{
+							Name:   "test-virtual-network",
 							Tenant: auth.SharedTenant,
 						}.Build(),
 						Spec: privatev1.VirtualNetworkSpec_builder{
@@ -1040,6 +1043,7 @@ var _ = Describe("Private virtual networks server", func() {
 				createResponse, err := server.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 					Object: privatev1.VirtualNetwork_builder{
 						Metadata: privatev1.Metadata_builder{
+							Name:   "test-virtual-network",
 							Tenant: auth.SharedTenant,
 						}.Build(),
 						Spec: privatev1.VirtualNetworkSpec_builder{
@@ -1331,6 +1335,9 @@ var _ = Describe("Private virtual networks server", func() {
 			// Create VN without network_class:
 			createResponse, err := vnServer.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 				Object: privatev1.VirtualNetwork_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Ipv4Cidr: new("10.0.0.0/16"),
 						Region:   "us-west-1",
@@ -1348,6 +1355,9 @@ var _ = Describe("Private virtual networks server", func() {
 			// Create VN without network_class (no default configured):
 			_, err := vnServer.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 				Object: privatev1.VirtualNetwork_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Ipv4Cidr: new("10.0.0.0/16"),
 						Region:   "us-west-1",
@@ -1368,6 +1378,9 @@ var _ = Describe("Private virtual networks server", func() {
 			// Create VN with explicit network_class=NC-B:
 			createResponse, err := vnServer.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 				Object: privatev1.VirtualNetwork_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Ipv4Cidr:     new("10.0.0.0/16"),
 						Region:       "us-west-1",
@@ -1386,6 +1399,9 @@ var _ = Describe("Private virtual networks server", func() {
 			// Create VN without network_class (default is not READY):
 			_, err := vnServer.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 				Object: privatev1.VirtualNetwork_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Ipv4Cidr: new("10.0.0.0/16"),
 						Region:   "us-west-1",
@@ -1428,6 +1444,9 @@ var _ = Describe("Private virtual networks server", func() {
 			// Must set both capabilities AND ipv6_cidr to trigger VN-VAL-06 check.
 			_, err = vnServer.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 				Object: privatev1.VirtualNetwork_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Ipv6Cidr: new("2001:db8::/32"),
 						Region:   "us-west-1",
@@ -1458,6 +1477,9 @@ var _ = Describe("Private virtual networks server", func() {
 			// Attempt to create VN without network_class (no default exists now):
 			_, err := vnServer.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 				Object: privatev1.VirtualNetwork_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Ipv4Cidr: new("10.0.0.0/16"),
 						Region:   "us-west-1",
@@ -1485,6 +1507,9 @@ var _ = Describe("Private virtual networks server", func() {
 			// soft-deleted rows, so no active default is found and creation fails.
 			_, err = vnServer.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 				Object: privatev1.VirtualNetwork_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Ipv4Cidr: new("10.0.0.0/16"),
 						Region:   "us-west-1",
@@ -1502,6 +1527,9 @@ var _ = Describe("Private virtual networks server", func() {
 			// Create VN without network_class (auto-populated):
 			createResponse, err := vnServer.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 				Object: privatev1.VirtualNetwork_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Ipv4Cidr: new("10.0.0.0/16"),
 						Region:   "us-west-1",
@@ -1569,6 +1597,7 @@ var _ = Describe("Private virtual networks server", func() {
 			createResp, err := vnServer.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 				Object: privatev1.VirtualNetwork_builder{
 					Metadata: privatev1.Metadata_builder{
+						Name:   "test-virtual-network",
 						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
@@ -1749,6 +1778,7 @@ var _ = Describe("Private virtual networks server", func() {
 			createResp, err := vnServer.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 				Object: privatev1.VirtualNetwork_builder{
 					Metadata: privatev1.Metadata_builder{
+						Name:   "default-virtual-network",
 						Tenant: auth.SharedTenant,
 						Labels: map[string]string{
 							"osac.openshift.io/default": "true",

--- a/fulfillment-service/internal/servers/security_groups_server_test.go
+++ b/fulfillment-service/internal/servers/security_groups_server_test.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
@@ -144,6 +145,9 @@ var _ = Describe("SecurityGroups server", func() {
 		It("Creates object", func() {
 			response, err := server.Create(ctx, publicv1.SecurityGroupsCreateRequest_builder{
 				Object: publicv1.SecurityGroup_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.SecurityGroupSpec_builder{
 						VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: virtualNetworkID}.Build(),
 						Ingress: []*publicv1.SecurityRule{
@@ -211,6 +215,9 @@ var _ = Describe("SecurityGroups server", func() {
 			for range count {
 				_, err := server.Create(ctx, publicv1.SecurityGroupsCreateRequest_builder{
 					Object: publicv1.SecurityGroup_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: publicv1.SecurityGroupSpec_builder{
 							VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: virtualNetworkID}.Build(),
 						}.Build(),
@@ -233,6 +240,9 @@ var _ = Describe("SecurityGroups server", func() {
 			for range count {
 				_, err := server.Create(ctx, publicv1.SecurityGroupsCreateRequest_builder{
 					Object: publicv1.SecurityGroup_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: publicv1.SecurityGroupSpec_builder{
 							VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: virtualNetworkID}.Build(),
 						}.Build(),
@@ -256,6 +266,9 @@ var _ = Describe("SecurityGroups server", func() {
 			for range count {
 				response, err := server.Create(ctx, publicv1.SecurityGroupsCreateRequest_builder{
 					Object: publicv1.SecurityGroup_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: publicv1.SecurityGroupSpec_builder{
 							VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: virtualNetworkID}.Build(),
 						}.Build(),
@@ -280,6 +293,9 @@ var _ = Describe("SecurityGroups server", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, publicv1.SecurityGroupsCreateRequest_builder{
 				Object: publicv1.SecurityGroup_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.SecurityGroupSpec_builder{
 						VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: virtualNetworkID}.Build(),
 						Ingress: []*publicv1.SecurityRule{
@@ -306,6 +322,9 @@ var _ = Describe("SecurityGroups server", func() {
 		It("Canonicalizes non-canonical rule CIDRs on Create", func() {
 			response, err := server.Create(ctx, publicv1.SecurityGroupsCreateRequest_builder{
 				Object: publicv1.SecurityGroup_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.SecurityGroupSpec_builder{
 						VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: virtualNetworkID}.Build(),
 						Ingress: []*publicv1.SecurityRule{
@@ -332,6 +351,9 @@ var _ = Describe("SecurityGroups server", func() {
 		It("Canonicalizes rule CIDRs on Update", func() {
 			createResponse, err := server.Create(ctx, publicv1.SecurityGroupsCreateRequest_builder{
 				Object: publicv1.SecurityGroup_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.SecurityGroupSpec_builder{
 						VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: virtualNetworkID}.Build(),
 						Ingress: []*publicv1.SecurityRule{
@@ -431,6 +453,9 @@ var _ = Describe("SecurityGroups server", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, publicv1.SecurityGroupsCreateRequest_builder{
 				Object: publicv1.SecurityGroup_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.SecurityGroupSpec_builder{
 						VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: virtualNetworkID}.Build(),
 					}.Build(),
@@ -470,6 +495,7 @@ var _ = Describe("SecurityGroups server", func() {
 			createResponse, err := server.Create(ctx, publicv1.SecurityGroupsCreateRequest_builder{
 				Object: publicv1.SecurityGroup_builder{
 					Metadata: publicv1.Metadata_builder{
+						Name: "default-security-group",
 						Labels: map[string]string{
 							"osac.openshift.io/default": "true",
 						},

--- a/fulfillment-service/internal/servers/subnets_server_test.go
+++ b/fulfillment-service/internal/servers/subnets_server_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
@@ -165,6 +166,9 @@ var _ = Describe("Subnets server", func() {
 		It("Creates object", func() {
 			response, err := server.Create(ctx, publicv1.SubnetsCreateRequest_builder{
 				Object: publicv1.Subnet_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.SubnetSpec_builder{
 						VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: virtualNetworkID}.Build(),
 						Ipv4Cidr:       new("10.0.1.0/24"),
@@ -184,6 +188,9 @@ var _ = Describe("Subnets server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, publicv1.SubnetsCreateRequest_builder{
 					Object: publicv1.Subnet_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: publicv1.SubnetSpec_builder{
 							VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: virtualNetworkID}.Build(),
 							Ipv4Cidr:       new(fmt.Sprintf("10.0.%d.0/24", i+1)),
@@ -207,6 +214,9 @@ var _ = Describe("Subnets server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, publicv1.SubnetsCreateRequest_builder{
 					Object: publicv1.Subnet_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: publicv1.SubnetSpec_builder{
 							VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: virtualNetworkID}.Build(),
 							Ipv4Cidr:       new(fmt.Sprintf("10.0.%d.0/24", i+1)),
@@ -230,6 +240,9 @@ var _ = Describe("Subnets server", func() {
 			for i := range count {
 				_, err := server.Create(ctx, publicv1.SubnetsCreateRequest_builder{
 					Object: publicv1.Subnet_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: publicv1.SubnetSpec_builder{
 							VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: virtualNetworkID}.Build(),
 							Ipv4Cidr:       new(fmt.Sprintf("10.0.%d.0/24", i+1)),
@@ -254,6 +267,9 @@ var _ = Describe("Subnets server", func() {
 			for i := range count {
 				response, err := server.Create(ctx, publicv1.SubnetsCreateRequest_builder{
 					Object: publicv1.Subnet_builder{
+						Metadata: publicv1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
 						Spec: publicv1.SubnetSpec_builder{
 							VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: virtualNetworkID}.Build(),
 							Ipv4Cidr:       new(fmt.Sprintf("10.0.%d.0/24", i+1)),
@@ -279,6 +295,9 @@ var _ = Describe("Subnets server", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, publicv1.SubnetsCreateRequest_builder{
 				Object: publicv1.Subnet_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.SubnetSpec_builder{
 						VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: virtualNetworkID}.Build(),
 						Ipv4Cidr:       new("10.0.1.0/24"),
@@ -339,6 +358,9 @@ var _ = Describe("Subnets server", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, publicv1.SubnetsCreateRequest_builder{
 				Object: publicv1.Subnet_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.SubnetSpec_builder{
 						VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: virtualNetworkID}.Build(),
 						Ipv4Cidr:       new("10.0.1.0/24"),
@@ -369,6 +391,9 @@ var _ = Describe("Subnets server", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, publicv1.SubnetsCreateRequest_builder{
 				Object: publicv1.Subnet_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.SubnetSpec_builder{
 						VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: virtualNetworkID}.Build(),
 						Ipv4Cidr:       new("10.0.2.0/24"),
@@ -399,6 +424,9 @@ var _ = Describe("Subnets server", func() {
 			// Create with "10.0.3.0/24":
 			createResponse, err := server.Create(ctx, publicv1.SubnetsCreateRequest_builder{
 				Object: publicv1.Subnet_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.SubnetSpec_builder{
 						VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: virtualNetworkID}.Build(),
 						Ipv4Cidr:       new("10.0.3.0/24"),
@@ -429,6 +457,9 @@ var _ = Describe("Subnets server", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, publicv1.SubnetsCreateRequest_builder{
 				Object: publicv1.Subnet_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.SubnetSpec_builder{
 						VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: virtualNetworkID}.Build(),
 						Ipv4Cidr:       new("10.0.5.0/24"),
@@ -463,6 +494,9 @@ var _ = Describe("Subnets server", func() {
 			// Create the object:
 			createResponse, err := server.Create(ctx, publicv1.SubnetsCreateRequest_builder{
 				Object: publicv1.Subnet_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: publicv1.SubnetSpec_builder{
 						VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: virtualNetworkID}.Build(),
 						Ipv4Cidr:       new("10.0.1.0/24"),

--- a/fulfillment-service/internal/servers/virtual_networks_server_test.go
+++ b/fulfillment-service/internal/servers/virtual_networks_server_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
@@ -146,6 +147,9 @@ var _ = Describe("Virtual networks server", func() {
 		createVirtualNetwork := func() *privatev1.VirtualNetwork {
 			response, err := privateServer.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 				Object: privatev1.VirtualNetwork_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Region:                 "us-east-1",
 						NetworkClass:           privatev1.NetworkClassReference_builder{Id: "default"}.Build(),

--- a/fulfillment-service/it/it_validation_test.go
+++ b/fulfillment-service/it/it_validation_test.go
@@ -62,6 +62,18 @@ var _ = Describe("Protovalidate validation", func() {
 		}
 	})
 
+	It("Rejects Tenant with missing metadata", func() {
+		_, err := tenantClient.Create(ctx, privatev1.TenantsCreateRequest_builder{
+			Object: privatev1.Tenant_builder{}.Build(),
+		}.Build())
+
+		Expect(err).To(HaveOccurred())
+		status, ok := grpcstatus.FromError(err)
+		Expect(ok).To(BeTrue(), "error should be a gRPC status error")
+		Expect(status.Code()).To(Equal(grpccodes.InvalidArgument), "should return InvalidArgument")
+		Expect(status.Message()).To(ContainSubstring("metadata is required"))
+	})
+
 	It("Rejects Tenant with invalid metadata name (too long)", func() {
 		// Create a Tenant with name > 63 chars:
 		invalidName := "this-name-is-way-too-long-and-exceeds-the-sixty-three-character-limit-for-dns-labels"


### PR DESCRIPTION
If an object is created with no metadata, this bypasses the metadata.name requirement and validation. Now we add a check in the server to require metadata exists when an object is created.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resource creation now requires metadata, with clear validation errors when metadata is missing.

* **Bug Fixes**
  * Improved validation for empty resource names, including clearer `InvalidArgument` responses.
  * Prevented test resource naming conflicts by using unique names across scenarios.

* **Tests**
  * Added integration and validation coverage for required metadata and resource-name handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->