### PR TITLE
OSAC-1112: link OpenAPI docs from the fulfillment-service README

### DIFF
--- a/fulfillment-service/README.md
+++ b/fulfillment-service/README.md
@@ -3,6 +3,12 @@
 This project contains the code for the fulfillment service. For instructions on how to install it
 in a production environment see the [installation guide](docs/INSTALL.md).
 
+The API is defined using protocol buffers in the [`proto`](proto) directory. An OpenAPI
+specification is generated automatically from those definitions and published as raw YAML at
+[openapi/v3/public.yaml](https://osac-project.github.io/osac/openapi/v3/public.yaml).
+The same documentation is also available with a more convenient UI at
+[osac-project.github.io/osac](https://osac-project.github.io/osac/).
+
 ## Required development tools
 
 To work with this project you will need the following tools:


### PR DESCRIPTION
## Summary
- Add a short README section explaining that the fulfillment-service API is defined with protocol buffers under `proto`.
- Link to the published OpenAPI YAML and the browsable GitHub Pages UI for the mono-repo docs site.

## Test plan
- [x] Confirm the README links open correctly:
  - https://osac-project.github.io/osac/openapi/v3/public.yaml
  - https://osac-project.github.io/osac/
- [x] Confirm the `proto` relative link resolves in the GitHub README view.

Related: https://redhat.atlassian.net/browse/OSAC-1112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on the protocol-buffer API source.
  * Documented the automatically generated OpenAPI YAML specification.
  * Added information about the hosted API documentation interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->