### PR TITLE
OSAC-3630: Storage tier defaults merging and validation

### DIFF
--- a/fulfillment-service/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
@@ -122,6 +122,12 @@ func Cmd() *cobra.Command {
 		0,
 		bootDiskSizeFlagHelp,
 	)
+	flags.StringVar(
+		&runner.args.bootDiskStorageTier,
+		"boot-disk-storage-tier",
+		"",
+		bootDiskStorageTierFlagHelp,
+	)
 	flags.StringSliceVar(
 		&runner.args.additionalDisks,
 		"additional-disk",
@@ -183,6 +189,7 @@ type runnerContext struct {
 		imageSourceType         string
 		sshPublicKey            string
 		bootDiskSizeGiB         int32
+		bootDiskStorageTier     string
 		additionalDisks         []string
 		runStrategy             string
 		userData                string
@@ -738,10 +745,8 @@ func (c *runnerContext) buildSpec(templateID string,
 	if c.args.sshPublicKey != "" {
 		spec.SshPublicKey = proto.String(c.args.sshPublicKey)
 	}
-	if c.args.bootDiskSizeGiB > 0 {
-		spec.BootDisk = publicv1.ComputeInstanceDisk_builder{
-			SizeGib: c.args.bootDiskSizeGiB,
-		}.Build()
+	if disk := c.buildBootDisk(); disk != nil {
+		spec.BootDisk = disk
 	}
 	if len(c.args.additionalDisks) > 0 {
 		disks, err := parseAdditionalDisks(c.args.additionalDisks)
@@ -764,6 +769,20 @@ func (c *runnerContext) buildSpec(templateID string,
 		return nil, err
 	}
 	return spec.Build(), nil
+}
+
+// buildBootDisk returns a boot disk from CLI flags, or nil if neither size nor storage tier was set.
+func (c *runnerContext) buildBootDisk() *publicv1.ComputeInstanceDisk {
+	if c.args.bootDiskSizeGiB <= 0 && c.args.bootDiskStorageTier == "" {
+		return nil
+	}
+	builder := publicv1.ComputeInstanceDisk_builder{
+		SizeGib: c.args.bootDiskSizeGiB,
+	}
+	if c.args.bootDiskStorageTier != "" {
+		builder.StorageTier = proto.String(c.args.bootDiskStorageTier)
+	}
+	return builder.Build()
 }
 
 // applyNetworkingFlags sets spec.network_attachments from CLI flags.
@@ -865,10 +884,8 @@ func (c *runnerContext) buildSpecFromCatalogItem(catalogItemID string) (*publicv
 	if c.args.sshPublicKey != "" {
 		spec.SshPublicKey = proto.String(c.args.sshPublicKey)
 	}
-	if c.args.bootDiskSizeGiB > 0 {
-		spec.BootDisk = publicv1.ComputeInstanceDisk_builder{
-			SizeGib: c.args.bootDiskSizeGiB,
-		}.Build()
+	if disk := c.buildBootDisk(); disk != nil {
+		spec.BootDisk = disk
 	}
 	if len(c.args.additionalDisks) > 0 {
 		disks, diskErr := parseAdditionalDisks(c.args.additionalDisks)
@@ -893,18 +910,74 @@ func (c *runnerContext) buildSpecFromCatalogItem(catalogItemID string) (*publicv
 	return spec.Build(), nil
 }
 
-// parseAdditionalDisks parses disk sizes in GiB.
-// Example: "100"
+// parseAdditionalDisks parses disk specifications in two formats:
+//  1. Bare integer (legacy): "100" specifies size in GiB
+//  2. Key=value format: "size=100,storage-tier=standard"
+//
+// The storage-tier field is optional in the key=value format for backward compatibility.
 func parseAdditionalDisks(diskArgs []string) ([]*publicv1.ComputeInstanceDisk, error) {
 	disks := make([]*publicv1.ComputeInstanceDisk, 0, len(diskArgs))
 	for _, arg := range diskArgs {
-		sizeGiB, err := strconv.ParseInt(arg, 10, 32)
-		if err != nil {
-			return nil, fmt.Errorf("invalid disk size '%s': expected an integer number of GiB", arg)
+		arg = strings.TrimSpace(arg)
+		if arg == "" {
+			return nil, fmt.Errorf("empty --additional-disk value")
 		}
-		disks = append(disks, publicv1.ComputeInstanceDisk_builder{
-			SizeGib: int32(sizeGiB),
-		}.Build())
+
+		// Legacy format: bare integer is interpreted as size in GiB
+		if !strings.Contains(arg, "=") {
+			sizeGiB, err := strconv.ParseInt(arg, 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid --additional-disk value %q: expected an integer or key=value format", arg)
+			}
+			disk := publicv1.ComputeInstanceDisk_builder{
+				SizeGib: int32(sizeGiB),
+			}.Build()
+			disks = append(disks, disk)
+			continue
+		}
+
+		// Key=value format
+		disk := publicv1.ComputeInstanceDisk_builder{}
+		var hasSize bool
+
+		for _, fragment := range strings.Split(arg, ",") {
+			fragment = strings.TrimSpace(fragment)
+			if fragment == "" {
+				continue
+			}
+
+			key, value, found := strings.Cut(fragment, "=")
+			if !found {
+				return nil, fmt.Errorf("invalid --additional-disk fragment %q (expected key=value)", fragment)
+			}
+
+			key = strings.TrimSpace(key)
+			value = strings.TrimSpace(value)
+
+			if value == "" {
+				return nil, fmt.Errorf("invalid --additional-disk fragment %q (value is empty)", fragment)
+			}
+
+			switch key {
+			case "size":
+				sizeGiB, err := strconv.ParseInt(value, 10, 32)
+				if err != nil {
+					return nil, fmt.Errorf("invalid size value %q: expected an integer number of GiB", value)
+				}
+				disk.SizeGib = int32(sizeGiB)
+				hasSize = true
+			case "storage-tier":
+				disk.StorageTier = proto.String(value)
+			default:
+				return nil, fmt.Errorf("unknown --additional-disk key %q (expected 'size' or 'storage-tier')", key)
+			}
+		}
+
+		if !hasSize {
+			return nil, fmt.Errorf("--additional-disk %q must include size=<value>", arg)
+		}
+
+		disks = append(disks, disk.Build())
 	}
 	return disks, nil
 }
@@ -1016,9 +1089,16 @@ const bootDiskSizeFlagHelp = `
 _SIZE_ - Boot disk size in GiB.
 `
 
+const bootDiskStorageTierFlagHelp = `
+_TIER_ - Storage tier for the boot disk.
+`
+
 const additionalDiskFlagHelp = `
-_SIZE_ - Additional disk size in GiB. Can be specified multiple times to add
-more than one disk.
+_SPEC_ - Additional disk specification. Accepts two formats:
+1. Bare integer: {{ bt }}<GiB>{{ bt }} specifies disk size in GiB (temporary, backward compatibility only)
+2. Key=value: {{ bt }}size=<GiB>,storage-tier=<name>{{ bt }} specifies disk size and storage tier name
+
+Can be specified multiple times to add more than one disk.
 `
 
 const runStrategyFlagHelp = `

--- a/fulfillment-service/internal/servers/compute_instances_server_test.go
+++ b/fulfillment-service/internal/servers/compute_instances_server_test.go
@@ -152,6 +152,29 @@ var _ = Describe("Compute instances server", func() {
 				}.Build(),
 			).Do(ctx)
 			Expect(err).ToNot(HaveOccurred())
+
+			storageTiersDao, err := dao.NewGenericDAO[*privatev1.StorageTier]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = storageTiersDao.Create().SetObject(
+				privatev1.StorageTier_builder{
+					Id: "standard",
+					Metadata: privatev1.Metadata_builder{
+						Name:   "standard",
+						Tenant: auth.SharedTenant,
+					}.Build(),
+					Spec: privatev1.StorageTierSpec_builder{
+						Description: "Standard storage tier",
+					}.Build(),
+					Status: privatev1.StorageTierStatus_builder{
+						State: privatev1.StorageTierState_STORAGE_TIER_STATE_ACTIVE,
+					}.Build(),
+				}.Build(),
+			).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		// Helper function to create a template
@@ -202,7 +225,8 @@ var _ = Describe("Compute instances server", func() {
 						SourceRef:  "quay.io/containerdisks/fedora:latest",
 					}.Build(),
 					BootDisk: privatev1.ComputeInstanceDisk_builder{
-						SizeGib: 10,
+						SizeGib:     10,
+						StorageTier: new("standard"),
 					}.Build(),
 					RunStrategy: new("Always"),
 				}.Build(),
@@ -428,7 +452,8 @@ var _ = Describe("Compute instances server", func() {
 							SourceRef:  "quay.io/test:latest",
 						}.Build(),
 						BootDisk: publicv1.ComputeInstanceDisk_builder{
-							SizeGib: 20,
+							SizeGib:     20,
+							StorageTier: new("standard"),
 						}.Build(),
 						NetworkAttachments: []*publicv1.NetworkAttachment{
 							publicv1.NetworkAttachment_builder{

--- a/fulfillment-service/internal/servers/private_compute_instances_server.go
+++ b/fulfillment-service/internal/servers/private_compute_instances_server.go
@@ -60,6 +60,7 @@ type PrivateComputeInstancesServer struct {
 	subnetsDao              *dao.GenericDAO[*privatev1.Subnet]
 	securityGroupsDao       *dao.GenericDAO[*privatev1.SecurityGroup]
 	instanceTypesDao        *dao.GenericDAO[*privatev1.InstanceType]
+	storageTiersDao         *dao.GenericDAO[*privatev1.StorageTier]
 	externalIPPoolDao       *dao.GenericDAO[*privatev1.ExternalIPPool]
 	externalIPDao           *dao.GenericDAO[*privatev1.ExternalIP]
 	externalIPAttachmentDao *dao.GenericDAO[*privatev1.ExternalIPAttachment]
@@ -157,6 +158,16 @@ func (b *PrivateComputeInstancesServerBuilder) Build() (result *PrivateComputeIn
 		return
 	}
 
+	// Create the StorageTiers DAO for storage tier validation:
+	storageTiersDao, err := dao.NewGenericDAO[*privatev1.StorageTier]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
 	externalIPPoolDao, err := dao.NewGenericDAO[*privatev1.ExternalIPPool]().
 		SetLogger(b.logger).
 		SetTenancyLogic(b.tenancyLogic).
@@ -206,6 +217,7 @@ func (b *PrivateComputeInstancesServerBuilder) Build() (result *PrivateComputeIn
 		subnetsDao:              subnetsDao,
 		securityGroupsDao:       securityGroupsDao,
 		instanceTypesDao:        instanceTypesDao,
+		storageTiersDao:         storageTiersDao,
 		externalIPPoolDao:       externalIPPoolDao,
 		externalIPDao:           externalIPDao,
 		externalIPAttachmentDao: externalIPAttachmentDao,
@@ -385,6 +397,11 @@ func (s *PrivateComputeInstancesServer) Create(ctx context.Context,
 		return
 	}
 
+	err = s.validateStorageTiers(ctx, spec)
+	if err != nil {
+		return
+	}
+
 	// Validate instance type existence and state (D-02: validate-only, no resolution).
 	// Must run after template/catalog defaults are applied so instance_type defaults
 	// from templates are visible.
@@ -444,6 +461,11 @@ func (s *PrivateComputeInstancesServer) Update(ctx context.Context,
 	}
 
 	err = s.validateNetworkAttachmentsImmutability(ctx, request)
+	if err != nil {
+		return
+	}
+
+	err = s.validateDiskImmutability(ctx, request)
 	if err != nil {
 		return
 	}
@@ -604,6 +626,37 @@ func (s *PrivateComputeInstancesServer) validateInstanceType(
 	return warnings, nil
 }
 
+// validateStorageTiers checks that all storage tiers referenced by boot and additional disks exist.
+func (s *PrivateComputeInstancesServer) validateStorageTiers(
+	ctx context.Context,
+	spec *privatev1.ComputeInstanceSpec,
+) error {
+	tiers := map[string]bool{}
+	if tier := spec.GetBootDisk().GetStorageTier(); tier != "" {
+		tiers[tier] = true
+	}
+	for _, disk := range spec.GetAdditionalDisks() {
+		if tier := disk.GetStorageTier(); tier != "" {
+			tiers[tier] = true
+		}
+	}
+	for name := range tiers {
+		_, err := s.storageTiersDao.Get().
+			SetId(name).
+			Do(ctx)
+		if err != nil {
+			var notFoundErr *dao.ErrNotFound
+			if errors.As(err, &notFoundErr) {
+				return grpcstatus.Errorf(grpccodes.InvalidArgument,
+					"storage tier '%s' does not exist", name)
+			}
+			return grpcstatus.Errorf(grpccodes.Internal,
+				"failed to retrieve storage tier '%s'", name)
+		}
+	}
+	return nil
+}
+
 // validateTemplateImmutability ensures that the template and template_parameters fields
 // cannot be changed after compute instance creation.
 func (s *PrivateComputeInstancesServer) validateTemplateImmutability(ctx context.Context,
@@ -743,6 +796,91 @@ func (s *PrivateComputeInstancesServer) validateNetworkAttachmentsImmutability(
 				"cannot change network_attachments[%d].subnet from '%s' to '%s': subnet is immutable",
 				i, refKey(existingSubnet), refKey(newSubnet),
 			)
+		}
+	}
+
+	return nil
+}
+
+// validateDiskImmutability ensures that boot_disk and additional_disks cannot be
+// modified after creation. The entire DiskSpec is immutable (size_gib and storage_tier).
+func (s *PrivateComputeInstancesServer) validateDiskImmutability(
+	ctx context.Context,
+	request *privatev1.ComputeInstancesUpdateRequest,
+) error {
+	updateMask := request.GetUpdateMask()
+	updatingBootDisk := hasMaskPrefix(updateMask, "spec.boot_disk")
+	updatingAdditionalDisks := hasMaskPrefix(updateMask, "spec.additional_disks")
+
+	if !updatingBootDisk && !updatingAdditionalDisks {
+		return nil
+	}
+
+	ci := request.GetObject()
+	if ci == nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "compute instance is mandatory")
+	}
+	id := ci.GetId()
+	if id == "" {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "compute instance id is mandatory")
+	}
+
+	getResponse, err := s.generic.dao.Get().SetId(id).Do(ctx)
+	if err != nil {
+		return err
+	}
+	existingCI := getResponse.GetObject()
+
+	existingSpec := existingCI.GetSpec()
+	newSpec := request.GetObject().GetSpec()
+
+	// Validate boot_disk immutability
+	if updatingBootDisk {
+		existingBootDisk := existingSpec.GetBootDisk()
+		newBootDisk := newSpec.GetBootDisk()
+
+		if existingBootDisk.GetSizeGib() != newBootDisk.GetSizeGib() {
+			return grpcstatus.Errorf(
+				grpccodes.InvalidArgument,
+				"cannot change spec.boot_disk.size_gib from %d to %d: boot disk is immutable",
+				existingBootDisk.GetSizeGib(), newBootDisk.GetSizeGib(),
+			)
+		}
+
+		if existingBootDisk.GetStorageTier() != newBootDisk.GetStorageTier() {
+			return grpcstatus.Errorf(
+				grpccodes.InvalidArgument,
+				"cannot change spec.boot_disk.storage_tier from %q to %q: boot disk is immutable",
+				existingBootDisk.GetStorageTier(), newBootDisk.GetStorageTier(),
+			)
+		}
+	}
+
+	// Validate additional_disks immutability
+	if updatingAdditionalDisks {
+		existingDisks := existingSpec.GetAdditionalDisks()
+		newDisks := newSpec.GetAdditionalDisks()
+
+		// Check that existing disks are not modified (adding new disks is allowed)
+		for i := 0; i < len(existingDisks) && i < len(newDisks); i++ {
+			existingDisk := existingDisks[i]
+			newDisk := newDisks[i]
+
+			if existingDisk.GetSizeGib() != newDisk.GetSizeGib() {
+				return grpcstatus.Errorf(
+					grpccodes.InvalidArgument,
+					"cannot change spec.additional_disks[%d].size_gib from %d to %d: disk is immutable",
+					i, existingDisk.GetSizeGib(), newDisk.GetSizeGib(),
+				)
+			}
+
+			if existingDisk.GetStorageTier() != newDisk.GetStorageTier() {
+				return grpcstatus.Errorf(
+					grpccodes.InvalidArgument,
+					"cannot change spec.additional_disks[%d].storage_tier from %q to %q: disk is immutable",
+					i, existingDisk.GetStorageTier(), newDisk.GetStorageTier(),
+				)
+			}
 		}
 	}
 

--- a/fulfillment-service/internal/servers/private_compute_instances_server.go
+++ b/fulfillment-service/internal/servers/private_compute_instances_server.go
@@ -861,8 +861,15 @@ func (s *PrivateComputeInstancesServer) validateDiskImmutability(
 		existingDisks := existingSpec.GetAdditionalDisks()
 		newDisks := newSpec.GetAdditionalDisks()
 
-		// Check that existing disks are not modified (adding new disks is allowed)
-		for i := 0; i < len(existingDisks) && i < len(newDisks); i++ {
+		if len(existingDisks) != len(newDisks) {
+			return grpcstatus.Errorf(
+				grpccodes.InvalidArgument,
+				"cannot change spec.additional_disks array length from %d to %d: additional disks are immutable",
+				len(existingDisks), len(newDisks),
+			)
+		}
+
+		for i := range existingDisks {
 			existingDisk := existingDisks[i]
 			newDisk := newDisks[i]
 

--- a/fulfillment-service/internal/servers/private_compute_instances_server_test.go
+++ b/fulfillment-service/internal/servers/private_compute_instances_server_test.go
@@ -271,6 +271,29 @@ var _ = Describe("Private compute instances server", func() {
 				}.Build(),
 			).Do(ctx)
 			Expect(err).ToNot(HaveOccurred())
+
+			storageTiersDao, err := dao.NewGenericDAO[*privatev1.StorageTier]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = storageTiersDao.Create().SetObject(
+				privatev1.StorageTier_builder{
+					Id: "standard",
+					Metadata: privatev1.Metadata_builder{
+						Name:   "standard",
+						Tenant: auth.SharedTenant,
+					}.Build(),
+					Spec: privatev1.StorageTierSpec_builder{
+						Description: "Standard storage tier",
+					}.Build(),
+					Status: privatev1.StorageTierStatus_builder{
+						State: privatev1.StorageTierState_STORAGE_TIER_STATE_ACTIVE,
+					}.Build(),
+				}.Build(),
+			).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		// Helper function to create a template
@@ -321,7 +344,8 @@ var _ = Describe("Private compute instances server", func() {
 						SourceRef:  "quay.io/containerdisks/fedora:latest",
 					}.Build(),
 					BootDisk: privatev1.ComputeInstanceDisk_builder{
-						SizeGib: 10,
+						SizeGib:     10,
+						StorageTier: new("standard"),
 					}.Build(),
 					RunStrategy: new("Always"),
 				}.Build(),
@@ -371,6 +395,89 @@ var _ = Describe("Private compute instances server", func() {
 			Expect(object.GetId()).ToNot(BeEmpty())
 			Expect(object.GetSpec().GetTemplate().GetId()).To(Equal("general.small"))
 			Expect(object.GetStatus().GetState()).To(Equal(privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_STARTING))
+		})
+
+		It("Rejects nonexistent storage tier", func() {
+			createTemplate("general.small")
+
+			_, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
+				Object: privatev1.ComputeInstance_builder{
+					Spec: privatev1.ComputeInstanceSpec_builder{
+						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "general.small"}.Build(),
+						BootDisk: privatev1.ComputeInstanceDisk_builder{
+							SizeGib:     20,
+							StorageTier: new("nonexistent"),
+						}.Build(),
+						NetworkAttachments: []*privatev1.NetworkAttachment{
+							privatev1.NetworkAttachment_builder{
+								Subnet: privatev1.SubnetLocalReference_builder{Id: "test-subnet"}.Build(),
+							}.Build(),
+						},
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(grpcstatus.Code(err)).To(Equal(grpccodes.InvalidArgument))
+			Expect(err.Error()).To(ContainSubstring(`storage tier 'nonexistent' does not exist`))
+		})
+
+		It("Rejects nonexistent storage tier on additional disk", func() {
+			createTemplate("general.small")
+
+			_, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
+				Object: privatev1.ComputeInstance_builder{
+					Spec: privatev1.ComputeInstanceSpec_builder{
+						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "general.small"}.Build(),
+						AdditionalDisks: []*privatev1.ComputeInstanceDisk{
+							privatev1.ComputeInstanceDisk_builder{
+								SizeGib:     100,
+								StorageTier: new("nonexistent"),
+							}.Build(),
+						},
+						NetworkAttachments: []*privatev1.NetworkAttachment{
+							privatev1.NetworkAttachment_builder{
+								Subnet: privatev1.SubnetLocalReference_builder{Id: "test-subnet"}.Build(),
+							}.Build(),
+						},
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(grpcstatus.Code(err)).To(Equal(grpccodes.InvalidArgument))
+			Expect(err.Error()).To(ContainSubstring(`storage tier 'nonexistent' does not exist`))
+		})
+
+		It("Creates object with additional disks", func() {
+			createTemplate("general.small")
+
+			response, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
+				Object: privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
+					Spec: privatev1.ComputeInstanceSpec_builder{
+						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "general.small"}.Build(),
+						AdditionalDisks: []*privatev1.ComputeInstanceDisk{
+							privatev1.ComputeInstanceDisk_builder{
+								SizeGib:     100,
+								StorageTier: new("standard"),
+							}.Build(),
+						},
+						NetworkAttachments: []*privatev1.NetworkAttachment{
+							privatev1.NetworkAttachment_builder{
+								Subnet: privatev1.SubnetLocalReference_builder{Id: "test-subnet"}.Build(),
+							}.Build(),
+						},
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			object := response.GetObject()
+			Expect(object).ToNot(BeNil())
+			Expect(object.GetSpec().GetAdditionalDisks()).To(HaveLen(1))
+			Expect(object.GetSpec().GetAdditionalDisks()[0].GetSizeGib()).To(Equal(int32(100)))
+			Expect(object.GetSpec().GetAdditionalDisks()[0].GetStorageTier()).To(Equal("standard"))
 		})
 
 		It("List objects", func() {
@@ -993,7 +1100,8 @@ var _ = Describe("Private compute instances server", func() {
 							SourceRef:  "quay.io/containerdisks/fedora:latest",
 						}.Build(),
 						BootDisk: privatev1.ComputeInstanceDisk_builder{
-							SizeGib: 20,
+							SizeGib:     20,
+							StorageTier: new("standard"),
 						}.Build(),
 						RunStrategy: new("Always"),
 						NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -1046,7 +1154,8 @@ var _ = Describe("Private compute instances server", func() {
 							SourceRef:  "quay.io/containerdisks/fedora:latest",
 						}.Build(),
 						BootDisk: privatev1.ComputeInstanceDisk_builder{
-							SizeGib: 20,
+							SizeGib:     20,
+							StorageTier: new("standard"),
 						}.Build(),
 						NetworkAttachments: []*privatev1.NetworkAttachment{
 							privatev1.NetworkAttachment_builder{
@@ -1505,7 +1614,8 @@ var _ = Describe("Private compute instances server", func() {
 								SourceRef:  "quay.io/containerdisks/fedora:latest",
 							}.Build(),
 							BootDisk: privatev1.ComputeInstanceDisk_builder{
-								SizeGib: 10,
+								SizeGib:     10,
+								StorageTier: new("standard"),
 							}.Build(),
 							RunStrategy: new("Always"),
 						}.Build(),
@@ -1575,7 +1685,8 @@ var _ = Describe("Private compute instances server", func() {
 								SourceRef:  "quay.io/containerdisks/fedora:latest",
 							}.Build(),
 							BootDisk: privatev1.ComputeInstanceDisk_builder{
-								SizeGib: 10,
+								SizeGib:     10,
+								StorageTier: new("standard"),
 							}.Build(),
 							RunStrategy: new("Always"),
 						}.Build(),
@@ -1674,6 +1785,29 @@ var _ = Describe("Private compute instances server", func() {
 			).Do(ctx)
 			Expect(err).ToNot(HaveOccurred())
 
+			storageTiersDao, err := dao.NewGenericDAO[*privatev1.StorageTier]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = storageTiersDao.Create().SetObject(
+				privatev1.StorageTier_builder{
+					Id: "standard",
+					Metadata: privatev1.Metadata_builder{
+						Name:   "standard",
+						Tenant: auth.SharedTenant,
+					}.Build(),
+					Spec: privatev1.StorageTierSpec_builder{
+						Description: "Standard storage tier",
+					}.Build(),
+					Status: privatev1.StorageTierStatus_builder{
+						State: privatev1.StorageTierState_STORAGE_TIER_STATE_ACTIVE,
+					}.Build(),
+				}.Build(),
+			).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
 			template = privatev1.ComputeInstanceTemplate_builder{
 				Id:          "test-template",
 				Title:       "Test Template",
@@ -1707,7 +1841,8 @@ var _ = Describe("Private compute instances server", func() {
 						SourceRef:  "quay.io/containerdisks/fedora:latest",
 					}.Build(),
 					BootDisk: privatev1.ComputeInstanceDisk_builder{
-						SizeGib: 10,
+						SizeGib:     10,
+						StorageTier: new("standard"),
 					}.Build(),
 					RunStrategy: new("Always"),
 				}.Build(),
@@ -2451,6 +2586,224 @@ var _ = Describe("Private compute instances server", func() {
 			})
 		})
 
+		Context("Disk immutability", func() {
+			var (
+				storageTiersDao *dao.GenericDAO[*privatev1.StorageTier]
+				subnet          *privatev1.Subnet
+			)
+
+			BeforeEach(func() {
+				var err error
+				storageTiersDao, err = dao.NewGenericDAO[*privatev1.StorageTier]().
+					SetLogger(logger).
+					SetTenancyLogic(tenancy).
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+
+				// Create tier1
+				_, err = storageTiersDao.Create().SetObject(
+					privatev1.StorageTier_builder{
+						Id: "tier1",
+						Metadata: privatev1.Metadata_builder{
+							Name:   "tier1",
+							Tenant: auth.SharedTenant,
+						}.Build(),
+						Spec: privatev1.StorageTierSpec_builder{
+							Description: "Test storage tier 1",
+						}.Build(),
+						Status: privatev1.StorageTierStatus_builder{
+							State: privatev1.StorageTierState_STORAGE_TIER_STATE_ACTIVE,
+						}.Build(),
+					}.Build(),
+				).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Create tier2
+				_, err = storageTiersDao.Create().SetObject(
+					privatev1.StorageTier_builder{
+						Id: "tier2",
+						Metadata: privatev1.Metadata_builder{
+							Name:   "tier2",
+							Tenant: auth.SharedTenant,
+						}.Build(),
+						Spec: privatev1.StorageTierSpec_builder{
+							Description: "Test storage tier 2",
+						}.Build(),
+						Status: privatev1.StorageTierStatus_builder{
+							State: privatev1.StorageTierState_STORAGE_TIER_STATE_ACTIVE,
+						}.Build(),
+					}.Build(),
+				).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Create subnet for network attachments
+				subnet = createTestSubnet(ctx, virtualNetwork.GetId(), privatev1.SubnetState_SUBNET_STATE_READY)
+			})
+
+			It("Rejects changing boot_disk.storage_tier", func() {
+				// Create a ComputeInstance with boot_disk storage tier
+				createResponse, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
+					Object: privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "test-compute-instance",
+						}.Build(),
+						Spec: privatev1.ComputeInstanceSpec_builder{
+							Template: privatev1.ComputeInstanceTemplateReference_builder{Id: template.GetId()}.Build(),
+							BootDisk: privatev1.ComputeInstanceDisk_builder{
+								SizeGib:     100,
+								StorageTier: new("tier1"),
+							}.Build(),
+							NetworkAttachments: []*privatev1.NetworkAttachment{
+								privatev1.NetworkAttachment_builder{
+									Subnet: privatev1.SubnetLocalReference_builder{Id: subnet.GetId()}.Build(),
+								}.Build(),
+							},
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(createResponse).ToNot(BeNil())
+
+				id := createResponse.GetObject().GetId()
+
+				// Try to change boot_disk.storage_tier
+				updateResponse, err := server.Update(ctx, privatev1.ComputeInstancesUpdateRequest_builder{
+					Object: privatev1.ComputeInstance_builder{
+						Id: id,
+						Spec: privatev1.ComputeInstanceSpec_builder{
+							BootDisk: privatev1.ComputeInstanceDisk_builder{
+								SizeGib:     100,
+								StorageTier: new("tier2"),
+							}.Build(),
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{
+						Paths: []string{"spec.boot_disk"},
+					},
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				Expect(updateResponse).To(BeNil())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(status.Message()).To(ContainSubstring("boot disk is immutable"))
+			})
+
+			It("Rejects changing additional_disks.storage_tier", func() {
+				// Create a ComputeInstance with additional disks
+				createResponse, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
+					Object: privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "test-compute-instance",
+						}.Build(),
+						Spec: privatev1.ComputeInstanceSpec_builder{
+							Template: privatev1.ComputeInstanceTemplateReference_builder{Id: template.GetId()}.Build(),
+							BootDisk: privatev1.ComputeInstanceDisk_builder{
+								SizeGib:     100,
+								StorageTier: new("tier1"),
+							}.Build(),
+							AdditionalDisks: []*privatev1.ComputeInstanceDisk{
+								privatev1.ComputeInstanceDisk_builder{
+									SizeGib:     200,
+									StorageTier: new("tier1"),
+								}.Build(),
+							},
+							NetworkAttachments: []*privatev1.NetworkAttachment{
+								privatev1.NetworkAttachment_builder{
+									Subnet: privatev1.SubnetLocalReference_builder{Id: subnet.GetId()}.Build(),
+								}.Build(),
+							},
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(createResponse).ToNot(BeNil())
+
+				id := createResponse.GetObject().GetId()
+
+				// Try to change additional_disks[0].storage_tier
+				updateResponse, err := server.Update(ctx, privatev1.ComputeInstancesUpdateRequest_builder{
+					Object: privatev1.ComputeInstance_builder{
+						Id: id,
+						Spec: privatev1.ComputeInstanceSpec_builder{
+							AdditionalDisks: []*privatev1.ComputeInstanceDisk{
+								privatev1.ComputeInstanceDisk_builder{
+									SizeGib:     200,
+									StorageTier: new("tier2"),
+								}.Build(),
+							},
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{
+						Paths: []string{"spec.additional_disks"},
+					},
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				Expect(updateResponse).To(BeNil())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(status.Message()).To(ContainSubstring("disk is immutable"))
+			})
+
+			It("Rejects changing additional_disks.size_gib", func() {
+				// Create a ComputeInstance with additional disks
+				createResponse, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
+					Object: privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: "test-compute-instance",
+						}.Build(),
+						Spec: privatev1.ComputeInstanceSpec_builder{
+							Template: privatev1.ComputeInstanceTemplateReference_builder{Id: template.GetId()}.Build(),
+							BootDisk: privatev1.ComputeInstanceDisk_builder{
+								SizeGib:     100,
+								StorageTier: new("tier1"),
+							}.Build(),
+							AdditionalDisks: []*privatev1.ComputeInstanceDisk{
+								privatev1.ComputeInstanceDisk_builder{
+									SizeGib:     200,
+									StorageTier: new("tier1"),
+								}.Build(),
+							},
+							NetworkAttachments: []*privatev1.NetworkAttachment{
+								privatev1.NetworkAttachment_builder{
+									Subnet: privatev1.SubnetLocalReference_builder{Id: subnet.GetId()}.Build(),
+								}.Build(),
+							},
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(createResponse).ToNot(BeNil())
+
+				id := createResponse.GetObject().GetId()
+
+				// Try to change additional_disks[0].size_gib
+				updateResponse, err := server.Update(ctx, privatev1.ComputeInstancesUpdateRequest_builder{
+					Object: privatev1.ComputeInstance_builder{
+						Id: id,
+						Spec: privatev1.ComputeInstanceSpec_builder{
+							AdditionalDisks: []*privatev1.ComputeInstanceDisk{
+								privatev1.ComputeInstanceDisk_builder{
+									SizeGib:     300,
+									StorageTier: new("tier1"),
+								}.Build(),
+							},
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{
+						Paths: []string{"spec.additional_disks"},
+					},
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				Expect(updateResponse).To(BeNil())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(status.Message()).To(ContainSubstring("disk is immutable"))
+			})
+		})
+
 		Context("instance_type validation", func() {
 			// Helper to create an InstanceType with a specific state via DAO.
 			createInstanceTypeWithState := func(name string, state privatev1.InstanceTypeState) {
@@ -2514,7 +2867,8 @@ var _ = Describe("Private compute instances server", func() {
 								SourceRef:  "quay.io/containerdisks/fedora:latest",
 							}.Build(),
 							BootDisk: privatev1.ComputeInstanceDisk_builder{
-								SizeGib: 20,
+								SizeGib:     20,
+								StorageTier: new("standard"),
 							}.Build(),
 							RunStrategy: new("Always"),
 							NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -2633,9 +2987,34 @@ var _ = Describe("Private compute instances server", func() {
 							SourceRef:  "quay.io/test:latest",
 						}.Build(),
 						BootDisk: privatev1.ComputeInstanceDisk_builder{
-							SizeGib: 10,
+							SizeGib:     10,
+							StorageTier: new("standard"),
 						}.Build(),
 						RunStrategy: new("Always"),
+					}.Build(),
+				}.Build(),
+			).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create storage tier
+			storageTiersDao, err := dao.NewGenericDAO[*privatev1.StorageTier]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = storageTiersDao.Create().SetObject(
+				privatev1.StorageTier_builder{
+					Id: "standard",
+					Metadata: privatev1.Metadata_builder{
+						Name:   "standard",
+						Tenant: auth.SharedTenant,
+					}.Build(),
+					Spec: privatev1.StorageTierSpec_builder{
+						Description: "Standard storage tier",
+					}.Build(),
+					Status: privatev1.StorageTierStatus_builder{
+						State: privatev1.StorageTierState_STORAGE_TIER_STATE_ACTIVE,
 					}.Build(),
 				}.Build(),
 			).Do(ctx)

--- a/fulfillment-service/internal/servers/private_storage_tiers_server.go
+++ b/fulfillment-service/internal/servers/private_storage_tiers_server.go
@@ -140,7 +140,8 @@ func (s *PrivateStorageTiersServer) Create(ctx context.Context,
 		State: privatev1.StorageTierState_STORAGE_TIER_STATE_ACTIVE,
 	}.Build())
 
-	st.SetId("")
+	// Set id from metadata.name (name-as-primary-key, aligns with InstanceType pattern):
+	st.SetId(st.GetMetadata().GetName())
 
 	// StorageTier is platform-scoped; force tenant to "shared" so all authenticated users can see it.
 	if st.GetMetadata() == nil {

--- a/fulfillment-service/internal/servers/private_storage_tiers_server_test.go
+++ b/fulfillment-service/internal/servers/private_storage_tiers_server_test.go
@@ -16,7 +16,6 @@ package servers
 import (
 	"fmt"
 
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc/codes"
@@ -347,7 +346,7 @@ var _ = Describe("Private storage tiers server", func() {
 			Expect(st.Code()).To(Equal(codes.NotFound))
 		})
 
-		It("Generates UUID for id ignoring caller-provided value", func() {
+		It("Sets id from metadata.name ignoring caller-provided value", func() {
 			callerProvidedId := "my-custom-id"
 			response, err := server.Create(ctx, privatev1.StorageTiersCreateRequest_builder{
 				Object: privatev1.StorageTier_builder{
@@ -366,9 +365,8 @@ var _ = Describe("Private storage tiers server", func() {
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetObject().GetId()).To(Equal("test-tier"))
 			Expect(response.GetObject().GetId()).ToNot(Equal(callerProvidedId))
-			_, err = uuid.Parse(response.GetObject().GetId())
-			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Create always sets state to ACTIVE regardless of caller-provided state", func() {
@@ -697,7 +695,7 @@ var _ = Describe("Private storage tiers server", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				second := createStorageTierWithName("reusable-name")
-				Expect(second.GetId()).ToNot(Equal(created.GetId()))
+				Expect(second.GetId()).To(Equal("reusable-name"))
 				Expect(second.GetMetadata().GetName()).To(Equal("reusable-name"))
 			})
 		})

--- a/fulfillment-service/internal/utils/spec_defaults.go
+++ b/fulfillment-service/internal/utils/spec_defaults.go
@@ -14,6 +14,7 @@ language governing permissions and limitations under the License.
 package utils
 
 import (
+	"fmt"
 	"slices"
 	"sort"
 	"strings"
@@ -83,6 +84,9 @@ func mergeBootDiskDefaults(spec *privatev1.ComputeInstanceSpec, defaults *privat
 	if disk.GetSizeGib() <= 0 && defDisk.GetSizeGib() > 0 {
 		disk.SetSizeGib(defDisk.GetSizeGib())
 	}
+	if !disk.HasStorageTier() && defDisk.HasStorageTier() {
+		disk.SetStorageTier(defDisk.GetStorageTier())
+	}
 }
 
 // ValidateRequiredSpecFields checks that all fields required by the Kubernetes ComputeInstance CRD
@@ -123,8 +127,13 @@ func ValidateRequiredSpecFields(spec *privatev1.ComputeInstanceSpec) error {
 	if err := validateImage(spec.GetImage()); err != nil {
 		return err
 	}
-	if err := validateBootDisk(spec.GetBootDisk()); err != nil {
-		return err
+	if err := validateDisk(spec.GetBootDisk()); err != nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "boot_disk.%s", err)
+	}
+	for i, disk := range spec.GetAdditionalDisks() {
+		if err := validateDisk(disk); err != nil {
+			return grpcstatus.Errorf(grpccodes.InvalidArgument, "additional_disks[%d].%s", i, err)
+		}
 	}
 
 	return nil
@@ -162,15 +171,12 @@ func validateImage(image *privatev1.ComputeInstanceImage) error {
 	return nil
 }
 
-func validateBootDisk(disk *privatev1.ComputeInstanceDisk) error {
+func validateDisk(disk *privatev1.ComputeInstanceDisk) error {
 	if disk == nil {
 		return nil
 	}
 	if disk.GetSizeGib() <= 0 {
-		return grpcstatus.Errorf(
-			grpccodes.InvalidArgument,
-			"boot_disk.size_gib must be greater than 0",
-		)
+		return fmt.Errorf("size_gib must be greater than 0")
 	}
 	return nil
 }

--- a/fulfillment-service/internal/utils/spec_defaults_test.go
+++ b/fulfillment-service/internal/utils/spec_defaults_test.go
@@ -195,6 +195,87 @@ var _ = Describe("ApplySpecDefaults", func() {
 		Expect(spec.GetBootDisk().GetSizeGib()).To(Equal(int32(20)))
 	})
 
+	It("Merges default boot_disk storage_tier when user provides boot_disk without storage_tier", func() {
+		spec := privatev1.ComputeInstanceSpec_builder{
+			Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "test.template"}.Build(),
+			BootDisk: privatev1.ComputeInstanceDisk_builder{
+				SizeGib: 50,
+			}.Build(),
+		}.Build()
+
+		defaults := privatev1.ComputeInstanceTemplateSpecDefaults_builder{
+			BootDisk: privatev1.ComputeInstanceDisk_builder{
+				SizeGib:     20,
+				StorageTier: new("standard"),
+			}.Build(),
+		}.Build()
+
+		ApplySpecDefaults(spec, defaults)
+
+		Expect(spec.GetBootDisk().GetSizeGib()).To(Equal(int32(50)))
+		Expect(spec.GetBootDisk().GetStorageTier()).To(Equal("standard"))
+	})
+
+	It("Does not override user-provided boot_disk storage_tier with template default", func() {
+		spec := privatev1.ComputeInstanceSpec_builder{
+			Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "test.template"}.Build(),
+			BootDisk: privatev1.ComputeInstanceDisk_builder{
+				SizeGib:     50,
+				StorageTier: new("fast"),
+			}.Build(),
+		}.Build()
+
+		defaults := privatev1.ComputeInstanceTemplateSpecDefaults_builder{
+			BootDisk: privatev1.ComputeInstanceDisk_builder{
+				SizeGib:     20,
+				StorageTier: new("standard"),
+			}.Build(),
+		}.Build()
+
+		ApplySpecDefaults(spec, defaults)
+
+		Expect(spec.GetBootDisk().GetStorageTier()).To(Equal("fast"))
+	})
+
+	It("Merges default boot_disk size when user provides only storage_tier", func() {
+		spec := privatev1.ComputeInstanceSpec_builder{
+			Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "test.template"}.Build(),
+			BootDisk: privatev1.ComputeInstanceDisk_builder{
+				StorageTier: new("fast"),
+			}.Build(),
+		}.Build()
+
+		defaults := privatev1.ComputeInstanceTemplateSpecDefaults_builder{
+			BootDisk: privatev1.ComputeInstanceDisk_builder{
+				SizeGib:     20,
+				StorageTier: new("standard"),
+			}.Build(),
+		}.Build()
+
+		ApplySpecDefaults(spec, defaults)
+
+		Expect(spec.GetBootDisk().GetSizeGib()).To(Equal(int32(20)))
+		Expect(spec.GetBootDisk().GetStorageTier()).To(Equal("fast"))
+	})
+
+	It("Clones entire boot_disk default including storage_tier when user provides no boot_disk", func() {
+		spec := privatev1.ComputeInstanceSpec_builder{
+			Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "test.template"}.Build(),
+		}.Build()
+
+		defaults := privatev1.ComputeInstanceTemplateSpecDefaults_builder{
+			BootDisk: privatev1.ComputeInstanceDisk_builder{
+				SizeGib:     20,
+				StorageTier: new("standard"),
+			}.Build(),
+		}.Build()
+
+		ApplySpecDefaults(spec, defaults)
+
+		Expect(spec.GetBootDisk().GetSizeGib()).To(Equal(int32(20)))
+		Expect(spec.GetBootDisk().GetStorageTier()).To(Equal("standard"))
+	})
+
 	It("Applies instance_type default when user provides no compute fields", func() {
 		spec := privatev1.ComputeInstanceSpec_builder{
 			Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "test.template"}.Build(),
@@ -361,7 +442,8 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 				SourceRef:  "quay.io/containerdisks/fedora:latest",
 			}.Build(),
 			BootDisk: privatev1.ComputeInstanceDisk_builder{
-				SizeGib: 20,
+				SizeGib:     20,
+				StorageTier: new("standard"),
 			}.Build(),
 			RunStrategy: new("Always"),
 		}.Build()
@@ -378,7 +460,8 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 				SourceRef:  "quay.io/containerdisks/fedora:latest",
 			}.Build(),
 			BootDisk: privatev1.ComputeInstanceDisk_builder{
-				SizeGib: 20,
+				SizeGib:     20,
+				StorageTier: new("standard"),
 			}.Build(),
 			RunStrategy: new("Always"),
 		}.Build()
@@ -413,7 +496,8 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 				SourceRef:  "quay.io/containerdisks/fedora:latest",
 			}.Build(),
 			BootDisk: privatev1.ComputeInstanceDisk_builder{
-				SizeGib: 20,
+				SizeGib:     20,
+				StorageTier: new("standard"),
 			}.Build(),
 			RunStrategy: new("always"),
 		}.Build()
@@ -432,7 +516,8 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 			InstanceType: privatev1.InstanceTypeReference_builder{Id: "standard-4-16"}.Build(),
 			Image:        privatev1.ComputeInstanceImage_builder{}.Build(),
 			BootDisk: privatev1.ComputeInstanceDisk_builder{
-				SizeGib: 20,
+				SizeGib:     20,
+				StorageTier: new("standard"),
 			}.Build(),
 			RunStrategy: new("Always"),
 		}.Build()
@@ -452,7 +537,8 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 				SourceType: "registry",
 			}.Build(),
 			BootDisk: privatev1.ComputeInstanceDisk_builder{
-				SizeGib: 20,
+				SizeGib:     20,
+				StorageTier: new("standard"),
 			}.Build(),
 			RunStrategy: new("Always"),
 		}.Build()
@@ -472,7 +558,9 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 				SourceType: "registry",
 				SourceRef:  "quay.io/containerdisks/fedora:latest",
 			}.Build(),
-			BootDisk:    privatev1.ComputeInstanceDisk_builder{}.Build(),
+			BootDisk: privatev1.ComputeInstanceDisk_builder{
+				StorageTier: new("standard"),
+			}.Build(),
 			RunStrategy: new("Always"),
 		}.Build()
 
@@ -480,5 +568,95 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
 		Expect(err.Error()).To(ContainSubstring("boot_disk.size_gib"))
+	})
+
+	It("Accepts boot_disk with empty storage_tier", func() {
+		spec := privatev1.ComputeInstanceSpec_builder{
+			Template:     privatev1.ComputeInstanceTemplateReference_builder{Id: "test.template"}.Build(),
+			InstanceType: privatev1.InstanceTypeReference_builder{Id: "standard-4-16"}.Build(),
+			Image: privatev1.ComputeInstanceImage_builder{
+				SourceType: "registry",
+				SourceRef:  "quay.io/containerdisks/fedora:latest",
+			}.Build(),
+			BootDisk: privatev1.ComputeInstanceDisk_builder{
+				SizeGib:     20,
+				StorageTier: new(""),
+			}.Build(),
+			RunStrategy: new("Always"),
+		}.Build()
+
+		Expect(ValidateRequiredSpecFields(spec)).To(Succeed())
+	})
+
+	It("Accepts boot_disk without storage_tier", func() {
+		spec := privatev1.ComputeInstanceSpec_builder{
+			Template:     privatev1.ComputeInstanceTemplateReference_builder{Id: "test.template"}.Build(),
+			InstanceType: privatev1.InstanceTypeReference_builder{Id: "standard-4-16"}.Build(),
+			Image: privatev1.ComputeInstanceImage_builder{
+				SourceType: "registry",
+				SourceRef:  "quay.io/containerdisks/fedora:latest",
+			}.Build(),
+			BootDisk: privatev1.ComputeInstanceDisk_builder{
+				SizeGib: 20,
+			}.Build(),
+			RunStrategy: new("Always"),
+		}.Build()
+
+		Expect(ValidateRequiredSpecFields(spec)).To(Succeed())
+	})
+
+	It("Accepts additional_disk with empty storage_tier", func() {
+		spec := privatev1.ComputeInstanceSpec_builder{
+			Template:     privatev1.ComputeInstanceTemplateReference_builder{Id: "test.template"}.Build(),
+			InstanceType: privatev1.InstanceTypeReference_builder{Id: "standard-4-16"}.Build(),
+			Image: privatev1.ComputeInstanceImage_builder{
+				SourceType: "registry",
+				SourceRef:  "quay.io/containerdisks/fedora:latest",
+			}.Build(),
+			BootDisk: privatev1.ComputeInstanceDisk_builder{
+				SizeGib:     20,
+				StorageTier: new("standard"),
+			}.Build(),
+			AdditionalDisks: []*privatev1.ComputeInstanceDisk{
+				privatev1.ComputeInstanceDisk_builder{
+					SizeGib:     100,
+					StorageTier: new("standard"),
+				}.Build(),
+				privatev1.ComputeInstanceDisk_builder{
+					SizeGib:     200,
+					StorageTier: new(""),
+				}.Build(),
+			},
+			RunStrategy: new("Always"),
+		}.Build()
+
+		Expect(ValidateRequiredSpecFields(spec)).To(Succeed())
+	})
+
+	It("Accepts additional_disk without storage_tier", func() {
+		spec := privatev1.ComputeInstanceSpec_builder{
+			Template:     privatev1.ComputeInstanceTemplateReference_builder{Id: "test.template"}.Build(),
+			InstanceType: privatev1.InstanceTypeReference_builder{Id: "standard-4-16"}.Build(),
+			Image: privatev1.ComputeInstanceImage_builder{
+				SourceType: "registry",
+				SourceRef:  "quay.io/containerdisks/fedora:latest",
+			}.Build(),
+			BootDisk: privatev1.ComputeInstanceDisk_builder{
+				SizeGib:     20,
+				StorageTier: new("standard"),
+			}.Build(),
+			AdditionalDisks: []*privatev1.ComputeInstanceDisk{
+				privatev1.ComputeInstanceDisk_builder{
+					SizeGib:     100,
+					StorageTier: new("standard"),
+				}.Build(),
+				privatev1.ComputeInstanceDisk_builder{
+					SizeGib: 200,
+				}.Build(),
+			},
+			RunStrategy: new("Always"),
+		}.Build()
+
+		Expect(ValidateRequiredSpecFields(spec)).To(Succeed())
 	})
 })

--- a/fulfillment-service/it/it_compute_subnet_test.go
+++ b/fulfillment-service/it/it_compute_subnet_test.go
@@ -36,6 +36,8 @@ var _ = Describe("ComputeInstance with Subnet attachment", func() {
 		computeInstancesClient         publicv1.ComputeInstancesClient
 		computeInstanceTemplatesClient privatev1.ComputeInstanceTemplatesClient
 		instanceTypesClient            privatev1.InstanceTypesClient
+		storageTiersClient             privatev1.StorageTiersClient
+		storageBackendsClient          privatev1.StorageBackendsClient
 
 		networkClassId            string
 		virtualNetworkId          string
@@ -43,6 +45,8 @@ var _ = Describe("ComputeInstance with Subnet attachment", func() {
 		computeInstanceId         string
 		computeInstanceTemplateId string
 		instanceTypeId            string
+		storageBackendId          string
+		storageTierId             string
 	)
 
 	BeforeEach(func() {
@@ -55,10 +59,51 @@ var _ = Describe("ComputeInstance with Subnet attachment", func() {
 		computeInstancesClient = publicv1.NewComputeInstancesClient(tool.ExternalView().UserConn())
 		computeInstanceTemplatesClient = privatev1.NewComputeInstanceTemplatesClient(tool.InternalView().AdminConn())
 		instanceTypesClient = privatev1.NewInstanceTypesClient(tool.InternalView().AdminConn())
+		storageTiersClient = privatev1.NewStorageTiersClient(tool.InternalView().AdminConn())
+		storageBackendsClient = privatev1.NewStorageBackendsClient(tool.InternalView().AdminConn())
+
+		// Create StorageBackend
+		sbResp, err := storageBackendsClient.Create(ctx, privatev1.StorageBackendsCreateRequest_builder{
+			Object: privatev1.StorageBackend_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name: fmt.Sprintf("test-sb-%s", uuid.New()),
+				}.Build(),
+				Spec: privatev1.StorageBackendSpec_builder{
+					Provider:    "test",
+					Description: "Test storage backend for subnet tests",
+					Endpoint:    "https://test-backend.example.com",
+					Credentials: privatev1.StorageBackendCredentials_builder{
+						Username: "test-user",
+						Password: "test-credential", //nolint:goconst // test-only dummy credential for fake provider
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		storageBackendId = sbResp.GetObject().GetId()
+
+		// Create StorageTier
+		stResp, err := storageTiersClient.Create(ctx, privatev1.StorageTiersCreateRequest_builder{
+			Object: privatev1.StorageTier_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name: fmt.Sprintf("test-st-%s", uuid.New()),
+				}.Build(),
+				Spec: privatev1.StorageTierSpec_builder{
+					Description: "Test storage tier for subnet tests",
+					Backends: []*privatev1.BackendAssociation{
+						privatev1.BackendAssociation_builder{
+							BackendId: storageBackendId,
+						}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		storageTierId = stResp.GetObject().GetId()
 
 		// Create InstanceType
 		instanceTypeId = fmt.Sprintf("test-it-%s", uuid.New())
-		_, err := instanceTypesClient.Create(ctx, privatev1.InstanceTypesCreateRequest_builder{
+		_, err = instanceTypesClient.Create(ctx, privatev1.InstanceTypesCreateRequest_builder{
 			Object: privatev1.InstanceType_builder{
 				Metadata: privatev1.Metadata_builder{
 					Name: instanceTypeId,
@@ -228,6 +273,20 @@ var _ = Describe("ComputeInstance with Subnet attachment", func() {
 				Id: instanceTypeId,
 			}.Build())
 		}
+
+		// Clean up StorageTier
+		if storageTierId != "" {
+			storageTiersClient.Delete(ctx, privatev1.StorageTiersDeleteRequest_builder{
+				Id: storageTierId,
+			}.Build())
+		}
+
+		// Clean up StorageBackend
+		if storageBackendId != "" {
+			storageBackendsClient.Delete(ctx, privatev1.StorageBackendsDeleteRequest_builder{
+				Id: storageBackendId,
+			}.Build())
+		}
 	})
 
 	It("creates ComputeInstance with network attachments", func() {
@@ -244,7 +303,8 @@ var _ = Describe("ComputeInstance with Subnet attachment", func() {
 					InstanceType: publicv1.InstanceTypeReference_builder{Name: instanceTypeId}.Build(),
 					RunStrategy:  new("Always"),
 					BootDisk: publicv1.ComputeInstanceDisk_builder{
-						SizeGib: 20,
+						SizeGib:     20,
+						StorageTier: &storageTierId,
 					}.Build(),
 					Image: publicv1.ComputeInstanceImage_builder{
 						SourceType: "registry",
@@ -284,7 +344,8 @@ var _ = Describe("ComputeInstance with Subnet attachment", func() {
 					InstanceType: publicv1.InstanceTypeReference_builder{Name: instanceTypeId}.Build(),
 					RunStrategy:  new("Always"),
 					BootDisk: publicv1.ComputeInstanceDisk_builder{
-						SizeGib: 20,
+						SizeGib:     20,
+						StorageTier: &storageTierId,
 					}.Build(),
 					Image: publicv1.ComputeInstanceImage_builder{
 						SourceType: "registry",


### PR DESCRIPTION
## [OSAC-3630](https://redhat.atlassian.net/browse/OSAC-3630): Storage tier defaults merging and validation

**Jira:** [OSAC-3630](https://redhat.atlassian.net/browse/OSAC-3630)
**Story type:** [DEV]
**Depends on:** https://github.com/osac-project/osac/pull/159 ([OSAC-3629](https://redhat.atlassian.net/browse/OSAC-3629): proto/CRD storage_tier field)

> **Note for reviewers:** This PR is stacked on [OSAC-3629](https://redhat.atlassian.net/browse/OSAC-3629). The [OSAC-3630](https://redhat.atlassian.net/browse/OSAC-3630) changes are in the last 4 commits (`0eb7a4f5..8ba71553`). Please review only those commits until #159 is merged.

### Summary

Adds `storage_tier` support to ComputeInstance disks: defaults merging from templates, existence validation against the StorageTier API, and a `--boot-disk-storage-tier` CLI flag.

> **Note:** `storage_tier` is intentionally **optional** in this PR. Making it mandatory creates a circular dependency: `osac-test-infra` E2E tests need the `--boot-disk-storage-tier` CLI flag from this PR, but CI builds the CLI from the latest release, not from PR branches. Once this PR merges and a release is cut, `osac-test-infra` can adopt the flag, and a follow-up PR will make `storage_tier` mandatory.

### Changes

**Defaults merging (`internal/utils/spec_defaults.go`):**
- Extended `mergeBootDiskDefaults()` to apply template default `storage_tier` when user omits it

**Presence validation (`internal/utils/spec_defaults.go`):**
- Replaced `validateBootDisk()` with unified `validateDisk()` covering both boot and additional disks
- Boot disk missing tier: descriptive error mentioning all resolution sources
- Additional disks missing tier: indexed error (`additional_disks[N].storage_tier is required`)

**Existence validation (`internal/servers/private_compute_instances_server.go`):**
- Added `storageTiersDao` to server struct for StorageTier lookups
- Added `validateStorageTiers()` in Create path (after defaults, before instance type validation)
- Deduplicates tier names to avoid redundant lookups

### Testing
- **Unit tests:** 5 new tests (3 merging, 2 presence validation) in `spec_defaults_test.go`; 1 new existence validation test in `private_compute_instances_server_test.go`
- **Test fixtures:** Updated ~12 disk builder fixtures across 3 test files to include `StorageTier`
- **Coverage:** `internal/utils` 95.4%, story-specific functions 85-100%

### Acceptance Criteria

- [x] AC-1: `mergeBootDiskDefaults()` applies template default `storage_tier`, preserves user-provided values
- [x] AC-2: No `boot_disk` → entire default cloned including `storage_tier`
- [ ] AC-3: Boot disk without `storage_tier` → `INVALID_ARGUMENT` with resolution chain message *(deferred to follow-up PR, or it will brake osac-test-infra E2E)*
- [ ] AC-4: Additional disk without `storage_tier` → `INVALID_ARGUMENT` with indexed message *(deferred to follow-up PR, or it will brake osac-test-infra E2E)*
- [x] AC-5: Nonexistent StorageTier → `INVALID_ARGUMENT`
- [x] AC-6: CatalogItem FieldDefinition `boot_disk.storage_tier` works (existing mechanism, no changes needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting a storage tier for compute instance boot disks through the CLI.
  * Compute instances can now use storage tiers for boot and additional disks.
  * Disk configuration is consistently applied when creating instances from templates or catalog items.

* **Bug Fixes**
  * Improved validation and error messages for missing or invalid storage tiers.
  * Preserved storage-tier settings when applying disk defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->