### PR TITLE
OSAC-3849: add GPU fields to describe instancetype output

### DIFF
--- a/fulfillment-service/internal/cmd/cli/describe/instancetype/describe_instancetype_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/describe/instancetype/describe_instancetype_cmd.go
@@ -109,6 +109,12 @@ func renderInstanceType(w io.Writer, it *publicv1.InstanceType) {
 		state := strings.TrimPrefix(spec.GetState().String(), "INSTANCE_TYPE_STATE_")
 		fmt.Fprintf(writer, "State:\t%s\n", state)
 
+		if gpu := spec.GetGpu(); gpu != nil {
+			fmt.Fprintf(writer, "GPU Count:\t%d\n", gpu.GetCount())
+			fmt.Fprintf(writer, "GPU Resource Name:\t%s\n", gpu.GetResourceName())
+			fmt.Fprintf(writer, "GPU PCI Device Selector:\t%s\n", gpu.GetPciDeviceSelector())
+		}
+
 		// Description (only when non-empty):
 		if desc := spec.GetDescription(); desc != "" {
 			fmt.Fprintf(writer, "Description:\t%s\n", desc)

--- a/fulfillment-service/internal/cmd/cli/describe/instancetype/describe_instancetype_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/describe/instancetype/describe_instancetype_cmd.go
@@ -105,15 +105,15 @@ func renderInstanceType(w io.Writer, it *publicv1.InstanceType) {
 		fmt.Fprintf(writer, "Cores:\t%d\n", spec.GetCores())
 		fmt.Fprintf(writer, "Memory (GiB):\t%d\n", spec.GetMemoryGib())
 
-		// State with prefix stripping (D-02):
-		state := strings.TrimPrefix(spec.GetState().String(), "INSTANCE_TYPE_STATE_")
-		fmt.Fprintf(writer, "State:\t%s\n", state)
-
 		if gpu := spec.GetGpu(); gpu != nil {
 			fmt.Fprintf(writer, "GPU Count:\t%d\n", gpu.GetCount())
 			fmt.Fprintf(writer, "GPU Resource Name:\t%s\n", gpu.GetResourceName())
 			fmt.Fprintf(writer, "GPU PCI Device Selector:\t%s\n", gpu.GetPciDeviceSelector())
 		}
+
+		// State with prefix stripping (D-02):
+		state := strings.TrimPrefix(spec.GetState().String(), "INSTANCE_TYPE_STATE_")
+		fmt.Fprintf(writer, "State:\t%s\n", state)
 
 		// Description (only when non-empty):
 		if desc := spec.GetDescription(); desc != "" {

--- a/fulfillment-service/internal/cmd/cli/describe/instancetype/describe_instancetype_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/describe/instancetype/describe_instancetype_cmd_test.go
@@ -148,4 +148,45 @@ var _ = Describe("Rendering tests", func() {
 		output := formatInstanceType(it)
 		Expect(output).To(MatchRegexp(`Description:\s+High memory`))
 	})
+
+	It("should display GPU fields when GpuSpec is present", func() {
+		it := publicv1.InstanceType_builder{
+			Id: "gpu-a100-4-16",
+			Metadata: publicv1.Metadata_builder{
+				Name: "gpu-a100-4-16",
+			}.Build(),
+			Spec: publicv1.InstanceTypeSpec_builder{
+				Cores:     4,
+				MemoryGib: 16,
+				State:     publicv1.InstanceTypeState_INSTANCE_TYPE_STATE_ACTIVE,
+				Gpu: publicv1.GpuSpec_builder{
+					PciDeviceSelector: "10DE:20B0",
+					ResourceName:      "nvidia.com/A100",
+					Count:             2,
+				}.Build(),
+			}.Build(),
+		}.Build()
+		output := formatInstanceType(it)
+		Expect(output).To(MatchRegexp(`GPU PCI Device Selector:\s+10DE:20B0`))
+		Expect(output).To(MatchRegexp(`GPU Resource Name:\s+nvidia.com/A100`))
+		Expect(output).To(MatchRegexp(`GPU Count:\s+2`))
+	})
+
+	It("should omit GPU fields when GpuSpec is absent", func() {
+		it := publicv1.InstanceType_builder{
+			Id: "standard-4-16",
+			Metadata: publicv1.Metadata_builder{
+				Name: "standard-4-16",
+			}.Build(),
+			Spec: publicv1.InstanceTypeSpec_builder{
+				Cores:     4,
+				MemoryGib: 16,
+				State:     publicv1.InstanceTypeState_INSTANCE_TYPE_STATE_ACTIVE,
+			}.Build(),
+		}.Build()
+		output := formatInstanceType(it)
+		Expect(output).NotTo(ContainSubstring("GPU PCI Device Selector:"))
+		Expect(output).NotTo(ContainSubstring("GPU Resource Name:"))
+		Expect(output).NotTo(ContainSubstring("GPU Count:"))
+	})
 })


### PR DESCRIPTION
## Summary
- Display GPU count, resource name, and PCI device selector in `describe instancetype` output when a GpuSpec is present
- GPU fields are omitted for non-GPU instance types
- Description field moved after GPU fields to group hardware specs together

## Jira
https://redhat.atlassian.net/browse/OSAC-3849

## Test plan
- [x] GPU fields displayed when GpuSpec is present
- [x] GPU fields omitted when GpuSpec is absent
- [x] Verified on cluster with `osac describe instancetype gpu-a100-test`
<img width="861" height="186" alt="image" src="https://github.com/user-attachments/assets/504f8e75-58bf-4e00-8611-cc45ac958161" />

- [x] Unit tests pass (`ginkgo run -r internal/cmd/cli/describe/instancetype/`)
- [x] Full lint pass (`uv run dev.py lint`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Instance type details now display GPU count, resource name, and PCI device selector when GPU configuration is available.

* **Bug Fixes**
  * GPU-specific fields are omitted when no GPU configuration is defined, keeping displayed details accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->