### PR TITLE
OSAC-3234: CaaS local storage — LVMS on guest cluster workers

### DIFF
--- a/osac-aap/collections/ansible_collections/osac/templates/README.md
+++ b/osac-aap/collections/ansible_collections/osac/templates/README.md
@@ -191,6 +191,7 @@ template role with the filtered tier subset.
      supports_nfs: true
      provisioning_targets:
        - vmaas
+       - caas
    ```
 
 3. Implement the three required action task files. Each receives `_provider_tiers`
@@ -214,16 +215,17 @@ template role with the filtered tier subset.
    osac-operator from the Tier API and keyed by `backend_id`) — there is no
    env-var or K8s Secret fallback for admin credentials.
 
-6. **Provisioning targets:** Each provider handles both VMaaS and CaaS provisioning
-   targets via the `_provisioning_target` parameter. Currently supported: `vmaas`.
-   CaaS targets (`hcp_control_plane`, `hcp_worker_root`, `hcp_data_plane`) are
-   defined in the enum but not yet implemented.
+6. **Provisioning targets:** Each provider handles VMaaS and CaaS provisioning
+   targets via the `_provisioning_target` parameter. Currently supported: `vmaas`
+   and `caas` (via the LVMS provider — installs LVMS operator on the guest cluster
+   and creates per-tenant StorageClasses backed by a local block device).
+   HCP-level targets (`hcp_control_plane`, `hcp_worker_root`, `hcp_data_plane`)
+   are defined but not yet implemented.
 
-**CaaS provisioning targets:** `hcp_control_plane`, `hcp_worker_root`, and
-`hcp_data_plane` are defined in the provisioning target enum but not yet implemented.
-When implemented, `hcp_data_plane` will support provisioning multiple StorageClasses
-into the guest HCP cluster (e.g., separate tiers for databases and general workloads).
-Currently, all CaaS targets return an explicit "not yet implemented" error.
+**CaaS provisioning targets:** `caas` is supported by the `lvms_storage` provider
+(OSAC-3234). `hcp_control_plane`, `hcp_worker_root`, and `hcp_data_plane` remain
+unimplemented — they are defined in the provisioning target enum for future
+network-attached storage providers that serve HCP worker nodes directly.
 
 **Configuration:** Storage tiers arrive via the `osac_job_vars.storage_tier_definitions`
 extra_var, populated by osac-operator from the Tier API:

--- a/osac-aap/collections/ansible_collections/osac/templates/README.md
+++ b/osac-aap/collections/ansible_collections/osac/templates/README.md
@@ -191,7 +191,7 @@ template role with the filtered tier subset.
      supports_nfs: true
      provisioning_targets:
        - vmaas
-       - caas
+       # Add caas only when this provider implements guest-cluster provisioning.
    ```
 
 3. Implement the three required action task files. Each receives `_provider_tiers`
@@ -215,12 +215,11 @@ template role with the filtered tier subset.
    osac-operator from the Tier API and keyed by `backend_id`) — there is no
    env-var or K8s Secret fallback for admin credentials.
 
-6. **Provisioning targets:** Each provider handles VMaaS and CaaS provisioning
-   targets via the `_provisioning_target` parameter. Currently supported: `vmaas`
-   and `caas` (via the LVMS provider — installs LVMS operator on the guest cluster
-   and creates per-tenant StorageClasses backed by a local block device).
+6. **Provisioning targets:** Each provider declares only the targets it implements
+   via `meta/osac.yaml`. `caas` is currently supported by the `lvms_storage`
+   provider (installs LVMS on the guest cluster, creates per-tenant StorageClasses).
    HCP-level targets (`hcp_control_plane`, `hcp_worker_root`, `hcp_data_plane`)
-   are defined but not yet implemented.
+   are defined but not yet implemented by any provider.
 
 **CaaS provisioning targets:** `caas` is supported by the `lvms_storage` provider
 (OSAC-3234). `hcp_control_plane`, `hcp_worker_root`, and `hcp_data_plane` remain

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/defaults/main.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/defaults/main.yaml
@@ -16,3 +16,10 @@ lvms_storage_provisioner: "topolvm.io"
 
 # LVMCluster device class name created by osac-installer's configure-lvms.sh hook.
 lvms_storage_device_class: "vg1"
+
+# OLM subscription channel for LVMS operator — used when installing LVMS on CaaS
+# guest clusters. Must match the OCP version of the guest cluster.
+lvms_storage_operator_channel: "stable-4.22"
+
+# Namespace where the LVMS operator is installed via OLM.
+lvms_storage_operator_namespace: "openshift-storage"

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/defaults/main.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/defaults/main.yaml
@@ -18,12 +18,12 @@ lvms_storage_provisioner: "topolvm.io"
 lvms_storage_device_class: "vg1"
 
 # OLM subscription channel for LVMS operator — used when installing LVMS on CaaS
