### PR TITLE
OSAC-3631: add StorageTier assertions to reconciler addExplicitFields test

### DIFF
--- a/fulfillment-service/internal/controllers/computeinstance/computeinstance_reconciler_function_test.go
+++ b/fulfillment-service/internal/controllers/computeinstance/computeinstance_reconciler_function_test.go
@@ -177,14 +177,17 @@ var _ = Describe("buildSpec", func() {
 							SourceRef:  "quay.io/fedora/fedora:latest",
 						}.Build(),
 						BootDisk: privatev1.ComputeInstanceDisk_builder{
-							SizeGib: 20,
+							SizeGib:     20,
+							StorageTier: new("fast"),
 						}.Build(),
 						AdditionalDisks: []*privatev1.ComputeInstanceDisk{
 							privatev1.ComputeInstanceDisk_builder{
-								SizeGib: 100,
+								SizeGib:     100,
+								StorageTier: new("standard"),
 							}.Build(),
 							privatev1.ComputeInstanceDisk_builder{
-								SizeGib: 50,
+								SizeGib:     50,
+								StorageTier: new("archive"),
 							}.Build(),
 						},
 						NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -209,10 +212,13 @@ var _ = Describe("buildSpec", func() {
 			Expect(spec.Image.SourceRef).To(Equal("quay.io/fedora/fedora:latest"))
 
 			Expect(spec.BootDisk.SizeGiB).To(Equal(int32(20)))
+			Expect(spec.BootDisk.StorageTier).To(Equal("fast"))
 
 			Expect(spec.AdditionalDisks).To(HaveLen(2))
 			Expect(spec.AdditionalDisks[0].SizeGiB).To(Equal(int32(100)))
+			Expect(spec.AdditionalDisks[0].StorageTier).To(Equal("standard"))
 			Expect(spec.AdditionalDisks[1].SizeGiB).To(Equal(int32(50)))
+			Expect(spec.AdditionalDisks[1].StorageTier).To(Equal("archive"))
 
 			Expect(spec.UserDataSecretRef).ToNot(BeNil())
 			Expect(spec.UserDataSecretRef.Name).To(Equal("test-explicit-fields-user-data"))


### PR DESCRIPTION
## [OSAC-3631](https://redhat.atlassian.net/browse/OSAC-3631): add StorageTier assertions to reconciler addExplicitFields test

**Jira:** [OSAC-3631](https://redhat.atlassian.net/browse/OSAC-3631)
**Story type:** [DEV]
**Depends on:** https://github.com/osac-project/osac/pull/159 ([OSAC-3629](https://redhat.atlassian.net/browse/OSAC-3629): proto/CRD storage_tier field)

> **Note for reviewers:** This PR is stacked on [OSAC-3629](https://redhat.atlassian.net/browse/OSAC-3629). The [OSAC-3631](https://redhat.atlassian.net/browse/OSAC-3631) change is in the last commit (`f53fd921`). Please review only that commit until #159 is merged.

### Summary

Adds test coverage for the `StorageTier` mapping in the reconciler's `addExplicitFields()` function. The mapping itself (proto `storage_tier` → CRD `DiskSpec.StorageTier`) was added by [OSAC-3629](https://redhat.atlassian.net/browse/OSAC-3629); this PR adds the missing assertions for boot disk and additional disks.

### Changes

- **fulfillment-service/internal/controllers/computeinstance/computeinstance_reconciler_function_test.go**
  - Added `StorageTier` values to proto disk fixtures (boot disk: `"fast"`, additional disks: `"standard"`, `"archive"`)
  - Added assertions verifying `StorageTier` flows through to CRD `DiskSpec`

### Testing

- **Unit tests:** 3 new assertions added to existing "Includes explicit fields" test
- **Integration tests:** N/A (test-only change)
- **Coverage:** All behavioral paths for StorageTier mapping covered (positive + negative via existing "Excludes explicit fields" test)

### Acceptance Criteria

- [x] `addExplicitFields()` maps `storage_tier` for boot disk and additional disks
- [x] Existing `SizeGiB` mapping unchanged

Assisted-by: Claude Code <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional storage-tier settings for boot and additional disks.
  * Supported tiers include `standard`, `fast`, and `archive`.
  * Storage tiers are validated for format and length.
  * Storage-tier values remain unchanged after a ComputeInstance is created.

* **Documentation**
  * Updated ComputeInstance examples to demonstrate the `standard` storage tier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->