### PR TITLE
OSAC-3829: add GPU flags to CLI create instancetype command

### DIFF
--- a/fulfillment-service/internal/cmd/cli/create/instancetype/create_instancetype_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/instancetype/create_instancetype_cmd.go
@@ -61,15 +61,37 @@ func Cmd() *cobra.Command {
 		"",
 		descriptionFlagHelp,
 	)
+	flags.StringVar(
+		&runner.gpuPCIDeviceSelector,
+		"gpu-pci-device-selector",
+		"",
+		gpuPCIDeviceSelectorFlagHelp,
+	)
+	flags.StringVar(
+		&runner.gpuResourceName,
+		"gpu-resource-name",
+		"",
+		gpuResourceNameFlagHelp,
+	)
+	flags.Int32Var(
+		&runner.gpuCount,
+		"gpu-count",
+		0,
+		gpuCountFlagHelp,
+	)
+	result.MarkFlagsRequiredTogether("gpu-pci-device-selector", "gpu-resource-name", "gpu-count")
 	return result
 }
 
 type runnerContext struct {
-	console     *terminal.Console
-	name        string
-	cores       int32
-	memoryGiB   int32
-	description string
+	console              *terminal.Console
+	name                 string
+	cores                int32
+	memoryGiB            int32
+	description          string
+	gpuPCIDeviceSelector string
+	gpuResourceName      string
+	gpuCount             int32
 }
 
 func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
@@ -95,6 +117,9 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	if c.memoryGiB <= 0 {
 		return fmt.Errorf("memory-gib must be greater than zero")
 	}
+	if cmd.Flags().Changed("gpu-count") && c.gpuCount <= 0 {
+		return fmt.Errorf("gpu-count must be greater than zero")
+	}
 
 	// Create the gRPC connection from the configuration:
 	conn, err := cfg.Connect(ctx, cmd.Flags())
@@ -107,16 +132,24 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	client := privatev1.NewInstanceTypesClient(conn)
 
 	// Prepare the instance type:
+	specBuilder := privatev1.InstanceTypeSpec_builder{
+		Cores:       c.cores,
+		MemoryGib:   c.memoryGiB,
+		Description: c.description,
+	}
+	if cmd.Flags().Changed("gpu-count") {
+		specBuilder.Gpu = privatev1.GpuSpec_builder{
+			PciDeviceSelector: c.gpuPCIDeviceSelector,
+			ResourceName:      c.gpuResourceName,
+			Count:             c.gpuCount,
+		}.Build()
+	}
 	instanceType := privatev1.InstanceType_builder{
 		Id: c.name,
 		Metadata: privatev1.Metadata_builder{
 			Name: c.name,
 		}.Build(),
-		Spec: privatev1.InstanceTypeSpec_builder{
-			Cores:       c.cores,
-			MemoryGib:   c.memoryGiB,
-			Description: c.description,
-		}.Build(),
+		Spec: specBuilder.Build(),
 	}.Build()
 
 	// Create the instance type:
@@ -146,6 +179,13 @@ To create an instance type:
 {{ bt 3 }}shell
 {{ binary }} create instancetype --name standard-4-16 --cores 4 --memory-gib 16 --description 'Balanced compute'
 {{ bt 3 }}
+
+To create a GPU-enabled instance type, provide all three GPU flags:
+
+{{ bt 3 }}shell
+{{ binary }} create instancetype --name gpu-a100-4-16 --cores 4 --memory-gib 16 \
+  --gpu-pci-device-selector '10DE:20B0' --gpu-resource-name 'nvidia.com/A100' --gpu-count 1
+{{ bt 3 }}
 `
 
 const nameFlagHelp = `
