### PR TITLE
OSAC-2252: Populate default network_attachments when omitted on BareMetalInstance create

### DIFF
--- a/fulfillment-service/internal/servers/private_baremetal_instances_server.go
+++ b/fulfillment-service/internal/servers/private_baremetal_instances_server.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"maps"
 	"strings"
@@ -49,6 +50,7 @@ var _ privatev1.BareMetalInstancesServer = (*PrivateBareMetalInstancesServer)(ni
 type PrivateBareMetalInstancesServer struct {
 	privatev1.UnimplementedBareMetalInstancesServer
 	logger             *slog.Logger
+	tenancyLogic       auth.TenancyLogic
 	generic            *GenericServer[*privatev1.BareMetalInstance]
 	catalogItemsDao    *dao.GenericDAO[*privatev1.BareMetalInstanceCatalogItem]
 	templatesDao       *dao.GenericDAO[*privatev1.BareMetalInstanceTemplate]
@@ -56,6 +58,7 @@ type PrivateBareMetalInstancesServer struct {
 	subnetsDao         *dao.GenericDAO[*privatev1.Subnet]
 	virtualNetworksDao *dao.GenericDAO[*privatev1.VirtualNetwork]
 	networkClassesDao  *dao.GenericDAO[*privatev1.NetworkClass]
+	securityGroupsDao  *dao.GenericDAO[*privatev1.SecurityGroup]
 }
 
 func NewPrivateBareMetalInstancesServer() *PrivateBareMetalInstancesServerBuilder {
@@ -155,6 +158,15 @@ func (b *PrivateBareMetalInstancesServerBuilder) Build() (result *PrivateBareMet
 		return
 	}
 
+	securityGroupsDao, err := dao.NewGenericDAO[*privatev1.SecurityGroup]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
 	generic, err := NewGenericServer[*privatev1.BareMetalInstance]().
 		SetLogger(b.logger).
 		SetService(privatev1.BareMetalInstances_ServiceDesc.ServiceName).
@@ -169,6 +181,7 @@ func (b *PrivateBareMetalInstancesServerBuilder) Build() (result *PrivateBareMet
 
 	result = &PrivateBareMetalInstancesServer{
 		logger:             b.logger,
+		tenancyLogic:       b.tenancyLogic,
 		generic:            generic,
 		catalogItemsDao:    catalogItemsDao,
 		templatesDao:       templatesDao,
@@ -176,6 +189,7 @@ func (b *PrivateBareMetalInstancesServerBuilder) Build() (result *PrivateBareMet
 		subnetsDao:         subnetsDao,
 		virtualNetworksDao: virtualNetworksDao,
 		networkClassesDao:  networkClassesDao,
+		securityGroupsDao:  securityGroupsDao,
 	}
 	return
 }
@@ -198,6 +212,9 @@ func (s *PrivateBareMetalInstancesServer) Create(ctx context.Context,
 		return
 	}
 	if err = s.validateSpec(request.GetObject()); err != nil {
+		return
+	}
+	if err = s.applyDefaultNetworkAttachments(ctx, request.GetObject()); err != nil {
 		return
 	}
 	if err = s.validateNetworkAttachments(ctx, request.GetObject()); err != nil {
@@ -266,6 +283,147 @@ func (s *PrivateBareMetalInstancesServer) validateSpec(bmi *privatev1.BareMetalI
 	}
 
 	return nil
+}
+
+// applyDefaultNetworkAttachments populates network_attachments with tenant defaults when
+// omitted at create time: default IPv4 Subnet, default SecurityGroup, first fabric-role
+// interface from the HostType.
+func (s *PrivateBareMetalInstancesServer) applyDefaultNetworkAttachments(
+	ctx context.Context, bmi *privatev1.BareMetalInstance) error {
+	if len(bmi.GetSpec().GetNetworkAttachments()) > 0 {
+		return nil
+	}
+
+	tenantName := bmi.GetMetadata().GetTenant()
+	if tenantName == "" {
+		var err error
+		tenantName, err = s.tenancyLogic.DetermineDefaultTenant(ctx)
+		if err != nil {
+			s.logger.ErrorContext(ctx, "Failed to determine default tenant for network attachment defaults",
+				slog.Any("error", err))
+			return grpcstatus.Errorf(grpccodes.Internal, "failed to determine tenant")
+		}
+	}
+
+	subnet, err := s.findDefaultSubnet(ctx, tenantName)
+	if err != nil {
+		return err
+	}
+	if subnet == nil {
+		return nil
+	}
+
+	sg, err := s.findDefaultSecurityGroup(ctx, tenantName)
+	if err != nil {
+		return err
+	}
+	if sg == nil {
+		return nil
+	}
+
+	ifaceName, err := s.resolveDefaultInterface(ctx, bmi)
+	if err != nil {
+		return err
+	}
+
+	attachment := privatev1.BareMetalNetworkAttachment_builder{
+		Subnet: privatev1.SubnetLocalReference_builder{Id: subnet.GetId()}.Build(),
+		SecurityGroups: []*privatev1.SecurityGroupLocalReference{
+			privatev1.SecurityGroupLocalReference_builder{Id: sg.GetId()}.Build(),
+		},
+	}
+	if ifaceName != "" {
+		attachment.Interface = &ifaceName
+	}
+
+	bmi.GetSpec().SetNetworkAttachments([]*privatev1.BareMetalNetworkAttachment{
+		attachment.Build(),
+	})
+
+	return nil
+}
+
+func (s *PrivateBareMetalInstancesServer) findDefaultSubnet(
+	ctx context.Context, tenantName string) (*privatev1.Subnet, error) {
+	filter := fmt.Sprintf(
+		"this.metadata.labels['%s'] == 'true' && this.metadata.tenant == %q",
+		defaultLabel, tenantName,
+	)
+	listResp, err := s.subnetsDao.List().SetFilter(filter).Do(ctx)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to list default subnets",
+			slog.String("tenant", tenantName), slog.Any("error", err))
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to find default subnet")
+	}
+	for _, subnet := range listResp.GetItems() {
+		if subnet.GetMetadata().HasDeletionTimestamp() {
+			continue
+		}
+		if subnet.GetSpec().HasIpv4Cidr() {
+			return subnet, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *PrivateBareMetalInstancesServer) findDefaultSecurityGroup(
+	ctx context.Context, tenantName string) (*privatev1.SecurityGroup, error) {
+	filter := fmt.Sprintf(
+		"this.metadata.labels['%s'] == 'true' && this.metadata.tenant == %q",
+		defaultLabel, tenantName,
+	)
+	listResp, err := s.securityGroupsDao.List().SetFilter(filter).Do(ctx)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "Failed to list default security groups",
+			slog.String("tenant", tenantName), slog.Any("error", err))
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to find default security group")
+	}
+	for _, sg := range listResp.GetItems() {
+		if sg.GetMetadata().HasDeletionTimestamp() {
+			continue
+		}
+		return sg, nil
+	}
+	return nil, nil
+}
+
+// resolveDefaultInterface returns the first fabric-role interface name from the HostType
+// resolved via the catalog_item → template → host_type chain. Returns ("", nil) if the
+// chain cannot be resolved (no template or no host_type). Returns an error if a HostType
+// is found but has no fabric-role interface.
+func (s *PrivateBareMetalInstancesServer) resolveDefaultInterface(
+	ctx context.Context, bmi *privatev1.BareMetalInstance) (string, error) {
+	catalogItemID := refKey(bmi.GetSpec().GetCatalogItem())
+	if catalogItemID == "" {
+		return "", nil
+	}
+	catResp, err := s.catalogItemsDao.Get().SetId(catalogItemID).Do(ctx)
+	if err != nil {
+		return "", nil
+	}
+	templateID := refKey(catResp.GetObject().GetTemplate())
+	if templateID == "" {
+		return "", nil
+	}
+	tmplResp, err := s.templatesDao.Get().SetId(templateID).Do(ctx)
+	if err != nil {
+		return "", nil
+	}
+	hostTypeID := tmplResp.GetObject().GetHostType()
+	if hostTypeID == "" {
+		return "", nil
+	}
+	htResp, err := s.hostTypesDao.Get().SetId(hostTypeID).Do(ctx)
+	if err != nil {
+		return "", nil
+	}
+	for _, ni := range htResp.GetObject().GetInterfaces() {
+		if strings.EqualFold(ni.GetRole(), "fabric") {
+			return ni.GetName(), nil
+		}
+	}
+	return "", grpcstatus.Errorf(grpccodes.FailedPrecondition,
+		"host type '%s' has no fabric-role interface for default network attachment", hostTypeID)
 }
 
 // validateAndApplyCatalogItem verifies the referenced catalog item exists, is accessible,

--- a/fulfillment-service/internal/servers/private_baremetal_instances_server.go
+++ b/fulfillment-service/internal/servers/private_baremetal_instances_server.go
@@ -399,7 +399,13 @@ func (s *PrivateBareMetalInstancesServer) resolveDefaultInterface(
 	}
 	catResp, err := s.catalogItemsDao.Get().SetId(catalogItemID).Do(ctx)
 	if err != nil {
-		return "", nil
+		var notFoundErr *dao.ErrNotFound
+		if errors.As(err, &notFoundErr) {
+			return "", nil
+		}
+		s.logger.ErrorContext(ctx, "Failed to lookup catalog item for default interface resolution",
+			slog.String("catalog_item", catalogItemID), slog.Any("error", err))
+		return "", grpcstatus.Errorf(grpccodes.Internal, "failed to resolve default interface")
 	}
 	templateID := refKey(catResp.GetObject().GetTemplate())
 	if templateID == "" {
@@ -407,7 +413,13 @@ func (s *PrivateBareMetalInstancesServer) resolveDefaultInterface(
 	}
 	tmplResp, err := s.templatesDao.Get().SetId(templateID).Do(ctx)
 	if err != nil {
-		return "", nil
+		var notFoundErr *dao.ErrNotFound
+		if errors.As(err, &notFoundErr) {
+			return "", nil
+		}
+		s.logger.ErrorContext(ctx, "Failed to lookup template for default interface resolution",
+			slog.String("template_id", templateID), slog.Any("error", err))
+		return "", grpcstatus.Errorf(grpccodes.Internal, "failed to resolve default interface")
 	}
 	hostTypeID := tmplResp.GetObject().GetHostType()
 	if hostTypeID == "" {
@@ -415,7 +427,13 @@ func (s *PrivateBareMetalInstancesServer) resolveDefaultInterface(
 	}
 	htResp, err := s.hostTypesDao.Get().SetId(hostTypeID).Do(ctx)
 	if err != nil {
-		return "", nil
+		var notFoundErr *dao.ErrNotFound
+		if errors.As(err, &notFoundErr) {
+			return "", nil
+		}
+		s.logger.ErrorContext(ctx, "Failed to lookup host type for default interface resolution",
+			slog.String("host_type_id", hostTypeID), slog.Any("error", err))
+		return "", grpcstatus.Errorf(grpccodes.Internal, "failed to resolve default interface")
 	}
 	for _, ni := range htResp.GetObject().GetInterfaces() {
 		if strings.EqualFold(ni.GetRole(), "fabric") {

--- a/fulfillment-service/internal/servers/private_baremetal_instances_server_test.go
+++ b/fulfillment-service/internal/servers/private_baremetal_instances_server_test.go
@@ -2384,4 +2384,374 @@ var _ = Describe("Private bare metal instances server", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
+
+	Describe("Default network_attachments population", func() {
+		var (
+			server        *PrivateBareMetalInstancesServer
+			catalogServer *PrivateBareMetalInstanceCatalogItemsServer
+			catIDWithHT   string
+			catIDNoHT     string
+			defaultSubnet *privatev1.Subnet
+			defaultSG     *privatev1.SecurityGroup
+		)
+
+		const testTenant = "system"
+
+		BeforeEach(func() {
+			var err error
+
+			catalogServer, err = NewPrivateBareMetalInstanceCatalogItemsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			server, err = NewPrivateBareMetalInstancesServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create a HostType with fabric + management + lifecycle interfaces.
+			hostTypesDao, err := dao.NewGenericDAO[*privatev1.HostType]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			_, err = hostTypesDao.Create().SetObject(privatev1.HostType_builder{
+				Id:    "default-test-host-type",
+				Title: "Default Test Host Type",
+				Metadata: privatev1.Metadata_builder{
+					Tenant: auth.SharedTenant,
+				}.Build(),
+				Interfaces: []*privatev1.NetworkInterface{
+					privatev1.NetworkInterface_builder{Name: "data-0", Role: "fabric"}.Build(),
+					privatev1.NetworkInterface_builder{Name: "data-1", Role: "fabric"}.Build(),
+					privatev1.NetworkInterface_builder{Name: "mgmt-0", Role: "management"}.Build(),
+					privatev1.NetworkInterface_builder{Name: "bmc-0", Role: "lifecycle"}.Build(),
+				},
+			}.Build()).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create templates.
+			templatesDao, err := dao.NewGenericDAO[*privatev1.BareMetalInstanceTemplate]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			_, err = templatesDao.Create().SetObject(privatev1.BareMetalInstanceTemplate_builder{
+				Id:       "default-template-with-ht",
+				Title:    "Template with HostType",
+				HostType: "default-test-host-type",
+				Metadata: privatev1.Metadata_builder{
+					Tenant: auth.SharedTenant,
+				}.Build(),
+			}.Build()).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = templatesDao.Create().SetObject(privatev1.BareMetalInstanceTemplate_builder{
+				Id:    "default-template-no-ht",
+				Title: "Template without HostType",
+				Metadata: privatev1.Metadata_builder{
+					Tenant: auth.SharedTenant,
+				}.Build(),
+			}.Build()).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create catalog items.
+			catResp, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
+					Title:     "Catalog with HT for defaults",
+					Template:  privatev1.BareMetalInstanceTemplateReference_builder{Id: "default-template-with-ht"}.Build(),
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			catIDWithHT = catResp.GetObject().GetId()
+
+			catResp2, err := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
+					Title:     "Catalog no HT for defaults",
+					Template:  privatev1.BareMetalInstanceTemplateReference_builder{Id: "default-template-no-ht"}.Build(),
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			catIDNoHT = catResp2.GetObject().GetId()
+
+			// Create a NetworkClass with fabric_manager for the fabric manager validation.
+			ncDao, err := dao.NewGenericDAO[*privatev1.NetworkClass]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			fabricMgr := "netris"
+			ncResp, err := ncDao.Create().SetObject(privatev1.NetworkClass_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "default-nc",
+					Tenant: "system",
+				}.Build(),
+				FabricManager:          &fabricMgr,
+				ImplementationStrategy: "netris",
+			}.Build()).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			ncID := ncResp.GetObject().GetId()
+
+			// Create a VirtualNetwork.
+			vnDao, err := dao.NewGenericDAO[*privatev1.VirtualNetwork]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			vnResp, err := vnDao.Create().SetObject(privatev1.VirtualNetwork_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "default",
+					Tenant: testTenant,
+					Labels: map[string]string{
+						"osac.openshift.io/default": "true",
+					},
+				}.Build(),
+				Spec: privatev1.VirtualNetworkSpec_builder{
+					NetworkClass: privatev1.NetworkClassReference_builder{Id: ncID}.Build(),
+				}.Build(),
+			}.Build()).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			vnID := vnResp.GetObject().GetId()
+
+			// Create default subnet with proper VN reference.
+			subnetDao, err := dao.NewGenericDAO[*privatev1.Subnet]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			ipv4Cidr := "10.0.1.0/24"
+			subnetResp, err := subnetDao.Create().SetObject(privatev1.Subnet_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "default-ipv4",
+					Tenant: testTenant,
+					Labels: map[string]string{
+						"osac.openshift.io/default": "true",
+					},
+				}.Build(),
+				Spec: privatev1.SubnetSpec_builder{
+					Ipv4Cidr:       &ipv4Cidr,
+					VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
+				}.Build(),
+				Status: privatev1.SubnetStatus_builder{
+					State: privatev1.SubnetState_SUBNET_STATE_READY,
+				}.Build(),
+			}.Build()).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			defaultSubnet = subnetResp.GetObject()
+
+			sgDao, err := dao.NewGenericDAO[*privatev1.SecurityGroup]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			sgResp, err := sgDao.Create().SetObject(privatev1.SecurityGroup_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "default",
+					Tenant: testTenant,
+					Labels: map[string]string{
+						"osac.openshift.io/default": "true",
+					},
+				}.Build(),
+				Spec: privatev1.SecurityGroupSpec_builder{
+					VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
+				}.Build(),
+				Status: privatev1.SecurityGroupStatus_builder{
+					State: privatev1.SecurityGroupState_SECURITY_GROUP_STATE_READY,
+				}.Build(),
+			}.Build()).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			defaultSG = sgResp.GetObject()
+		})
+
+		It("Populates default network_attachments when omitted", func() {
+			response, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
+				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
+					Spec: privatev1.BareMetalInstanceSpec_builder{
+						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDWithHT}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			attachments := response.GetObject().GetSpec().GetNetworkAttachments()
+			Expect(attachments).To(HaveLen(1))
+			Expect(attachments[0].GetSubnet().GetId()).To(Equal(defaultSubnet.GetId()))
+			Expect(attachments[0].GetSecurityGroups()).To(HaveLen(1))
+			Expect(attachments[0].GetSecurityGroups()[0].GetId()).To(Equal(defaultSG.GetId()))
+			Expect(attachments[0].GetInterface()).To(Equal("data-0"))
+		})
+
+		It("Does not override explicitly provided network_attachments", func() {
+			response, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
+				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
+					Spec: privatev1.BareMetalInstanceSpec_builder{
+						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDWithHT}.Build(),
+						NetworkAttachments: []*privatev1.BareMetalNetworkAttachment{
+							privatev1.BareMetalNetworkAttachment_builder{
+								Subnet: privatev1.SubnetLocalReference_builder{Id: "custom-subnet"}.Build(),
+							}.Build(),
+						},
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			attachments := response.GetObject().GetSpec().GetNetworkAttachments()
+			Expect(attachments).To(HaveLen(1))
+			Expect(attachments[0].GetSubnet().GetId()).To(Equal("custom-subnet"))
+		})
+
+		It("Omits interface when template has no HostType", func() {
+			response, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
+				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
+					Spec: privatev1.BareMetalInstanceSpec_builder{
+						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDNoHT}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			attachments := response.GetObject().GetSpec().GetNetworkAttachments()
+			Expect(attachments).To(HaveLen(1))
+			Expect(attachments[0].GetSubnet().GetId()).To(Equal(defaultSubnet.GetId()))
+			Expect(attachments[0].GetInterface()).To(BeEmpty())
+		})
+
+		It("Skips defaults when no default subnet exists", func() {
+			// Delete the default subnet — Create should succeed with no network_attachments.
+			subnetDao, sdErr := dao.NewGenericDAO[*privatev1.Subnet]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(sdErr).ToNot(HaveOccurred())
+			_, sdErr = subnetDao.Delete().SetId(defaultSubnet.GetId()).Do(ctx)
+			Expect(sdErr).ToNot(HaveOccurred())
+
+			response, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
+				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
+					Spec: privatev1.BareMetalInstanceSpec_builder{
+						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDWithHT}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetObject().GetSpec().GetNetworkAttachments()).To(BeEmpty())
+		})
+
+		It("Skips defaults when no default security group exists", func() {
+			// Delete the default security group — Create should succeed with no network_attachments.
+			sgDao, sgErr := dao.NewGenericDAO[*privatev1.SecurityGroup]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(sgErr).ToNot(HaveOccurred())
+			_, sgErr = sgDao.Delete().SetId(defaultSG.GetId()).Do(ctx)
+			Expect(sgErr).ToNot(HaveOccurred())
+
+			response, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
+				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
+					Spec: privatev1.BareMetalInstanceSpec_builder{
+						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catIDWithHT}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response.GetObject().GetSpec().GetNetworkAttachments()).To(BeEmpty())
+		})
+
+		It("Fails when HostType has no fabric interface", func() {
+			// Create a HostType with only management and lifecycle interfaces.
+			htDao, htErr := dao.NewGenericDAO[*privatev1.HostType]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(htErr).ToNot(HaveOccurred())
+			_, htErr = htDao.Create().SetObject(privatev1.HostType_builder{
+				Id:    "no-fabric-host-type",
+				Title: "No Fabric Host Type",
+				Metadata: privatev1.Metadata_builder{
+					Tenant: auth.SharedTenant,
+				}.Build(),
+				Interfaces: []*privatev1.NetworkInterface{
+					privatev1.NetworkInterface_builder{Name: "mgmt-0", Role: "management"}.Build(),
+					privatev1.NetworkInterface_builder{Name: "bmc-0", Role: "lifecycle"}.Build(),
+				},
+			}.Build()).Do(ctx)
+			Expect(htErr).ToNot(HaveOccurred())
+
+			// Create template and catalog item referencing this host type.
+			tmplDao, tmplErr := dao.NewGenericDAO[*privatev1.BareMetalInstanceTemplate]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(tmplErr).ToNot(HaveOccurred())
+			_, tmplErr = tmplDao.Create().SetObject(privatev1.BareMetalInstanceTemplate_builder{
+				Id:       "no-fabric-template",
+				Title:    "No Fabric Template",
+				HostType: "no-fabric-host-type",
+				Metadata: privatev1.Metadata_builder{
+					Tenant: auth.SharedTenant,
+				}.Build(),
+			}.Build()).Do(ctx)
+			Expect(tmplErr).ToNot(HaveOccurred())
+
+			catResp, catErr := catalogServer.Create(ctx, privatev1.BareMetalInstanceCatalogItemsCreateRequest_builder{
+				Object: privatev1.BareMetalInstanceCatalogItem_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
+					Title:     "Catalog no fabric",
+					Template:  privatev1.BareMetalInstanceTemplateReference_builder{Id: "no-fabric-template"}.Build(),
+					Published: true,
+				}.Build(),
+			}.Build())
+			Expect(catErr).ToNot(HaveOccurred())
+
+			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
+				Object: privatev1.BareMetalInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					}.Build(),
+					Spec: privatev1.BareMetalInstanceSpec_builder{
+						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catResp.GetObject().GetId()}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+			Expect(status.Message()).To(ContainSubstring("fabric"))
+		})
+	})
 })


