### PR TITLE
OSAC-3734: add label-gate workflow for merge queue

### DIFF
--- a/.github/workflows/label-gate.yml
+++ b/.github/workflows/label-gate.yml
@@ -1,0 +1,40 @@
+---
+name: label-gate
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize, reopened]
+    branches: [main]
+  merge_group:
+
+jobs:
+  check-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-pass for merge queue
+        if: github.event_name == 'merge_group'
+        run: echo "Labels already validated on PR"
+      - name: Check required Prow labels
+        if: github.event_name == 'pull_request'
+        env:
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          missing=()
+          for label in lgtm approved jira/valid-reference; do
+            if ! echo "$LABELS" | jq -e "index(\"$label\")" > /dev/null 2>&1; then
+              missing+=("$label")
+            fi
+          done
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            echo "::error::Missing required labels: ${missing[*]}"
+            echo ""
+            echo "Required labels are set by Prow plugins via OWNERS files:"
+            echo "  lgtm           - reviewer types /lgtm"
+            echo "  approved       - approver types /approve"
+            echo "  jira/valid-reference - PR title has valid Jira key"
+            exit 1
+          fi
+          echo "All required labels present"


### PR DESCRIPTION
## Summary

Adds two GitHub Actions workflows for the merge queue migration:

### 1. `label-gate.yml` — bridge Prow labels to status checks

Merge queue can only gate on status checks, not labels. Prow plugins set labels (`lgtm`, `approved`, `jira/valid-reference`) via OWNERS files. This workflow reads those labels and reports a pass/fail status check that the merge queue can gate on.

- Triggers on `pull_request` label events (`labeled`, `unlabeled`, `synchronize`)
- Checks if all 3 required labels are present
- Auto-passes on `merge_group` events (labels were validated on the PR)
- On rebase/force-push: Prow removes `lgtm` → label-gate re-triggers → fails until reviewer re-`/lgtm`s

### 2. `auto-queue.yml` — automatic queue entry (same UX as Tide)

Automatically enables auto-merge on every non-draft PR from org members. When all required checks pass (E2E + label-gate), the PR enters the merge queue without any manual click.

- Uses `pull_request_target` so GITHUB_TOKEN has write permissions for fork PRs (all OSAC PRs come from forks)
- Safe: never checks out fork code, just calls `gh pr merge --auto`
- External contributors excluded (`author_association` check) — they use manual "Add to merge queue" after `ok-to-test`

### Companion PRs — merge in this order

1. **This PR** — must merge first so the status check exists
2. **osac-project/github-config#180** — enables merge queue, adds `label-gate / check-labels` to required status checks
3. **openshift/release#83121** — removes Tide merge queries (keeps all Prow plugins)

## Test plan

- [ ] label-gate passes when all 3 labels present, fails when any missing
- [ ] label-gate auto-passes on `merge_group` events
- [ ] Adding a missing label re-triggers label-gate
- [ ] auto-queue enables auto-merge on new non-draft PRs from org members
- [ ] auto-queue skips draft PRs and external contributors
- [ ] On force-push: Prow removes `lgtm`, label-gate fails, reviewer must re-`/lgtm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)