-# guest clusters. Must match the OCP version of the guest cluster; this default
-# targets OCP 4.22 (the CaaS CI flavor). Override via extra_vars or the
-# storage-operations-ig ConfigMap when guest clusters run a different OCP version.
-# TODO: consider passing the channel derived from ClusterOrder.spec.templateID
-# so it auto-tracks the guest cluster version without manual overrides.
-lvms_storage_operator_channel: "stable-4.22"
+# guest clusters. When empty (default), the role queries the lvms-operator
+# PackageManifest on the guest cluster and uses its defaultChannel, which OLM
+# sets automatically for the running OCP version. Set explicitly via extra_vars
+# or the storage-operations-ig ConfigMap to pin a specific channel (e.g.
+# "stable-4.18") and override auto-detection.
+lvms_storage_operator_channel: ""
 
 # Namespace where the LVMS operator is installed via OLM.
 lvms_storage_operator_namespace: "openshift-storage"

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/defaults/main.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/defaults/main.yaml
@@ -18,7 +18,11 @@ lvms_storage_provisioner: "topolvm.io"
 lvms_storage_device_class: "vg1"
 
 # OLM subscription channel for LVMS operator — used when installing LVMS on CaaS
-# guest clusters. Must match the OCP version of the guest cluster.
+# guest clusters. Must match the OCP version of the guest cluster; this default
+# targets OCP 4.22 (the CaaS CI flavor). Override via extra_vars or the
+# storage-operations-ig ConfigMap when guest clusters run a different OCP version.
+# TODO: consider passing the channel derived from ClusterOrder.spec.templateID
+# so it auto-tracks the guest cluster version without manual overrides.
 lvms_storage_operator_channel: "stable-4.22"
 
 # Namespace where the LVMS operator is installed via OLM.

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/defaults/main.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/defaults/main.yaml
@@ -23,3 +23,13 @@ lvms_storage_operator_channel: "stable-4.22"
 
 # Namespace where the LVMS operator is installed via OLM.
 lvms_storage_operator_namespace: "openshift-storage"
+
+# OLM CatalogSource for LVMS operator. Override for disconnected clusters that
+# mirror operators to a custom catalog.
+lvms_storage_operator_catalog_source: "redhat-operators"
+lvms_storage_operator_catalog_namespace: "openshift-marketplace"
+
+# Block device path to bind to the LVMCluster deviceSelector on CaaS guest clusters
+# (e.g. /dev/vdb for the second qcow2 disk created by setup-caas-agents.sh).
+# Empty (default): LVMS auto-discovers all eligible block devices.
+lvms_storage_data_device: ""

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/meta/osac.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/meta/osac.yaml
@@ -1,12 +1,15 @@
 ---
 title: LVMS Storage Provider
 description: >
-  Provisions per-tenant StorageClasses on the hub cluster using the LVMS (LVM Storage)
-  topolvm provisioner. No external backend or credentials required — LVMS is
-  installed on the hub by osac-installer when lvms.enabled=true. Hub cluster only;
-  CaaS guest cluster storage is out of scope.
+  Provisions per-tenant StorageClasses using the LVMS (LVM Storage) topolvm provisioner.
+  No external backend or credentials required. Hub path: LVMS is installed on the hub by
+  osac-installer when lvms.enabled=true. CaaS guest-cluster path: LVMS operator is
+  installed via OLM on the guest cluster when admin_kubeconfig is provided in the event
+  (requires a raw block device on the worker node — see setup-caas-agents.sh
+  AGENT_VM_DATA_DISK_SIZE).
 template_type: storage_provider
 implementation_strategy: lvms
 capabilities:
   provisioning_targets:
     - vmaas
+    - caas

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/tasks/ensure_storage_class.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/tasks/ensure_storage_class.yaml
@@ -112,7 +112,7 @@
           thinPoolConfig:
             name: thin-pool-1
             sizePercent: 90
-            overprovisionFactor: 10
+            overprovisionRatio: 10
         _lvms_device_selector: >-
           {{ {'deviceSelector': {'paths': [lvms_storage_data_device]}}
              if lvms_storage_data_device else {} }}

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/tasks/ensure_storage_class.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/tasks/ensure_storage_class.yaml
@@ -40,6 +40,37 @@
             targetNamespaces:
               - "{{ lvms_storage_operator_namespace }}"
 
