### PR TITLE
OSAC-3712: fix LVMS namespace resolution and tenant_name for hub storage

### DIFF
--- a/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/defaults/main.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/defaults/main.yaml
@@ -4,7 +4,10 @@ lvms_storage_tenant_config_secret_prefix: "lvms-tenant-config-"
 
 # Namespace for hub-cluster config Secrets — matches OSAC_STORAGE_CONFIG_NAMESPACE
 # set in the storage-operations-ig pod spec (downward API metadata.namespace).
-lvms_storage_config_namespace: "{{ lookup('env', 'OSAC_STORAGE_CONFIG_NAMESPACE') | default('osac-system', true) }}"
+lvms_storage_config_namespace: >-
+  {{ lookup('env', 'OSAC_STORAGE_CONFIG_NAMESPACE')
+     | default(lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/namespace', errors='ignore'), true)
+     | default('osac-system', true) }}
 
 # topolvm StorageClass provisioner name.
 lvms_storage_provisioner: "topolvm.io"

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/defaults/main.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/defaults/main.yaml
@@ -2,12 +2,14 @@
 # Hub Secret prefix for per-tenant lifecycle markers.
 lvms_storage_tenant_config_secret_prefix: "lvms-tenant-config-"
 
-# Namespace for hub-cluster config Secrets — matches OSAC_STORAGE_CONFIG_NAMESPACE
-# set in the storage-operations-ig pod spec (downward API metadata.namespace).
+# Namespace for hub-cluster config Secrets. Resolution order:
+#   1. OSAC_STORAGE_CONFIG_NAMESPACE env var (explicit override).
+#   2. Pod's own namespace via downward API (always available in-cluster).
+# No hardcoded fallback — fail loudly if neither source is available
+# rather than silently targeting a wrong namespace.
 lvms_storage_config_namespace: >-
   {{ lookup('env', 'OSAC_STORAGE_CONFIG_NAMESPACE')
-     | default(lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/namespace', errors='ignore'), true)
-     | default('osac-system', true) }}
+     | default(lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/namespace', errors='ignore'), true) }}
 
 # topolvm StorageClass provisioner name.
 lvms_storage_provisioner: "topolvm.io"

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/defaults/main.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/defaults/main.yaml
@@ -16,11 +16,11 @@ vast_storage_tenant_config_secret_prefix: "vast-tenant-config-"
 #      ConfigMap, only needed if the config namespace differs from the IG pod's own namespace.
 #   2. The IG pod's own namespace, read from the standard K8s-mounted service account file —
 #      always accurate for wherever the pod actually runs, no per-deployment config needed.
-#   3. "osac-system" — last-resort fallback for local/test execution outside a pod.
+# No hardcoded fallback — fail loudly if neither source is available
+# rather than silently targeting a wrong namespace.
 vast_storage_config_namespace: >-
   {{ lookup('env', 'OSAC_STORAGE_CONFIG_NAMESPACE')
-     | default(lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/namespace', errors='ignore'), true)
-     | default('osac-system', true) }}
+     | default(lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/namespace', errors='ignore'), true) }}
 
 # TLS certificate validation for VAST VMS API calls.
 vast_storage_validate_certs: "{{ lookup('env', 'VAST_VALIDATE_CERTS') | default('true', true) | bool }}"

--- a/osac-aap/playbook_osac_create_tenant_cluster_storage.yml
+++ b/osac-aap/playbook_osac_create_tenant_cluster_storage.yml
@@ -17,13 +17,13 @@
     tenant_name: >-
       {%- if osac_job_vars.resource.kind == 'ClusterOrder' -%}
       {{ osac_job_vars.resource.metadata.annotations['osac.openshift.io/tenant'] }}
-      {%- else -%}
+      {%- elif osac_job_vars.resource.kind == 'Tenant' -%}
       {{ osac_job_vars.resource.metadata.name }}
       {%- endif -%}
     tenant_namespace: >-
       {%- if osac_job_vars.resource.kind == 'ClusterOrder' -%}
       openshift-osac-storage
-      {%- else -%}
+      {%- elif osac_job_vars.resource.kind == 'Tenant' -%}
       {{ osac_job_vars.resource.metadata.namespace }}
       {%- endif -%}
     tenant_uid: "{{ osac_job_vars.resource.metadata.uid }}"

--- a/osac-aap/playbook_osac_create_tenant_cluster_storage.yml
+++ b/osac-aap/playbook_osac_create_tenant_cluster_storage.yml
@@ -4,7 +4,6 @@
   gather_facts: false
 
   vars:
-    tenant_name: "{{ osac_job_vars.resource.metadata.annotations['osac.openshift.io/tenant'] }}"
     # This template is triggered from two different call sites in storage_controller.go,
     # sharing the same AAP job template but passing different resource kinds as payload:
     #   - handleClusterStorageProvisioning (hub storage) sends a Tenant object, whose own
@@ -15,6 +14,12 @@
     #     guest cluster. For that case we target a fixed OSAC system namespace on the guest
     #     cluster instead (mirrors vast_storage_csi_operator_namespace's "vast-csi-system"
     #     pattern; openshift-* is appropriate here since OSAC is a Red Hat product).
+    tenant_name: >-
+      {%- if osac_job_vars.resource.kind == 'ClusterOrder' -%}
+      {{ osac_job_vars.resource.metadata.annotations['osac.openshift.io/tenant'] }}
+      {%- else -%}
+      {{ osac_job_vars.resource.metadata.name }}
+      {%- endif -%}
     tenant_namespace: >-
       {%- if osac_job_vars.resource.kind == 'ClusterOrder' -%}
       openshift-osac-storage

--- a/osac-aap/playbook_osac_delete_tenant_cluster_storage.yml
+++ b/osac-aap/playbook_osac_delete_tenant_cluster_storage.yml
@@ -4,7 +4,6 @@
   gather_facts: false
 
   vars:
-    tenant_name: "{{ osac_job_vars.resource.metadata.annotations['osac.openshift.io/tenant'] }}"
     # This template is triggered from two different call sites in storage_controller.go,
     # sharing the same AAP job template but passing different resource kinds as payload:
     #   - handleClusterStorageDeprovisioning (hub storage) sends a Tenant object, whose own
@@ -14,6 +13,12 @@
     #     metadata.namespace ("osac-devel") is hub-side bookkeeping with no relation to the
     #     guest cluster. For that case we target the fixed OSAC system namespace on the guest
     #     cluster instead (mirrors the create playbook's routing).
+    tenant_name: >-
+      {%- if osac_job_vars.resource.kind == 'ClusterOrder' -%}
+      {{ osac_job_vars.resource.metadata.annotations['osac.openshift.io/tenant'] }}
+      {%- else -%}
+      {{ osac_job_vars.resource.metadata.name }}
+      {%- endif -%}
     tenant_namespace: >-
       {%- if osac_job_vars.resource.kind == 'ClusterOrder' -%}
       openshift-osac-storage

--- a/osac-aap/playbook_osac_delete_tenant_cluster_storage.yml
+++ b/osac-aap/playbook_osac_delete_tenant_cluster_storage.yml
@@ -16,13 +16,13 @@
     tenant_name: >-
       {%- if osac_job_vars.resource.kind == 'ClusterOrder' -%}
       {{ osac_job_vars.resource.metadata.annotations['osac.openshift.io/tenant'] }}
-      {%- else -%}
+      {%- elif osac_job_vars.resource.kind == 'Tenant' -%}
       {{ osac_job_vars.resource.metadata.name }}
       {%- endif -%}
     tenant_namespace: >-
       {%- if osac_job_vars.resource.kind == 'ClusterOrder' -%}
       openshift-osac-storage
-      {%- else -%}
+      {%- elif osac_job_vars.resource.kind == 'Tenant' -%}
       {{ osac_job_vars.resource.metadata.namespace }}
       {%- endif -%}
 

--- a/osac-aap/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
+++ b/osac-aap/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
@@ -95,6 +95,7 @@
     OSAC_STORAGE_CONFIG_NAMESPACE: "osac-system"
 
   vars:
+    vast_storage_config_namespace: osac-system
     tenant_name: "test-ensuresc"
     tenant_namespace: "osac-system"
     _cluster_name: "test-cluster"
@@ -353,6 +354,7 @@
     OSAC_STORAGE_CONFIG_NAMESPACE: "osac-system"
 
   vars:
+    vast_storage_config_namespace: osac-system
     tenant_name: "test-ensuresc"
     tenant_namespace: "osac-system"
     _cluster_name: "test-cluster"
@@ -495,6 +497,7 @@
     OSAC_STORAGE_CONFIG_NAMESPACE: "osac-system"
 
   vars:
+    vast_storage_config_namespace: osac-system
     tenant_name: "test-ensuresc-nosnap"
     tenant_namespace: "osac-system"
     _cluster_name: "test-cluster"

--- a/osac-aap/tests/integration/targets/storage_provider_onboarding/tasks/main.yml
+++ b/osac-aap/tests/integration/targets/storage_provider_onboarding/tasks/main.yml
@@ -58,6 +58,7 @@
     OSAC_STORAGE_CONFIG_NAMESPACE: "osac-system"
 
   vars:
+    vast_storage_config_namespace: osac-system
     tenant_name: "test-onboard"
     tenant_namespace: "osac-system"
     tenant_uid: "test-uid-12345"

--- a/osac-aap/tests/integration/targets/storage_provider_setup/tasks/main.yml
+++ b/osac-aap/tests/integration/targets/storage_provider_setup/tasks/main.yml
@@ -15,6 +15,7 @@
     OSAC_STORAGE_CONFIG_NAMESPACE: "osac-system"
 
   vars:
+    vast_storage_config_namespace: osac-system
     tenant_name: "test-setup"
     tenant_namespace: "osac-system"
     tenant_uid: "test-uid-setup"
@@ -74,6 +75,7 @@
     OSAC_STORAGE_CONFIG_NAMESPACE: "osac-system"
 
   vars:
+    vast_storage_config_namespace: osac-system
     tenant_name: "test-setup"
 
   tasks:

--- a/osac-aap/tests/integration/targets/storage_provider_setup_rollback/tasks/main.yml
+++ b/osac-aap/tests/integration/targets/storage_provider_setup_rollback/tasks/main.yml
@@ -45,6 +45,7 @@
     OSAC_STORAGE_CONFIG_NAMESPACE: "osac-system"
 
   vars:
+    vast_storage_config_namespace: osac-system
     tenant_name: "test-rollback"
     tenant_namespace: "osac-system"
     tenant_uid: "test-uid-rollback"

--- a/osac-aap/tests/integration/targets/storage_provider_teardown/tasks/main.yml
+++ b/osac-aap/tests/integration/targets/storage_provider_teardown/tasks/main.yml
@@ -218,6 +218,7 @@
     OSAC_STORAGE_CONFIG_NAMESPACE: "osac-system"
 
   vars:
+    vast_storage_config_namespace: osac-system
     tenant_name: "test-teardown"
     tenant_namespace: "osac-system"
     storage_provider_tiers:


### PR DESCRIPTION
## Summary

- Fix LVMS storage role namespace resolution: add service account namespace file lookup so the role uses the pod's actual namespace instead of hardcoded `osac-system`
- Remove `osac-system` hardcoded fallback from both `lvms_storage` and `vast_storage` roles — missing namespace propagates as empty string and fails at the k8s API call rather than silently targeting the wrong namespace
- Fix `tenant_name` and `tenant_namespace` in cluster storage playbooks: use explicit `elif Tenant` dispatch instead of `else` fallback, so unknown resource kinds produce an empty value caught by downstream validation

## Root Cause

The LVMS role had a 2-tier namespace fallback (env var → `osac-system`) that skipped the SA namespace file the pod already mounts. In CI (deployed to `osac-e2e-ci`), backend jobs targeted `osac-system` (404), cascading: no backends → no StorageTiers → empty `storage_tier_definitions` → `ClusterStorageReady` stays `False` → all VMaaS tests fail.

Separately, `tenant_name` read `osac.openshift.io/tenant` annotation unconditionally, but Tenant CRs don't carry it — only ClusterOrders do. And all kind-dispatch vars used `else` fallbacks that would silently accept unknown resource kinds.

## Design decisions

**No `osac-system` fallback.** The SA namespace file is always available in-cluster (mounted via downward API in the storage-operations-ig pod spec). If both the env var and the file are unavailable, that's a deployment bug that should fail — not silently target a hardcoded namespace. The file lookup uses `errors='ignore'` (not `errors='strict'`) because integration tests run outside a pod on GH Actions runners where the SA file doesn't exist; those tests set `OSAC_STORAGE_CONFIG_NAMESPACE` explicitly via `environment:` on each task.

**Explicit kind dispatch.** `tenant_name` and `tenant_namespace` use `elif Tenant` instead of `else`, so an unexpected resource kind produces an empty value caught by downstream validation rather than silently taking the Tenant path.

## Test plan

- [ ] VMaaS CI (`e2e-vmaas-full-install`) passes with this change
- [ ] LVMS backend jobs target correct namespace (`osac-e2e-ci` in CI)
- [ ] `ClusterStorageReady` condition becomes `True`
- [ ] CaaS path (ClusterOrder) still works (annotation-based tenant_name preserved)
- [ ] Integration tests pass (env var set explicitly, no SA file needed)

Jira: [OSAC-3712](https://redhat.atlassian.net/browse/OSAC-3712)

🤖 Generated with [Claude Code](https://claude.com/claude-code)