### PR DESCRIPTION
## [OSAC-2252](https://redhat.atlassian.net/browse/OSAC-2252): Populate default network_attachments when omitted on BareMetalInstance create

**Jira:** https://redhat.atlassian.net/browse/OSAC-2252
**Story type:** Task
**EP:** [BMaaS Networking](/enhancements/OSAC-1437-bmaas-networking) §Workflow

### Summary

When `network_attachments` is omitted on BareMetalInstance creation, the fulfillment-service now auto-populates with the tenant's default IPv4 Subnet and default SecurityGroup (labeled `osac.openshift.io/default`), using the first `fabric`-role interface from the HostType. If no defaults exist (tenant networking not yet provisioned), the field remains empty — existing behavior is preserved.

### Changes

- **`fulfillment-service/internal/servers/private_baremetal_instances_server.go`:**
  - Added `securityGroupsDao` and `tenancyLogic` to server struct for default resource lookup and tenant resolution
  - Added `applyDefaultNetworkAttachments()` in the `Create()` flow between `validateSpec` and `validateNetworkAttachments`
  - Added `findDefaultSubnet()` — lists subnets by `osac.openshift.io/default` label, filtered to tenant, returns first non-deleted IPv4 subnet
  - Added `findDefaultSecurityGroup()` — same pattern for security groups
  - Added `resolveDefaultInterface()` — walks catalog_item → template → host_type chain, returns first `fabric`-role interface name; returns error if HostType exists but has no fabric interface