+    - name: Resolve effective LVMS operator channel
+      when: lvms_storage_operator_channel | length == 0
+      block:
+        - name: Query LVMS packagemanifest default channel
+          kubernetes.core.k8s_info:
+            kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
+            validate_certs: "{{ not (_remote_kubeconfig_insecure | default(false)) }}"
+            api_version: packages.operators.coreos.com/v1
+            kind: PackageManifest
+            name: lvms-operator
+            namespace: openshift-marketplace
+          register: _lvms_pm
+
+        - name: Set channel from packagemanifest default
+          ansible.builtin.set_fact:
+            _lvms_effective_channel: "{{ _lvms_pm.resources[0].status.defaultChannel }}"
+          when: _lvms_pm.resources | length > 0
+
+        - name: Fail if packagemanifest not found and no channel override set
+          ansible.builtin.fail:
+            msg: >-
+              lvms-operator PackageManifest not found in openshift-marketplace and
+              lvms_storage_operator_channel is not set. Set lvms_storage_operator_channel
+              explicitly (e.g. stable-4.18) to proceed.
+          when: _lvms_pm.resources | length == 0
+
+    - name: Use explicit channel override
+      ansible.builtin.set_fact:
+        _lvms_effective_channel: "{{ lvms_storage_operator_channel }}"
+      when: lvms_storage_operator_channel | length > 0
+
     - name: Create LVMS Subscription on guest cluster
       kubernetes.core.k8s:
         kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
@@ -52,7 +83,7 @@
             name: lvms-operator
             namespace: "{{ lvms_storage_operator_namespace }}"
           spec:
-            channel: "{{ lvms_storage_operator_channel }}"
+            channel: "{{ _lvms_effective_channel }}"
             installPlanApproval: Automatic
             name: lvms-operator
             source: "{{ lvms_storage_operator_catalog_source }}"

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/tasks/ensure_storage_class.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/tasks/ensure_storage_class.yaml
@@ -101,7 +101,10 @@
       register: _lvms_csv
       until:
         - _lvms_csv.resources | length > 0
-        - _lvms_csv.resources[0].status.phase | default('') == 'Succeeded'
+        - _lvms_csv.resources[0].status.phase | default('') in ['Succeeded', 'Failed', 'CopierFailed']
+      failed_when:
+        - _lvms_csv.resources | length > 0
+        - _lvms_csv.resources[0].status.phase | default('') != 'Succeeded'
       retries: 30
       delay: 20
 

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/tasks/ensure_storage_class.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/tasks/ensure_storage_class.yaml
@@ -1,7 +1,125 @@
 ---
