### PR TITLE
OSAC-3370: Gate expensive e2e on CodeRabbit, lgtm, or e2e-ready

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,16 @@
+# .github/ Agent Context
+
+## E2E readiness gate (OSAC-3370)
+
+Full-install e2e (`e2e-vmaas-full-install`, `e2e-bmaas-full-install`, `e2e-caas-full-install`) does **not** auto-spend runners on every PR push. Cheap `e2e-readiness` job **fails closed** until unlocked.
+
+**Allow when any of:**
+- `lgtm` label present (Prow removes on push)
+- `e2e-ready` label applied by `github-actions[bot]` via `/e2e-ready` (cleanup removes on push; manual UI labels are rejected)
+- `coderabbitai[bot]` `APPROVED` on the **exact current HEAD** (blocked while a human still has `CHANGES_REQUESTED`). Auto-start: same-repo via `e2e-on-approval`; forks via `e2e-on-approval-fork` (`workflow_run` replay — default-branch YAML, write token). `lgtm` / `/e2e-ready` still work.
+
+Human GitHub `APPROVED` does **not** unlock. Fork PRs still need `ok-to-test` (or org membership) for secrets/cluster — readiness is cost-only.
+
+Cheap checks stay ungated. Schedules / `workflow_dispatch` / `merge_group` skip the readiness job.
+
+Details + smoke checklist: [`.github/e2e-readiness.md`](e2e-readiness.md).

