### PR TITLE
OSAC-3783: wait for Netris V-Net provisioning to complete after creation

### DIFF
--- a/osac-aap/collections/ansible_collections/netris/controller/roles/vnet/defaults/main.yaml
+++ b/osac-aap/collections/ansible_collections/netris/controller/roles/vnet/defaults/main.yaml
@@ -1,3 +1,5 @@
 ---
 vnet_state: present
 vnet_vlan_id: auto
+vnet_wait_retries: 30
+vnet_wait_delay: 10

--- a/osac-aap/collections/ansible_collections/netris/controller/roles/vnet/tasks/create.yaml
+++ b/osac-aap/collections/ansible_collections/netris/controller/roles/vnet/tasks/create.yaml
@@ -91,3 +91,23 @@
     - _vnet_create_resp is not skipped
     - _vnet_create_resp is changed or (_vnet_create_resp.status | default(0)) in [200, 201]
     - _vnet_create_resp.json is mapping
+
+- name: Wait for V-Net to finish provisioning
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/vnet/{{ vnet_id }}"
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    return_content: true
+    status_code: 200
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _vnet_status_resp
+  no_log: true
+  until: >-
+    _vnet_status_resp.json is mapping
+    and ((_vnet_status_resp.json.data | default([]) | first | default({}))['provisioning'] | default(true)) == false
+    and ((_vnet_status_resp.json.data | default([]) | first | default({}))['state'] | default('')) == 'active'
+  retries: "{{ vnet_wait_retries }}"
+  delay: "{{ vnet_wait_delay }}"
+  when: not (vnet_already_existed | default(false))


### PR DESCRIPTION
## Summary

- The `netris.controller.vnet` create role was fire-and-forget — it sent `POST /api/v2/vnet` and returned immediately without verifying the V-Net had finished propagating to switches
- Downstream operations (adding server ports, MetalLB setup, DHCP) could race against Netris's async provisioning
- Added a polling loop after V-Net creation that waits for `provisioning=false` and `state=active` via `GET /api/v2/vnet/{id}`, matching the existing pattern in the `server_cluster` role
- Configurable via `vnet_wait_retries` (default 30) and `vnet_wait_delay` (default 10s)
- Skipped when the V-Net already existed (idempotent path)

## Test plan

- [ ] Deploy with Netris controller and verify V-Net creation waits for provisioning to complete before returning
- [ ] Verify subnet creation succeeds on first attempt (no race with V-Net propagation)
- [ ] Verify idempotent re-run skips the wait when V-Net already exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)