-# LVMS ensure_storage_class: create per-tenant labeled StorageClass on the hub cluster.
-# Uses the topolvm provisioner backed by the lvms-vg1 VolumeGroup created by
-# osac-installer's configure-lvms.sh hook. One StorageClass per tier. Idempotent.
+# LVMS ensure_storage_class: create per-tenant labeled StorageClass on the target cluster.
+#
+# Hub path (_remote_kubeconfig undefined): targets the hub cluster. Assumes LVMS is
+# already installed (by osac-installer's configure-lvms.sh hook).
+#
+# CaaS path (_remote_kubeconfig defined): targets a HCP guest cluster. Installs the
+# LVMS operator via OLM, creates an LVMCluster that auto-discovers the second data
+# disk (added to the agent VM by setup-caas-agents.sh via AGENT_VM_DATA_DISK_SIZE),
+# then creates per-tenant StorageClasses on the guest cluster.
+#
+# Both paths are idempotent.
+
+- name: Install LVMS on guest cluster
+  when: _remote_kubeconfig is defined
+  block:
+    - name: Create openshift-storage namespace on guest cluster
+      kubernetes.core.k8s:
+        kubeconfig: "{{ _remote_kubeconfig }}"
+        validate_certs: "{{ not (_remote_kubeconfig_insecure | default(false)) }}"
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: "{{ lvms_storage_operator_namespace }}"
+
+    - name: Create LVMS OperatorGroup on guest cluster
+      kubernetes.core.k8s:
+        kubeconfig: "{{ _remote_kubeconfig }}"
+        validate_certs: "{{ not (_remote_kubeconfig_insecure | default(false)) }}"
+        state: present
+        definition:
+          apiVersion: operators.coreos.com/v1
+          kind: OperatorGroup
+          metadata:
+            name: lvms-operator
+            namespace: "{{ lvms_storage_operator_namespace }}"
+
+    - name: Create LVMS Subscription on guest cluster
+      kubernetes.core.k8s:
+        kubeconfig: "{{ _remote_kubeconfig }}"
+        validate_certs: "{{ not (_remote_kubeconfig_insecure | default(false)) }}"
+        state: present
+        definition:
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            name: lvms-operator
+            namespace: "{{ lvms_storage_operator_namespace }}"
+          spec:
+            channel: "{{ lvms_storage_operator_channel }}"
+            installPlanApproval: Automatic
+            name: lvms-operator
+            source: redhat-operators
+            sourceNamespace: openshift-marketplace
+
+    - name: Wait for LVMS CSV to reach Succeeded phase
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ _remote_kubeconfig }}"
+        validate_certs: "{{ not (_remote_kubeconfig_insecure | default(false)) }}"
+        api_version: operators.coreos.com/v1alpha1
+        kind: ClusterServiceVersion
+        namespace: "{{ lvms_storage_operator_namespace }}"
+        label_selectors:
+          - "operators.coreos.com/lvms-operator.{{ lvms_storage_operator_namespace }}"
+      register: _lvms_csv
+      until:
+        - _lvms_csv.resources | length > 0
+        - _lvms_csv.resources[0].status.phase | default('') == 'Succeeded'
+      retries: 30
+      delay: 20
+
+    - name: Create LVMCluster on guest cluster
+      kubernetes.core.k8s:
+        kubeconfig: "{{ _remote_kubeconfig }}"
+        validate_certs: "{{ not (_remote_kubeconfig_insecure | default(false)) }}"
+        state: present
+        definition:
+          apiVersion: lvm.topolvm.io/v1alpha1
+          kind: LVMCluster
+          metadata:
+            name: lvms-cluster
+            namespace: "{{ lvms_storage_operator_namespace }}"
+          spec:
+            storage:
+              deviceClasses:
+                - name: "{{ lvms_storage_device_class }}"
+                  thinPoolConfig:
+                    name: thin-pool-1
+                    sizePercent: 90
+                    overprovisionFactor: 10
+
+    - name: Wait for LVMCluster to be Ready on guest cluster
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ _remote_kubeconfig }}"
+        validate_certs: "{{ not (_remote_kubeconfig_insecure | default(false)) }}"
+        api_version: lvm.topolvm.io/v1alpha1
+        kind: LVMCluster
+        name: lvms-cluster
+        namespace: "{{ lvms_storage_operator_namespace }}"
+      register: _lvms_cluster_status
+      until:
+        - _lvms_cluster_status.resources | length > 0
+        - _lvms_cluster_status.resources[0].status.state | default('') == 'Ready'
+      failed_when:
+        - _lvms_cluster_status.resources | length > 0
+        - _lvms_cluster_status.resources[0].status.state | default('') == 'Failed'
+      retries: 30
+      delay: 20
+
+    - name: Wait for LVMS StorageClass to appear on guest cluster
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ _remote_kubeconfig }}"
+        validate_certs: "{{ not (_remote_kubeconfig_insecure | default(false)) }}"
+        api_version: storage.k8s.io/v1
+        kind: StorageClass
+        name: "lvms-{{ lvms_storage_device_class }}"
+      register: _lvms_guest_sc
+      until: _lvms_guest_sc.resources | length > 0
+      retries: 30
+      delay: 20
 
 - name: Assert _provider_tiers is defined and non-empty
   ansible.builtin.assert:
@@ -33,6 +151,8 @@
 
 - name: Check existing tenant StorageClasses
   kubernetes.core.k8s_info:
+    kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
+    validate_certs: "{{ not (_remote_kubeconfig_insecure | default(false)) }}"
     api_version: storage.k8s.io/v1
     kind: StorageClass
     label_selectors:
@@ -49,6 +169,8 @@
 
 - name: Create missing per-tenant StorageClasses
   kubernetes.core.k8s:
+    kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
+    validate_certs: "{{ not (_remote_kubeconfig_insecure | default(false)) }}"
     state: present
     definition:
       apiVersion: storage.k8s.io/v1

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/tasks/ensure_storage_class.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/tasks/ensure_storage_class.yaml
@@ -16,7 +16,7 @@
   block:
     - name: Create openshift-storage namespace on guest cluster
       kubernetes.core.k8s:
-        kubeconfig: "{{ _remote_kubeconfig }}"
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         validate_certs: "{{ not (_remote_kubeconfig_insecure | default(false)) }}"
         state: present
         definition:
@@ -27,7 +27,7 @@
 
     - name: Create LVMS OperatorGroup on guest cluster
       kubernetes.core.k8s:
-        kubeconfig: "{{ _remote_kubeconfig }}"
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         validate_certs: "{{ not (_remote_kubeconfig_insecure | default(false)) }}"
         state: present
         definition:
@@ -36,10 +36,13 @@
           metadata:
             name: lvms-operator
             namespace: "{{ lvms_storage_operator_namespace }}"
