### PR TITLE
OSAC-3759: Add BCM HTTP client

### DIFF
--- a/bare-metal-fulfillment-operator/internal/bcmclient/bcmclient_suite_test.go
+++ b/bare-metal-fulfillment-operator/internal/bcmclient/bcmclient_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bcmclient
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
+	. "github.com/onsi/gomega"    //nolint:revive,staticcheck
+)
+
+func TestBCMClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "BCM Client Suite")
+}

--- a/bare-metal-fulfillment-operator/internal/bcmclient/client.go
+++ b/bare-metal-fulfillment-operator/internal/bcmclient/client.go
@@ -1,0 +1,471 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package bcmclient provides a Go HTTP client for the NVIDIA Base Command
+// Manager (BCM) JSON API. It handles mTLS authentication, automatic
+// certificate rotation, version validation, and typed error classification.
+package bcmclient
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	jsonPath    = "/json"
+	versionPath = "/rest/v1/version"
+
+	minMajorVersion  = 10
+	minMinorVersion  = 25
+	minPatchVersion  = 3
+	defaultTimeoutS  = 30
+	maxResponseBytes = 64 << 20 // 64 MiB
+)
+
+// ExtraValues keys used by OSAC in BCM device extra_values.
+const (
+	ExtraValueInstanceID     = "osac_instance_id"
+	ExtraValueResourceClass  = "resource_class"
+	ExtraValueBMCAddress     = "osac_bmc_address"
+	ExtraValueBMCCredentials = "osac_bmc_credentials_secret"
+)
+
+// Typed errors for BCM API failures.
+var (
+	ErrConnectionFailed = errors.New("bcm connection failed")
+	ErrTLSFailed        = errors.New("bcm TLS handshake failed")
+	ErrAuthFailed       = errors.New("bcm authentication failed")
+	ErrServerError      = errors.New("bcm server error")
+	ErrVersionTooOld    = errors.New("bcm version below minimum required")
+)
+
+// ValidationError wraps BCM field validation failures from UpdateDevice.
+type ValidationError struct {
+	Validations []Validation
+}
+
+func (e *ValidationError) Error() string {
+	msgs := make([]string, 0, len(e.Validations))
+	for _, v := range e.Validations {
+		msgs = append(msgs, fmt.Sprintf("%s: %s (%s)", v.Field, v.Message, v.ErrorCode))
+	}
+	return fmt.Sprintf("bcm validation error: %s", strings.Join(msgs, "; "))
+}
+
+// Prometheus metrics.
+var (
+	apiRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "osac_bcm_api_requests_total",
+			Help: "Total BCM API calls",
+		},
+		[]string{"method", "status"},
+	)
+	apiLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "osac_bcm_api_duration_seconds",
+			Help: "BCM API call latency",
+		},
+		[]string{"method"},
+	)
+)
+
+var metricsOnce sync.Once
+
+func registerMetrics() {
+	metricsOnce.Do(func() {
+		metrics.Registry.MustRegister(apiRequestsTotal, apiLatency)
+	})
+}
+
+// Config holds BCM connection parameters.
+type Config struct {
+	URL                string `json:"url"`
+	CertFile           string `json:"certFile"`
+	KeyFile            string `json:"keyFile"`
+	CAFile             string `json:"caFile"`
+	InsecureSkipVerify bool   `json:"insecureSkipVerify"`
+}
+
+// Validate checks that required fields are set.
+func (c *Config) Validate() error {
+	if c.URL == "" {
+		return fmt.Errorf("bcm url is required in config")
+	}
+	if c.CertFile == "" {
+		return fmt.Errorf("bcm certFile is required in config")
+	}
+	if c.KeyFile == "" {
+		return fmt.Errorf("bcm keyFile is required in config")
+	}
+	return nil
+}
+
+// Client talks to the BCM JSON API over mTLS.
+type Client struct {
+	httpClient  *http.Client
+	certWatcher *certwatcher.CertWatcher
+	baseURL     string
+}
+
+// NewClient creates a BCM client. It validates connectivity by checking
+// the BCM version at startup.
+func NewClient(ctx context.Context, cfg *Config) (*Client, error) {
+	registerMetrics()
+
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	httpClient, watcher, err := newHTTPClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.InsecureSkipVerify {
+		log := ctrllog.FromContext(ctx)
+		log.Info("WARNING: BCM TLS certificate verification is disabled")
+	}
+
+	c := &Client{
+		httpClient:  httpClient,
+		certWatcher: watcher,
+		baseURL:     strings.TrimRight(cfg.URL, "/"),
+	}
+
+	if err := c.checkVersion(ctx); err != nil {
+		return nil, fmt.Errorf("bcm version check failed: %w", err)
+	}
+
+	return c, nil
+}
+
+// CertWatcher returns the certificate watcher for registration with the
+// controller manager via mgr.Add(). This enables automatic cert rotation.
+func (c *Client) CertWatcher() *certwatcher.CertWatcher {
+	return c.certWatcher
+}
+
+// NewClientForTest creates a Client with an injected http.Client for testing.
+func NewClientForTest(httpClient *http.Client, baseURL string) *Client {
+	return &Client{
+		httpClient: httpClient,
+		baseURL:    strings.TrimRight(baseURL, "/"),
+	}
+}
+
+func newHTTPClient(cfg *Config) (*http.Client, *certwatcher.CertWatcher, error) {
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: cfg.InsecureSkipVerify, //nolint:gosec
+		MinVersion:         tls.VersionTLS12,
+	}
+
+	if cfg.CAFile != "" {
+		caCert, err := os.ReadFile(cfg.CAFile)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to read bcm CA certificate: %w", err)
+		}
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			return nil, nil, fmt.Errorf("failed to parse bcm CA certificate")
+		}
+		tlsConfig.RootCAs = caCertPool
+	}
+
+	watcher, err := certwatcher.New(cfg.CertFile, cfg.KeyFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to initialize bcm certificate watcher: %w", err)
+	}
+	tlsConfig.GetClientCertificate = func(_ *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+		return watcher.GetCertificate(nil)
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+		Timeout: defaultTimeoutS * time.Second,
+	}, watcher, nil
+}
+
+func (c *Client) checkVersion(ctx context.Context) error {
+	log := ctrllog.FromContext(ctx)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+versionPath, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create version request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return classifyHTTPError(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%w: version endpoint returned %d", ErrServerError, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
+	if err != nil {
+		return fmt.Errorf("failed to read version response: %w", err)
+	}
+	if int64(len(body)) > maxResponseBytes {
+		return fmt.Errorf("bcm version response exceeds %d bytes", maxResponseBytes)
+	}
+
+	var version versionResponse
+	if err := json.Unmarshal(body, &version); err != nil {
+		return fmt.Errorf("failed to parse version response: %w", err)
+	}
+
+	var major, minor, patch int
+	n, _ := fmt.Sscanf(version.CMVersion, "%d.%d.%d", &major, &minor, &patch)
+	if n < 2 {
+		return fmt.Errorf("failed to parse cm_version %q: expected at least major.minor", version.CMVersion)
+	}
+	if major < minMajorVersion ||
+		(major == minMajorVersion && minor < minMinorVersion) ||
+		(major == minMajorVersion && minor == minMinorVersion && patch < minPatchVersion) {
+		return fmt.Errorf("%w: got %s, need >= %d.%d.%02d",
+			ErrVersionTooOld, version.CMVersion, minMajorVersion, minMinorVersion, minPatchVersion)
+	}
+
+	log.Info("BCM version check passed", "cm_version", version.CMVersion, "cmd_version", version.CMDVersion)
+	return nil
+}
+
+// doJSONCall executes a BCM JSON API call and returns the raw response body.
+func (c *Client) doJSONCall(ctx context.Context, service, call string, args any) (json.RawMessage, error) { //nolint:gocyclo
+	log := ctrllog.FromContext(ctx)
+
+	if args == nil {
+		args = []any{}
+	}
+
+	reqBody := jsonRequest{
+		Service: service,
+		Call:    call,
+		Args:    args,
+	}
+
+	reqJSON, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal bcm request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+jsonPath, bytes.NewReader(reqJSON))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create bcm request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	start := time.Now()
+	resp, err := c.httpClient.Do(req)
+	duration := time.Since(start).Seconds()
+	apiLatency.WithLabelValues(call).Observe(duration)
+
+	if err != nil {
+		apiRequestsTotal.WithLabelValues(call, "error").Inc()
+		log.V(1).Info("BCM API call failed", "service", service, "call", call, "error", err)
+		return nil, classifyHTTPError(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	log.V(1).Info("BCM API call completed", "service", service, "call", call,
+		"status", resp.StatusCode, "duration_seconds", duration)
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
+	if err != nil {
+		apiRequestsTotal.WithLabelValues(call, "error").Inc()
+		return nil, fmt.Errorf("failed to read bcm response: %w", err)
+	}
+	if int64(len(body)) > maxResponseBytes {
+		apiRequestsTotal.WithLabelValues(call, "error").Inc()
+		return nil, fmt.Errorf("bcm response exceeds %d bytes", maxResponseBytes)
+	}
+
+	if resp.StatusCode >= 400 {
+		apiRequestsTotal.WithLabelValues(call, "error").Inc()
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return nil, fmt.Errorf("%w: HTTP %d", ErrAuthFailed, resp.StatusCode)
+		}
+		if resp.StatusCode >= 500 {
+			return nil, fmt.Errorf("%w: %d %s", ErrServerError, resp.StatusCode, string(body))
+		}
+		return nil, fmt.Errorf("bcm api error: HTTP %d %s", resp.StatusCode, string(body))
+	}
+
+	var errResp errorResponse
+	if json.Unmarshal(body, &errResp) == nil && errResp.ErrorMessage != "" {
+		apiRequestsTotal.WithLabelValues(call, "error").Inc()
+		msg := strings.TrimSpace(errResp.ErrorMessage)
+		if strings.Contains(msg, "certificate") || strings.Contains(msg, "does not allow access") {
+			return nil, fmt.Errorf("%w: %s", ErrAuthFailed, msg)
+		}
+		return nil, fmt.Errorf("bcm api error: %s", msg)
+	}
+
+	apiRequestsTotal.WithLabelValues(call, "success").Inc()
+	return json.RawMessage(body), nil
+}
+
+// GetDevices returns all devices from BCM.
+func (c *Client) GetDevices(ctx context.Context) ([]Device, error) {
+	body, err := c.doJSONCall(ctx, "cmdevice", "getDevices", []any{})
+	if err != nil {
+		return nil, fmt.Errorf("GetDevices: %w", err)
+	}
+
+	var rawDevices []json.RawMessage
+	if err := json.Unmarshal(body, &rawDevices); err != nil {
+		return nil, fmt.Errorf("GetDevices: failed to parse response: %w", err)
+	}
+
+	devices := make([]Device, 0, len(rawDevices))
+	for _, raw := range rawDevices {
+		var d Device
+		if err := json.Unmarshal(raw, &d); err != nil {
+			return nil, fmt.Errorf("GetDevices: failed to parse device: %w", err)
+		}
+		d.Raw = raw
+		devices = append(devices, d)
+	}
+
+	return devices, nil
+}
+
+// GetDevice returns a single device by hostname, or nil if not found.
+// Always use GetDevice instead of getNode — getNode returns null for LiteNodes.
+func (c *Client) GetDevice(ctx context.Context, hostname string) (*Device, error) {
+	body, err := c.doJSONCall(ctx, "cmdevice", "getDevice", []any{hostname})
+	if err != nil {
+		return nil, fmt.Errorf("GetDevice %s: %w", hostname, err)
+	}
+
+	if string(body) == "null" {
+		return nil, nil
+	}
+
+	var d Device
+	if err := json.Unmarshal(body, &d); err != nil {
+		return nil, fmt.Errorf("GetDevice %s: failed to parse response: %w", hostname, err)
+	}
+	d.Raw = body
+
+	return &d, nil
+}
+
+// UpdateDevice sends a full device object to BCM. The raw JSON must be the
+// complete device as returned by GetDevice, with modifications applied.
+func (c *Client) UpdateDevice(ctx context.Context, deviceRaw json.RawMessage) (*UpdateResponse, error) {
+	body, err := c.doJSONCall(ctx, "cmdevice", "updateDevice", []json.RawMessage{deviceRaw})
+	if err != nil {
+		return nil, fmt.Errorf("UpdateDevice: %w", err)
+	}
+
+	var resp UpdateResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("UpdateDevice: failed to parse response: %w", err)
+	}
+
+	if !resp.Success {
+		if len(resp.Validation) > 0 {
+			return &resp, &ValidationError{Validations: resp.Validation}
+		}
+		return &resp, fmt.Errorf("UpdateDevice: bcm reported failure without validation details")
+	}
+
+	return &resp, nil
+}
+
+// SetExtraValue updates a single key in the device's extra_values and returns
+// the modified raw JSON for use with UpdateDevice.
+func SetExtraValue(deviceRaw json.RawMessage, key string, value any) (json.RawMessage, error) {
+	obj, err := unmarshalPreservingNumbers(deviceRaw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal device for extra_values update: %w", err)
+	}
+
+	extraValues, _ := obj["extra_values"].(map[string]any)
+	if extraValues == nil {
+		extraValues = make(map[string]any)
+	}
+	extraValues[key] = value
+	obj["extra_values"] = extraValues
+
+	return json.Marshal(obj)
+}
+
+// RemoveExtraValue removes a key from the device's extra_values and returns
+// the modified raw JSON for use with UpdateDevice.
+func RemoveExtraValue(deviceRaw json.RawMessage, key string) (json.RawMessage, error) {
+	obj, err := unmarshalPreservingNumbers(deviceRaw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal device for extra_values removal: %w", err)
+	}
+
+	if extraValues, ok := obj["extra_values"].(map[string]any); ok {
+		delete(extraValues, key)
+		obj["extra_values"] = extraValues
+	}
+
+	return json.Marshal(obj)
+}
+
+func unmarshalPreservingNumbers(deviceRaw json.RawMessage) (map[string]any, error) {
+	dec := json.NewDecoder(bytes.NewReader(deviceRaw))
+	dec.UseNumber()
+	var obj map[string]any
+	if err := dec.Decode(&obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func classifyHTTPError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if _, ok := errors.AsType[*tls.CertificateVerificationError](err); ok {
+		return fmt.Errorf("%w: %v", ErrTLSFailed, err)
+	}
+
+	errMsg := err.Error()
+	if strings.Contains(errMsg, "tls:") || strings.Contains(errMsg, "certificate") ||
+		strings.Contains(errMsg, "x509:") {
+		return fmt.Errorf("%w: %v", ErrTLSFailed, err)
+	}
+
+	return fmt.Errorf("%w: %v", ErrConnectionFailed, err)
+}

--- a/bare-metal-fulfillment-operator/internal/bcmclient/client_test.go
+++ b/bare-metal-fulfillment-operator/internal/bcmclient/client_test.go
@@ -1,0 +1,422 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bcmclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
+	. "github.com/onsi/gomega"    //nolint:revive,staticcheck
+)
+
+func mustWrite(w http.ResponseWriter, body string) {
+	_, err := fmt.Fprint(w, body)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+}
+
+func newTestServer(handler http.Handler) (*httptest.Server, *http.Client) {
+	server := httptest.NewTLSServer(handler)
+	DeferCleanup(server.Close)
+	return server, server.Client()
+}
+
+func expectJSONCall(r *http.Request, expectedService, expectedCall string) json.RawMessage {
+	ExpectWithOffset(1, r.Method).To(Equal(http.MethodPost))
+	ExpectWithOffset(1, r.URL.Path).To(Equal(jsonPath))
+
+	var req struct {
+		Service string          `json:"service"`
+		Call    string          `json:"call"`
+		Args    json.RawMessage `json:"args"`
+	}
+	ExpectWithOffset(1, json.NewDecoder(r.Body).Decode(&req)).To(Succeed())
+	ExpectWithOffset(1, req.Service).To(Equal(expectedService))
+	ExpectWithOffset(1, req.Call).To(Equal(expectedCall))
+	return req.Args
+}
+
+var _ = Describe("BCM Client", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	Describe("Config validation", func() {
+		It("should accept a valid config", func() {
+			cfg := &Config{
+				URL:      "https://bcm-head:8081",
+				CertFile: "/certs/tls.crt",
+				KeyFile:  "/certs/tls.key",
+			}
+			Expect(cfg.Validate()).To(Succeed())
+		})
+
+		It("should return error when url is missing", func() {
+			cfg := &Config{CertFile: "/certs/tls.crt", KeyFile: "/certs/tls.key"}
+			Expect(cfg.Validate()).To(MatchError(ContainSubstring("bcm url is required")))
+		})
+
+		It("should return error when certFile is missing", func() {
+			cfg := &Config{URL: "https://bcm-head:8081", KeyFile: "/certs/tls.key"}
+			Expect(cfg.Validate()).To(MatchError(ContainSubstring("bcm certFile is required")))
+		})
+
+		It("should return error when keyFile is missing", func() {
+			cfg := &Config{URL: "https://bcm-head:8081", CertFile: "/certs/tls.crt"}
+			Expect(cfg.Validate()).To(MatchError(ContainSubstring("bcm keyFile is required")))
+		})
+	})
+
+	Describe("checkVersion", func() {
+		It("should succeed with a valid version", func() {
+			server, client := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.URL.Path).To(Equal(versionPath))
+				w.Header().Set("Content-Type", "application/json")
+				mustWrite(w, `{"cm_version":"11.0","cmd_version":"3.1","build_hash":"abc","build_index":1,"database_version":1}`)
+			}))
+
+			c := NewClientForTest(client, server.URL)
+			Expect(c.checkVersion(ctx)).To(Succeed())
+		})
+
+		It("should return ErrVersionTooOld for an old version", func() {
+			server, client := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				mustWrite(w, `{"cm_version":"9.2","cmd_version":"2.0","build_hash":"old","build_index":1,"database_version":1}`)
+			}))
+
+			c := NewClientForTest(client, server.URL)
+			Expect(c.checkVersion(ctx)).To(MatchError(ContainSubstring(ErrVersionTooOld.Error())))
+		})
+
+		It("should succeed with the exact minimum version", func() {
+			server, client := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				mustWrite(w, `{"cm_version":"10.25.03","cmd_version":"3.0","build_hash":"min","build_index":1,"database_version":1}`)
+			}))
+
+			c := NewClientForTest(client, server.URL)
+			Expect(c.checkVersion(ctx)).To(Succeed())
+		})
+
+		It("should reject version with old patch", func() {
+			server, client := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				mustWrite(w, `{"cm_version":"10.25.02","cmd_version":"3.0","build_hash":"old-patch","build_index":1,"database_version":1}`)
+			}))
+
+			c := NewClientForTest(client, server.URL)
+			Expect(c.checkVersion(ctx)).To(MatchError(ContainSubstring(ErrVersionTooOld.Error())))
+		})
+
+		It("should reject version without patch component", func() {
+			server, client := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				mustWrite(w, `{"cm_version":"10.25","cmd_version":"3.0","build_hash":"no-patch","build_index":1,"database_version":1}`)
+			}))
+
+			c := NewClientForTest(client, server.URL)
+			Expect(c.checkVersion(ctx)).To(MatchError(ContainSubstring(ErrVersionTooOld.Error())))
+		})
+
+		It("should accept higher minor version without patch", func() {
+			server, client := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				mustWrite(w, `{"cm_version":"10.26","cmd_version":"3.0","build_hash":"newer","build_index":1,"database_version":1}`)
+			}))
+
+			c := NewClientForTest(client, server.URL)
+			Expect(c.checkVersion(ctx)).To(Succeed())
+		})
+
+		It("should return ErrServerError on HTTP 500", func() {
+			server, client := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+
+			c := NewClientForTest(client, server.URL)
+			Expect(c.checkVersion(ctx)).To(MatchError(ContainSubstring(ErrServerError.Error())))
+		})
+	})
+
+	Describe("GetDevices", func() {
+		It("should return a list of devices", func() {
+			server, client := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				expectJSONCall(r, "cmdevice", "getDevices")
+				w.Header().Set("Content-Type", "application/json")
+				mustWrite(w, `[
+					{"baseType":"Device","childType":"LiteNode","uuid":"uuid1","hostname":"node001","mac":"aa:bb:cc:dd:ee:01","extra_values":{"resource_class":"h100"}},
+					{"baseType":"Device","childType":"PhysicalNode","uuid":"uuid2","hostname":"head01","mac":"aa:bb:cc:dd:ee:02","extra_values":null}
+				]`)
+			}))
+
+			c := NewClientForTest(client, server.URL)
+			devices, err := c.GetDevices(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(devices).To(HaveLen(2))
+			Expect(devices[0].Hostname).To(Equal("node001"))
+			Expect(devices[0].ChildType).To(Equal("LiteNode"))
+			Expect(devices[0].Raw).NotTo(BeNil())
+		})
+
+		It("should return an empty list", func() {
+			server, client := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				mustWrite(w, `[]`)
+			}))
+
+			c := NewClientForTest(client, server.URL)
+			devices, err := c.GetDevices(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(devices).To(BeEmpty())
+		})
+	})
+
+	Describe("GetDevice", func() {
+		It("should return a device when found", func() {
+			server, client := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				args := expectJSONCall(r, "cmdevice", "getDevice")
+				var positionalArgs []string
+				Expect(json.Unmarshal(args, &positionalArgs)).To(Succeed())
+				Expect(positionalArgs).To(Equal([]string{"node001"}))
+				w.Header().Set("Content-Type", "application/json")
+				mustWrite(w, `{"baseType":"Device","childType":"LiteNode","uuid":"uuid1","hostname":"node001","mac":"aa:bb:cc:dd:ee:01","extra_values":{"resource_class":"h100"}}`)
+			}))
+
+			c := NewClientForTest(client, server.URL)
+			device, err := c.GetDevice(ctx, "node001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(device).NotTo(BeNil())
+			Expect(device.Hostname).To(Equal("node001"))
+			Expect(device.ExtraValues["resource_class"]).To(Equal("h100"))
+		})
+
+		It("should return nil when device is not found", func() {
+			server, client := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				mustWrite(w, `null`)
+			}))
+
+			c := NewClientForTest(client, server.URL)
+			device, err := c.GetDevice(ctx, "nonexistent")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(device).To(BeNil())
+		})
+	})
+
+	Describe("UpdateDevice", func() {
+		It("should succeed on a successful update", func() {
+			server, client := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				expectJSONCall(r, "cmdevice", "updateDevice")
+				w.Header().Set("Content-Type", "application/json")
+				mustWrite(w, `{"success":true,"task_uuid":"00000000-0000-0000-0000-000000000000","updated_entity":null,"validation":[]}`)
+			}))
+
+			c := NewClientForTest(client, server.URL)
+			resp, err := c.UpdateDevice(ctx, json.RawMessage(`{"baseType":"Device","childType":"LiteNode","hostname":"node001"}`))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Success).To(BeTrue())
+		})
+
+		It("should return ValidationError on validation failure", func() {
+			server, client := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				mustWrite(w, `{"success":false,"task_uuid":"00000000-0000-0000-0000-000000000000","updated_entity":null,"validation":[{"baseType":"Validation","error_code":"NOT_NULL","field":"partition","message":"partition is required","severity":"ERROR"}]}`)
+			}))
+
+			c := NewClientForTest(client, server.URL)
+			resp, err := c.UpdateDevice(ctx, json.RawMessage(`{"baseType":"Device","hostname":"node001"}`))
+			Expect(err).To(HaveOccurred())
+			Expect(resp).NotTo(BeNil())
+
+			var valErr *ValidationError
+			Expect(errors.As(err, &valErr)).To(BeTrue())
+			Expect(valErr.Validations).To(HaveLen(1))
+			Expect(valErr.Validations[0].ErrorCode).To(Equal("NOT_NULL"))
+		})
+
+		It("should return error on success:false with no validations", func() {
+			server, client := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				mustWrite(w, `{"success":false,"task_uuid":"00000000-0000-0000-0000-000000000000","updated_entity":null,"validation":[]}`)
+			}))
+
+			c := NewClientForTest(client, server.URL)
+			_, err := c.UpdateDevice(ctx, json.RawMessage(`{"baseType":"Device","hostname":"node001"}`))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("bcm reported failure"))
+		})
+	})
+
+	Describe("doJSONCall", func() {
+		It("should return ErrAuthFailed on certificate error message", func() {
+			server, client := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				mustWrite(w, `{"errormessage":"Your certificate (profile:) does not allow access to CMDevice::getDevices\n"}`)
+			}))
+
+			c := NewClientForTest(client, server.URL)
+			_, err := c.doJSONCall(ctx, "cmdevice", "getDevices", []any{})
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring(ErrAuthFailed.Error())))
+		})
+
+		It("should return a generic error on unknown service", func() {
+			server, client := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				mustWrite(w, `{"errormessage":"No such service: '(cm)fake'\n"}`)
+			}))
+
+			c := NewClientForTest(client, server.URL)
+			_, err := c.doJSONCall(ctx, "cmfake", "getDevices", []any{})
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, ErrAuthFailed)).To(BeFalse())
+		})
+
+		It("should return ErrServerError on HTTP 500", func() {
+			server, client := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				mustWrite(w, "internal error")
+			}))
+
+			c := NewClientForTest(client, server.URL)
+			_, err := c.doJSONCall(ctx, "cmdevice", "getDevices", []any{})
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring(ErrServerError.Error())))
+		})
+
+		It("should return ErrAuthFailed on HTTP 401", func() {
+			server, client := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			}))
+
+			c := NewClientForTest(client, server.URL)
+			_, err := c.doJSONCall(ctx, "cmdevice", "getDevices", []any{})
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring(ErrAuthFailed.Error())))
+		})
+
+		It("should return a generic error on HTTP 404", func() {
+			server, client := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			}))
+
+			c := NewClientForTest(client, server.URL)
+			_, err := c.doJSONCall(ctx, "cmdevice", "getDevices", []any{})
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, ErrAuthFailed)).To(BeFalse())
+			Expect(errors.Is(err, ErrServerError)).To(BeFalse())
+		})
+
+		It("should return ErrConnectionFailed on connection error", func() {
+			c := NewClientForTest(&http.Client{}, "https://localhost:1")
+			_, err := c.doJSONCall(ctx, "cmdevice", "getDevices", []any{})
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring(ErrConnectionFailed.Error())))
+		})
+
+		It("should default nil args to empty array", func() {
+			server, client := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				args := expectJSONCall(r, "cmdevice", "getDevices")
+				Expect(string(args)).To(Equal("[]"))
+				w.Header().Set("Content-Type", "application/json")
+				mustWrite(w, `[]`)
+			}))
+
+			c := NewClientForTest(client, server.URL)
+			_, err := c.doJSONCall(ctx, "cmdevice", "getDevices", nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("SetExtraValue", func() {
+		It("should add a key to existing extra_values", func() {
+			raw := json.RawMessage(`{"hostname":"node001","extra_values":{"resource_class":"h100"}}`)
+			updated, err := SetExtraValue(raw, "osac_instance_id", "test-uid-123")
+			Expect(err).NotTo(HaveOccurred())
+
+			var obj map[string]any
+			Expect(json.Unmarshal(updated, &obj)).To(Succeed())
+			ev := obj["extra_values"].(map[string]any)
+			Expect(ev["osac_instance_id"]).To(Equal("test-uid-123"))
+			Expect(ev["resource_class"]).To(Equal("h100"))
+		})
+
+		It("should create extra_values when null", func() {
+			raw := json.RawMessage(`{"hostname":"node001","extra_values":null}`)
+			updated, err := SetExtraValue(raw, "osac_instance_id", "test-uid-123")
+			Expect(err).NotTo(HaveOccurred())
+
+			var obj map[string]any
+			Expect(json.Unmarshal(updated, &obj)).To(Succeed())
+			ev := obj["extra_values"].(map[string]any)
+			Expect(ev["osac_instance_id"]).To(Equal("test-uid-123"))
+		})
+	})
+
+	Describe("RemoveExtraValue", func() {
+		It("should remove a key and preserve others", func() {
+			raw := json.RawMessage(`{"hostname":"node001","extra_values":{"resource_class":"h100","osac_instance_id":"uid-123"}}`)
+			updated, err := RemoveExtraValue(raw, "osac_instance_id")
+			Expect(err).NotTo(HaveOccurred())
+
+			var obj map[string]any
+			Expect(json.Unmarshal(updated, &obj)).To(Succeed())
+			ev := obj["extra_values"].(map[string]any)
+			Expect(ev).NotTo(HaveKey("osac_instance_id"))
+			Expect(ev["resource_class"]).To(Equal("h100"))
+		})
+	})
+
+	Describe("classifyHTTPError", func() {
+		DescribeTable("should classify transport errors",
+			func(err error, expected error) {
+				result := classifyHTTPError(err)
+				if expected == nil {
+					Expect(result).ToNot(HaveOccurred())
+				} else {
+					Expect(result).To(MatchError(ContainSubstring(expected.Error())))
+				}
+			},
+			Entry("nil error", nil, nil),
+			Entry("tls keyword", fmt.Errorf("tls: handshake failure"), ErrTLSFailed),
+			Entry("x509 keyword", fmt.Errorf("x509: certificate signed by unknown authority"), ErrTLSFailed),
+			Entry("certificate keyword", fmt.Errorf("remote error: certificate required"), ErrTLSFailed),
+			Entry("generic connection error", fmt.Errorf("dial tcp 10.0.0.1:8081: connect: connection refused"), ErrConnectionFailed),
+		)
+	})
+
+	Describe("ValidationError", func() {
+		It("should format validation details in the error message", func() {
+			err := &ValidationError{
+				Validations: []Validation{
+					{ErrorCode: "NOT_NULL", Field: "partition", Message: "partition is required"},
+					{ErrorCode: "BAD_VALUE", Field: "uuid", Message: "invalid UUID"},
+				},
+			}
+			Expect(err.Error()).To(ContainSubstring("partition"))
+			Expect(err.Error()).To(ContainSubstring("NOT_NULL"))
+			Expect(err.Error()).To(ContainSubstring("BAD_VALUE"))
+		})
+	})
+})

