### PR TITLE
OSAC-3734: rename E2E gate jobs for merge queue compatibility

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -96,11 +96,8 @@ jobs:
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
 
-  e2e:
-    if: >-
-      always()
-      && !(needs.e2e-bmaas-full-install.result == 'skipped'
-           && needs.changes.result == 'success')
+  e2e-bmaas-gate:
+    if: always()
     needs: [changes, e2e-bmaas-full-install]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -111,11 +111,8 @@ jobs:
       # defaults -- none are required and this caller has no need to override
       # them today.
 
-  e2e:
-    if: >-
-      always()
-      && !(needs.e2e-caas-full-install.result == 'skipped'
-           && needs.changes.result == 'success')
+  e2e-caas-gate:
+    if: always()
     needs: [changes, e2e-caas-full-install]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -103,11 +103,8 @@ jobs:
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
 
-  e2e:
-    if: >-
-      always()
-      && !(needs.e2e-vmaas-full-install.result == 'skipped'
-           && needs.changes.result == 'success')
+  e2e-vmaas-gate:
+    if: always()
     needs: [changes, e2e-vmaas-full-install]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Rename E2E aggregate gate jobs to unique names and make them always run, fixing two issues with merge queue:

1. **All three gate jobs reported as `e2e`** — merge queue couldn't distinguish them
2. **Gate jobs skipped on docs-only PRs** — "skipped" doesn't satisfy required checks, blocking merge queue entry forever

### Changes

| Workflow | Old job name | New job name | Old `if` | New `if` |
|----------|-------------|-------------|----------|----------|
| `e2e-vmaas-full-install.yml` | `e2e` | `e2e-vmaas-gate` | skip on docs-only | `always()` |
| `e2e-bmaas-full-install.yml` | `e2e` | `e2e-bmaas-gate` | skip on docs-only | `always()` |
| `e2e-caas-full-install.yml` | `e2e` | `e2e-caas-gate` | skip on docs-only | `always()` |

### Behavior

- **Code PR**: E2E runs → gate passes/fails based on result
- **Docs-only PR**: E2E skipped → gate runs and passes (no upstream failure)
- **E2E failure**: gate runs and fails (upstream failure detected)

### Companion PR

github-config PR to update required checks from `e2e-vmaas-full-install / e2e` → `e2e-vmaas-gate` (etc.)

**Merge order**: this PR first, then github-config.

## Test plan

- [ ] Code PR: gate jobs run and reflect E2E result
- [ ] Docs-only PR: gate jobs run and pass (not skipped)
- [ ] Check names visible as `e2e-vmaas-gate`, `e2e-bmaas-gate`, `e2e-caas-gate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end validation workflows for BMaaS, CaaS, and VMaaS.
  * Final validation gates now run consistently after upstream checks, including when installation steps are skipped.
  * Preserved existing failure and cancellation reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->