### PR TITLE
NO-ISSUE: add jira-check workflow for merge queue gate

### DIFF
--- a/.github/workflows/jira-check.yml
+++ b/.github/workflows/jira-check.yml
@@ -1,0 +1,30 @@
+---
+name: jira-check
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+  merge_group:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate Jira reference in PR title
+        if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [[ "$PR_TITLE" =~ ^[A-Z]+-[0-9]+: ]] || [[ "$PR_TITLE" =~ ^NO-ISSUE: ]]; then
+            echo "Valid Jira reference: $PR_TITLE"
+          else
+            echo "::error::PR title must start with a Jira key (e.g., OSAC-1234: description) or NO-ISSUE:"
+            exit 1
+          fi
+      - name: Auto-pass for merge queue
+        if: github.event_name == 'merge_group'
+        run: echo "Jira reference already validated on PR"


### PR DESCRIPTION
## Summary

- Adds `jira-check.yml` workflow that validates PR titles start with a Jira key (`OSAC-1234:`) or `NO-ISSUE:`
- Triggers on `pull_request` and `merge_group` events (auto-passes on merge_group since PR-level check already ran)
- Replaces Tide's `jira/valid-reference` label as the merge gate — this workflow produces a commit status that the merge queue can gate on

## Context

Part of the migration from Prow Tide to GitHub merge queue. Three PRs in total, **merge in this order**:

1. **This PR** (osac) — deploy jira-check workflow first so the status check exists
2. **github-config PR** — enable merge queue + add `jira-check / validate` to required status checks
3. **openshift/release PR** — remove Tide merge queries

## Test plan

- [ ] Verify workflow runs on a PR with valid title (e.g., `OSAC-1234: test`)
- [ ] Verify workflow fails on a PR with invalid title (e.g., `fix stuff`)
- [ ] Verify workflow auto-passes on `merge_group` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated pull request title validation requiring a Jira key or an approved `NO-ISSUE:` prefix.
  * Merge queue checks now recognize previously validated pull requests.
  * Validation runs for relevant pull request updates targeting the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->