+          spec:
+            targetNamespaces:
+              - "{{ lvms_storage_operator_namespace }}"
 
     - name: Create LVMS Subscription on guest cluster
       kubernetes.core.k8s:
-        kubeconfig: "{{ _remote_kubeconfig }}"
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         validate_certs: "{{ not (_remote_kubeconfig_insecure | default(false)) }}"
         state: present
         definition:
@@ -52,12 +55,12 @@
             channel: "{{ lvms_storage_operator_channel }}"
             installPlanApproval: Automatic
             name: lvms-operator
-            source: redhat-operators
-            sourceNamespace: openshift-marketplace
+            source: "{{ lvms_storage_operator_catalog_source }}"
+            sourceNamespace: "{{ lvms_storage_operator_catalog_namespace }}"
 
     - name: Wait for LVMS CSV to reach Succeeded phase
       kubernetes.core.k8s_info:
-        kubeconfig: "{{ _remote_kubeconfig }}"
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         validate_certs: "{{ not (_remote_kubeconfig_insecure | default(false)) }}"
         api_version: operators.coreos.com/v1alpha1
         kind: ClusterServiceVersion
@@ -72,8 +75,18 @@
       delay: 20
 
     - name: Create LVMCluster on guest cluster
+      vars:
+        _lvms_base_device_class:
+          name: "{{ lvms_storage_device_class }}"
+          thinPoolConfig:
+            name: thin-pool-1
+            sizePercent: 90
+            overprovisionFactor: 10
+        _lvms_device_selector: >-
+          {{ {'deviceSelector': {'paths': [lvms_storage_data_device]}}
+             if lvms_storage_data_device else {} }}
       kubernetes.core.k8s:
-        kubeconfig: "{{ _remote_kubeconfig }}"
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         validate_certs: "{{ not (_remote_kubeconfig_insecure | default(false)) }}"
         state: present
         definition:
@@ -85,15 +98,11 @@
           spec:
             storage:
               deviceClasses:
-                - name: "{{ lvms_storage_device_class }}"
-                  thinPoolConfig:
-                    name: thin-pool-1
-                    sizePercent: 90
-                    overprovisionFactor: 10
+                - "{{ _lvms_base_device_class | combine(_lvms_device_selector) }}"
 
     - name: Wait for LVMCluster to be Ready on guest cluster
       kubernetes.core.k8s_info:
-        kubeconfig: "{{ _remote_kubeconfig }}"
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         validate_certs: "{{ not (_remote_kubeconfig_insecure | default(false)) }}"
         api_version: lvm.topolvm.io/v1alpha1
         kind: LVMCluster
@@ -102,7 +111,7 @@
       register: _lvms_cluster_status
       until:
         - _lvms_cluster_status.resources | length > 0
-        - _lvms_cluster_status.resources[0].status.state | default('') == 'Ready'
+        - _lvms_cluster_status.resources[0].status.state | default('') in ['Ready', 'Failed']
       failed_when:
         - _lvms_cluster_status.resources | length > 0
         - _lvms_cluster_status.resources[0].status.state | default('') == 'Failed'
@@ -111,7 +120,7 @@
 
     - name: Wait for LVMS StorageClass to appear on guest cluster
       kubernetes.core.k8s_info:
-        kubeconfig: "{{ _remote_kubeconfig }}"
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         validate_certs: "{{ not (_remote_kubeconfig_insecure | default(false)) }}"
         api_version: storage.k8s.io/v1
         kind: StorageClass

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/tasks/ensure_storage_class.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/tasks/ensure_storage_class.yaml
@@ -50,7 +50,7 @@
             api_version: packages.operators.coreos.com/v1
             kind: PackageManifest
             name: lvms-operator
-            namespace: openshift-marketplace
+            namespace: "{{ lvms_storage_operator_catalog_namespace }}"
           register: _lvms_pm
 
         - name: Set channel from packagemanifest default

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/tasks/teardown_cluster_storage.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/lvms_storage/tasks/teardown_cluster_storage.yaml
@@ -1,5 +1,5 @@
 ---
-# LVMS teardown_cluster_storage: remove per-tenant StorageClasses from the hub cluster.
+# LVMS teardown_cluster_storage: remove per-tenant StorageClasses from the target cluster.
 # Finds SCs by label selector. The target cluster may be unreachable (being destroyed)
 # so failures are tolerated and reported rather than fatal.
 

