### PR TITLE
OSAC-3735: force file-based secret storage in it harness

### DIFF
--- a/fulfillment-service/internal/cmd/cli/root_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/root_cmd.go
@@ -256,7 +256,8 @@ environment variable. If both are provided, the flag takes precedence.
 Configuration is stored in a file named {{ bt }}config.json{{ bt }} inside this directory.
 
 Secrets, such as tokens and passwords, are stored in the operating system keyring. If the keyring is not available,
-they are stored in a file named {{ bt }}secrets.json{{ bt }} inside this directory.
+they are stored in a file named {{ bt }}secrets.json{{ bt }} inside this directory. Set the {{ bt }}OSAC_SECRET_STORE{{ bt }}
+environment variable to {{ bt }}file{{ bt }} to force the file-based store even when a keyring is detected.
 `
 
 const tenantFlagHelp = `

--- a/fulfillment-service/internal/config/config_secret_store.go
+++ b/fulfillment-service/internal/config/config_secret_store.go
@@ -81,7 +81,7 @@ func (b *SecretStoreBuilder) Build() (result SecretStore, err error) {
 	// $HOME still reports 'not found' rather than 'unavailable', so the probe alone would incorrectly select the
 	// keyring backend. Callers that know the keyring won't be usable, such as the integration test harness, use
 	// this override to force file-based storage without depending on the probe's outcome.
-	if os.Getenv(secretStoreEnvVar) == secretStoreFileValue {
+	if os.Getenv(secretStoreEnvVar) == secretStoreFile {
 		result, err = NewFileSecretStore().
 			SetLogger(b.logger).
 			SetDir(b.dir).
@@ -322,7 +322,7 @@ func (s *fileSecretStore) Save(ctx context.Context, object any) error {
 		return fmt.Errorf("failed to marshal secrets: %w", err)
 	}
 	dir := filepath.Dir(s.file)
-	err = os.MkdirAll(dir, os.FileMode(0755))
+	err = os.MkdirAll(dir, os.FileMode(0700))
 	if err != nil {
 		return fmt.Errorf("failed to create directory '%s': %w", dir, err)
 	}
@@ -339,15 +339,13 @@ func (s *fileSecretStore) Save(ctx context.Context, object any) error {
 	return nil
 }
 
-// Keyring service and key used to store all secret data as a single entry in the operating system keyring.
 const (
+	// Keyring service and key used to store all secret data as a single entry in the operating system keyring.
 	keyringService = "osac"
 	keyringKey     = "secrets"
-)
 
-// Name of the environment variable that, when set to secretStoreFileValue, forces the use of the file-based
-// secret store regardless of keyring availability.
-const (
-	secretStoreEnvVar    = "OSAC_SECRET_STORE"
-	secretStoreFileValue = "file"
+	// Name of the environment variable that, when set to secretStoreFile, forces the use of the file-based
+	// secret store regardless of keyring availability.
+	secretStoreEnvVar = "OSAC_SECRET_STORE"
+	secretStoreFile   = "file"
 )

--- a/fulfillment-service/internal/config/config_secret_store.go
+++ b/fulfillment-service/internal/config/config_secret_store.go
@@ -64,13 +64,28 @@ func (b *SecretStoreBuilder) SetDir(value string) *SecretStoreBuilder {
 	return b
 }
 
-// Build uses the data stored in the builder to create and configure a new secret store. It probes the operating system
-// keyring by attempting to read the secrets key: if the call succeeds or returns ErrNotFound the keyring is usable;
-// any other error indicates the backend is not available and a file-based store is returned instead.
+// Build uses the data stored in the builder to create and configure a new secret store. If the OSAC_SECRET_STORE
+// environment variable is set to 'file' the file-based store is used unconditionally, bypassing the keyring probe
+// below. Otherwise it probes the operating system keyring by attempting to read the secrets key: if the call
+// succeeds or returns ErrNotFound the keyring is usable; any other error indicates the backend is not available and
+// a file-based store is returned instead.
 func (b *SecretStoreBuilder) Build() (result SecretStore, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
+		return
+	}
+
+	// Honor the explicit override, if set. This exists because the keyring probe below can't distinguish a
+	// keyring that is genuinely usable from one that doesn't exist at all: on macOS, probing a keychain-less
+	// $HOME still reports 'not found' rather than 'unavailable', so the probe alone would incorrectly select the
+	// keyring backend. Callers that know the keyring won't be usable, such as the integration test harness, use
+	// this override to force file-based storage without depending on the probe's outcome.
+	if os.Getenv(secretStoreEnvVar) == secretStoreFileValue {
+		result, err = NewFileSecretStore().
+			SetLogger(b.logger).
+			SetDir(b.dir).
+			Build()
 		return
 	}
 
@@ -328,4 +343,11 @@ func (s *fileSecretStore) Save(ctx context.Context, object any) error {
 const (
 	keyringService = "osac"
 	keyringKey     = "secrets"
+)
+
+// Name of the environment variable that, when set to secretStoreFileValue, forces the use of the file-based
+// secret store regardless of keyring availability.
+const (
+	secretStoreEnvVar    = "OSAC_SECRET_STORE"
+	secretStoreFileValue = "file"
 )

--- a/fulfillment-service/internal/config/config_secret_store_test.go
+++ b/fulfillment-service/internal/config/config_secret_store_test.go
@@ -41,6 +41,14 @@ var _ = Describe("Secret store", func() {
 	})
 
 	Describe("Store selection", func() {
+		BeforeEach(func() {
+			// Ensure a clean baseline: an OSAC_SECRET_STORE inherited from the host shell (e.g. a
+			// developer working around the exact keychain issue this override exists for) would
+			// otherwise make these tests silently select the wrong store.
+			err := os.Unsetenv("OSAC_SECRET_STORE")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		It("Selects the keyring store when the keyring is available", func() {
 			keyring.MockInit()
 			store, err := NewSecretStore().

--- a/fulfillment-service/internal/config/config_secret_store_test.go
+++ b/fulfillment-service/internal/config/config_secret_store_test.go
@@ -61,6 +61,36 @@ var _ = Describe("Secret store", func() {
 			Expect(store).To(BeAssignableToTypeOf(&fileSecretStore{}))
 		})
 
+		It("Forces the file store when OSAC_SECRET_STORE=file, even if the keyring is available", func() {
+			// Make the keyring appear available: without the override this would select the keyring store, as
+			// proven by the "Selects the keyring store..." test above.
+			keyring.MockInit()
+
+			os.Setenv("OSAC_SECRET_STORE", "file")
+			DeferCleanup(os.Unsetenv, "OSAC_SECRET_STORE")
+
+			store, err := NewSecretStore().
+				SetLogger(logger).
+				SetDir("/some/dir").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(store).To(BeAssignableToTypeOf(&fileSecretStore{}))
+		})
+
+		It("Does not force the file store for other OSAC_SECRET_STORE values", func() {
+			keyring.MockInit()
+
+			os.Setenv("OSAC_SECRET_STORE", "keyring")
+			DeferCleanup(os.Unsetenv, "OSAC_SECRET_STORE")
+
+			store, err := NewSecretStore().
+				SetLogger(logger).
+				SetDir("/some/dir").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(store).To(BeAssignableToTypeOf(&keyringSecretStore{}))
+		})
+
 		It("Passes the directory to the file store when the keyring is not available", func() {
 			// Create the store using a temporary directory::
 			keyring.MockInitWithError(fmt.Errorf("keyring backend not available"))

--- a/fulfillment-service/internal/config/config_secret_store_test.go
+++ b/fulfillment-service/internal/config/config_secret_store_test.go
@@ -66,7 +66,8 @@ var _ = Describe("Secret store", func() {
 			// proven by the "Selects the keyring store..." test above.
 			keyring.MockInit()
 
-			os.Setenv("OSAC_SECRET_STORE", "file")
+			err := os.Setenv("OSAC_SECRET_STORE", "file")
+			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(os.Unsetenv, "OSAC_SECRET_STORE")
 
 			store, err := NewSecretStore().
@@ -80,7 +81,8 @@ var _ = Describe("Secret store", func() {
 		It("Does not force the file store for other OSAC_SECRET_STORE values", func() {
 			keyring.MockInit()
 
-			os.Setenv("OSAC_SECRET_STORE", "keyring")
+			err := os.Setenv("OSAC_SECRET_STORE", "keyring")
+			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(os.Unsetenv, "OSAC_SECRET_STORE")
 
 			store, err := NewSecretStore().

--- a/fulfillment-service/it/it_tool.go
+++ b/fulfillment-service/it/it_tool.go
@@ -2492,6 +2492,9 @@ func (t *Tool) RunCLI(ctx context.Context, homeDir string, args ...string) (stdo
 
 // RunCLIWithEnv executes the osac binary with additional environment variables beyond the HOME
 // override. Each entry in extraEnv should be in "KEY=VALUE" format. Use "KEY=" to unset a variable.
+// OSAC_SECRET_STORE is the one exception: any entry for it in extraEnv is stripped, since cliEnv's
+// own OSAC_SECRET_STORE decision (forced file-based storage locally, none in CI) must not be
+// overridable by callers.
 func (t *Tool) RunCLIWithEnv(ctx context.Context, homeDir string, extraEnv []string, args ...string) (stdout, stderr string, exitCode int) {
 	return t.runCLI(ctx, homeDir, extraEnv, args...)
 }

--- a/fulfillment-service/it/it_tool.go
+++ b/fulfillment-service/it/it_tool.go
@@ -2503,10 +2503,11 @@ func (t *Tool) RunCLIWithEnv(ctx context.Context, homeDir string, extraEnv []str
 func (t *Tool) runCLI(ctx context.Context, homeDir string, extraEnv []string, args ...string) (stdout, stderr string, exitCode int) {
 	cmd := exec.CommandContext(ctx, t.cliBinaryPath, args...)
 	// extraEnv is appended after cliEnv(homeDir) so callers can override HOME, OSAC_CONFIG, etc., but
-	// OSAC_SECRET_STORE=file is re-appended last: for duplicate keys, Go's own env parsing in the
+	// OSAC_SECRET_STORE is stripped out of it first: for duplicate keys, Go's own env parsing in the
 	// spawned CLI process uses the last occurrence, so without this an extraEnv entry could silently
-	// re-enable the real keyring and reintroduce the failure this override exists to prevent.
-	cmd.Env = append(append(cliEnv(homeDir), extraEnv...), "OSAC_SECRET_STORE=file")
+	// override cliEnv's OSAC_SECRET_STORE decision (forced file-based storage locally, or no override
+	// at all in CI, where the keyring probe already falls back to file storage on its own).
+	cmd.Env = append(cliEnv(homeDir), stripOSACSecretStore(extraEnv)...)
 	cmd.Dir = t.projectDir
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
@@ -2536,17 +2537,44 @@ func (t *Tool) runCLI(ctx context.Context, homeDir string, extraEnv []string, ar
 
 // cliEnv builds a minimal sandboxed environment for CLI subprocess execution. Only the
 // variables strictly required by the CLI binary are set; everything else from the host
-// is excluded to guarantee full test isolation. OSAC_SECRET_STORE=file forces file-based
-// secret storage: homeDir has no operating system keychain, so probing it would otherwise
-// misdetect the keyring as usable and fail (or prompt interactively) on save.
+// is excluded to guarantee full test isolation.
+//
+// Outside CI, OSAC_SECRET_STORE=file forces file-based secret storage: homeDir has no
+// operating system keychain, so probing it would otherwise misdetect the keyring as usable
+// and fail (or prompt interactively) on save. In CI there's no Secret Service either way, so
+// the keyring probe already falls back to file storage on its own -- leaving the override
+// unset there keeps CI exercising that real fallback path instead of a forced substitute.
 func cliEnv(homeDir string) []string {
-	return []string{
+	env := []string{
 		"HOME=" + homeDir,
 		"PATH=" + os.Getenv("PATH"),
 		"OSAC_CONFIG=" + filepath.Join(homeDir, ".config", "osac"),
 		"OSAC_CACHE=" + filepath.Join(homeDir, ".cache", "osac"),
-		"OSAC_SECRET_STORE=file",
 	}
+	if !runningInCI() {
+		env = append(env, "OSAC_SECRET_STORE=file")
+	}
+	return env
+}
+
+// runningInCI reports whether the test process itself is running under a CI system. CI is the
+// de facto standard environment variable for this: GitHub Actions, GitLab CI, CircleCI, and
+// Travis all set it unconditionally.
+func runningInCI() bool {
+	return os.Getenv("CI") != ""
+}
+
+// stripOSACSecretStore returns a copy of env with any OSAC_SECRET_STORE entries removed, so
+// that appending it after cliEnv(homeDir) can't override cliEnv's OSAC_SECRET_STORE decision.
+func stripOSACSecretStore(env []string) []string {
+	filtered := make([]string, 0, len(env))
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "OSAC_SECRET_STORE=") {
+			continue
+		}
+		filtered = append(filtered, kv)
+	}
+	return filtered
 }
 
 // redactCLIArgs returns a copy of args with sensitive flag values masked.

--- a/fulfillment-service/it/it_tool.go
+++ b/fulfillment-service/it/it_tool.go
@@ -2532,13 +2532,16 @@ func (t *Tool) runCLI(ctx context.Context, homeDir string, extraEnv []string, ar
 
 // cliEnv builds a minimal sandboxed environment for CLI subprocess execution. Only the
 // variables strictly required by the CLI binary are set; everything else from the host
-// is excluded to guarantee full test isolation.
+// is excluded to guarantee full test isolation. OSAC_SECRET_STORE=file forces file-based
+// secret storage: homeDir has no operating system keychain, so probing it would otherwise
+// misdetect the keyring as usable and fail (or prompt interactively) on save.
 func cliEnv(homeDir string) []string {
 	return []string{
 		"HOME=" + homeDir,
 		"PATH=" + os.Getenv("PATH"),
 		"OSAC_CONFIG=" + filepath.Join(homeDir, ".config", "osac"),
 		"OSAC_CACHE=" + filepath.Join(homeDir, ".cache", "osac"),
+		"OSAC_SECRET_STORE=file",
 	}
 }
 

--- a/fulfillment-service/it/it_tool.go
+++ b/fulfillment-service/it/it_tool.go
@@ -2502,7 +2502,11 @@ func (t *Tool) RunCLIWithEnv(ctx context.Context, homeDir string, extraEnv []str
 // behavior, not errors).
 func (t *Tool) runCLI(ctx context.Context, homeDir string, extraEnv []string, args ...string) (stdout, stderr string, exitCode int) {
 	cmd := exec.CommandContext(ctx, t.cliBinaryPath, args...)
-	cmd.Env = append(cliEnv(homeDir), extraEnv...)
+	// extraEnv is appended after cliEnv(homeDir) so callers can override HOME, OSAC_CONFIG, etc., but
+	// OSAC_SECRET_STORE=file is re-appended last: for duplicate keys, Go's own env parsing in the
+	// spawned CLI process uses the last occurrence, so without this an extraEnv entry could silently
+	// re-enable the real keyring and reintroduce the failure this override exists to prevent.
+	cmd.Env = append(append(cliEnv(homeDir), extraEnv...), "OSAC_SECRET_STORE=file")
 	cmd.Dir = t.projectDir
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf


### PR DESCRIPTION
## Summary
- `SecretStoreBuilder.Build()`'s keyring probe can't tell "keyring available" from "no keychain exists" on macOS, so the IT harness's per-test sandboxed `$HOME` (no keychain) always selects the keyring backend, which then fails or pops a real authorization dialog on save
- Adds an `OSAC_SECRET_STORE=file` override checked before the probe, wires it into the IT harness's `cliEnv()`, and documents it in the CLI's `--help` text
- Verified against the real `security` binary (dialog reproduced pre-fix) and the full IT suite's `cli`-labeled specs end-to-end (8/8 passing, no dialog, post-fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for forcing file-based secret storage with `OSAC_SECRET_STORE=file`.
  * Updated configuration help text to explain file-based storage and keyring fallback behavior.
  * Secret storage remains available when the system keyring is unavailable or file storage is explicitly selected.

* **Bug Fixes**
  * Preserved normal keyring selection when the environment variable is unset or set to another value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->