### PR TITLE
OSAC-3830: Skip CI for non-code changes: AI agent config, design, tooling

### DIFF
--- a/.github/workflows/check-generated-code.yaml
+++ b/.github/workflows/check-generated-code.yaml
@@ -8,11 +8,13 @@ on:
       - '!fulfillment-service/LICENSE'
       - '!fulfillment-service/**/*.md'
       - '!fulfillment-service/docs/**'
+      - '!fulfillment-service/.claude/**'
       - 'osac-operator/**'
       - '!osac-operator/OWNERS'
       - '!osac-operator/LICENSE'
       - '!osac-operator/**/*.md'
       - '!osac-operator/docs/**'
+      - '!osac-operator/.claude/**'
 
 permissions:
   contents: read
@@ -38,12 +40,14 @@ jobs:
               - '!fulfillment-service/LICENSE'
               - '!fulfillment-service/**/*.md'
               - '!fulfillment-service/docs/**'
+              - '!fulfillment-service/.claude/**'
             osac-operator:
               - 'osac-operator/**'
               - '!osac-operator/OWNERS'
               - '!osac-operator/LICENSE'
               - '!osac-operator/**/*.md'
               - '!osac-operator/docs/**'
+              - '!osac-operator/.claude/**'
 
   check-generated-code:
     name: Check generated code (${{ matrix.component }})

--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -57,6 +57,12 @@ jobs:
               - '!**/LICENSE'
               - '!**/*.md'
               - '!**/docs/**'
+              - '!**/.claude/**'
+              - '!**/.cursor/**'
+              - '!**/.gemini/**'
+              - '!.design/**'
+              - '!.skillsaw.yaml'
+              - '!.pre-commit-config.yaml'
 
   # Builds fulfillment-service, osac-operator, osac-aap's execution
   # environment (twice -- once each for aap.bootstrap.image and

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -57,6 +57,12 @@ jobs:
               - '!**/LICENSE'
               - '!**/*.md'
               - '!**/docs/**'
+              - '!**/.claude/**'
+              - '!**/.cursor/**'
+              - '!**/.gemini/**'
+              - '!.design/**'
+              - '!.skillsaw.yaml'
+              - '!.pre-commit-config.yaml'
 
   # Builds fulfillment-service, osac-operator, osac-aap's execution
   # environment (twice -- once each for aap.bootstrap.image and

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -57,6 +57,12 @@ jobs:
               - '!**/LICENSE'
               - '!**/*.md'
               - '!**/docs/**'
+              - '!**/.claude/**'
+              - '!**/.cursor/**'
+              - '!**/.gemini/**'
+              - '!.design/**'
+              - '!.skillsaw.yaml'
+              - '!.pre-commit-config.yaml'
 
   # Builds fulfillment-service, osac-operator, osac-aap's execution
   # environment (twice -- once each for aap.bootstrap.image and

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -42,6 +42,12 @@ jobs:
               - '!**/LICENSE'
               - '!**/*.md'
               - '!**/docs/**'
+              - '!**/.claude/**'
+              - '!**/.cursor/**'
+              - '!**/.gemini/**'
+              - '!.design/**'
+              - '!.skillsaw.yaml'
+              - '!.pre-commit-config.yaml'
 
   # fulfillment-service, osac-operator, and osac-aap use genuinely different
   # integration test mechanisms (ginkgo directly, a Kind cluster + Makefile

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -52,6 +52,12 @@ jobs:
               - '!**/LICENSE'
               - '!**/*.md'
               - '!**/docs/**'
+              - '!**/.claude/**'
+              - '!**/.cursor/**'
+              - '!**/.gemini/**'
+              - '!.design/**'
+              - '!.skillsaw.yaml'
+              - '!.pre-commit-config.yaml'
 
   run-unit-tests:
     name: Run unit tests


### PR DESCRIPTION
## Summary
- Extend the `dorny/paths-filter` exclusion list in all 6 workflows that use it (3 e2e, unit-tests, integration-tests, check-generated-code)
- New exclusions: `.claude/`, `.cursor/`, `.gemini/` (AI agent config), `.design/` (design context), `.skillsaw.yaml`, `.pre-commit-config.yaml`
- The existing exclusions (`*.md`, `OWNERS`, `LICENSE`, `docs/`) already cover documentation-only PRs — these additions cover AI agent configuration and development tooling that don't affect runtime behavior

## Context
PR #213 (docs-only: adding AGENTS.md for osac-csi-driver) triggered all e2e workflow runs. The `changes` job correctly skipped the actual test jobs via the `!**/*.md` filter, but non-md files in `.claude/` directories (settings.json, hooks) would not have been caught.

## Test plan
- [ ] Verify `dorny/paths-filter` syntax is correct (negation patterns follow `.gitignore` semantics)
- [ ] Confirm existing code-change PRs still trigger tests (positive patterns unchanged)
- [ ] This PR itself should demonstrate the skip behavior (workflow-only changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow triggers to ignore changes limited to development-tooling, design, and assistant configuration files.
  * Prevents unnecessary unit, integration, end-to-end, and generated-code checks when application code is unaffected.
  * Keeps validation focused on changes that can impact product behavior, improving development feedback efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->