### Testing

- **Unit tests:** 6 new tests in `private_baremetal_instances_server_test.go` covering:
  - Happy path: defaults populated with correct subnet, SG, and interface
  - Explicit attachments: no-op (unchanged)
  - No HostType on template: interface omitted
  - No default subnet: graceful skip
  - No default security group: graceful skip
  - No fabric interface on HostType: FailedPrecondition error
- **Regression:** All 1545 existing tests pass, 0 failures
- **Coverage:** All behavioral paths through public `Create` API are tested

### Acceptance Criteria

- [x] Auto-populate `network_attachments` when omitted on Create
- [x] Default Subnet from tenant's default IPv4 Subnet (labeled `osac.openshift.io/default`)
- [x] Default SecurityGroup from tenant's default SG (same label)
- [x] Default interface from first `fabric`-role HostType interface
- [x] Resolved attachments stored in spec (self-describing after creation)
- [x] Explicit `network_attachments` unchanged (no default population)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bare-metal instance creation now automatically selects default subnet, security group, and fabric network attachments when applicable.
  * Explicit network attachments remain unchanged.
  * Interfaces without a host type are handled without unnecessary defaults.

* **Bug Fixes**
  * Improved fallback behavior when defaults are unavailable.
  * Added validation and clearer failure handling for host types missing required fabric interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->