--- a/osac-installer/scripts/setup-caas-agents.sh
+++ b/osac-installer/scripts/setup-caas-agents.sh
@@ -41,8 +41,8 @@ validate_safe "AGENT_VM_STORAGE_DIR" "${AGENT_VM_STORAGE_DIR}"
 validate_safe "LIBVIRT_NETWORK" "${LIBVIRT_NETWORK}"
 validate_safe "AGENT_VM_DISK_SIZE" "${AGENT_VM_DISK_SIZE}"
 [[ -n "${AGENT_VM_DATA_DISK_SIZE}" ]] && {
-    [[ "${AGENT_VM_DATA_DISK_SIZE}" =~ ^[1-9][0-9]*[kMGTb]?$ ]] || {
-        echo "ERROR: AGENT_VM_DATA_DISK_SIZE must be a positive integer with optional size suffix (k/M/G/T/b): ${AGENT_VM_DATA_DISK_SIZE}" >&2; exit 1
+    [[ "${AGENT_VM_DATA_DISK_SIZE}" =~ ^[1-9][0-9]*[kMGT]?$ ]] || {
+        echo "ERROR: AGENT_VM_DATA_DISK_SIZE must be a positive integer with optional size suffix (k/M/G/T): ${AGENT_VM_DATA_DISK_SIZE}" >&2; exit 1
     }
 }
 

--- a/osac-installer/scripts/setup-caas-agents.sh
+++ b/osac-installer/scripts/setup-caas-agents.sh
@@ -23,6 +23,7 @@ AGENT_VM_VCPUS=${AGENT_VM_VCPUS:-"4"}
 [[ "${AGENT_VM_MEMORY}" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: AGENT_VM_MEMORY must be a positive integer: ${AGENT_VM_MEMORY}" >&2; exit 1; }
 [[ "${AGENT_VM_VCPUS}" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: AGENT_VM_VCPUS must be a positive integer: ${AGENT_VM_VCPUS}" >&2; exit 1; }
 AGENT_VM_DISK_SIZE=${AGENT_VM_DISK_SIZE:-"120G"}
+AGENT_VM_DATA_DISK_SIZE=${AGENT_VM_DATA_DISK_SIZE:-""}
 AGENT_VM_STORAGE_DIR=${AGENT_VM_STORAGE_DIR:-"/data/osac-storage"}
 LIBVIRT_NETWORK=${LIBVIRT_NETWORK:?"LIBVIRT_NETWORK must be set"}
 SSH_CONFIG=${SSH_CONFIG:-""}
@@ -39,6 +40,7 @@ validate_safe() {
 validate_safe "AGENT_VM_STORAGE_DIR" "${AGENT_VM_STORAGE_DIR}"
 validate_safe "LIBVIRT_NETWORK" "${LIBVIRT_NETWORK}"
 validate_safe "AGENT_VM_DISK_SIZE" "${AGENT_VM_DISK_SIZE}"
+[[ -n "${AGENT_VM_DATA_DISK_SIZE}" ]] && validate_safe "AGENT_VM_DATA_DISK_SIZE" "${AGENT_VM_DATA_DISK_SIZE}"
 
 echo "=== Setting up CaaS agent infrastructure ==="
 echo "Agent namespace: ${AGENT_NAMESPACE}"
@@ -184,20 +186,28 @@ curl -k -L --fail-with-body -o '${ISO_FILE}' '${ISO_URL}'
 virsh --connect qemu:///system destroy '${AGENT_VM_NAME}' 2>/dev/null || true
 virsh --connect qemu:///system undefine '${AGENT_VM_NAME}' 2>/dev/null || true
 rm -f '${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}.qcow2'
+${AGENT_VM_DATA_DISK_SIZE:+rm -f '${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}-data.qcow2'}
 
 qemu-img create -f qcow2 '${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}.qcow2' '${AGENT_VM_DISK_SIZE}'
+${AGENT_VM_DATA_DISK_SIZE:+qemu-img create -f qcow2 '${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}-data.qcow2' '${AGENT_VM_DATA_DISK_SIZE}'}
 
-virt-install --connect qemu:///system \
-  --name '${AGENT_VM_NAME}' \
-  --memory '${AGENT_VM_MEMORY}' \
-  --vcpus '${AGENT_VM_VCPUS}' \
-  --disk '${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}.qcow2' \
-  --disk '${ISO_FILE},device=cdrom,readonly=on' \
-  --network network='${LIBVIRT_NETWORK}' \
-  --os-variant rhel9.0 \
-  --boot hd,cdrom \
-  --events on_poweroff=restart \
+_virt_install_args=(
+  --connect qemu:///system
+  --name '${AGENT_VM_NAME}'
+  --memory '${AGENT_VM_MEMORY}'
+  --vcpus '${AGENT_VM_VCPUS}'
+  --disk '${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}.qcow2'
+)
+${AGENT_VM_DATA_DISK_SIZE:+_virt_install_args+=(--disk '${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}-data.qcow2')}
+_virt_install_args+=(
+  --disk '${ISO_FILE},device=cdrom,readonly=on'
+  --network network='${LIBVIRT_NETWORK}'
+  --os-variant rhel9.0
+  --boot hd,cdrom
+  --events on_poweroff=restart
   --noautoconsole
+)
+virt-install "\${_virt_install_args[@]}"
 
 echo "Agent VM created and booting"
 HVEOF

--- a/osac-installer/scripts/setup-caas-agents.sh
+++ b/osac-installer/scripts/setup-caas-agents.sh
@@ -40,7 +40,11 @@ validate_safe() {
 validate_safe "AGENT_VM_STORAGE_DIR" "${AGENT_VM_STORAGE_DIR}"
 validate_safe "LIBVIRT_NETWORK" "${LIBVIRT_NETWORK}"
 validate_safe "AGENT_VM_DISK_SIZE" "${AGENT_VM_DISK_SIZE}"
-[[ -n "${AGENT_VM_DATA_DISK_SIZE}" ]] && validate_safe "AGENT_VM_DATA_DISK_SIZE" "${AGENT_VM_DATA_DISK_SIZE}"
+[[ -n "${AGENT_VM_DATA_DISK_SIZE}" ]] && {
+    [[ "${AGENT_VM_DATA_DISK_SIZE}" =~ ^[1-9][0-9]*[kMGTb]?$ ]] || {
+        echo "ERROR: AGENT_VM_DATA_DISK_SIZE must be a positive integer with optional size suffix (k/M/G/T/b): ${AGENT_VM_DATA_DISK_SIZE}" >&2; exit 1
+    }
+}
 
 echo "=== Setting up CaaS agent infrastructure ==="
 echo "Agent namespace: ${AGENT_NAMESPACE}"
@@ -186,10 +190,14 @@ curl -k -L --fail-with-body -o '${ISO_FILE}' '${ISO_URL}'
 virsh --connect qemu:///system destroy '${AGENT_VM_NAME}' 2>/dev/null || true
 virsh --connect qemu:///system undefine '${AGENT_VM_NAME}' 2>/dev/null || true
 rm -f '${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}.qcow2'
-${AGENT_VM_DATA_DISK_SIZE:+rm -f '${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}-data.qcow2'}
+if [[ -n '${AGENT_VM_DATA_DISK_SIZE}' ]]; then
+    rm -f '${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}-data.qcow2'
+fi
 
 qemu-img create -f qcow2 '${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}.qcow2' '${AGENT_VM_DISK_SIZE}'
-${AGENT_VM_DATA_DISK_SIZE:+qemu-img create -f qcow2 '${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}-data.qcow2' '${AGENT_VM_DATA_DISK_SIZE}'}
+if [[ -n '${AGENT_VM_DATA_DISK_SIZE}' ]]; then
+    qemu-img create -f qcow2 '${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}-data.qcow2' '${AGENT_VM_DATA_DISK_SIZE}'
+fi
 
 _virt_install_args=(
   --connect qemu:///system
@@ -198,7 +206,9 @@ _virt_install_args=(
   --vcpus '${AGENT_VM_VCPUS}'
   --disk '${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}.qcow2'
 )
-${AGENT_VM_DATA_DISK_SIZE:+_virt_install_args+=(--disk '${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}-data.qcow2')}
+if [[ -n '${AGENT_VM_DATA_DISK_SIZE}' ]]; then
+    _virt_install_args+=(--disk '${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}-data.qcow2')
+fi
 _virt_install_args+=(
   --disk '${ISO_FILE},device=cdrom,readonly=on'
   --network network='${LIBVIRT_NETWORK}'

--- a/osac-operator/charts/operator/templates/clusterrole.yaml
+++ b/osac-operator/charts/operator/templates/clusterrole.yaml
@@ -21,6 +21,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - get

--- a/osac-operator/charts/operator/templates/clusterrole.yaml
+++ b/osac-operator/charts/operator/templates/clusterrole.yaml
@@ -48,6 +48,8 @@ rules:
   - get
   - list
   - watch
+# hostedcontrolplanes: get only — storage controller reads the kubeconfig secret name,
+# no watch/list needed (looked up by name from the ClusterOrder).
 - apiGroups:
   - hypershift.openshift.io
   resources:

--- a/osac-operator/charts/operator/templates/clusterrole.yaml
+++ b/osac-operator/charts/operator/templates/clusterrole.yaml
@@ -35,12 +35,17 @@ rules:
   - hypershift.openshift.io
   resources:
   - hostedclusters
-  - hostedcontrolplanes
   - nodepools
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - hypershift.openshift.io
+  resources:
+  - hostedcontrolplanes
+  verbs:
+  - get
 - apiGroups:
   - k8s.ovn.org
   resources:

--- a/osac-operator/charts/operator/templates/clusterrole.yaml
+++ b/osac-operator/charts/operator/templates/clusterrole.yaml
@@ -35,6 +35,7 @@ rules:
   - hypershift.openshift.io
   resources:
   - hostedclusters
+  - hostedcontrolplanes
   - nodepools
   verbs:
   - get


### PR DESCRIPTION
## Summary

Enable developers without VAST to provision CaaS clusters and create PVCs
using LVMS — no external storage backend required.

This is a temporary approach using LVMS directly on guest cluster workers.
A CSI-based approach is planned for a later phase ([OSAC-3702](https://redhat.atlassian.net/browse/OSAC-3702)).

**Design: LVMS directly on guest cluster workers**
The dispatcher already passes `_remote_kubeconfig` (from `admin_kubeconfig`
in the storage event for ClusterOrder resources). The `ensure_storage_class`
role is extended to use it when present, keeping the hub path unchanged.

## Changes

### osac-aap — `lvms_storage/tasks/ensure_storage_class.yaml`

New CaaS block (gated on `_remote_kubeconfig is defined`):
- Auto-detects the LVMS OLM channel from the guest cluster's
  `PackageManifest.status.defaultChannel` (OLM sets this per cluster version).
  Explicit `lvms_storage_operator_channel` override still works for pinning.
- Installs LVMS operator on guest cluster via OLM subscription
- Applies LVMCluster CR with `overprovisionRatio` (required field in LVMS 4.16+)
  and optional `deviceSelector.paths` for explicit disk binding
- Waits for LVMCluster to reach `Ready` state — fails immediately if
  `Failed` (e.g. no eligible block device found on the worker node)
- Waits for StorageClass to become available
- Creates per-tenant StorageClass on guest cluster (`topolvm.io` provisioner
  + OSAC labels)

Hub path is unchanged.

### osac-aap — `lvms_storage/defaults/main.yaml`

New variables:
- `lvms_storage_operator_channel` — defaults to `""` (auto-detect from
  PackageManifest); set explicitly to pin a channel (e.g. `stable-4.18`)
- `lvms_storage_operator_catalog_source/namespace` — configurable for
  disconnected clusters
- `lvms_storage_data_device` — bind LVMCluster to a specific device path;
  empty (default) = auto-discover

### osac-installer — `scripts/setup-caas-agents.sh`

`AGENT_VM_DATA_DISK_SIZE` (opt-in): when set, creates a second qcow2 image and
passes it to `virt-install`. Required for LVMS in the `setup-caas-agents.sh`
path (bare metal nodes have physical data disks; `cluster-tool` already adds
a second disk via its own workflow).

### osac-operator — `charts/operator/templates/clusterrole.yaml`

Adds `hostedcontrolplanes` to the existing hypershift RBAC rule.

The storage controller's `getClusterKubeconfig()` reads the HostedControlPlane
resource to locate the admin kubeconfig secret for a CaaS guest cluster
(pre-existing code, not added by this PR). The kubebuilder marker at
`storage_controller.go:111` already declared this permission, so
`config/rbac/role.yaml` was correct — but the Helm chart was out of sync.
This PR exercises the CaaS kubeconfig path for the first time and surfaces
the gap.

## Test Plan

- [x] Provision CaaS cluster via ClusterOrder with `AGENT_VM_DATA_DISK_SIZE=50G`
- [x] Verify LVMS operator installs on guest cluster via OLM
- [x] Verify LVMCluster CR reaches `Ready` state on guest cluster
- [x] Verify `topolvm.io` StorageClass available on guest cluster
- [x] Create PVC on guest cluster — verify it binds
- [x] Point LVMCluster at non-existent device (`/dev/vdc`) — verify job fails
  immediately on first retry (`attempts: 1`) with `state: Failed` and a clear
  `lstat /dev/vdc: no such file or directory` reason; no 30-retry silent timeout

Closes [OSAC-3234](https://redhat.atlassian.net/browse/OSAC-3234)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for installing and configuring LVMS storage on hub and guest clusters.
  * Added configurable operator channels, namespaces, catalogs, and optional guest-cluster block devices.
  * Added optional VM data-disk creation and attachment during CaaS agent setup.
  * Enabled required access for hosted control plane discovery.
  * Storage classes can now be created and removed on the target cluster.

* **Documentation**
  * Documented hub and guest-cluster provisioning requirements and supported targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->