--- a/.github/e2e-readiness.md
+++ b/.github/e2e-readiness.md
@@ -1,0 +1,43 @@
+# E2E readiness gate (OSAC-3370)
+
+Expensive e2e (`e2e-vmaas-full-install`, `e2e-bmaas-full-install`, `e2e-caas-full-install`) **fails** the cheap readiness job until an unlock signal is present. Goal: save runner bandwidth until CodeRabbit is happy.
+
+Action + `/e2e-ready` + label cleanup live in [osac-test-infra](https://github.com/osac-project/osac-test-infra) (`check-e2e-readiness@main`). This repo is the caller.
+
+## Signals (any one is enough)
+
+| Signal | Notes |
+|--------|--------|
+| `coderabbitai[bot]` `APPROVED` on exact HEAD | Primary. **Starts** e2e. Same-repo: `e2e-on-approval` (`pull_request_review`). Fork: that event has a read-only token / no secrets, so `e2e-on-approval` only hands off; `e2e-on-approval-fork.yml` (`workflow_run`, YAML from default branch) verifies APPROVED on exact HEAD and reruns. Blocked while any human still has outstanding `CHANGES_REQUESTED`. Abbreviated SHA does not count. The replay workflow must already be on `main` (this PR cannot replay itself before merge). |
+| `lgtm` label | Alternate. **Starts** e2e (`e2e-on-label`). Prow removes the label on new pushes. |
+| `e2e-ready` via `/e2e-ready` | Quiet override. Must be applied by `github-actions[bot]` (slash command). Manual UI labels are rejected. Cleanup removes the label on push. |
+
+**Human `APPROVED` reviews do not unlock expensive e2e.**
+
+`/test` and `/retest` only **rerun** workflows; they do not apply unlock labels.
+If readiness already failed, a rerun still fails the gate until a signal is present.
+
+Non-`pull_request` events (schedule, `workflow_dispatch`, `merge_group`) skip the gate.
+
+Fork PRs: readiness is a **cost** gate only. Secrets / cluster e2e still need
+`ok-to-test` (or org membership) via `authorize-fork-pr` — same as before.
+CodeRabbit APPROVED **does** auto-start fork e2e after this workflow is on
+`main` (`workflow_run` replay). `/ok-to-test` is still required for secrets,
+not for the cost unlock.
+
+## Author flow
+
+1. Open PR → cheap `e2e-readiness` fails; no heavy runners.
+2. When ready: CodeRabbit `APPROVED` on current head, **or** `/lgtm`, **or** `/e2e-ready`.
+3. Push more commits → `lgtm` (Prow) and `e2e-ready` (cleanup) drop → gate fails until CodeRabbit re-approves or a label is re-applied.
+
+## Smoke checklist
+
+- [ ] Open a PR with a code change (not docs-only).
+- [ ] Confirm `e2e-readiness` fails quickly (no CR / `lgtm` / `/e2e-ready`).
+- [ ] Confirm no EC2 / full-install reusable jobs start while unreadiness fails.
+- [ ] CodeRabbit `APPROVED` on exact head → e2e starts (same-repo: `e2e-on-approval`; fork: `e2e-on-approval-fork` after the handoff run completes).
+- [ ] Apply `lgtm` → `e2e-on-label` starts e2e.
+- [ ] `/e2e-ready` (bot-applied) unlocks; a manual `e2e-ready` label does not.
+- [ ] Push a new commit → unlock labels removed → readiness fails again.
+- [ ] Optional: schedule / `workflow_dispatch` still runs without the label.

--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -75,6 +75,24 @@ jobs:
               - '!.skillsaw.yaml'
               - '!.pre-commit-config.yaml'
 
+  # OSAC-3370: cheap readiness gate before expensive runners.
+  # Allow: lgtm present, e2e-ready applied by github-actions[bot], or
+  # coderabbitai[bot] APPROVED on exact HEAD (blocked by human CHANGES_REQUESTED).
+  # Human APPROVED does not unlock. Non-PR events skip this job.
+  e2e-readiness:
+    needs: changes
+    if: needs.changes.outputs.should-run == 'true' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: read
+    steps:
+      - name: Check e2e readiness
+        uses: osac-project/osac-test-infra/.github/actions/check-e2e-readiness@main
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
+
   # Builds fulfillment-service, osac-operator, osac-aap's execution
   # environment (twice -- once each for aap.bootstrap.image and
   # aap.configAsCode.eeImage, see OSAC-3546), and bare-metal-fulfillment-operator
@@ -85,8 +103,13 @@ jobs:
   # avoid running both suites when only one changed is deferred to the future
   # full path-based CI matrix, once its skip-logic pattern is verified.
   e2e-bmaas-full-install:
-    needs: changes
-    if: needs.changes.outputs.should-run == 'true'
+    needs: [changes, e2e-readiness]
+    if: >-
+      always()
+      && needs.changes.result == 'success'
+      && needs.changes.outputs.should-run == 'true'
+      && (needs.e2e-readiness.result == 'success'
+          || needs.e2e-readiness.result == 'skipped')
     uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-full-install.yml@main
     with:
       test-suite: ${{ inputs.test-suite || 'bmaas' }}
@@ -115,13 +138,23 @@ jobs:
 
   e2e-bmaas-gate:
     if: always()
-    needs: [changes, e2e-bmaas-full-install]
+    needs: [changes, e2e-readiness, e2e-bmaas-full-install]
     runs-on: ubuntu-latest
     steps:
-      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+      - if: needs.e2e-readiness.result == 'failure'
+        run: |
+          echo "e2e-readiness failed: expensive e2e is gated until unlock."
+          echo "Need coderabbitai[bot] APPROVED on this HEAD, lgtm, or /e2e-ready."
+          echo "See .github/e2e-readiness.md"
+          echo "Upstream: changes=${{ needs.changes.result }} e2e-readiness=failure full-install=${{ needs.e2e-bmaas-full-install.result }}"
+          exit 1
+      - if: >-
+          needs.e2e-readiness.result != 'failure'
+          && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
         run: |
           echo "Upstream job results:"
           echo "  changes: ${{ needs.changes.result }}"
+          echo "  e2e-readiness: ${{ needs.e2e-readiness.result }}"
           echo "  e2e-bmaas-full-install: ${{ needs.e2e-bmaas-full-install.result }}"
           echo ""
           echo "One or more upstream jobs failed or were cancelled."

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -75,6 +75,24 @@ jobs:
               - '!.skillsaw.yaml'
               - '!.pre-commit-config.yaml'
 
+  # OSAC-3370: cheap readiness gate before expensive runners.
+  # Allow: lgtm present, e2e-ready applied by github-actions[bot], or
+  # coderabbitai[bot] APPROVED on exact HEAD (blocked by human CHANGES_REQUESTED).
+  # Human APPROVED does not unlock. Non-PR events skip this job.
+  e2e-readiness:
+    needs: changes
+    if: needs.changes.outputs.should-run == 'true' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: read
+    steps:
+      - name: Check e2e readiness
+        uses: osac-project/osac-test-infra/.github/actions/check-e2e-readiness@main
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
+
   # Builds fulfillment-service, osac-operator, osac-aap's execution
   # environment (twice -- once each for aap.bootstrap.image and
   # aap.configAsCode.eeImage, see OSAC-3546), and bare-metal-fulfillment-operator
@@ -96,8 +114,13 @@ jobs:
   # built from source for consistency with the other components -- revisit
   # if caas ever needs BMF enabled.
   e2e-caas-full-install:
-    needs: changes
-    if: needs.changes.outputs.should-run == 'true'
+    needs: [changes, e2e-readiness]
+    if: >-
+      always()
+      && needs.changes.result == 'success'
+      && needs.changes.outputs.should-run == 'true'
+      && (needs.e2e-readiness.result == 'success'
+          || needs.e2e-readiness.result == 'skipped')
     uses: osac-project/osac-test-infra/.github/workflows/e2e-caas-full-install.yml@main
     with:
       test-suite: ${{ inputs.test-suite || 'caas' }}
@@ -130,13 +153,23 @@ jobs:
 
   e2e-caas-gate:
     if: always()
-    needs: [changes, e2e-caas-full-install]
+    needs: [changes, e2e-readiness, e2e-caas-full-install]
     runs-on: ubuntu-latest
     steps:
-      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+      - if: needs.e2e-readiness.result == 'failure'
+        run: |
+          echo "e2e-readiness failed: expensive e2e is gated until unlock."
+          echo "Need coderabbitai[bot] APPROVED on this HEAD, lgtm, or /e2e-ready."
+          echo "See .github/e2e-readiness.md"
+          echo "Upstream: changes=${{ needs.changes.result }} e2e-readiness=failure full-install=${{ needs.e2e-caas-full-install.result }}"
+          exit 1
+      - if: >-
+          needs.e2e-readiness.result != 'failure'
+          && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
         run: |
           echo "Upstream job results:"
           echo "  changes: ${{ needs.changes.result }}"
+          echo "  e2e-readiness: ${{ needs.e2e-readiness.result }}"
           echo "  e2e-caas-full-install: ${{ needs.e2e-caas-full-install.result }}"
           echo ""
           echo "One or more upstream jobs failed or were cancelled."

--- a/.github/workflows/e2e-on-approval-fork.yml
+++ b/.github/workflows/e2e-on-approval-fork.yml
@@ -1,0 +1,376 @@
+---
+# OSAC-3370: fork CodeRabbit APPROVED cannot gh run rerun from
+# pull_request_review (read-only token, no secrets). This workflow_run
+# listener runs default-branch YAML with a write token. No checkout of
+# the PR. Independently verify coderabbitai[bot] APPROVED on current HEAD
+# — do not trust the triggering workflow (fork merge can rename/copy it).
+name: E2E on CodeRabbit approval (fork replay)
+
+on:
+  workflow_run:
+    # Must match name: in e2e-on-approval.yml (GitHub matches display name,
+    # not filename). Rename both or this listener never fires.
+    workflows: ["E2E on CodeRabbit approval"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+# Fork payload often has empty pull_requests; key on head SHA.
+concurrency:
+  group: e2e-start-fork-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  start-e2e:
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: write
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request_review' &&
+      github.event.workflow_run.head_repository.full_name != github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Start e2e workflows for fork CodeRabbit approval
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          REVIEWER: coderabbitai[bot]
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${EVENT_HEAD_SHA}" || -z "${HEAD_REPO}" ]]; then
+            echo "workflow_run missing head_sha or head_repository; skipping."
+            exit 0
+          fi
+
+          # Triggering workflow may be attacker-controlled (same name). Require
+          # the trusted fork-handoff job; still verify CR APPROVED below.
+          # Display name equals job id (no name: on producer). e2e-on-approval.yml
+          # fork-handoff must stay in sync; a rename breaks this gate.
+          if ! gh run view "${WORKFLOW_RUN_ID}" -R "${REPO}" --json jobs \
+            | jq -e '.jobs[] | select(.name == "fork-handoff" and .conclusion == "success")' >/dev/null; then
+            echo "No successful fork-handoff job on run #${WORKFLOW_RUN_ID}; skipping."
+            exit 0
+          fi
+
+          if ! prs_json=$(gh api "repos/${REPO}/commits/${EVENT_HEAD_SHA}/pulls"); then
+            echo "Failed to list PRs for ${HEAD_REPO}@${EVENT_HEAD_SHA:0:7}; skipping."
+            exit 0
+          fi
+          pr_json=$(jq -c --arg sha "${EVENT_HEAD_SHA}" --arg repo "${HEAD_REPO}" '
+            [.[]
+              | select(.state == "open")
+              | select(.base.ref == "main")
+              | select(.head.sha == $sha)
+              | select((.head.repo.full_name // "") == $repo)
+            ]
+            | if length == 1 then .[0] else empty end
+          ' <<<"${prs_json}")
+          if [[ -z "${pr_json}" || "${pr_json}" == "null" ]]; then
+            echo "No unique open main PR for ${HEAD_REPO}@${EVENT_HEAD_SHA:0:7}; skipping."
+            exit 0
+          fi
+
+          PR_NUMBER=$(jq -r '.number' <<<"${pr_json}")
+          HEAD_SHA=$(jq -r '.head.sha' <<<"${pr_json}")
+          HEAD_REF=$(jq -r '.head.ref // empty' <<<"${pr_json}")
+
+          pr_is_open() {
+            [[ "$(jq -r '.state' <<<"${pr_json}")" == "open" ]]
+          }
+
+          human_cr_blocks_bot() {
+            local reviews_json="$1"
+            local rc e_was=0
+            [[ $- == *e* ]] && e_was=1
+            set +e
+            jq -e '
+              [.[]
+                | select(.user != null)
+                | select(((.user.login // "") | endswith("[bot]")) | not)
+                | select((.user.type // "User") != "Bot")
+                | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
+              ]
+              | group_by(.user.login)
+              | map(max_by([(.submitted_at // ""), (.id // 0)]))
+              | map(select(.state == "CHANGES_REQUESTED"))
+              | length > 0
+            ' <<<"${reviews_json}" >/dev/null
+            rc=$?
+            [[ ${e_was} -eq 1 ]] && set -e
+            # 0 = blocked, 1 = not blocked, anything else = jq/input error.
+            if [[ ${rc} -ne 0 && ${rc} -ne 1 ]]; then
+              echo "Cannot evaluate human review state (jq rc=${rc}); treating as blocked." >&2
+              return 0
+            fi
+            return ${rc}
+          }
+
+          approval_still_valid() {
+            local sha="$1"
+            local reviews_json
+            if ! reviews_json=$(gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUMBER}/reviews" | jq 'add'); then
+              return 2
+            fi
+            if human_cr_blocks_bot "${reviews_json}"; then
+              return 1
+            fi
+            jq -e --arg sha "${sha}" --arg who "${REVIEWER}" '
+              ([.[]
+                | select(.user.login == $who)
+                | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
+              ] | max_by([(.submitted_at // ""), (.id // 0)]) // empty) as $latest
+              | ($latest != null)
+                and ($latest.state == "APPROVED")
+                and ($latest.commit_id != null)
+                and ($latest.commit_id == $sha)
+            ' <<<"${reviews_json}" >/dev/null 2>&1
+          }
+
+          av_rc=0
+          approval_still_valid "${HEAD_SHA}" || av_rc=$?
+          if [[ ${av_rc} -eq 2 ]]; then
+            echo "Failed to fetch reviews for PR #${PR_NUMBER}; skipping."
+            {
+              echo "### E2E on approval (fork) skipped"
+              echo ""
+              echo "Could not read review state for \`${HEAD_SHA:0:7}\` on PR #${PR_NUMBER}."
+              echo "Re-approve or use \`lgtm\` / \`/e2e-ready\`."
+            } > /tmp/e2e-on-approval-fork-skip.md
+            gh pr comment "${PR_NUMBER}" -R "${REPO}" --body "$(cat /tmp/e2e-on-approval-fork-skip.md)"
+            exit 1
+          fi
+          if [[ ${av_rc} -ne 0 ]]; then
+            echo "No current ${REVIEWER} APPROVED on ${HEAD_SHA:0:7} (or human CHANGES_REQUESTED); skipping."
+            {
+              echo "### E2E on approval skipped"
+              echo ""
+              echo "\`${REVIEWER}\` is not APPROVED on exact head \`${HEAD_SHA:0:7}\` (different SHA, withdrawn, or a human still has CHANGES_REQUESTED)."
+              echo "Expensive e2e will not start until that is cleared, or a \`lgtm\` / \`/e2e-ready\` unlock is applied."
+            } > /tmp/e2e-on-approval-fork-blocked.md
+            gh pr comment "${PR_NUMBER}" -R "${REPO}" --body "$(cat /tmp/e2e-on-approval-fork-blocked.md)"
+            exit 0
+          fi
+
+          E2E_WORKFLOWS=(
+            e2e-vmaas-full-install.yml
+            e2e-bmaas-full-install.yml
+            e2e-caas-full-install.yml
+          )
+
+          STARTED=0
+          ERRORS=0
+          SKIPPED=0
+          STALE=0
+          TIMEOUTS=0
+
+          find_pr_run() {
+            local wf="$1"
+            local runs
+            runs=$(gh api \
+              "repos/${REPO}/actions/workflows/${wf}/runs?event=pull_request&per_page=100" \
+              --jq '[.workflow_runs[]]')
+            jq -c --arg sha "${HEAD_SHA}" --argjson pr "${PR_NUMBER}" \
+              --arg repo "${HEAD_REPO}" --arg ref "${HEAD_REF}" '
+              ([.[]
+                | select(.head_sha == $sha)
+                | select(any(.pull_requests[]?; .number == $pr))
+              ][0])
+              // (if ($repo | length) > 0 and ($ref | length) > 0 then
+                  ([.[]
+                    | select(.head_sha == $sha)
+                    | select((.pull_requests // []) | length == 0)
+                    | select((.head_repository.full_name // "") == $repo)
+                    | select(.head_branch == $ref)
+                  ] | if length == 1 then .[0] else empty end)
+                else empty end)
+              // empty
+            ' <<<"${runs}"
+          }
+
+          wait_until_rerun_or_skip() {
+            local run_id="$1"
+            local view status conclusion busy
+            for _ in $(seq 1 90); do
+              view=$(gh run view "${run_id}" -R "${REPO}" --json status,conclusion,jobs)
+              status=$(jq -r '.status' <<<"${view}")
+              conclusion=$(jq -r '.conclusion // empty' <<<"${view}")
+              busy=$(jq -r '
+                [.jobs[]
+                  | select(.name | test("full-install"; "i"))
+                  | select(.name | test("readiness"; "i") | not)
+                  | .status
+                ]
+                | if length == 0 then "unknown"
+                  else (map(select(. == "in_progress" or . == "queued")) | length > 0 | tostring)
+                  end
+              ' <<<"${view}")
+
+              if [[ "${busy}" == "unknown" && "${status}" != "completed" ]]; then
+                sleep 2
+                continue
+              fi
+
+              if [[ "${busy}" == "true" ]]; then
+                echo "Expensive job already active on run #${run_id}; skip rerun."
+                return 2
+              fi
+
+              if [[ "${status}" == "completed" ]]; then
+                if [[ "${conclusion}" == "success" ]]; then
+                  return 2
+                fi
+                echo "Run #${run_id} completed (conclusion=${conclusion:-none}); will rerun."
+                return 0
+              fi
+              sleep 2
+            done
+            echo "Timed out waiting on run #${run_id}; expensive job never started."
+            return 1
+          }
+
+          start_via_pr_run() {
+            local wf="$1"
+            local candidates run_id rc cur_sha av_rc
+
+            if ! pr_json=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}"); then
+              echo "Failed to fetch PR #${PR_NUMBER} while processing ${wf}."
+              ERRORS=$((ERRORS + 1))
+              return
+            fi
+            if ! pr_is_open; then
+              echo "PR #${PR_NUMBER} is no longer open; aborting ${wf}."
+              STALE=$((STALE + 1))
+              return
+            fi
+            cur_sha=$(jq -r '.head.sha' <<<"${pr_json}")
+            if [[ "${cur_sha}" != "${HEAD_SHA}" ]]; then
+              echo "PR head moved before starting ${wf} (${HEAD_SHA:0:7} → ${cur_sha:0:7}); aborting."
+              STALE=$((STALE + 1))
+              return
+            fi
+            approval_still_valid "${HEAD_SHA}"
+            av_rc=$?
+            if [[ ${av_rc} -eq 2 ]]; then
+              echo "Failed to fetch reviews for PR #${PR_NUMBER} while processing ${wf}."
+              ERRORS=$((ERRORS + 1))
+              return
+            fi
+            if [[ ${av_rc} -ne 0 ]]; then
+              echo "Approval from ${REVIEWER} no longer valid on ${HEAD_SHA:0:7}; aborting ${wf}."
+              STALE=$((STALE + 1))
+              return
+            fi
+
+            candidates=""
+            for _ in $(seq 1 30); do
+              candidates=$(find_pr_run "${wf}")
+              if [[ -n "${candidates}" && "${candidates}" != "null" ]]; then
+                break
+              fi
+              echo "Waiting for pull_request run for ${wf} at ${HEAD_SHA:0:7}..."
+              sleep 2
+            done
+            if [[ -z "${candidates}" || "${candidates}" == "null" ]]; then
+              echo "No pull_request run for ${wf} at ${HEAD_SHA:0:7} on PR #${PR_NUMBER}."
+              ERRORS=$((ERRORS + 1))
+              return
+            fi
+
+            run_id=$(jq -r '.id' <<<"${candidates}")
+            echo "Considering ${wf} PR run #${run_id}..."
+
+            wait_until_rerun_or_skip "${run_id}"
+            rc=$?
+            if [[ ${rc} -eq 2 ]]; then
+              SKIPPED=$((SKIPPED + 1))
+              return
+            fi
+            if [[ ${rc} -ne 0 ]]; then
+              TIMEOUTS=$((TIMEOUTS + 1))
+              return
+            fi
+
+            if ! pr_json=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}"); then
+              echo "Failed to fetch PR #${PR_NUMBER} before rerun of ${wf}."
+              ERRORS=$((ERRORS + 1))
+              return
+            fi
+            if ! pr_is_open; then
+              echo "PR #${PR_NUMBER} is no longer open; skipping rerun of ${wf}."
+              STALE=$((STALE + 1))
+              return
+            fi
+            cur_sha=$(jq -r '.head.sha' <<<"${pr_json}")
+            if [[ "${cur_sha}" != "${HEAD_SHA}" ]]; then
+              echo "Head/approval changed immediately before rerun of ${wf}; skipping."
+              STALE=$((STALE + 1))
+              return
+            fi
+            approval_still_valid "${HEAD_SHA}"
+            av_rc=$?
+            if [[ ${av_rc} -eq 2 ]]; then
+              echo "Failed to fetch reviews for PR #${PR_NUMBER} before rerun of ${wf}."
+              ERRORS=$((ERRORS + 1))
+              return
+            fi
+            if [[ ${av_rc} -ne 0 ]]; then
+              echo "Head/approval changed immediately before rerun of ${wf}; skipping."
+              STALE=$((STALE + 1))
+              return
+            fi
+
+            if gh run rerun "${run_id}" -R "${REPO}"; then
+              STARTED=$((STARTED + 1))
+            else
+              echo "Failed to start ${wf} from run #${run_id}"
+              ERRORS=$((ERRORS + 1))
+            fi
+          }
+
+          echo "Fork PR #${PR_NUMBER}: ${REVIEWER} APPROVED ${HEAD_SHA:0:7} — starting e2e via pull_request rerun."
+
+          for wf in "${E2E_WORKFLOWS[@]}"; do
+            set +e
+            start_via_pr_run "${wf}"
+            wf_rc=$?
+            set -e
+            if [[ ${wf_rc} -ne 0 ]]; then
+              echo "Unexpected failure while processing ${wf} (rc=${wf_rc})."
+              ERRORS=$((ERRORS + 1))
+            fi
+          done
+
+          {
+            echo "### E2E on approval (fork)"
+            echo ""
+            echo "\`${REVIEWER}\` approved \`${HEAD_SHA:0:7}\` on fork PR #${PR_NUMBER} — starting expensive e2e (PR run replay)."
+            echo "- Started: ${STARTED}/${#E2E_WORKFLOWS[@]}"
+            if [[ ${SKIPPED} -gt 0 ]]; then
+              echo "- Already active/green (skipped rerun): ${SKIPPED}"
+            fi
+            if [[ ${STALE} -gt 0 ]]; then
+              echo "- Head moved or approval withdrawn (no rerun): ${STALE}"
+            fi
+            if [[ ${TIMEOUTS} -gt 0 ]]; then
+              echo "- Timed out waiting for the expensive job to reach a terminal state: ${TIMEOUTS}"
+            fi
+            if [[ ${ERRORS} -gt 0 ]]; then
+              echo "- Errors: ${ERRORS}"
+              echo ""
+              echo "Needs a prior \`pull_request\` e2e run at this head for PR #${PR_NUMBER}."
+            fi
+          } > /tmp/e2e-on-approval-fork.md
+
+          gh pr comment "${PR_NUMBER}" -R "${REPO}" --body "$(cat /tmp/e2e-on-approval-fork.md)"
+
+          if [[ ${ERRORS} -gt 0 || ${TIMEOUTS} -gt 0 ]]; then
+            exit 1
+          fi

--- a/.github/workflows/e2e-on-approval.yml
+++ b/.github/workflows/e2e-on-approval.yml
@@ -1,0 +1,388 @@
+---
+# OSAC-3370: when CodeRabbit approves the PR head, start expensive e2e callers.
+# Human APPROVED does not unlock (cost gate trusts CodeRabbit / lgtm / quiet
+# e2e-ready only). Replay the pull_request run at HEAD.
+# Fork pull_request_review withholds secrets and makes GITHUB_TOKEN read-only.
+# Same-repo: this workflow reruns e2e. Fork: cheap handoff only; privileged
+# e2e-on-approval-fork.yml (workflow_run, default-branch YAML) does the rerun.
+# Display name is the workflow_run filter in e2e-on-approval-fork.yml; rename
+# both or fork replay never starts.
+name: E2E on CodeRabbit approval
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+
+# Shared with e2e-on-label. Queue, do not cancel: a killed starter leaves
+# partial reruns and no summary. Revalidation makes a queued run idempotent.
+concurrency:
+  group: e2e-start-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  start-e2e:
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: write
+    if: >-
+      github.event.review.state == 'approved' &&
+      github.event.review.user.login == 'coderabbitai[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Start e2e workflows for approved head
+        env:
+          GH_TOKEN: ${{ secrets.OSAC_BOT_PAT || github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REVIEW_SHA: ${{ github.event.review.commit_id }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REVIEWER: ${{ github.event.review.user.login }}
+        run: |
+          set -euo pipefail
+
+          pr_is_open() {
+            [[ "$(jq -r '.state' <<<"${pr_json}")" == "open" ]]
+          }
+
+          pr_json=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
+          if ! pr_is_open; then
+            echo "PR #${PR_NUMBER} is $(jq -r '.state' <<<"${pr_json}") (not open); skipping."
+            exit 0
+          fi
+          HEAD_SHA=$(jq -r '.head.sha' <<<"${pr_json}")
+          HEAD_REPO=$(jq -r '.head.repo.full_name // empty' <<<"${pr_json}")
+          HEAD_REF=$(jq -r '.head.ref // empty' <<<"${pr_json}")
+          if [[ "${HEAD_REPO}" != "${REPO}" ]]; then
+            echo "Fork PR ${HEAD_REPO}; e2e-on-approval cannot rerun (no secrets / read-only token). Use lgtm or /e2e-ready."
+            exit 0
+          fi
+          if [[ "$(jq -r '.base.ref' <<<"${pr_json}")" != "main" ]]; then
+            echo "PR targets $(jq -r '.base.ref' <<<"${pr_json}"), not main; skipping."
+            exit 0
+          fi
+          if [[ -n "${REVIEW_SHA}" && "${REVIEW_SHA}" != "${HEAD_SHA}" ]]; then
+            echo "Approval commit ${REVIEW_SHA:0:7} is not current head ${HEAD_SHA:0:7}; skipping."
+            exit 0
+          fi
+          if [[ "${HEAD_SHA}" != "${EVENT_HEAD_SHA}" ]]; then
+            echo "PR head moved (${EVENT_HEAD_SHA:0:7} → ${HEAD_SHA:0:7}); skipping."
+            exit 0
+          fi
+
+          human_cr_blocks_bot() {
+            local reviews_json="$1"
+            local rc e_was=0
+            [[ $- == *e* ]] && e_was=1
+            set +e
+            jq -e '
+              [.[]
+                | select(.user != null)
+                | select(((.user.login // "") | endswith("[bot]")) | not)
+                | select((.user.type // "User") != "Bot")
+                | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
+              ]
+              | group_by(.user.login)
+              | map(max_by([(.submitted_at // ""), (.id // 0)]))
+              | map(select(.state == "CHANGES_REQUESTED"))
+              | length > 0
+            ' <<<"${reviews_json}" >/dev/null
+            rc=$?
+            [[ ${e_was} -eq 1 ]] && set -e
+            # 0 = blocked, 1 = not blocked, anything else = jq/input error.
+            if [[ ${rc} -ne 0 && ${rc} -ne 1 ]]; then
+              echo "Cannot evaluate human review state (jq rc=${rc}); treating as blocked." >&2
+              return 0
+            fi
+            return ${rc}
+          }
+
+          approval_still_valid() {
+            local sha="$1"
+            local reviews_json
+            if ! reviews_json=$(gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUMBER}/reviews" | jq 'add'); then
+              return 2
+            fi
+            if [[ "${REVIEWER}" == *"[bot]" ]]; then
+              if human_cr_blocks_bot "${reviews_json}"; then
+                return 1
+              fi
+            fi
+            # Latest decision from this reviewer must be APPROVED on head.
+            jq -e --arg sha "${sha}" --arg who "${REVIEWER}" '
+              ([.[]
+                | select(.user.login == $who)
+                | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "DISMISSED")
+              ] | max_by([(.submitted_at // ""), (.id // 0)]) // empty) as $latest
+              | ($latest != null)
+                and ($latest.state == "APPROVED")
+                and ($latest.commit_id != null)
+                and ($latest.commit_id == $sha)
+            ' <<<"${reviews_json}" >/dev/null 2>&1
+          }
+
+          if [[ "${REVIEWER}" == *"[bot]" ]]; then
+            reviews_json=$(gh api --paginate --slurp "repos/${REPO}/pulls/${PR_NUMBER}/reviews" | jq 'add')
+            if human_cr_blocks_bot "${reviews_json}"; then
+              echo "Skipping: ${REVIEWER} approved, but a human still has CHANGES_REQUESTED."
+              {
+                echo "### E2E on approval skipped"
+                echo ""
+                echo "\`${REVIEWER}\` approved \`${HEAD_SHA:0:7}\`, but a human still requested changes."
+                echo "Expensive e2e will not start until that is cleared, or a \`lgtm\` / \`/e2e-ready\` unlock is applied."
+              } > /tmp/e2e-on-approval-skip.md
+              gh pr comment "${PR_NUMBER}" -R "${REPO}" --body "$(cat /tmp/e2e-on-approval-skip.md)"
+              exit 0
+            fi
+          fi
+
+          E2E_WORKFLOWS=(
+            e2e-vmaas-full-install.yml
+            e2e-bmaas-full-install.yml
+            e2e-caas-full-install.yml
+          )
+
+          STARTED=0
+          ERRORS=0
+          SKIPPED=0
+          STALE=0
+          TIMEOUTS=0
+
+          find_pr_run() {
+            local wf="$1"
+            local runs
+            # Runs come back newest-first; current head is on page 1.
+            runs=$(gh api \
+              "repos/${REPO}/actions/workflows/${wf}/runs?event=pull_request&per_page=100" \
+              --jq '[.workflow_runs[]]')
+            # Prefer PR-number match; fork runs often have empty pull_requests —
+            # fall back only when head repo+branch uniquely match this PR.
+            jq -c --arg sha "${HEAD_SHA}" --argjson pr "${PR_NUMBER}" \
+              --arg repo "${HEAD_REPO}" --arg ref "${HEAD_REF}" '
+              ([.[]
+                | select(.head_sha == $sha)
+                | select(any(.pull_requests[]?; .number == $pr))
+              ][0])
+              // (if ($repo | length) > 0 and ($ref | length) > 0 then
+                  ([.[]
+                    | select(.head_sha == $sha)
+                    | select((.pull_requests // []) | length == 0)
+                    | select((.head_repository.full_name // "") == $repo)
+                    | select(.head_branch == $ref)
+                  ] | if length == 1 then .[0] else empty end)
+                else empty end)
+              // empty
+            ' <<<"${runs}"
+          }
+
+          wait_until_rerun_or_skip() {
+            local run_id="$1"
+            local view status conclusion busy
+            for _ in $(seq 1 90); do
+              view=$(gh run view "${run_id}" -R "${REPO}" --json status,conclusion,jobs)
+              status=$(jq -r '.status' <<<"${view}")
+              conclusion=$(jq -r '.conclusion // empty' <<<"${view}")
+              # Reusable calls prefix every child with the caller job name
+              # (e2e-*-full-install / ...). Do not trust the first match.
+              busy=$(jq -r '
+                [.jobs[]
+                  | select(.name | test("full-install"; "i"))
+                  | select(.name | test("readiness"; "i") | not)
+                  | .status
+                ]
+                | if length == 0 then "unknown"
+                  else (map(select(. == "in_progress" or . == "queued")) | length > 0 | tostring)
+                  end
+              ' <<<"${view}")
+
+              # No expensive job matched yet: do not assume idle.
+              if [[ "${busy}" == "unknown" && "${status}" != "completed" ]]; then
+                sleep 2
+                continue
+              fi
+
+              if [[ "${busy}" == "true" ]]; then
+                echo "Expensive job already active on run #${run_id}; skip rerun."
+                return 2
+              fi
+
+              if [[ "${status}" == "completed" ]]; then
+                if [[ "${conclusion}" == "success" ]]; then
+                  return 2
+                fi
+                echo "Run #${run_id} completed (conclusion=${conclusion:-none}); will rerun."
+                return 0
+              fi
+              sleep 2
+            done
+            echo "Timed out waiting on run #${run_id}; expensive job never started."
+            return 1
+          }
+
+          start_via_pr_run() {
+            local wf="$1"
+            local candidates run_id rc cur_sha av_rc
+
+            # Re-fetch head + approval eligibility immediately before each rerun.
+            if ! pr_json=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}"); then
+              echo "Failed to fetch PR #${PR_NUMBER} while processing ${wf}."
+              ERRORS=$((ERRORS + 1))
+              return
+            fi
+            if ! pr_is_open; then
+              echo "PR #${PR_NUMBER} is no longer open; aborting ${wf}."
+              STALE=$((STALE + 1))
+              return
+            fi
+            cur_sha=$(jq -r '.head.sha' <<<"${pr_json}")
+            if [[ "${cur_sha}" != "${HEAD_SHA}" ]]; then
+              echo "PR head moved before starting ${wf} (${HEAD_SHA:0:7} → ${cur_sha:0:7}); aborting."
+              STALE=$((STALE + 1))
+              return
+            fi
+            approval_still_valid "${HEAD_SHA}"
+            av_rc=$?
+            if [[ ${av_rc} -eq 2 ]]; then
+              echo "Failed to fetch reviews for PR #${PR_NUMBER} while processing ${wf}."
+              ERRORS=$((ERRORS + 1))
+              return
+            fi
+            if [[ ${av_rc} -ne 0 ]]; then
+              echo "Approval from ${REVIEWER} no longer valid on ${HEAD_SHA:0:7}; aborting ${wf}."
+              STALE=$((STALE + 1))
+              return
+            fi
+
+            candidates=""
+            for _ in $(seq 1 30); do
+              candidates=$(find_pr_run "${wf}")
+              if [[ -n "${candidates}" && "${candidates}" != "null" ]]; then
+                break
+              fi
+              echo "Waiting for pull_request run for ${wf} at ${HEAD_SHA:0:7}..."
+              sleep 2
+            done
+            if [[ -z "${candidates}" || "${candidates}" == "null" ]]; then
+              echo "No pull_request run for ${wf} at ${HEAD_SHA:0:7} on PR #${PR_NUMBER}."
+              ERRORS=$((ERRORS + 1))
+              return
+            fi
+
+            run_id=$(jq -r '.id' <<<"${candidates}")
+            echo "Considering ${wf} PR run #${run_id}..."
+
+            wait_until_rerun_or_skip "${run_id}"
+            rc=$?
+            if [[ ${rc} -eq 2 ]]; then
+              SKIPPED=$((SKIPPED + 1))
+              return
+            fi
+            if [[ ${rc} -ne 0 ]]; then
+              TIMEOUTS=$((TIMEOUTS + 1))
+              return
+            fi
+
+            # Fresh check again right before gh run rerun.
+            if ! pr_json=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}"); then
+              echo "Failed to fetch PR #${PR_NUMBER} before rerun of ${wf}."
+              ERRORS=$((ERRORS + 1))
+              return
+            fi
+            if ! pr_is_open; then
+              echo "PR #${PR_NUMBER} is no longer open; skipping rerun of ${wf}."
+              STALE=$((STALE + 1))
+              return
+            fi
+            cur_sha=$(jq -r '.head.sha' <<<"${pr_json}")
+            if [[ "${cur_sha}" != "${HEAD_SHA}" ]]; then
+              echo "Head/approval changed immediately before rerun of ${wf}; skipping."
+              STALE=$((STALE + 1))
+              return
+            fi
+            approval_still_valid "${HEAD_SHA}"
+            av_rc=$?
+            if [[ ${av_rc} -eq 2 ]]; then
+              echo "Failed to fetch reviews for PR #${PR_NUMBER} before rerun of ${wf}."
+              ERRORS=$((ERRORS + 1))
+              return
+            fi
+            if [[ ${av_rc} -ne 0 ]]; then
+              echo "Head/approval changed immediately before rerun of ${wf}; skipping."
+              STALE=$((STALE + 1))
+              return
+            fi
+
+            if gh run rerun "${run_id}" -R "${REPO}"; then
+              STARTED=$((STARTED + 1))
+            else
+              echo "Failed to start ${wf} from run #${run_id}"
+              ERRORS=$((ERRORS + 1))
+            fi
+          }
+
+          echo "Approval from ${REVIEWER} on ${HEAD_SHA:0:7} — starting e2e via pull_request rerun."
+
+          for wf in "${E2E_WORKFLOWS[@]}"; do
+            set +e
+            start_via_pr_run "${wf}"
+            wf_rc=$?
+            set -e
+            if [[ ${wf_rc} -ne 0 ]]; then
+              echo "Unexpected failure while processing ${wf} (rc=${wf_rc})."
+              ERRORS=$((ERRORS + 1))
+            fi
+          done
+
+          {
+            echo "### E2E on approval"
+            echo ""
+            echo "Approval from \`${REVIEWER}\` on \`${HEAD_SHA:0:7}\` — starting expensive e2e (PR run replay)."
+            echo "- Started: ${STARTED}/${#E2E_WORKFLOWS[@]}"
+            if [[ ${SKIPPED} -gt 0 ]]; then
+              echo "- Already active/green (skipped rerun): ${SKIPPED}"
+            fi
+            if [[ ${STALE} -gt 0 ]]; then
+              echo "- Head moved or approval withdrawn (no rerun): ${STALE}"
+            fi
+            if [[ ${TIMEOUTS} -gt 0 ]]; then
+              echo "- Timed out waiting for the expensive job to reach a terminal state: ${TIMEOUTS}"
+            fi
+            if [[ ${ERRORS} -gt 0 ]]; then
+              echo "- Errors: ${ERRORS}"
+              echo ""
+              echo "Needs a prior \`pull_request\` e2e run at this head for PR #${PR_NUMBER}."
+            fi
+          } > /tmp/e2e-on-approval.md
+
+          gh pr comment "${PR_NUMBER}" -R "${REPO}" --body "$(cat /tmp/e2e-on-approval.md)"
+
+          if [[ ${ERRORS} -gt 0 || ${TIMEOUTS} -gt 0 ]]; then
+            exit 1
+          fi
+
+  # Fork CR APPROVED: job must succeed so workflow_run can replay. Do not call
+  # gh run rerun here (read-only token / no secrets).
+  # Job id "fork-handoff" is the display name (no name:). e2e-on-approval-fork.yml
+  # matches that string; rename both or fork replay never starts.
+  fork-handoff:
+    permissions: {}
+    if: >-
+      github.event.review.state == 'approved' &&
+      github.event.review.user.login == 'coderabbitai[bot]' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Handoff fork approval to workflow_run replay
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          echo "Fork PR ${HEAD_REPO}: pull_request_review cannot rerun workflows."
+          echo "e2e-on-approval-fork.yml (workflow_run on the default branch) starts e2e after this run completes."

--- a/.github/workflows/e2e-on-label.yml
+++ b/.github/workflows/e2e-on-label.yml
@@ -1,0 +1,364 @@
+---
+# OSAC-3370: when lgtm (or quiet e2e-ready override) is added, start expensive
+# e2e callers. Replay the pull_request run at HEAD (paths-filter + readiness).
+# e2e-ready must come from github-actions[bot] (/e2e-ready); match the gate.
+# pull_request_target: fork PRs can manage runs/comments with base-repo token.
+name: E2E on unlock label
+
+on:
+  pull_request_target:
+    types: [labeled]
+    branches: [main]
+
+permissions:
+  contents: read
+
+# Shared with e2e-on-approval. Queue, do not cancel: a killed starter leaves
+# partial reruns and no summary. Revalidation makes a queued run idempotent.
+concurrency:
+  group: e2e-start-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  start-e2e:
+    permissions:
+      actions: write
+      contents: read
+      issues: read
+      pull-requests: write
+    if: contains(fromJSON('["lgtm","e2e-ready"]'), github.event.label.name)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Start e2e workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          TRIGGER_LABEL: ${{ github.event.label.name }}
+        run: |
+          set -euo pipefail
+
+          pr_is_open() {
+            [[ "$(jq -r '.state' <<<"${pr_json}")" == "open" ]]
+          }
+
+          pr_json=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
+          if ! pr_is_open; then
+            echo "PR #${PR_NUMBER} is $(jq -r '.state' <<<"${pr_json}") (not open); skipping."
+            exit 0
+          fi
+          HEAD_SHA=$(jq -r '.head.sha' <<<"${pr_json}")
+          HEAD_REPO=$(jq -r '.head.repo.full_name // empty' <<<"${pr_json}")
+          HEAD_REF=$(jq -r '.head.ref // empty' <<<"${pr_json}")
+          if [[ "${HEAD_SHA}" != "${EVENT_HEAD_SHA}" ]]; then
+            echo "PR head moved (${EVENT_HEAD_SHA:0:7} → ${HEAD_SHA:0:7}); skipping start."
+            exit 0
+          fi
+          labels_json=$(gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUMBER}/labels" | jq 'add')
+          if ! jq -e --arg n "${TRIGGER_LABEL}" '[.[].name] | index($n) != null' <<<"${labels_json}" >/dev/null; then
+            echo "${TRIGGER_LABEL} label no longer present; skipping start."
+            exit 0
+          fi
+
+          # Match gate: e2e-ready counts only when applied by github-actions[bot].
+          e2e_ready_applied_by_bot() {
+            local events_json
+            if ! events_json=$(gh api --paginate --slurp \
+              "repos/${REPO}/issues/${PR_NUMBER}/events?per_page=100" | jq 'add'); then
+              return 2
+            fi
+            jq -e '
+              [.[]
+                | select(.event == "labeled")
+                | select(.label.name == "e2e-ready")
+              ] | last
+              | . != null and .actor.login == "github-actions[bot]"
+            ' <<<"${events_json}" >/dev/null 2>&1
+          }
+
+          pr_has_trigger_label() {
+            local labels_json
+            if ! labels_json=$(gh api --paginate --slurp \
+              "repos/${REPO}/issues/${PR_NUMBER}/labels" | jq 'add'); then
+              return 2
+            fi
+            jq -e --arg n "${TRIGGER_LABEL}" '[.[].name] | index($n) != null' \
+              <<<"${labels_json}" >/dev/null
+          }
+
+          if [[ "${TRIGGER_LABEL}" == "e2e-ready" ]]; then
+            e2e_rc=0
+            e2e_ready_applied_by_bot || e2e_rc=$?
+            if [[ ${e2e_rc} -eq 2 ]]; then
+              echo "Failed to fetch issue events for PR #${PR_NUMBER}; skipping start."
+              exit 1
+            fi
+            if [[ ${e2e_rc} -ne 0 ]]; then
+              echo "e2e-ready was not applied by github-actions[bot]; skipping start."
+              {
+                echo "### E2E on \`e2e-ready\` skipped"
+                echo ""
+                echo "Label \`e2e-ready\` must be applied by \`/e2e-ready\` (\`github-actions[bot]\`)."
+                echo "Manual UI labels do not unlock expensive e2e."
+              } > /tmp/e2e-on-label-untrusted.md
+              gh pr comment "${PR_NUMBER}" -R "${REPO}" --body "$(cat /tmp/e2e-on-label-untrusted.md)"
+              exit 0
+            fi
+          fi
+
+          E2E_WORKFLOWS=(
+            e2e-vmaas-full-install.yml
+            e2e-bmaas-full-install.yml
+            e2e-caas-full-install.yml
+          )
+
+          STARTED=0
+          ERRORS=0
+          SKIPPED=0
+          STALE=0
+          TIMEOUTS=0
+
+          find_pr_run() {
+            local wf="$1"
+            local runs
+            # Runs come back newest-first; current head is on page 1.
+            runs=$(gh api \
+              "repos/${REPO}/actions/workflows/${wf}/runs?event=pull_request&per_page=100" \
+              --jq '[.workflow_runs[]]')
+            # Prefer PR-number match; fork runs often have empty pull_requests —
+            # fall back only when head repo+branch uniquely match this PR.
+            jq -c --arg sha "${HEAD_SHA}" --argjson pr "${PR_NUMBER}" \
+              --arg repo "${HEAD_REPO}" --arg ref "${HEAD_REF}" '
+              ([.[]
+                | select(.head_sha == $sha)
+                | select(any(.pull_requests[]?; .number == $pr))
+              ][0])
+              // (if ($repo | length) > 0 and ($ref | length) > 0 then
+                  ([.[]
+                    | select(.head_sha == $sha)
+                    | select((.pull_requests // []) | length == 0)
+                    | select((.head_repository.full_name // "") == $repo)
+                    | select(.head_branch == $ref)
+                  ] | if length == 1 then .[0] else empty end)
+                else empty end)
+              // empty
+            ' <<<"${runs}"
+          }
+
+          # Returns: 0 = ok to rerun (run completed, not success),
+          #          2 = already going / already green (skip),
+          #          1 = error / timeout.
+          wait_until_rerun_or_skip() {
+            local run_id="$1"
+            local view status conclusion busy
+            for _ in $(seq 1 90); do
+              view=$(gh run view "${run_id}" -R "${REPO}" --json status,conclusion,jobs)
+              status=$(jq -r '.status' <<<"${view}")
+              conclusion=$(jq -r '.conclusion // empty' <<<"${view}")
+              # Reusable calls prefix every child with the caller job name
+              # (e2e-*-full-install / ...). Do not trust the first match.
+              busy=$(jq -r '
+                [.jobs[]
+                  | select(.name | test("full-install"; "i"))
+                  | select(.name | test("readiness"; "i") | not)
+                  | .status
+                ]
+                | if length == 0 then "unknown"
+                  else (map(select(. == "in_progress" or . == "queued")) | length > 0 | tostring)
+                  end
+              ' <<<"${view}")
+
+              # No expensive job matched yet: do not assume idle.
+              if [[ "${busy}" == "unknown" && "${status}" != "completed" ]]; then
+                sleep 2
+                continue
+              fi
+
+              if [[ "${busy}" == "true" ]]; then
+                echo "Expensive job already active on run #${run_id}; skip rerun."
+                return 2
+              fi
+
+              if [[ "${status}" == "completed" ]]; then
+                if [[ "${conclusion}" == "success" ]]; then
+                  return 2
+                fi
+                echo "Run #${run_id} completed (conclusion=${conclusion:-none}); will rerun."
+                return 0
+              fi
+              sleep 2
+            done
+            echo "Timed out waiting on run #${run_id}; expensive job never started."
+            return 1
+          }
+
+          start_via_pr_run() {
+            local wf="$1"
+            local candidates run_id rc cur_sha lbl_rc e2e_rc
+
+            # Re-validate head/label before each workflow touch.
+            if ! pr_json=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}"); then
+              echo "Failed to fetch PR #${PR_NUMBER} while processing ${wf}."
+              ERRORS=$((ERRORS + 1))
+              return
+            fi
+            if ! pr_is_open; then
+              echo "PR #${PR_NUMBER} is no longer open; aborting ${wf}."
+              STALE=$((STALE + 1))
+              return
+            fi
+            cur_sha=$(jq -r '.head.sha' <<<"${pr_json}")
+            if [[ "${cur_sha}" != "${HEAD_SHA}" ]]; then
+              echo "PR head moved before starting ${wf} (${HEAD_SHA:0:7} → ${cur_sha:0:7}); aborting."
+              STALE=$((STALE + 1))
+              return
+            fi
+            pr_has_trigger_label
+            lbl_rc=$?
+            if [[ ${lbl_rc} -eq 2 ]]; then
+              echo "Failed to fetch labels for PR #${PR_NUMBER} while processing ${wf}."
+              ERRORS=$((ERRORS + 1))
+              return
+            fi
+            if [[ ${lbl_rc} -ne 0 ]]; then
+              echo "${TRIGGER_LABEL} label removed before starting ${wf}; aborting."
+              STALE=$((STALE + 1))
+              return
+            fi
+            if [[ "${TRIGGER_LABEL}" == "e2e-ready" ]]; then
+              e2e_ready_applied_by_bot
+              e2e_rc=$?
+              if [[ ${e2e_rc} -eq 2 ]]; then
+                echo "Failed to fetch issue events for PR #${PR_NUMBER} while processing ${wf}."
+                ERRORS=$((ERRORS + 1))
+                return
+              fi
+              if [[ ${e2e_rc} -ne 0 ]]; then
+                echo "e2e-ready no longer trusted before starting ${wf}; aborting."
+                STALE=$((STALE + 1))
+                return
+              fi
+            fi
+
+            candidates=""
+            for _ in $(seq 1 30); do
+              candidates=$(find_pr_run "${wf}")
+              if [[ -n "${candidates}" && "${candidates}" != "null" ]]; then
+                break
+              fi
+              echo "Waiting for pull_request run for ${wf} at ${HEAD_SHA:0:7}..."
+              sleep 2
+            done
+            if [[ -z "${candidates}" || "${candidates}" == "null" ]]; then
+              echo "No pull_request run for ${wf} at ${HEAD_SHA:0:7} on PR #${PR_NUMBER}."
+              ERRORS=$((ERRORS + 1))
+              return
+            fi
+
+            run_id=$(jq -r '.id' <<<"${candidates}")
+            echo "Considering ${wf} PR run #${run_id}..."
+
+            wait_until_rerun_or_skip "${run_id}"
+            rc=$?
+            if [[ ${rc} -eq 2 ]]; then
+              SKIPPED=$((SKIPPED + 1))
+              return
+            fi
+            if [[ ${rc} -ne 0 ]]; then
+              TIMEOUTS=$((TIMEOUTS + 1))
+              return
+            fi
+
+            # Re-check head + label (and e2e-ready actor) immediately before rerun.
+            if ! pr_json=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}"); then
+              echo "Failed to fetch PR #${PR_NUMBER} before rerun of ${wf}."
+              ERRORS=$((ERRORS + 1))
+              return
+            fi
+            if ! pr_is_open; then
+              echo "PR #${PR_NUMBER} is no longer open; skipping rerun of ${wf}."
+              STALE=$((STALE + 1))
+              return
+            fi
+            cur_sha=$(jq -r '.head.sha' <<<"${pr_json}")
+            if [[ "${cur_sha}" != "${HEAD_SHA}" ]]; then
+              echo "PR head moved while waiting for ${wf}; skipping rerun."
+              STALE=$((STALE + 1))
+              return
+            fi
+            pr_has_trigger_label
+            lbl_rc=$?
+            if [[ ${lbl_rc} -eq 2 ]]; then
+              echo "Failed to fetch labels for PR #${PR_NUMBER} before rerun of ${wf}."
+              ERRORS=$((ERRORS + 1))
+              return
+            fi
+            if [[ ${lbl_rc} -ne 0 ]]; then
+              echo "${TRIGGER_LABEL} label gone before rerun of ${wf}; skipping."
+              STALE=$((STALE + 1))
+              return
+            fi
+            if [[ "${TRIGGER_LABEL}" == "e2e-ready" ]]; then
+              e2e_ready_applied_by_bot
+              e2e_rc=$?
+              if [[ ${e2e_rc} -eq 2 ]]; then
+                echo "Failed to fetch issue events for PR #${PR_NUMBER} before rerun of ${wf}."
+                ERRORS=$((ERRORS + 1))
+                return
+              fi
+              if [[ ${e2e_rc} -ne 0 ]]; then
+                echo "e2e-ready no longer trusted before rerun of ${wf}; skipping."
+                STALE=$((STALE + 1))
+                return
+              fi
+            fi
+
+            if gh run rerun "${run_id}" -R "${REPO}"; then
+              STARTED=$((STARTED + 1))
+            else
+              echo "Failed to start ${wf} from run #${run_id}"
+              ERRORS=$((ERRORS + 1))
+            fi
+          }
+
+          echo "${TRIGGER_LABEL} label on PR #${PR_NUMBER} (${HEAD_SHA:0:7}) — starting e2e via pull_request rerun."
+
+          for wf in "${E2E_WORKFLOWS[@]}"; do
+            set +e
+            start_via_pr_run "${wf}"
+            wf_rc=$?
+            set -e
+            if [[ ${wf_rc} -ne 0 ]]; then
+              echo "Unexpected failure while processing ${wf} (rc=${wf_rc})."
+              ERRORS=$((ERRORS + 1))
+            fi
+          done
+
+          {
+            echo "### E2E on \`${TRIGGER_LABEL}\`"
+            echo ""
+            echo "Label \`${TRIGGER_LABEL}\` applied — starting expensive e2e (PR run replay)."
+            echo "- Started: ${STARTED}/${#E2E_WORKFLOWS[@]}"
+            if [[ ${SKIPPED} -gt 0 ]]; then
+              echo "- Already active/green (skipped rerun): ${SKIPPED}"
+            fi
+            if [[ ${STALE} -gt 0 ]]; then
+              echo "- Head moved or label withdrawn (no rerun): ${STALE}"
+            fi
+            if [[ ${TIMEOUTS} -gt 0 ]]; then
+              echo "- Timed out waiting for the expensive job to reach a terminal state: ${TIMEOUTS}"
+            fi
+            if [[ ${ERRORS} -gt 0 ]]; then
+              echo "- Errors: ${ERRORS}"
+              echo ""
+              echo "Needs a prior \`pull_request\` e2e run at this head for PR #${PR_NUMBER}."
+            fi
+          } > /tmp/e2e-on-label.md
+
+          gh pr comment "${PR_NUMBER}" -R "${REPO}" --body "$(cat /tmp/e2e-on-label.md)"
+
+          if [[ ${ERRORS} -gt 0 || ${TIMEOUTS} -gt 0 ]]; then
+            exit 1
+          fi

--- a/.github/workflows/e2e-ready-label-cleanup.yml
+++ b/.github/workflows/e2e-ready-label-cleanup.yml
@@ -1,0 +1,14 @@
+---
+# Remove e2e-ready on new push. lgtm staleness is Prow; this caller only
+# strips the quiet override. Reusable lives in osac-test-infra (OSAC-3370).
+name: Remove e2e-ready label on new push
+on:
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  remove-label:
+    permissions:
+      pull-requests: write
+    if: contains(github.event.pull_request.labels.*.name, 'e2e-ready')
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-ready-label-cleanup.yml@main

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -75,6 +75,24 @@ jobs:
               - '!.skillsaw.yaml'
               - '!.pre-commit-config.yaml'
 
+  # OSAC-3370: cheap readiness gate before expensive runners.
+  # Allow: lgtm present, e2e-ready applied by github-actions[bot], or
+  # coderabbitai[bot] APPROVED on exact HEAD (blocked by human CHANGES_REQUESTED).
+  # Human APPROVED does not unlock. Non-PR events skip this job.
+  e2e-readiness:
+    needs: changes
+    if: needs.changes.outputs.should-run == 'true' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: read
+    steps:
+      - name: Check e2e readiness
+        uses: osac-project/osac-test-infra/.github/actions/check-e2e-readiness@main
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
+
   # Builds fulfillment-service, osac-operator, osac-aap's execution
   # environment (twice -- once each for aap.bootstrap.image and
   # aap.configAsCode.eeImage, see OSAC-3546), and bare-metal-fulfillment-operator
@@ -92,8 +110,13 @@ jobs:
   # should build from the PR in every e2e flow, even where one isn't
   # currently deployed) -- revisit if vmaas ever needs BMF enabled.
   e2e-vmaas-full-install:
-    needs: changes
-    if: needs.changes.outputs.should-run == 'true'
+    needs: [changes, e2e-readiness]
+    if: >-
+      always()
+      && needs.changes.result == 'success'
+      && needs.changes.outputs.should-run == 'true'
+      && (needs.e2e-readiness.result == 'success'
+          || needs.e2e-readiness.result == 'skipped')
     uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main
     with:
       test-suite: ${{ inputs.test-suite || 'vmaas' }}
@@ -122,13 +145,23 @@ jobs:
 
   e2e-vmaas-gate:
     if: always()
-    needs: [changes, e2e-vmaas-full-install]
+    needs: [changes, e2e-readiness, e2e-vmaas-full-install]
     runs-on: ubuntu-latest
     steps:
-      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+      - if: needs.e2e-readiness.result == 'failure'
+        run: |
+          echo "e2e-readiness failed: expensive e2e is gated until unlock."
+          echo "Need coderabbitai[bot] APPROVED on this HEAD, lgtm, or /e2e-ready."
+          echo "See .github/e2e-readiness.md"
+          echo "Upstream: changes=${{ needs.changes.result }} e2e-readiness=failure full-install=${{ needs.e2e-vmaas-full-install.result }}"
+          exit 1
+      - if: >-
+          needs.e2e-readiness.result != 'failure'
+          && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
         run: |
           echo "Upstream job results:"
           echo "  changes: ${{ needs.changes.result }}"
+          echo "  e2e-readiness: ${{ needs.e2e-readiness.result }}"
           echo "  e2e-vmaas-full-install: ${{ needs.e2e-vmaas-full-install.result }}"
           echo ""
           echo "One or more upstream jobs failed or were cancelled."

--- a/.github/workflows/slash-command.yml
+++ b/.github/workflows/slash-command.yml
@@ -18,6 +18,7 @@ jobs:
       (startsWith(github.event.comment.body, '/test') ||
        startsWith(github.event.comment.body, '/retest') ||
        startsWith(github.event.comment.body, '/cancel') ||
-       startsWith(github.event.comment.body, '/ok-to-test'))
+       startsWith(github.event.comment.body, '/ok-to-test') ||
+       startsWith(github.event.comment.body, '/e2e-ready'))
     uses: osac-project/osac-test-infra/.github/workflows/slash-command-handler.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary
- Gate `e2e-vmaas` / `e2e-bmaas` / `e2e-caas-full-install` on readiness (fail closed for PRs; skip for schedule / dispatch / merge_group)
- Unlock via `coderabbitai[bot]` APPROVED on exact HEAD, `lgtm`, or `/e2e-ready` (`github-actions[bot]` only; manual UI labels rejected)
- Starters: `e2e-on-approval` (CodeRabbit-only) and `e2e-on-label` (`lgtm` / `e2e-ready`) replay existing PR runs
- Thin cleanup caller strips stale `e2e-ready` on push (`lgtm` staleness is Prow)
- Depends on merged [osac-test-infra#334](https://github.com/osac-project/osac-test-infra/pull/334); callers pin `check-e2e-readiness@main` and cleanup reusable `@main`

## Test plan
- [x] Merge test-infra PR so `@main` action + cleanup reusable exist
- [ ] PR with no unlock → expensive e2e fail closed
- [ ] CodeRabbit APPROVED → gate passes; human APPROVED alone does not
- [ ] `lgtm` or `/e2e-ready` → starters rerun e2e; push clears `e2e-ready` (Prow clears `lgtm`)
- [ ] Manual `e2e-ready` UI label does not unlock
- [ ] Non-PR events still skip readiness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added readiness checks before resource-intensive end-to-end test runs.
  - E2E tests can be initiated through approved labels, CodeRabbit approval, or the `/e2e-ready` command.
  - Pull request updates show which test runs started, were skipped, or failed.
  - Readiness labels are automatically cleared when new changes are pushed.
  - Scheduled and manually triggered test runs continue without pull request readiness requirements.
  - Added fork-safe handling for approved pull request test reruns.

- **Documentation**
  - Added guidance covering readiness requirements, supported signals, fork behavior, and troubleshooting steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->