### PR TITLE
OSAC-3765: Wire BMH lifecycle manager, RBAC, and Helm bcmCerts

### DIFF
--- a/bare-metal-fulfillment-operator/charts/operator/templates/clusterrole.yaml
+++ b/bare-metal-fulfillment-operator/charts/operator/templates/clusterrole.yaml
@@ -11,6 +11,8 @@ rules:
   resources:
   - baremetalhosts
   verbs:
+  - create
+  - delete
   - get
   - list
   - patch

--- a/bare-metal-fulfillment-operator/charts/operator/templates/deployment.yaml
+++ b/bare-metal-fulfillment-operator/charts/operator/templates/deployment.yaml
@@ -108,6 +108,9 @@ spec:
             mountPath: /etc/openstack/
           - name: profiles
             mountPath: /etc/osac/profile/
+          - name: bcm-certs
+            mountPath: /etc/osac/bcm-certs/
+            readOnly: true
       volumes:
         - name: inventory-config
           secret:
@@ -122,6 +125,10 @@ spec:
         - name: profiles
           configMap:
             name: {{ .Values.configMaps.profiles }}
+            optional: true
+        - name: bcm-certs
+          secret:
+            secretName: {{ .Values.secrets.bcmCerts }}
             optional: true
       serviceAccountName: {{ include "bare-metal-fulfillment-operator.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10

--- a/bare-metal-fulfillment-operator/charts/operator/values.yaml
+++ b/bare-metal-fulfillment-operator/charts/operator/values.yaml
@@ -23,6 +23,7 @@ secrets:
   inventoryConfig: "osac-inventory-config"
   managementConfig: "osac-management-config"
   osClouds: "osac-os-clouds"
+  bcmCerts: ""
 
 configMaps:
   profiles: "osac-profiles"

--- a/bare-metal-fulfillment-operator/cmd/main.go
+++ b/bare-metal-fulfillment-operator/cmd/main.go
@@ -422,15 +422,8 @@ func setupBareMetalInstanceController(
 		return fmt.Errorf("failed to parse management config: %w", err)
 	}
 
-	if managementConfig.Type == "metal3" {
-		metal3Namespace, err := management.ParseMetal3Namespace(&managementConfig)
-		if err != nil {
-			return fmt.Errorf("failed to parse metal3 namespace for BMH lifecycle: %w", err)
-		}
-		inventoryConfig.BMHLifecycleManager = inventory.NewBMHLifecycleManager(
-			mgr.GetClient(), metal3Namespace,
-		)
-		setupLog.Info("BMH lifecycle manager configured", "namespace", metal3Namespace)
+	if err := wireBMHLifecycleManager(&managementConfig, &inventoryConfig, mgr.GetClient()); err != nil {
+		return err
 	}
 
 	inventoryClient, err := inventory.NewClient(ctx, &inventoryConfig)
@@ -484,5 +477,22 @@ func setupBareMetalInstanceController(
 	).SetupWithManager(mgr, maxConcurrentReconciles); err != nil {
 		return fmt.Errorf("baremetalinstance controller: %w", err)
 	}
+	return nil
+}
+
+func wireBMHLifecycleManager(
+	managementCfg *management.Config,
+	inventoryCfg *inventory.Config,
+	k8sClient client.Client,
+) error {
+	if managementCfg.Type != "metal3" {
+		return nil
+	}
+	ns, err := management.ParseMetal3Namespace(managementCfg)
+	if err != nil {
+		return fmt.Errorf("failed to parse metal3 namespace for BMH lifecycle: %w", err)
+	}
+	inventoryCfg.BMHLifecycleManager = inventory.NewBMHLifecycleManager(k8sClient, ns)
+	setupLog.Info("BMH lifecycle manager configured", "namespace", ns)
 	return nil
 }

--- a/bare-metal-fulfillment-operator/cmd/main.go
+++ b/bare-metal-fulfillment-operator/cmd/main.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/yaml"
 
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	osacv1alpha1 "github.com/osac-project/osac/bare-metal-fulfillment-operator/api/v1alpha1"
 	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/controller"
 	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/helpers"
@@ -85,8 +86,8 @@ const (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-
 	utilruntime.Must(osacv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(metal3api.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 
@@ -408,15 +409,8 @@ func setupBareMetalInstanceController(
 		return fmt.Errorf("failed to parse inventory config: %w", err)
 	}
 
-	inventoryClient, err := inventory.NewClient(ctx, &inventoryConfig)
-	if err != nil {
-		return fmt.Errorf("failed to create inventory client: %w", err)
-	}
-	if inventoryClient == nil {
-		return fmt.Errorf("unsupported inventory type %q", inventoryConfig.Type)
-	}
-
-	// Read and parse management configuration
+	// Parse management config before inventory client — Metal3 management
+	// triggers BMH lifecycle manager wiring on the inventory config.
 	managementConfigPath := helpers.GetEnvWithDefault(envManagementConfigPath, "/etc/osac/management/management.yaml")
 	managementConfigData, err := os.ReadFile(managementConfigPath)
 	if err != nil {
@@ -426,6 +420,25 @@ func setupBareMetalInstanceController(
 	var managementConfig management.Config
 	if err := yaml.Unmarshal(managementConfigData, &managementConfig); err != nil {
 		return fmt.Errorf("failed to parse management config: %w", err)
+	}
+
+	if managementConfig.Type == "metal3" {
+		metal3Namespace, err := management.ParseMetal3Namespace(&managementConfig)
+		if err != nil {
+			return fmt.Errorf("failed to parse metal3 namespace for BMH lifecycle: %w", err)
+		}
+		inventoryConfig.BMHLifecycleManager = inventory.NewBMHLifecycleManager(
+			mgr.GetClient(), metal3Namespace,
+		)
+		setupLog.Info("BMH lifecycle manager configured", "namespace", metal3Namespace)
+	}
+
+	inventoryClient, err := inventory.NewClient(ctx, &inventoryConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create inventory client: %w", err)
+	}
+	if inventoryClient == nil {
+		return fmt.Errorf("unsupported inventory type %q", inventoryConfig.Type)
 	}
 
 	managementClient, err := management.NewClient(ctx, &managementConfig)

--- a/bare-metal-fulfillment-operator/cmd/main_test.go
+++ b/bare-metal-fulfillment-operator/cmd/main_test.go
@@ -101,8 +101,8 @@ var _ = Describe("Scheme Initialization", func() {
 })
 
 var _ = Describe("BMH Lifecycle Manager Wiring", func() {
-	It("should set BMHLifecycleManager on inventory config when management is metal3", func() {
-		managementConfig := management.Config{
+	It("should set BMHLifecycleManager when management is metal3", func() {
+		managementCfg := &management.Config{
 			Type: "metal3",
 			Options: map[string]any{
 				"metal3": map[string]any{
@@ -111,37 +111,45 @@ var _ = Describe("BMH Lifecycle Manager Wiring", func() {
 			},
 		}
 
-		var inventoryConfig inventory.Config
-
-		metal3Namespace, err := management.ParseMetal3Namespace(&managementConfig)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(metal3Namespace).To(Equal("osac-baremetal"))
-
+		var inventoryCfg inventory.Config
 		testScheme := runtime.NewScheme()
 		Expect(metal3api.AddToScheme(testScheme)).To(Succeed())
 		k8sClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
 
-		inventoryConfig.BMHLifecycleManager = inventory.NewBMHLifecycleManager(
-			k8sClient, metal3Namespace,
-		)
-
-		Expect(inventoryConfig.BMHLifecycleManager).NotTo(BeNil())
+		err := wireBMHLifecycleManager(managementCfg, &inventoryCfg, k8sClient)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(inventoryCfg.BMHLifecycleManager).NotTo(BeNil())
 	})
 
-	It("should not set BMHLifecycleManager when management is not metal3", func() {
-		managementConfig := management.Config{
+	It("should not set BMHLifecycleManager when management is openstack", func() {
+		managementCfg := &management.Config{
 			Type: "openstack",
 			Options: map[string]any{
 				"openstack": map[string]any{},
 			},
 		}
 
-		var inventoryConfig inventory.Config
+		var inventoryCfg inventory.Config
+		k8sClient := fake.NewClientBuilder().Build()
 
-		if managementConfig.Type == "metal3" {
-			Fail("should not enter metal3 wiring path for openstack management")
+		err := wireBMHLifecycleManager(managementCfg, &inventoryCfg, k8sClient)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(inventoryCfg.BMHLifecycleManager).To(BeNil())
+	})
+
+	It("should return error when metal3 namespace is missing", func() {
+		managementCfg := &management.Config{
+			Type: "metal3",
+			Options: map[string]any{
+				"metal3": map[string]any{},
+			},
 		}
 
-		Expect(inventoryConfig.BMHLifecycleManager).To(BeNil())
+		var inventoryCfg inventory.Config
+		k8sClient := fake.NewClientBuilder().Build()
+
+		err := wireBMHLifecycleManager(managementCfg, &inventoryCfg, k8sClient)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("namespace is required"))
 	})
 })

--- a/bare-metal-fulfillment-operator/cmd/main_test.go
+++ b/bare-metal-fulfillment-operator/cmd/main_test.go
@@ -22,10 +22,14 @@ import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
 	. "github.com/onsi/gomega"    //nolint:revive,staticcheck
 
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	osacv1alpha1 "github.com/osac-project/osac/bare-metal-fulfillment-operator/api/v1alpha1"
+	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/inventory"
+	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/management"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestMain(t *testing.T) {
@@ -82,5 +86,62 @@ var _ = Describe("Scheme Initialization", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(gvks).NotTo(BeEmpty())
 		Expect(gvks[0].Kind).To(Equal("Pod"))
+	})
+
+	It("should register metal3 BareMetalHost types", func() {
+		Expect(scheme.IsGroupRegistered("metal3.io")).To(BeTrue(),
+			"metal3.io types should be registered for BMH lifecycle manager")
+
+		bmh := &metal3api.BareMetalHost{}
+		gvks, _, err := scheme.ObjectKinds(bmh)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gvks).NotTo(BeEmpty())
+		Expect(gvks[0].Kind).To(Equal("BareMetalHost"))
+	})
+})
+
+var _ = Describe("BMH Lifecycle Manager Wiring", func() {
+	It("should set BMHLifecycleManager on inventory config when management is metal3", func() {
+		managementConfig := management.Config{
+			Type: "metal3",
+			Options: map[string]any{
+				"metal3": map[string]any{
+					"namespace": "osac-baremetal",
+				},
+			},
+		}
+
+		var inventoryConfig inventory.Config
+
+		metal3Namespace, err := management.ParseMetal3Namespace(&managementConfig)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(metal3Namespace).To(Equal("osac-baremetal"))
+
+		testScheme := runtime.NewScheme()
+		Expect(metal3api.AddToScheme(testScheme)).To(Succeed())
+		k8sClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
+
+		inventoryConfig.BMHLifecycleManager = inventory.NewBMHLifecycleManager(
+			k8sClient, metal3Namespace,
+		)
+
+		Expect(inventoryConfig.BMHLifecycleManager).NotTo(BeNil())
+	})
+
+	It("should not set BMHLifecycleManager when management is not metal3", func() {
+		managementConfig := management.Config{
+			Type: "openstack",
+			Options: map[string]any{
+				"openstack": map[string]any{},
+			},
+		}
+
+		var inventoryConfig inventory.Config
+
+		if managementConfig.Type == "metal3" {
+			Fail("should not enter metal3 wiring path for openstack management")
+		}
+
+		Expect(inventoryConfig.BMHLifecycleManager).To(BeNil())
 	})
 })

--- a/bare-metal-fulfillment-operator/config/manager/manager.yaml
+++ b/bare-metal-fulfillment-operator/config/manager/manager.yaml
@@ -108,6 +108,9 @@ spec:
             mountPath: /etc/openstack/
           - name: profiles
             mountPath: /etc/osac/profile/
+          - name: bcm-certs
+            mountPath: /etc/osac/bcm-certs/
+            readOnly: true
       volumes:
         - name: inventory-config
           secret:
@@ -122,6 +125,10 @@ spec:
         - name: profiles
           configMap:
             name: osac-profiles
+            optional: true
+        - name: bcm-certs
+          secret:
+            secretName: osac-bcm-certs
             optional: true
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/bare-metal-fulfillment-operator/config/rbac/role.yaml
+++ b/bare-metal-fulfillment-operator/config/rbac/role.yaml
@@ -9,6 +9,8 @@ rules:
   resources:
   - baremetalhosts
   verbs:
+  - create
+  - delete
   - get
   - list
   - patch

--- a/bare-metal-fulfillment-operator/hack/sync-helm-operator.py
+++ b/bare-metal-fulfillment-operator/hack/sync-helm-operator.py
@@ -53,6 +53,7 @@ SECRET_TO_VALUES: dict[str, str] = {
     "osac-inventory-config": "{{ .Values.secrets.inventoryConfig }}",
     "osac-management-config": "{{ .Values.secrets.managementConfig }}",
     "osac-os-clouds": "{{ .Values.secrets.osClouds }}",
+    "osac-bcm-certs": "{{ .Values.secrets.bcmCerts }}",
 }
 CONFIGMAP_TO_VALUES: dict[str, str] = {
     "osac-profiles": "{{ .Values.configMaps.profiles }}",

--- a/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_controller.go
+++ b/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_controller.go
@@ -97,7 +97,7 @@ func NewBareMetalInstanceReconciler(
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=baremetalinstances,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=baremetalinstances/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=baremetalinstances/finalizers,verbs=update
-// +kubebuilder:rbac:groups=metal3.io,resources=baremetalhosts,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=metal3.io,resources=baremetalhosts,verbs=get;list;watch;create;delete;update;patch
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=subnets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=networkclasses,verbs=get;list;watch
 

--- a/bare-metal-fulfillment-operator/internal/inventory/bcm.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/bcm.go
@@ -1,0 +1,527 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inventory
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	_ Client        = (*BCMClient)(nil)
+	_ NewClientFunc = NewClientFunc(NewBCMClient)
+)
+
+const (
+	bcmJSONPath    = "/json"
+	bcmVersionPath = "/rest/v1/version"
+
+	bcmMinMajorVersion = 10
+	bcmMinMinorVersion = 25
+	bcmDefaultTimeoutS = 30
+)
+
+// BCM extra_values keys used by OSAC
+const (
+	BCMExtraValueInstanceID     = "osac_instance_id"
+	BCMExtraValueResourceClass  = "resource_class"
+	BCMExtraValueBMCAddress     = "osac_bmc_address"
+	BCMExtraValueBMCCredentials = "osac_bmc_credentials_secret"
+)
+
+// Typed errors for BCM API failures
+var (
+	ErrBCMConnectionFailed = errors.New("bcm connection failed")
+	ErrBCMTLSFailed        = errors.New("bcm TLS handshake failed")
+	ErrBCMAuthFailed       = errors.New("bcm authentication failed")
+	ErrBCMServerError      = errors.New("bcm server error")
+	ErrBCMVersionTooOld    = errors.New("bcm version below minimum required")
+)
+
+// BCMValidationError wraps BCM field validation failures from updateDevice.
+type BCMValidationError struct {
+	Validations []bcmValidation
+}
+
+func (e *BCMValidationError) Error() string {
+	msgs := make([]string, 0, len(e.Validations))
+	for _, v := range e.Validations {
+		msgs = append(msgs, fmt.Sprintf("%s: %s (%s)", v.Field, v.Message, v.ErrorCode))
+	}
+	return fmt.Sprintf("bcm validation error: %s", strings.Join(msgs, "; "))
+}
+
+// Prometheus metrics
+var (
+	bcmAPIRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "osac_bcm_api_requests_total",
+			Help: "Total BCM API calls",
+		},
+		[]string{"method", "status"},
+	)
+	bcmAPILatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "osac_bcm_api_duration_seconds",
+			Help: "BCM API call latency",
+		},
+		[]string{"method"},
+	)
+)
+
+func init() {
+	newClientFuncs["bcm"] = NewBCMClient
+}
+
+var metricsOnce sync.Once
+
+func registerBCMMetrics() {
+	metricsOnce.Do(func() {
+		metrics.Registry.MustRegister(bcmAPIRequestsTotal, bcmAPILatency)
+	})
+}
+
+// bcmClientConfig holds BCM connection parameters parsed from inventory config.
+type bcmClientConfig struct {
+	URL                string `json:"url"`
+	CertFile           string `json:"certFile"`
+	KeyFile            string `json:"keyFile"`
+	CAFile             string `json:"caFile"`
+	InsecureSkipVerify bool   `json:"insecureSkipVerify"`
+}
+
+// BCMClient talks to the BCM JSON API over mTLS.
+type BCMClient struct {
+	httpClient *http.Client
+	baseURL    string
+	hostClass  string
+}
+
+// bcmJSONRequest is the envelope for all BCM JSON API calls.
+type bcmJSONRequest struct {
+	Service string `json:"service"`
+	Call    string `json:"call"`
+	Args    any    `json:"args"`
+}
+
+// bcmDevice represents a BCM device with typed access to OSAC-relevant
+// fields plus the raw JSON needed for full-object update round-trips.
+type bcmDevice struct {
+	BaseType    string         `json:"baseType"`
+	ChildType   string         `json:"childType"`
+	UUID        string         `json:"uuid"`
+	Hostname    string         `json:"hostname"`
+	MAC         string         `json:"mac"`
+	ExtraValues map[string]any `json:"extra_values"`
+
+	raw json.RawMessage
+}
+
+// bcmUpdateResponse is the response from cmdevice.updateDevice.
+type bcmUpdateResponse struct {
+	Success    bool            `json:"success"`
+	TaskUUID   string          `json:"task_uuid"`
+	Validation []bcmValidation `json:"validation"`
+}
+
+type bcmValidation struct {
+	ErrorCode string `json:"error_code"`
+	Field     string `json:"field"`
+	Message   string `json:"message"`
+	Severity  string `json:"severity"`
+}
+
+// bcmVersionResponse is the response from GET /rest/v1/version.
+type bcmVersionResponse struct {
+	CMVersion       string `json:"cm_version"`
+	CMDVersion      string `json:"cmd_version"`
+	BuildHash       string `json:"build_hash"`
+	BuildIndex      int    `json:"build_index"`
+	DatabaseVersion int    `json:"database_version"`
+}
+
+// bcmErrorResponse captures error messages from the BCM JSON API.
+type bcmErrorResponse struct {
+	ErrorMessage string `json:"errormessage"`
+}
+
+// NewBCMClient creates a BCM inventory client. It validates connectivity
+// by checking the BCM version at startup.
+func NewBCMClient(ctx context.Context, cfg *Config) (Client, error) {
+	registerBCMMetrics()
+
+	bcmCfg, err := parseBCMConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient, err := newBCMHTTPClient(bcmCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &BCMClient{
+		httpClient: httpClient,
+		baseURL:    strings.TrimRight(bcmCfg.URL, "/"),
+		hostClass:  cfg.HostClass,
+	}
+
+	if err := c.checkVersion(ctx); err != nil {
+		return nil, fmt.Errorf("bcm version check failed: %w", err)
+	}
+
+	return c, nil
+}
+
+// NewBCMClientForTest creates a BCMClient with an injected http.Client for testing.
+func NewBCMClientForTest(httpClient *http.Client, baseURL, hostClass string) *BCMClient {
+	return &BCMClient{
+		httpClient: httpClient,
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		hostClass:  hostClass,
+	}
+}
+
+func parseBCMConfig(cfg *Config) (*bcmClientConfig, error) {
+	bcmOpts, ok := cfg.Options["bcm"]
+	if !ok {
+		return nil, fmt.Errorf("bcm options not found in config")
+	}
+
+	optsJSON, err := json.Marshal(bcmOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal bcm options: %w", err)
+	}
+
+	var bcmCfg bcmClientConfig
+	if err := json.Unmarshal(optsJSON, &bcmCfg); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal bcm options: %w", err)
+	}
+
+	if bcmCfg.URL == "" {
+		return nil, fmt.Errorf("bcm url is required in config")
+	}
+	if bcmCfg.CertFile == "" {
+		return nil, fmt.Errorf("bcm certFile is required in config")
+	}
+	if bcmCfg.KeyFile == "" {
+		return nil, fmt.Errorf("bcm keyFile is required in config")
+	}
+
+	return &bcmCfg, nil
+}
+
+func newBCMHTTPClient(cfg *bcmClientConfig) (*http.Client, error) {
+	cert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load bcm client certificate: %w", err)
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates:       []tls.Certificate{cert},
+		InsecureSkipVerify: cfg.InsecureSkipVerify, //nolint:gosec
+		MinVersion:         tls.VersionTLS12,
+	}
+
+	if cfg.CAFile != "" {
+		caCert, err := os.ReadFile(cfg.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read bcm CA certificate: %w", err)
+		}
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("failed to parse bcm CA certificate")
+		}
+		tlsConfig.RootCAs = caCertPool
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+		Timeout: bcmDefaultTimeoutS * time.Second,
+	}, nil
+}
+
+// checkVersion validates BCM connectivity and minimum version.
+func (c *BCMClient) checkVersion(ctx context.Context) error {
+	log := ctrllog.FromContext(ctx)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+bcmVersionPath, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create version request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return classifyHTTPError(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%w: version endpoint returned %d", ErrBCMServerError, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read version response: %w", err)
+	}
+
+	var version bcmVersionResponse
+	if err := json.Unmarshal(body, &version); err != nil {
+		return fmt.Errorf("failed to parse version response: %w", err)
+	}
+
+	var major, minor int
+	if _, err := fmt.Sscanf(version.CMVersion, "%d.%d", &major, &minor); err != nil {
+		return fmt.Errorf("failed to parse cm_version %q: %w", version.CMVersion, err)
+	}
+	if major < bcmMinMajorVersion || (major == bcmMinMajorVersion && minor < bcmMinMinorVersion) {
+		return fmt.Errorf("%w: got %s, need >= %d.%d",
+			ErrBCMVersionTooOld, version.CMVersion, bcmMinMajorVersion, bcmMinMinorVersion)
+	}
+
+	log.Info("BCM version check passed", "cm_version", version.CMVersion, "cmd_version", version.CMDVersion)
+	return nil
+}
+
+// doJSONCall executes a BCM JSON API call and returns the raw response body.
+func (c *BCMClient) doJSONCall(ctx context.Context, service, call string, args any) (json.RawMessage, error) {
+	if args == nil {
+		args = []any{}
+	}
+
+	reqBody := bcmJSONRequest{
+		Service: service,
+		Call:    call,
+		Args:    args,
+	}
+
+	reqJSON, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal bcm request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+bcmJSONPath, bytes.NewReader(reqJSON))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create bcm request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	start := time.Now()
+	resp, err := c.httpClient.Do(req)
+	duration := time.Since(start).Seconds()
+	bcmAPILatency.WithLabelValues(call).Observe(duration)
+
+	if err != nil {
+		bcmAPIRequestsTotal.WithLabelValues(call, "error").Inc()
+		return nil, classifyHTTPError(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		bcmAPIRequestsTotal.WithLabelValues(call, "error").Inc()
+		return nil, fmt.Errorf("failed to read bcm response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		bcmAPIRequestsTotal.WithLabelValues(call, "error").Inc()
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return nil, fmt.Errorf("%w: HTTP %d", ErrBCMAuthFailed, resp.StatusCode)
+		}
+		if resp.StatusCode >= 500 {
+			return nil, fmt.Errorf("%w: %d %s", ErrBCMServerError, resp.StatusCode, string(body))
+		}
+		return nil, fmt.Errorf("bcm api error: HTTP %d %s", resp.StatusCode, string(body))
+	}
+
+	var errResp bcmErrorResponse
+	if json.Unmarshal(body, &errResp) == nil && errResp.ErrorMessage != "" {
+		bcmAPIRequestsTotal.WithLabelValues(call, "error").Inc()
+		msg := strings.TrimSpace(errResp.ErrorMessage)
+		if strings.Contains(msg, "certificate") || strings.Contains(msg, "does not allow access") {
+			return nil, fmt.Errorf("%w: %s", ErrBCMAuthFailed, msg)
+		}
+		return nil, fmt.Errorf("bcm api error: %s", msg)
+	}
+
+	bcmAPIRequestsTotal.WithLabelValues(call, "success").Inc()
+	return json.RawMessage(body), nil
+}
+
+// getDevices returns all devices from BCM.
+func (c *BCMClient) getDevices(ctx context.Context) ([]bcmDevice, error) {
+	body, err := c.doJSONCall(ctx, "cmdevice", "getDevices", []any{})
+	if err != nil {
+		return nil, fmt.Errorf("getDevices: %w", err)
+	}
+
+	var rawDevices []json.RawMessage
+	if err := json.Unmarshal(body, &rawDevices); err != nil {
+		return nil, fmt.Errorf("getDevices: failed to parse response: %w", err)
+	}
+
+	devices := make([]bcmDevice, 0, len(rawDevices))
+	for _, raw := range rawDevices {
+		var d bcmDevice
+		if err := json.Unmarshal(raw, &d); err != nil {
+			return nil, fmt.Errorf("getDevices: failed to parse device: %w", err)
+		}
+		d.raw = raw
+		devices = append(devices, d)
+	}
+
+	return devices, nil
+}
+
+// getDevice returns a single device by hostname, or nil if not found.
+// Always use getDevice instead of getNode — getNode returns null for LiteNodes.
+func (c *BCMClient) getDevice(ctx context.Context, hostname string) (*bcmDevice, error) {
+	body, err := c.doJSONCall(ctx, "cmdevice", "getDevice", []any{hostname})
+	if err != nil {
+		return nil, fmt.Errorf("getDevice %s: %w", hostname, err)
+	}
+
+	if string(body) == "null" {
+		return nil, nil
+	}
+
+	var d bcmDevice
+	if err := json.Unmarshal(body, &d); err != nil {
+		return nil, fmt.Errorf("getDevice %s: failed to parse response: %w", hostname, err)
+	}
+	d.raw = body
+
+	return &d, nil
+}
+
+// updateDevice sends a full device object to BCM. The raw JSON must be the
+// complete device as returned by getDevice, with modifications applied.
+func (c *BCMClient) updateDevice(ctx context.Context, deviceRaw json.RawMessage) (*bcmUpdateResponse, error) {
+	body, err := c.doJSONCall(ctx, "cmdevice", "updateDevice", []json.RawMessage{deviceRaw})
+	if err != nil {
+		return nil, fmt.Errorf("updateDevice: %w", err)
+	}
+
+	var resp bcmUpdateResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("updateDevice: failed to parse response: %w", err)
+	}
+
+	if !resp.Success {
+		if len(resp.Validation) > 0 {
+			return &resp, &BCMValidationError{Validations: resp.Validation}
+		}
+		return &resp, fmt.Errorf("updateDevice: bcm reported failure without validation details")
+	}
+
+	return &resp, nil
+}
+
+func unmarshalDevicePreservingNumbers(deviceRaw json.RawMessage) (map[string]any, error) {
+	dec := json.NewDecoder(bytes.NewReader(deviceRaw))
+	dec.UseNumber()
+	var obj map[string]any
+	if err := dec.Decode(&obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+// setExtraValue updates a single key in the device's extra_values and returns
+// the modified raw JSON for use with updateDevice.
+func setExtraValue(deviceRaw json.RawMessage, key string, value any) (json.RawMessage, error) {
+	obj, err := unmarshalDevicePreservingNumbers(deviceRaw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal device for extra_values update: %w", err)
+	}
+
+	extraValues, _ := obj["extra_values"].(map[string]any)
+	if extraValues == nil {
+		extraValues = make(map[string]any)
+	}
+	extraValues[key] = value
+	obj["extra_values"] = extraValues
+
+	return json.Marshal(obj)
+}
+
+// removeExtraValue removes a key from the device's extra_values and returns
+// the modified raw JSON for use with updateDevice.
+func removeExtraValue(deviceRaw json.RawMessage, key string) (json.RawMessage, error) {
+	obj, err := unmarshalDevicePreservingNumbers(deviceRaw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal device for extra_values removal: %w", err)
+	}
+
+	if extraValues, ok := obj["extra_values"].(map[string]any); ok {
+		delete(extraValues, key)
+		obj["extra_values"] = extraValues
+	}
+
+	return json.Marshal(obj)
+}
+
+// classifyHTTPError maps transport-level errors to typed BCM errors.
+func classifyHTTPError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if _, ok := errors.AsType[*tls.CertificateVerificationError](err); ok {
+		return fmt.Errorf("%w: %v", ErrBCMTLSFailed, err)
+	}
+
+	errMsg := err.Error()
+	if strings.Contains(errMsg, "tls:") || strings.Contains(errMsg, "certificate") ||
+		strings.Contains(errMsg, "x509:") {
+		return fmt.Errorf("%w: %v", ErrBCMTLSFailed, err)
+	}
+
+	return fmt.Errorf("%w: %v", ErrBCMConnectionFailed, err)
+}
+
+// FindFreeHost is implemented in Phase 2 (OSAC-3766).
+func (c *BCMClient) FindFreeHost(_ context.Context, _ map[string]string) (*Host, error) {
+	return nil, fmt.Errorf("bcm FindFreeHost not yet implemented")
+}
+
+// AssignHost is implemented in Phase 2 (OSAC-3767).
+func (c *BCMClient) AssignHost(_ context.Context, _ string, _ string, _ map[string]string) (*Host, error) {
+	return nil, fmt.Errorf("bcm AssignHost not yet implemented")
+}
+
+// UnassignHost is implemented in Phase 2 (OSAC-3771).
+func (c *BCMClient) UnassignHost(_ context.Context, _ string, _ []string) error {
+	return fmt.Errorf("bcm UnassignHost not yet implemented")
+}

--- a/bare-metal-fulfillment-operator/internal/inventory/bcm.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/bcm.go
@@ -177,6 +177,10 @@ type bcmErrorResponse struct {
 // NewBCMClient creates a BCM inventory client. It validates connectivity
 // by checking the BCM version at startup.
 func NewBCMClient(ctx context.Context, cfg *Config) (Client, error) {
+	if cfg.BMHLifecycleManager == nil {
+		return nil, fmt.Errorf("BCM inventory backend requires Metal3 management backend")
+	}
+
 	registerBCMMetrics()
 
 	bcmCfg, err := parseBCMConfig(cfg)

--- a/bare-metal-fulfillment-operator/internal/inventory/bcm_test.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/bcm_test.go
@@ -570,6 +570,27 @@ func TestBCMBackendRegistration(t *testing.T) {
 	}
 }
 
+func TestNewBCMClientRequiresBMHLifecycleManager(t *testing.T) {
+	cfg := &Config{
+		Type: "bcm",
+		Options: map[string]any{
+			"bcm": map[string]any{
+				"url":      "https://bcm-head:8081",
+				"certFile": "/certs/tls.crt",
+				"keyFile":  "/certs/tls.key",
+			},
+		},
+	}
+
+	_, err := NewBCMClient(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("expected error when BMHLifecycleManager is nil, got nil")
+	}
+	if !strings.Contains(err.Error(), "BCM inventory backend requires Metal3 management backend") {
+		t.Errorf("expected Metal3 requirement error, got: %v", err)
+	}
+}
+
 // assertJSONCall reads and validates the BCM JSON API request body.
 func assertJSONCall(t *testing.T, r *http.Request, expectedService, expectedCall string) *bcmJSONRequest {
 	t.Helper()

--- a/bare-metal-fulfillment-operator/internal/inventory/bcm_test.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/bcm_test.go
@@ -1,0 +1,598 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inventory
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTestBCMServer(t *testing.T, handler http.Handler) (*httptest.Server, *http.Client) {
+	t.Helper()
+	server := httptest.NewTLSServer(handler)
+	t.Cleanup(server.Close)
+	return server, server.Client()
+}
+
+func TestParseBCMConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *Config
+		wantErr string
+	}{
+		{
+			name: "valid config",
+			cfg: &Config{
+				Options: map[string]any{
+					"bcm": map[string]any{
+						"url":      "https://bcm-head:8081",
+						"certFile": "/certs/tls.crt",
+						"keyFile":  "/certs/tls.key",
+					},
+				},
+			},
+		},
+		{
+			name:    "missing bcm options",
+			cfg:     &Config{Options: map[string]any{}},
+			wantErr: "bcm options not found",
+		},
+		{
+			name: "missing url",
+			cfg: &Config{
+				Options: map[string]any{
+					"bcm": map[string]any{
+						"certFile": "/certs/tls.crt",
+						"keyFile":  "/certs/tls.key",
+					},
+				},
+			},
+			wantErr: "bcm url is required",
+		},
+		{
+			name: "missing certFile",
+			cfg: &Config{
+				Options: map[string]any{
+					"bcm": map[string]any{
+						"url":     "https://bcm-head:8081",
+						"keyFile": "/certs/tls.key",
+					},
+				},
+			},
+			wantErr: "bcm certFile is required",
+		},
+		{
+			name: "missing keyFile",
+			cfg: &Config{
+				Options: map[string]any{
+					"bcm": map[string]any{
+						"url":      "https://bcm-head:8081",
+						"certFile": "/certs/tls.crt",
+					},
+				},
+			},
+			wantErr: "bcm keyFile is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseBCMConfig(tt.cfg)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.URL != "https://bcm-head:8081" {
+				t.Errorf("expected URL %q, got %q", "https://bcm-head:8081", result.URL)
+			}
+		})
+	}
+}
+
+func TestCheckVersion(t *testing.T) {
+	t.Run("valid version", func(t *testing.T) {
+		server, client := newTestBCMServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != bcmVersionPath {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"cm_version":"11.0","cmd_version":"3.1","build_hash":"abc","build_index":1,"database_version":1}`)
+		}))
+
+		c := NewBCMClientForTest(client, server.URL, "test")
+		if err := c.checkVersion(context.Background()); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("version too old", func(t *testing.T) {
+		server, client := newTestBCMServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"cm_version":"9.2","cmd_version":"2.0","build_hash":"old","build_index":1,"database_version":1}`)
+		}))
+
+		c := NewBCMClientForTest(client, server.URL, "test")
+		err := c.checkVersion(context.Background())
+		if err == nil {
+			t.Fatal("expected error for old version, got nil")
+		}
+		if !errors.Is(err, ErrBCMVersionTooOld) {
+			t.Errorf("expected ErrBCMVersionTooOld, got: %v", err)
+		}
+	})
+
+	t.Run("exact minimum version", func(t *testing.T) {
+		server, client := newTestBCMServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"cm_version":"10.25","cmd_version":"3.0","build_hash":"min","build_index":1,"database_version":1}`)
+		}))
+
+		c := NewBCMClientForTest(client, server.URL, "test")
+		if err := c.checkVersion(context.Background()); err != nil {
+			t.Fatalf("expected minimum version to pass, got: %v", err)
+		}
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		server, client := newTestBCMServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+
+		c := NewBCMClientForTest(client, server.URL, "test")
+		err := c.checkVersion(context.Background())
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !errors.Is(err, ErrBCMServerError) {
+			t.Errorf("expected ErrBCMServerError, got: %v", err)
+		}
+	})
+}
+
+func TestGetDevices(t *testing.T) {
+	t.Run("returns list of devices", func(t *testing.T) {
+		server, client := newTestBCMServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertJSONCall(t, r, "cmdevice", "getDevices")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `[
+				{"baseType":"Device","childType":"LiteNode","uuid":"uuid1","hostname":"node001","mac":"aa:bb:cc:dd:ee:01","extra_values":{"resource_class":"h100"}},
+				{"baseType":"Device","childType":"PhysicalNode","uuid":"uuid2","hostname":"head01","mac":"aa:bb:cc:dd:ee:02","extra_values":null}
+			]`)
+		}))
+
+		c := NewBCMClientForTest(client, server.URL, "test")
+		devices, err := c.getDevices(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(devices) != 2 {
+			t.Fatalf("expected 2 devices, got %d", len(devices))
+		}
+		if devices[0].Hostname != "node001" {
+			t.Errorf("expected hostname node001, got %s", devices[0].Hostname)
+		}
+		if devices[0].ChildType != "LiteNode" {
+			t.Errorf("expected childType LiteNode, got %s", devices[0].ChildType)
+		}
+		if devices[0].raw == nil {
+			t.Error("expected raw JSON to be preserved")
+		}
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		server, client := newTestBCMServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `[]`)
+		}))
+
+		c := NewBCMClientForTest(client, server.URL, "test")
+		devices, err := c.getDevices(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(devices) != 0 {
+			t.Fatalf("expected 0 devices, got %d", len(devices))
+		}
+	})
+}
+
+func TestGetDevice(t *testing.T) {
+	t.Run("found", func(t *testing.T) {
+		server, client := newTestBCMServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			req := assertJSONCall(t, r, "cmdevice", "getDevice")
+			var args []string
+			if err := json.Unmarshal(req.Args.(json.RawMessage), &args); err != nil {
+				t.Fatalf("failed to parse args: %v", err)
+			}
+			if args[0] != "node001" {
+				t.Errorf("expected hostname node001, got %s", args[0])
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"baseType":"Device","childType":"LiteNode","uuid":"uuid1","hostname":"node001","mac":"aa:bb:cc:dd:ee:01","extra_values":{"resource_class":"h100"}}`)
+		}))
+
+		c := NewBCMClientForTest(client, server.URL, "test")
+		device, err := c.getDevice(context.Background(), "node001")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if device == nil {
+			t.Fatal("expected device, got nil")
+		}
+		if device.Hostname != "node001" {
+			t.Errorf("expected hostname node001, got %s", device.Hostname)
+		}
+		if device.ExtraValues["resource_class"] != "h100" {
+			t.Errorf("expected resource_class h100, got %v", device.ExtraValues["resource_class"])
+		}
+	})
+
+	t.Run("not found returns nil", func(t *testing.T) {
+		server, client := newTestBCMServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `null`)
+		}))
+
+		c := NewBCMClientForTest(client, server.URL, "test")
+		device, err := c.getDevice(context.Background(), "nonexistent")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if device != nil {
+			t.Errorf("expected nil device for not found, got %+v", device)
+		}
+	})
+}
+
+func TestUpdateDevice(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server, client := newTestBCMServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assertJSONCall(t, r, "cmdevice", "updateDevice")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"success":true,"task_uuid":"00000000-0000-0000-0000-000000000000","updated_entity":null,"validation":[]}`)
+		}))
+
+		deviceJSON := json.RawMessage(`{"baseType":"Device","childType":"LiteNode","hostname":"node001"}`)
+		c := NewBCMClientForTest(client, server.URL, "test")
+		resp, err := c.updateDevice(context.Background(), deviceJSON)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !resp.Success {
+			t.Error("expected success=true")
+		}
+	})
+
+	t.Run("validation error", func(t *testing.T) {
+		server, client := newTestBCMServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"success":false,"task_uuid":"00000000-0000-0000-0000-000000000000","updated_entity":null,"validation":[{"baseType":"Validation","error_code":"NOT_NULL","field":"partition","message":"partition is required","severity":"ERROR"}]}`)
+		}))
+
+		deviceJSON := json.RawMessage(`{"baseType":"Device","hostname":"node001"}`)
+		c := NewBCMClientForTest(client, server.URL, "test")
+		resp, err := c.updateDevice(context.Background(), deviceJSON)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+
+		var valErr *BCMValidationError
+		if !errors.As(err, &valErr) {
+			t.Fatalf("expected BCMValidationError, got: %T %v", err, err)
+		}
+		if len(valErr.Validations) != 1 {
+			t.Fatalf("expected 1 validation, got %d", len(valErr.Validations))
+		}
+		if valErr.Validations[0].ErrorCode != "NOT_NULL" {
+			t.Errorf("expected error_code NOT_NULL, got %s", valErr.Validations[0].ErrorCode)
+		}
+
+		if resp == nil {
+			t.Fatal("expected response even on validation error")
+		}
+	})
+}
+
+func TestDoJSONCall(t *testing.T) {
+	t.Run("auth error from certificate message", func(t *testing.T) {
+		server, client := newTestBCMServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"errormessage":"Your certificate (profile:) does not allow access to CMDevice::getDevices\n"}`)
+		}))
+
+		c := NewBCMClientForTest(client, server.URL, "test")
+		_, err := c.doJSONCall(context.Background(), "cmdevice", "getDevices", []any{})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !errors.Is(err, ErrBCMAuthFailed) {
+			t.Errorf("expected ErrBCMAuthFailed, got: %v", err)
+		}
+	})
+
+	t.Run("generic api error", func(t *testing.T) {
+		server, client := newTestBCMServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"errormessage":"No such service: '(cm)fake'\n"}`)
+		}))
+
+		c := NewBCMClientForTest(client, server.URL, "test")
+		_, err := c.doJSONCall(context.Background(), "cmfake", "getDevices", []any{})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if errors.Is(err, ErrBCMAuthFailed) {
+			t.Error("should not be auth error for service not found")
+		}
+	})
+
+	t.Run("server error 500", func(t *testing.T) {
+		server, client := newTestBCMServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = fmt.Fprint(w, "internal error")
+		}))
+
+		c := NewBCMClientForTest(client, server.URL, "test")
+		_, err := c.doJSONCall(context.Background(), "cmdevice", "getDevices", []any{})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !errors.Is(err, ErrBCMServerError) {
+			t.Errorf("expected ErrBCMServerError, got: %v", err)
+		}
+	})
+
+	t.Run("auth error from HTTP 401", func(t *testing.T) {
+		server, client := newTestBCMServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+
+		c := NewBCMClientForTest(client, server.URL, "test")
+		_, err := c.doJSONCall(context.Background(), "cmdevice", "getDevices", []any{})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !errors.Is(err, ErrBCMAuthFailed) {
+			t.Errorf("expected ErrBCMAuthFailed, got: %v", err)
+		}
+	})
+
+	t.Run("client error 404", func(t *testing.T) {
+		server, client := newTestBCMServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+
+		c := NewBCMClientForTest(client, server.URL, "test")
+		_, err := c.doJSONCall(context.Background(), "cmdevice", "getDevices", []any{})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if errors.Is(err, ErrBCMAuthFailed) || errors.Is(err, ErrBCMServerError) {
+			t.Errorf("404 should be generic client error, got: %v", err)
+		}
+	})
+
+	t.Run("connection error", func(t *testing.T) {
+		client := &http.Client{Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		}}
+
+		c := NewBCMClientForTest(client, "https://localhost:1", "test")
+		_, err := c.doJSONCall(context.Background(), "cmdevice", "getDevices", []any{})
+		if err == nil {
+			t.Fatal("expected connection error, got nil")
+		}
+		if !errors.Is(err, ErrBCMConnectionFailed) {
+			t.Errorf("expected ErrBCMConnectionFailed, got: %v", err)
+		}
+	})
+
+	t.Run("nil args defaults to empty array", func(t *testing.T) {
+		server, client := newTestBCMServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			req := assertJSONCall(t, r, "cmdevice", "getDevices")
+			raw := req.Args.(json.RawMessage)
+			if string(raw) != "[]" {
+				t.Errorf("expected args to be [], got %s", string(raw))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `[]`)
+		}))
+
+		c := NewBCMClientForTest(client, server.URL, "test")
+		_, err := c.doJSONCall(context.Background(), "cmdevice", "getDevices", nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestSetExtraValue(t *testing.T) {
+	raw := json.RawMessage(`{"hostname":"node001","extra_values":{"resource_class":"h100"}}`)
+
+	updated, err := setExtraValue(raw, "osac_instance_id", "test-uid-123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal(updated, &obj); err != nil {
+		t.Fatalf("failed to unmarshal updated JSON: %v", err)
+	}
+
+	ev := obj["extra_values"].(map[string]any)
+	if ev["osac_instance_id"] != "test-uid-123" {
+		t.Errorf("expected osac_instance_id=test-uid-123, got %v", ev["osac_instance_id"])
+	}
+	if ev["resource_class"] != "h100" {
+		t.Errorf("expected resource_class=h100 preserved, got %v", ev["resource_class"])
+	}
+}
+
+func TestSetExtraValueNilExtraValues(t *testing.T) {
+	raw := json.RawMessage(`{"hostname":"node001","extra_values":null}`)
+
+	updated, err := setExtraValue(raw, "osac_instance_id", "test-uid-123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal(updated, &obj); err != nil {
+		t.Fatalf("failed to unmarshal updated JSON: %v", err)
+	}
+
+	ev := obj["extra_values"].(map[string]any)
+	if ev["osac_instance_id"] != "test-uid-123" {
+		t.Errorf("expected osac_instance_id=test-uid-123, got %v", ev["osac_instance_id"])
+	}
+}
+
+func TestRemoveExtraValue(t *testing.T) {
+	raw := json.RawMessage(`{"hostname":"node001","extra_values":{"resource_class":"h100","osac_instance_id":"uid-123"}}`)
+
+	updated, err := removeExtraValue(raw, "osac_instance_id")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal(updated, &obj); err != nil {
+		t.Fatalf("failed to unmarshal updated JSON: %v", err)
+	}
+
+	ev := obj["extra_values"].(map[string]any)
+	if _, ok := ev["osac_instance_id"]; ok {
+		t.Error("expected osac_instance_id to be removed")
+	}
+	if ev["resource_class"] != "h100" {
+		t.Errorf("expected resource_class=h100 preserved, got %v", ev["resource_class"])
+	}
+}
+
+func TestClassifyHTTPError(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		target error
+	}{
+		{
+			name:   "nil error",
+			err:    nil,
+			target: nil,
+		},
+		{
+			name:   "tls keyword in error",
+			err:    fmt.Errorf("tls: handshake failure"),
+			target: ErrBCMTLSFailed,
+		},
+		{
+			name:   "x509 keyword in error",
+			err:    fmt.Errorf("x509: certificate signed by unknown authority"),
+			target: ErrBCMTLSFailed,
+		},
+		{
+			name:   "certificate keyword in error",
+			err:    fmt.Errorf("remote error: certificate required"),
+			target: ErrBCMTLSFailed,
+		},
+		{
+			name:   "generic connection error",
+			err:    fmt.Errorf("dial tcp 10.0.0.1:8081: connect: connection refused"),
+			target: ErrBCMConnectionFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := classifyHTTPError(tt.err)
+			if tt.target == nil {
+				if result != nil {
+					t.Errorf("expected nil, got %v", result)
+				}
+				return
+			}
+			if !errors.Is(result, tt.target) {
+				t.Errorf("expected %v, got %v", tt.target, result)
+			}
+		})
+	}
+}
+
+func TestBCMValidationErrorFormat(t *testing.T) {
+	err := &BCMValidationError{
+		Validations: []bcmValidation{
+			{ErrorCode: "NOT_NULL", Field: "partition", Message: "partition is required"},
+			{ErrorCode: "BAD_VALUE", Field: "uuid", Message: "invalid UUID"},
+		},
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "partition") || !strings.Contains(msg, "NOT_NULL") {
+		t.Errorf("error message should contain field details, got: %s", msg)
+	}
+	if !strings.Contains(msg, "BAD_VALUE") {
+		t.Errorf("error message should contain all validations, got: %s", msg)
+	}
+}
+
+func TestBCMBackendRegistration(t *testing.T) {
+	if _, ok := newClientFuncs["bcm"]; !ok {
+		t.Fatal("bcm backend not registered in newClientFuncs")
+	}
+}
+
+// assertJSONCall reads and validates the BCM JSON API request body.
+func assertJSONCall(t *testing.T, r *http.Request, expectedService, expectedCall string) *bcmJSONRequest {
+	t.Helper()
+	if r.Method != http.MethodPost {
+		t.Errorf("expected POST, got %s", r.Method)
+	}
+	if r.URL.Path != bcmJSONPath {
+		t.Errorf("expected path %s, got %s", bcmJSONPath, r.URL.Path)
+	}
+
+	var req struct {
+		Service string          `json:"service"`
+		Call    string          `json:"call"`
+		Args    json.RawMessage `json:"args"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		t.Fatalf("failed to decode request body: %v", err)
+	}
+	if req.Service != expectedService {
+		t.Errorf("expected service %q, got %q", expectedService, req.Service)
+	}
+	if req.Call != expectedCall {
+		t.Errorf("expected call %q, got %q", expectedCall, req.Call)
+	}
+	return &bcmJSONRequest{Service: req.Service, Call: req.Call, Args: req.Args}
+}

--- a/bare-metal-fulfillment-operator/internal/inventory/bmh_lifecycle.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/bmh_lifecycle.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inventory
+
+import (
+	"context"
+	"fmt"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// BMHCreateParams holds the parameters for creating a BareMetalHost CR.
+type BMHCreateParams struct {
+	Name                           string
+	BMCAddress                     string
+	CredentialsSecret              string
+	BootMACAddress                 string
+	DisableCertificateVerification bool
+	ConsumerRef                    *corev1.ObjectReference
+	Labels                         map[string]string
+}
+
+// BMHLifecycleManager handles on-demand BareMetalHost CR creation,
+// deletion, and readiness checking. Any inventory backend paired with
+// Metal3 management can use it for on-demand BMH CRs.
+type BMHLifecycleManager struct {
+	client    client.Client
+	namespace string
+}
+
+// NewBMHLifecycleManager creates a manager for the given Metal3 namespace.
+func NewBMHLifecycleManager(k8sClient client.Client, namespace string) *BMHLifecycleManager {
+	return &BMHLifecycleManager{
+		client:    k8sClient,
+		namespace: namespace,
+	}
+}
+
+// CreateBMH creates a BareMetalHost CR in the configured namespace.
+// Sets spec.online = false — the controller manages power via reconcileManagement.
+// Idempotent: if a BMH with the same name already exists and its consumerRef
+// matches, treats it as success. If consumerRef does not match, returns an error.
+func (m *BMHLifecycleManager) CreateBMH(ctx context.Context, params BMHCreateParams) error {
+	log := ctrllog.FromContext(ctx)
+
+	bmh := &metal3api.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      params.Name,
+			Namespace: m.namespace,
+			Labels:    params.Labels,
+		},
+		Spec: metal3api.BareMetalHostSpec{
+			BMC: metal3api.BMCDetails{
+				Address:                        params.BMCAddress,
+				CredentialsName:                params.CredentialsSecret,
+				DisableCertificateVerification: params.DisableCertificateVerification,
+			},
+			BootMACAddress: params.BootMACAddress,
+			Online:         false,
+			ConsumerRef:    params.ConsumerRef,
+		},
+	}
+
+	err := m.client.Create(ctx, bmh)
+	if err == nil {
+		log.Info("Created BareMetalHost", "name", params.Name, "namespace", m.namespace)
+		return nil
+	}
+
+	if !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to create BareMetalHost %s/%s: %w", m.namespace, params.Name, err)
+	}
+
+	existing := &metal3api.BareMetalHost{}
+	if getErr := m.client.Get(ctx, client.ObjectKey{Namespace: m.namespace, Name: params.Name}, existing); getErr != nil {
+		return fmt.Errorf("failed to get existing BareMetalHost %s/%s: %w", m.namespace, params.Name, getErr)
+	}
+
+	if existing.Spec.ConsumerRef != nil && params.ConsumerRef != nil &&
+		existing.Spec.ConsumerRef.APIVersion == params.ConsumerRef.APIVersion &&
+		existing.Spec.ConsumerRef.Kind == params.ConsumerRef.Kind &&
+		existing.Spec.ConsumerRef.Name == params.ConsumerRef.Name &&
+		existing.Spec.ConsumerRef.Namespace == params.ConsumerRef.Namespace {
+		log.Info("BareMetalHost already exists with matching consumerRef", "name", params.Name)
+		return nil
+	}
+
+	return fmt.Errorf("BareMetalHost %s/%s already exists with different consumerRef", m.namespace, params.Name)
+}
+
+// DeleteBMH deletes a BareMetalHost CR by name. Idempotent — ignores NotFound.
+// Does not delete BMC credentials Secrets (they are admin-managed and reusable).
+func (m *BMHLifecycleManager) DeleteBMH(ctx context.Context, name string) error {
+	log := ctrllog.FromContext(ctx)
+
+	bmh := &metal3api.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: m.namespace,
+		},
+	}
+
+	if err := m.client.Delete(ctx, bmh); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("BareMetalHost already deleted", "name", name, "namespace", m.namespace)
+			return nil
+		}
+		return fmt.Errorf("failed to delete BareMetalHost %s/%s: %w", m.namespace, name, err)
+	}
+
+	log.Info("Deleted BareMetalHost", "name", name, "namespace", m.namespace)
+	return nil
+}
+
+// IsBMHReady checks whether the BMH has completed Metal3 registration and is
+// ready for power management. Returns true when the BMH provisioning state is
+// "available" and operational status is "OK". Returns false while the BMH is
+// in registering, inspecting, or preparing state. Returns an error if the BMH
+// does not exist or has an error operational status.
+func (m *BMHLifecycleManager) IsBMHReady(ctx context.Context, name string) (bool, error) {
+	log := ctrllog.FromContext(ctx)
+
+	bmh := &metal3api.BareMetalHost{}
+	if err := m.client.Get(ctx, client.ObjectKey{Namespace: m.namespace, Name: name}, bmh); err != nil {
+		return false, fmt.Errorf("failed to get BareMetalHost %s/%s: %w", m.namespace, name, err)
+	}
+
+	if bmh.Status.OperationalStatus == metal3api.OperationalStatusError {
+		return false, fmt.Errorf("BareMetalHost %s/%s has error status: %s",
+			m.namespace, name, bmh.Status.ErrorMessage)
+	}
+
+	ready := bmh.Status.Provisioning.State == metal3api.StateAvailable &&
+		bmh.Status.OperationalStatus == metal3api.OperationalStatusOK
+
+	log.V(1).Info("BareMetalHost readiness check",
+		"name", name,
+		"provisioningState", bmh.Status.Provisioning.State,
+		"operationalStatus", bmh.Status.OperationalStatus,
+		"ready", ready)
+
+	return ready, nil
+}

--- a/bare-metal-fulfillment-operator/internal/inventory/bmh_lifecycle_test.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/bmh_lifecycle_test.go
@@ -1,0 +1,255 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inventory
+
+import (
+	"context"
+	"testing"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func newBMHTestManager(t *testing.T, objects ...client.Object) *BMHLifecycleManager {
+	t.Helper()
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(newTestScheme()).
+		WithObjects(objects...).
+		WithStatusSubresource(&metal3api.BareMetalHost{}).
+		Build()
+	return NewBMHLifecycleManager(k8sClient, testNamespace)
+}
+
+func TestCreateBMH(t *testing.T) {
+	t.Run("creates new BMH", func(t *testing.T) {
+		mgr := newBMHTestManager(t)
+
+		err := mgr.CreateBMH(context.Background(), BMHCreateParams{
+			Name:              "node001",
+			BMCAddress:        "redfish-virtualmedia+https://10.0.0.1/redfish/v1/Systems/1",
+			CredentialsSecret: "bmc-creds",
+			BootMACAddress:    "aa:bb:cc:dd:ee:01",
+			ConsumerRef: &corev1.ObjectReference{
+				APIVersion: "osac.openshift.io/v1alpha1",
+				Kind:       "BareMetalInstance",
+				Name:       "test-instance-uid",
+			},
+			Labels: map[string]string{"osac.openshift.io/pool-id": "pool1"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		bmh := &metal3api.BareMetalHost{}
+		if err := mgr.client.Get(context.Background(), client.ObjectKey{
+			Namespace: testNamespace, Name: "node001",
+		}, bmh); err != nil {
+			t.Fatalf("failed to get created BMH: %v", err)
+		}
+
+		if bmh.Spec.BMC.Address != "redfish-virtualmedia+https://10.0.0.1/redfish/v1/Systems/1" {
+			t.Errorf("expected BMC address, got %s", bmh.Spec.BMC.Address)
+		}
+		if bmh.Spec.BMC.CredentialsName != "bmc-creds" {
+			t.Errorf("expected credentials name bmc-creds, got %s", bmh.Spec.BMC.CredentialsName)
+		}
+		if bmh.Spec.BootMACAddress != "aa:bb:cc:dd:ee:01" {
+			t.Errorf("expected boot MAC aa:bb:cc:dd:ee:01, got %s", bmh.Spec.BootMACAddress)
+		}
+		if bmh.Spec.Online {
+			t.Error("expected online=false")
+		}
+		if bmh.Spec.ConsumerRef == nil || bmh.Spec.ConsumerRef.Name != "test-instance-uid" {
+			t.Error("expected consumerRef with test-instance-uid")
+		}
+		if bmh.Labels["osac.openshift.io/pool-id"] != "pool1" {
+			t.Errorf("expected pool-id label, got %v", bmh.Labels)
+		}
+	})
+
+	t.Run("idempotent with matching consumerRef", func(t *testing.T) {
+		existing := &metal3api.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "node001",
+				Namespace: testNamespace,
+			},
+			Spec: metal3api.BareMetalHostSpec{
+				ConsumerRef: &corev1.ObjectReference{
+					Name: "test-instance-uid",
+				},
+			},
+		}
+		mgr := newBMHTestManager(t, existing)
+
+		err := mgr.CreateBMH(context.Background(), BMHCreateParams{
+			Name:              "node001",
+			BMCAddress:        "redfish+https://10.0.0.1",
+			CredentialsSecret: "creds",
+			BootMACAddress:    "aa:bb:cc:dd:ee:01",
+			ConsumerRef: &corev1.ObjectReference{
+				Name: "test-instance-uid",
+			},
+		})
+		if err != nil {
+			t.Fatalf("expected idempotent success, got: %v", err)
+		}
+	})
+
+	t.Run("error with different consumerRef", func(t *testing.T) {
+		existing := &metal3api.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "node001",
+				Namespace: testNamespace,
+			},
+			Spec: metal3api.BareMetalHostSpec{
+				ConsumerRef: &corev1.ObjectReference{
+					Name: "other-instance-uid",
+				},
+			},
+		}
+		mgr := newBMHTestManager(t, existing)
+
+		err := mgr.CreateBMH(context.Background(), BMHCreateParams{
+			Name:              "node001",
+			BMCAddress:        "redfish+https://10.0.0.1",
+			CredentialsSecret: "creds",
+			BootMACAddress:    "aa:bb:cc:dd:ee:01",
+			ConsumerRef: &corev1.ObjectReference{
+				Name: "my-instance-uid",
+			},
+		})
+		if err == nil {
+			t.Fatal("expected error for different consumerRef, got nil")
+		}
+	})
+}
+
+func TestDeleteBMH(t *testing.T) {
+	t.Run("deletes existing BMH", func(t *testing.T) {
+		existing := &metal3api.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "node001",
+				Namespace: testNamespace,
+			},
+		}
+		mgr := newBMHTestManager(t, existing)
+
+		if err := mgr.DeleteBMH(context.Background(), "node001"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		bmh := &metal3api.BareMetalHost{}
+		err := mgr.client.Get(context.Background(), client.ObjectKey{
+			Namespace: testNamespace, Name: "node001",
+		}, bmh)
+		if err == nil {
+			t.Error("expected BMH to be deleted")
+		}
+	})
+
+	t.Run("idempotent for not found", func(t *testing.T) {
+		mgr := newBMHTestManager(t)
+
+		if err := mgr.DeleteBMH(context.Background(), "nonexistent"); err != nil {
+			t.Fatalf("expected idempotent success for not found, got: %v", err)
+		}
+	})
+}
+
+func TestIsBMHReady(t *testing.T) {
+	t.Run("ready when available and OK", func(t *testing.T) {
+		bmh := &metal3api.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "node001",
+				Namespace: testNamespace,
+			},
+			Status: metal3api.BareMetalHostStatus{
+				Provisioning: metal3api.ProvisionStatus{
+					State: metal3api.StateAvailable,
+				},
+				OperationalStatus: metal3api.OperationalStatusOK,
+			},
+		}
+		mgr := newBMHTestManager(t, bmh)
+
+		ready, err := mgr.IsBMHReady(context.Background(), "node001")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !ready {
+			t.Error("expected ready=true")
+		}
+	})
+
+	t.Run("not ready when registering", func(t *testing.T) {
+		bmh := &metal3api.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "node001",
+				Namespace: testNamespace,
+			},
+			Status: metal3api.BareMetalHostStatus{
+				Provisioning: metal3api.ProvisionStatus{
+					State: metal3api.StateRegistering,
+				},
+				OperationalStatus: metal3api.OperationalStatusOK,
+			},
+		}
+		mgr := newBMHTestManager(t, bmh)
+
+		ready, err := mgr.IsBMHReady(context.Background(), "node001")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ready {
+			t.Error("expected ready=false for registering state")
+		}
+	})
+
+	t.Run("error when operational status is error", func(t *testing.T) {
+		bmh := &metal3api.BareMetalHost{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "node001",
+				Namespace: testNamespace,
+			},
+			Status: metal3api.BareMetalHostStatus{
+				Provisioning: metal3api.ProvisionStatus{
+					State: metal3api.StateAvailable,
+				},
+				OperationalStatus: metal3api.OperationalStatusError,
+				ErrorMessage:      "BMC connection failed",
+			},
+		}
+		mgr := newBMHTestManager(t, bmh)
+
+		_, err := mgr.IsBMHReady(context.Background(), "node001")
+		if err == nil {
+			t.Fatal("expected error for error operational status, got nil")
+		}
+	})
+
+	t.Run("error when BMH not found", func(t *testing.T) {
+		mgr := newBMHTestManager(t)
+
+		_, err := mgr.IsBMHReady(context.Background(), "nonexistent")
+		if err == nil {
+			t.Fatal("expected error for not found, got nil")
+		}
+	})
+}

--- a/bare-metal-fulfillment-operator/internal/inventory/client.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/client.go
@@ -27,6 +27,11 @@ type Config struct {
 	Type      string         `json:"type"`
 	Options   map[string]any `json:"options"`
 	HostClass string         `json:"hostClass"`
+
+	// BMHLifecycleManager is set by main.go when the management backend is
+	// Metal3. Inventory backends that create on-demand BareMetalHost CRs
+	// (e.g., BCM) use this for BMH creation, deletion, and readiness checks.
+	BMHLifecycleManager *BMHLifecycleManager `json:"-"`
 }
 
 // Host is the common return type all clients must use

--- a/bare-metal-fulfillment-operator/internal/management/metal3.go
+++ b/bare-metal-fulfillment-operator/internal/management/metal3.go
@@ -59,7 +59,7 @@ func (m *Metal3Client) TestClient() client.Client {
 }
 
 func NewMetal3ManagementClient(ctx context.Context, cfg *Config) (Client, error) {
-	namespace, err := parseMetal3ManagementNamespace(cfg)
+	namespace, err := ParseMetal3Namespace(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,8 @@ func NewMetal3ManagementClient(ctx context.Context, cfg *Config) (Client, error)
 	}, nil
 }
 
-func parseMetal3ManagementNamespace(cfg *Config) (string, error) {
+// ParseMetal3Namespace extracts the Metal3 namespace from management config options.
+func ParseMetal3Namespace(cfg *Config) (string, error) {
 	metal3Opts, ok := cfg.Options["metal3"]
 	if !ok {
 		return "", fmt.Errorf("metal3 options not found in management config")


### PR DESCRIPTION
## Summary

Phase 1 Task 2 for BCM inventory backend ([OSAC-1339](https://redhat.atlassian.net/browse/OSAC-1339)):

- **Operator wiring**: Wire `BMHLifecycleManager` in `main.go` when management backend is Metal3 — extracts namespace from management config, creates manager, passes via `inventory.Config`
- **Scheme registration**: Add `metal3api` to manager scheme so `mgr.GetClient()` works with BareMetalHost CRs
- **RBAC**: Add `create` and `delete` verbs for `metal3.io/baremetalhosts` (previously only get/list/watch/update/patch)
- **Helm**: Add `secrets.bcmCerts` to values (optional, empty default), conditional bcm-certs volume mount at `/etc/osac/bcm-certs/`
- **Export**: `ParseMetal3Namespace` from management package for reuse by main.go

**Depends on:** [osac#228](https://github.com/osac-project/osac/pull/228) (BCM HTTP client + BMH lifecycle manager)

## Test plan

- [ ] `make build` passes
- [ ] `make test` passes (no new tests — wiring only)
- [ ] `make lint` passes (0 issues)
- [ ] `helm lint charts/operator` passes
- [ ] `config/rbac/role.yaml` has `create` and `delete` for `baremetalhosts`
- [ ] Helm chart renders correctly with and without `bcmCerts` set

Assisted-by: Claude Code <noreply@anthropic.com>