--- a/bare-metal-fulfillment-operator/internal/bcmclient/types.go
+++ b/bare-metal-fulfillment-operator/internal/bcmclient/types.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bcmclient
+
+import "encoding/json"
+
+// jsonRequest is the envelope for all BCM JSON API calls.
+type jsonRequest struct {
+	Service string `json:"service"`
+	Call    string `json:"call"`
+	Args    any    `json:"args"`
+}
+
+// Device represents a BCM device with typed access to OSAC-relevant
+// fields plus the raw JSON needed for full-object update round-trips.
+type Device struct {
+	BaseType    string         `json:"baseType"`
+	ChildType   string         `json:"childType"`
+	UUID        string         `json:"uuid"`
+	Hostname    string         `json:"hostname"`
+	MAC         string         `json:"mac"`
+	ExtraValues map[string]any `json:"extra_values"`
+
+	Raw json.RawMessage `json:"-"`
+}
+
+// UpdateResponse is the response from cmdevice.updateDevice.
+type UpdateResponse struct {
+	Success    bool         `json:"success"`
+	TaskUUID   string       `json:"task_uuid"`
+	Validation []Validation `json:"validation"`
+}
+
+// Validation represents a single BCM field validation error.
+type Validation struct {
+	ErrorCode string `json:"error_code"`
+	Field     string `json:"field"`
+	Message   string `json:"message"`
+	Severity  string `json:"severity"`
+}
+
+// versionResponse is the response from GET /rest/v1/version.
+type versionResponse struct {
+	CMVersion       string `json:"cm_version"`
+	CMDVersion      string `json:"cmd_version"`
+	BuildHash       string `json:"build_hash"`
+	BuildIndex      int    `json:"build_index"`
+	DatabaseVersion int    `json:"database_version"`
+}
+
+// errorResponse captures error messages from the BCM JSON API.
+type errorResponse struct {
+	ErrorMessage string `json:"errormessage"`
+}