@@ -163,4 +203,16 @@ _MEMORY_ - Amount of memory in GiB for this instance type. Must be greater than 
 
 const descriptionFlagHelp = `
 _DESCRIPTION_ - Human friendly description of the instance type.
+`
+
+const gpuPCIDeviceSelectorFlagHelp = `
+_SELECTOR_ - PCI device selector identifying the GPU hardware (e.g., {{ bt }}10DE:20B0{{ bt }}).
+`
+
+const gpuResourceNameFlagHelp = `
+_RESOURCE_ - Kubernetes device plugin resource name (e.g., {{ bt }}nvidia.com/A100{{ bt }}).
+`
+
+const gpuCountFlagHelp = `
+_COUNT_ - Number of GPU devices of this type. Must be greater than zero.
 `

--- a/fulfillment-service/internal/cmd/cli/create/instancetype/create_instancetype_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/create/instancetype/create_instancetype_cmd_test.go
@@ -60,4 +60,31 @@ var _ = Describe("Create instancetype flag registration", func() {
 		Expect(flag).NotTo(BeNil())
 		Expect(flag.Usage).To(ContainSubstring("description"))
 	})
+
+	It("should register --gpu-pci-device-selector flag", func() {
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		flag := cmd.Flags().Lookup("gpu-pci-device-selector")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Usage).To(ContainSubstring("PCI"))
+	})
+
+	It("should register --gpu-resource-name flag", func() {
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		flag := cmd.Flags().Lookup("gpu-resource-name")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Usage).To(ContainSubstring("resource"))
+	})
+
+	It("should register --gpu-count flag", func() {
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		flag := cmd.Flags().Lookup("gpu-count")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Usage).To(ContainSubstring("GPU"))
+	})
 })


### PR DESCRIPTION
## [OSAC-3829](https://redhat.atlassian.net/browse/OSAC-3829): add GPU flags to CLI create instancetype command

**Jira:** [OSAC-3829](https://redhat.atlassian.net/browse/OSAC-3829)
**Story type:** [DEV]

### Summary

Adds `--gpu-pci-device-selector`, `--gpu-resource-name`, and `--gpu-count` flags to the `osac create instancetype` CLI command, enabling Cloud Provider Admins to create GPU-enabled InstanceTypes directly from the CLI. All three GPU flags are required together (all-or-nothing via cobra's `MarkFlagsRequiredTogether`), and client-side validation ensures `gpu-count` is greater than zero.

### Changes

- Added three GPU fields to `runnerContext` and registered corresponding cobra flags
- Added `MarkFlagsRequiredTogether` for all-or-nothing GPU flag validation
- Added client-side `gpu-count > 0` validation matching existing `cores`/`memory-gib` pattern
- Wired GPU fields into `InstanceTypeSpec_builder` via `GpuSpec_builder` (conditional — only when GPU flags are provided)
- Added GPU example to `longHelp` and flag help text constants
- Added 3 unit tests for GPU flag registration (Ginkgo, matching existing pattern)

### Testing

- **Unit tests:** 3 new flag registration tests for `--gpu-pci-device-selector`, `--gpu-resource-name`, `--gpu-count` (8/8 pass)
- **Manual:** Verified on dev cluster — created GPU instance type via CLI, confirmed GPU fields persisted via `get instancetypes -o json`
- **Coverage:** `Cmd()` at 100%; `run()` at 0% (pre-existing — requires live gRPC server)

### Acceptance Criteria

- [x] AC-1: `osac create instancetype` accepts `--gpu-pci-device-selector`, `--gpu-resource-name`, and `--gpu-count` flags
- [x] AC-2: When all three GPU flags are provided, the created InstanceType includes a populated gpu spec
- [x] AC-3: When no GPU flags are provided, behavior is unchanged (backward compatible)
- [x] AC-4: Partial GPU flags produce a clear validation error
- [x] AC-5: `osac create instancetype --help` documents the new GPU flags

### Related PRs

- E2E tests: [osac-project/osac-test-infra#342](https://github.com/osac-project/osac-test-infra/pull/342) — [OSAC-3837](https://redhat.atlassian.net/browse/OSAC-3837): add GPU flags to E2E CLI wrapper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added GPU configuration options when creating instance types.
  - Supports specifying the GPU PCI device selector, resource name, and count.
  - Requires all GPU options together and validates that the GPU count is positive.
  - Updated command help with GPU flag descriptions and an example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->