### PR TITLE
OSAC-3838: bump operator versions and fix v1.4.x install plan rejection

### DIFF
--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/defaults/main.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/defaults/main.yaml
@@ -28,20 +28,20 @@ ocp_4_20_ai_maas_cert_manager_source: redhat-operators
 
 # Service Mesh (must install BEFORE RHCL)
 ocp_4_20_ai_maas_sm_channel: stable-3.2
-ocp_4_20_ai_maas_sm_starting_csv: servicemeshoperator3.v3.2.7
+ocp_4_20_ai_maas_sm_starting_csv: servicemeshoperator3.v3.2.8
 ocp_4_20_ai_maas_sm_source: redhat-operators
 
 # RHCL sub-operators (pre-create to prevent OLM auto-upgrade to v1.4.0)
-ocp_4_20_ai_maas_authorino_starting_csv: authorino-operator.v1.3.2
-ocp_4_20_ai_maas_limitador_starting_csv: limitador-operator.v1.3.1
-ocp_4_20_ai_maas_dns_starting_csv: dns-operator.v1.3.1
+ocp_4_20_ai_maas_authorino_starting_csv: authorino-operator.v1.3.3
+ocp_4_20_ai_maas_limitador_starting_csv: limitador-operator.v1.3.2
+ocp_4_20_ai_maas_dns_starting_csv: dns-operator.v1.3.2
 
 # RHCL operator
-ocp_4_20_ai_maas_rhcl_starting_csv: rhcl-operator.v1.3.5
+ocp_4_20_ai_maas_rhcl_starting_csv: rhcl-operator.v1.3.6
 ocp_4_20_ai_maas_rhcl_source: redhat-operators
 
 # Version to reject/accept in install plans
-ocp_4_20_ai_maas_reject_version: "v1.4.0"
+ocp_4_20_ai_maas_reject_version: "v1.4"
 ocp_4_20_ai_maas_accept_version: "v1.3"
 
 # Observability operators (COO + OTel, installed in isolated namespaces)

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/defaults/main.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/defaults/main.yaml
@@ -31,7 +31,7 @@ ocp_4_20_ai_maas_sm_channel: stable-3.2
 ocp_4_20_ai_maas_sm_starting_csv: servicemeshoperator3.v3.2.8
 ocp_4_20_ai_maas_sm_source: redhat-operators
 
-# RHCL sub-operators (pre-create to prevent OLM auto-upgrade to v1.4.0)
+# RHCL sub-operators (pre-create to prevent OLM auto-upgrade to v1.4.x)
 ocp_4_20_ai_maas_authorino_starting_csv: authorino-operator.v1.3.3
 ocp_4_20_ai_maas_limitador_starting_csv: limitador-operator.v1.3.2
 ocp_4_20_ai_maas_dns_starting_csv: dns-operator.v1.3.2

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/verify.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/verify.yaml
@@ -106,6 +106,9 @@
     validate_certs: false
   no_log: true
   register: _api_key_response
+  retries: 6
+  delay: 10
+  until: _api_key_response is not failed
   when: ocp_4_20_ai_maas_enable_keycloak | default(true) | bool
 
 - name: Report API key creation


### PR DESCRIPTION
## Summary

[OSAC-3838](https://redhat.atlassian.net/browse/OSAC-3838) — Version pinning upgrade for `ocp_4_20_ai_maas` template role:

- **Bump startingCSV** to current channel heads: SM 3.2.8, Authorino 1.3.3, Limitador 1.3.2, DNS 1.3.2, RHCL 1.3.6
- **Fix v1.4.x install plan rejection**: `reject_version` changed from `"v1.4.0"` (exact match) to `"v1.4"` (prefix match, consistent with `accept_version: "v1.3"`). The old exact match missed v1.4.1/v1.4.2, allowing OLM to auto-upgrade sub-operators — breaking RHCL resolution
- **API key creation retries**: Add retries (6x, 10s) to `verify.yaml` API key creation task — handles transient 500 from maas-controller after subscription creation

## Test plan

- [x] Full MaaS + Keycloak deployed on spoke1 (OCP 4.20.26)
- [x] External model (secured) deployed on osacmaas via Ansible role with spoke1 as upstream
- [x] All 4 governance tests passed: 401 (unauthenticated), 403 (invalid key), 200 (valid inference), 429 (rate limiting)
- [x] Version pinning held — zero v1.4.x CSVs installed
- [x] `ansible-lint` passes (0 failures, 0 warnings)

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated operator versions for Service Mesh, RHCL, Authorino, Limitador, and DNS components.
  * Improved API key creation reliability by retrying failed requests up to six times.
  * Updated install-plan version handling for compatibility with the newer release format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->