### PR DESCRIPTION
## Summary

Pure BCM API client in `internal/bcmclient/` ([OSAC-1339](https://redhat.atlassian.net/browse/OSAC-1339), Phase 1 Task 1a):

- mTLS HTTP client with `certwatcher` for automatic certificate rotation
- BCM JSON API: `GetDevices`, `GetDevice`, `UpdateDevice`
- REST version check enforcing minimum 10.25.03+
- Typed error classification: connection, TLS, auth (HTTP 401/403 and certificate messages), server (5xx), validation, generic 4xx
- Prometheus metrics: `osac_bcm_api_requests_total`, `osac_bcm_api_duration_seconds`
- Per-call debug logging (V=1)
- Bounded response reads (64 MiB) with explicit truncation detection
- Full-object round-trip helpers (`SetExtraValue`, `RemoveExtraValue`) preserving numeric precision via `json.Decoder.UseNumber()`
- CA loading before certwatcher to prevent fsnotify watcher leak on failure

Separated from the inventory package per reviewer feedback — the inventory adapter implementing `inventory.Client` will be added in a follow-up PR.

## Test plan

- [x] `make build` passes
- [x] `make test` passes (34 Ginkgo specs, 70% coverage)
- [x] `make lint` passes (0 issues)
- [x] Config validation (url, certFile, keyFile required)
- [x] Version check (valid, too old, exact minimum, patch validation)
- [x] GetDevices (list, empty)
- [x] GetDevice (found, not found/null)
- [x] UpdateDevice (success, validation error, success:false without validations)
- [x] Error classification (auth message, unknown service, HTTP 500/401/404, connection error)
- [x] SetExtraValue / RemoveExtraValue (add, create from null, remove)
- [x] classifyHTTPError (TLS, x509, certificate, connection)

Assisted-by: Claude Code <noreply@anthropic.com>