### PR TITLE
OSAC-3424: implement M360 metering adapter

### DIFF
--- a/.github/workflows/build-metering-m360-adapter-image.yaml
+++ b/.github/workflows/build-metering-m360-adapter-image.yaml
@@ -1,0 +1,77 @@
+name: Build metering-m360-adapter image
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'osac-metering/adapters/**'
+      - '!osac-metering/adapters/**/*.md'
+  push:
+    branches:
+    - main
+    tags:
+    - 'osac-metering/v*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: osac-project/metering-m360-adapter
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute release version
+        if: startsWith(github.ref, 'refs/tags/osac-metering/')
+        run: |
+          version="${GITHUB_REF_NAME#osac-metering/}"
+          semver_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?$'
+          if ! [[ "${version}" =~ ${semver_re} ]]; then
+            echo "::error::Tag '${GITHUB_REF_NAME}' is not a valid semver release tag"
+            exit 1
+          fi
+          core="${version%%-*}"
+          echo "RELEASE_VERSION=${version}" >> "$GITHUB_ENV"
+          echo "RELEASE_MAJOR_MINOR=${core%.*}" >> "$GITHUB_ENV"
+          echo "RELEASE_MAJOR=${core%%.*}" >> "$GITHUB_ENV"
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ env.RELEASE_VERSION }},enable=${{ env.RELEASE_VERSION != '' }}
+            type=raw,value=${{ env.RELEASE_MAJOR_MINOR }},enable=${{ env.RELEASE_VERSION != '' }}
+            type=raw,value=${{ env.RELEASE_MAJOR }},enable=${{ env.RELEASE_VERSION != '' }}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: osac-metering/adapters
+          file: osac-metering/adapters/Containerfile.m360-adapter
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -105,4 +105,4 @@ jobs:
         working-directory: osac-metering/adapters
     - working-directory: osac-metering/adapters
       run: |
-        ginkgo run .
+        ginkgo run -r .

--- a/osac-metering/AGENTS.md
+++ b/osac-metering/AGENTS.md
@@ -32,6 +32,7 @@ make clean                     # Clean build artifacts
 # adapters (consumer framework)
 cd adapters
 make build-echo-adapter        # Build the echo-adapter binary
+make build-m360-adapter        # Build the m360-adapter binary
 make test                      # Run unit tests with Ginkgo
 make lint                      # Run golangci-lint
 make clean                     # Clean build artifacts
@@ -43,7 +44,7 @@ make clean                     # Clean build artifacts
 |-----------|---------|
 | `metering-service/` | Producer — watches fulfillment-service gRPC Watch stream, publishes CloudEvents to Kafka |
 | `adapters/` | Consumer framework — Kafka-to-provider bridge with `ProviderAdapter` interface and `Runner` |
-| `charts/osac-metering/` | Helm chart for deploying metering-service and echo-adapter |
+| `charts/osac-metering/` | Helm chart for deploying metering-service, echo-adapter, and m360-adapter |
 
 ## Architecture
 
@@ -56,7 +57,7 @@ Kafka Topics
   ↓ Sarama consumer group
 adapters.Runner (dedup → out-of-order check → retry → Submit → Flush → offset commit)
   ↓ ProviderAdapter interface
-Concrete Adapters (echo-adapter, billing providers)
+Concrete Adapters (echo-adapter, m360-adapter, billing providers)
 ```
 
 ### Key Packages
@@ -113,6 +114,20 @@ The `adapters/` package is a standalone Go module that provides everything a bil
 
 Deployed via Helm with `echoAdapter.enabled: true` (disabled by default; enabled in CI values profiles).
 
+### M360 Adapter
+
+`adapters/cmd/m360-adapter/` forwards OSAC metering CloudEvents to the Monetize360 (M360) Usage API via REST. It translates nested CloudEvents to M360's flat payload format and routes to the correct M360 endpoint by resource type (`/vmaas/event`, `/caas/event`, `/maas/event`).
+
+- Per-event submit (M360 API is per-event; no batch endpoint)
+- Bearer token auth from K8s Secret file mount
+- Error classification: 4xx → non-retryable (except 408/429), 5xx → retryable
+- TLS enabled by default, configurable API version (default `v1`)
+- `GET /healthz` — liveness probe (always 200)
+- `GET /readyz` — readiness probe (M360 connectivity check)
+- `GET /metrics` — Prometheus metrics
+
+Deployed via Helm with `m360Adapter.enabled: true` (disabled by default).
+
 ## Deployment
 
 The metering subsystem is deployed via the osac-installer umbrella chart with `metering.enabled: true`.
@@ -136,17 +151,22 @@ Key configuration parameters in `charts/osac-metering/values.yaml`:
 - `reconciliation.interval` — Reconciliation sweep interval (default `60m`)
 - `certs.caBundle.configMap` — CA bundle ConfigMap name
 - `echoAdapter.enabled` — Deploy the echo-adapter (default `false`)
+- `m360Adapter.enabled` — Deploy the m360-adapter (default `false`)
+- `m360Adapter.m360.apiUrl` — M360 Usage API base URL
+- `m360Adapter.m360.apiKeySecret` — K8s Secret name containing the M360 API key
+- `m360Adapter.m360.apiVersion` — M360 API version (default `v1`)
 
 ## CI Integration
 
 - **build-metering-service-image.yaml** — Builds and pushes metering-service container image
 - **build-metering-echo-adapter-image.yaml** — Builds echo-adapter image on `osac-metering/adapters/**` changes
+- **build-metering-m360-adapter-image.yaml** — Builds m360-adapter image on `osac-metering/adapters/**` changes
 - **run-osac-metering-tests** — Runs unit tests as part of the mono-repo test suite
 - **E2E workflows** (CaaS, VMaaS, BMaaS) — Tests metering in full OSAC deployments
 
 ## Testing
 
 - **metering-service unit tests** — `make test` in `metering-service/`
-- **adapters unit tests** — `make test` in `adapters/` (covers Runner, dedup, retry, order tracker, metrics)
+- **adapters unit tests** — `make test` in `adapters/` (covers Runner, dedup, retry, order tracker, metrics, echo-adapter, m360-adapter)
 - **E2E validation** — echo-adapter deployed in CI, queried via HTTP to assert event delivery
 - **Integration tests** — Included in E2E workflows with full Kafka setup

--- a/osac-metering/CLAUDE.md
+++ b/osac-metering/CLAUDE.md
@@ -20,6 +20,7 @@ make lint                      # Run golangci-lint
 # adapters (consumer framework)
 cd adapters
 make build-echo-adapter        # Build the echo-adapter binary
+make build-m360-adapter        # Build the m360-adapter binary
 make test                      # Run unit tests
 make lint                      # Run golangci-lint
 ```

--- a/osac-metering/README.md
+++ b/osac-metering/README.md
@@ -12,16 +12,23 @@ Metering pipeline for OSAC — collects resource usage events and publishes them
 | Directory | Description |
 |-----------|-------------|
 | `metering-service/` | Watch Consumer: connects to fulfillment-service gRPC Watch stream, maps lifecycle events to CloudEvents, publishes to Kafka |
+| `adapters/` | Provider Adapter framework (`Runner`, Kafka consumer, dedup, retry) and concrete adapters (`echo-adapter`, `m360-adapter`) |
 | `charts/osac-metering/` | Helm umbrella chart for the metering subsystem |
 
 ## Build and Test
 
 ```bash
+# metering-service (producer)
 cd metering-service
 make build    # Build the metering-service binary
 make test     # Run unit tests (ginkgo)
 make lint     # Run golangci-lint
 make generate # Regenerate proto client code from BSR
+
+# adapters (consumer framework)
+cd adapters
+make test     # Run unit tests (ginkgo, recursive)
+make lint     # Run golangci-lint
 ```
 
 ## Deployment

--- a/osac-metering/adapters/Containerfile.m360-adapter
+++ b/osac-metering/adapters/Containerfile.m360-adapter
@@ -1,0 +1,17 @@
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /opt/app-root/src
+COPY --chown=1001:0 go.mod go.sum ./
+RUN go mod download
+
+COPY . ./
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -buildvcs=false -a -o m360-adapter ./cmd/m360-adapter
+
+FROM registry.access.redhat.com/ubi10-minimal:10.2
+WORKDIR /
+COPY --from=builder /opt/app-root/src/m360-adapter .
+USER 65532:65532
+ENTRYPOINT ["/m360-adapter"]

--- a/osac-metering/adapters/Makefile
+++ b/osac-metering/adapters/Makefile
@@ -13,17 +13,23 @@ GOLANGCI_LINT_VERSION ?= v2.12.1
 LOCALBIN ?= $(shell pwd)/bin
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
-.PHONY: build-echo-adapter test lint clean
+.PHONY: all build-echo-adapter build-m360-adapter test lint clean
+
+all: build-echo-adapter build-m360-adapter
 
 build-echo-adapter:
 	@mkdir -p bin
 	go build -o bin/echo-adapter ./cmd/echo-adapter
 
+build-m360-adapter:
+	@mkdir -p bin
+	go build -o bin/m360-adapter ./cmd/m360-adapter
+
 test:
-	$(GINKGO) run .
+	$(GINKGO) run -r .
 
 lint: $(GOLANGCI_LINT)
-	$(GOLANGCI_LINT) run .
+	$(GOLANGCI_LINT) run ./...
 
 $(GOLANGCI_LINT):
 	@mkdir -p $(LOCALBIN)

--- a/osac-metering/adapters/cmd/echo-adapter/store_test.go
+++ b/osac-metering/adapters/cmd/echo-adapter/store_test.go
@@ -32,13 +32,13 @@ func makeEvent(id, eventType, source, resourceID string) adapters.MeteringEvent 
 	ce.SetExtension("osacresourcetype", "compute_instance")
 	ce.SetExtension("osactenant", "test-tenant")
 	_ = ce.SetData(cloudevents.ApplicationJSON, map[string]any{
-		"resource_id":   resourceID,
-		"resource_type": "ComputeInstance",
-		"tenant_id":     "test-tenant",
+		"resource_id":    resourceID,
+		"resource_type":  "ComputeInstance",
+		"tenant_id":      "test-tenant",
 		"schema_version": "v1",
 		"billing_dimensions": map[string]any{
-			"instance_type":     "m5.large",
-			"image_ref":         "rhel-9",
+			"instance_type":      "m5.large",
+			"image_ref":          "rhel-9",
 			"boot_disk_size_gib": 50,
 		},
 		"transition_time": time.Now().UTC().Format(time.RFC3339),

--- a/osac-metering/adapters/cmd/m360-adapter/client.go
+++ b/osac-metering/adapters/cmd/m360-adapter/client.go
@@ -1,0 +1,135 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/osac-project/osac-metering/adapters"
+)
+
+const (
+	httpTimeout = 30 * time.Second
+	// maxBodyLog caps M360 response body excerpts in error messages
+	// to avoid leaking large payloads into logs.
+	maxBodyLog = 256
+)
+
+// m360Client sends events to the M360 Usage API.
+type m360Client struct {
+	httpClient *http.Client
+	baseURL    string
+	apiVersion string
+	apiKey     string
+	logger     logr.Logger
+}
+
+// newM360Client creates a client for the M360 Usage API.
+func newM360Client(baseURL, apiVersion, apiKey string) *m360Client {
+	return &m360Client{
+		httpClient: &http.Client{Timeout: httpTimeout},
+		baseURL:    baseURL,
+		apiVersion: apiVersion,
+		apiKey:     apiKey,
+		logger:     logr.Discard(),
+	}
+}
+
+// post sends a flat M360 payload to the given endpoint.
+// Returns NonRetryableError for 4xx responses (except 408 and 429,
+// which are retryable), plain error for 5xx.
+func (c *m360Client) post(ctx context.Context, endpoint string, payload map[string]any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return &adapters.NonRetryableError{
+			Err: fmt.Errorf("marshal M360 payload: %w", err),
+		}
+	}
+
+	url := fmt.Sprintf("%s/api/%s/external/run%s", c.baseURL, c.apiVersion, endpoint)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create M360 request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("M360 request to %s: %w", endpoint, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MB cap
+	if readErr != nil {
+		respBody = []byte("[body read error]")
+	}
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		c.logResponse(respBody)
+		return nil
+	}
+
+	excerpt := string(respBody)
+	if len(excerpt) > maxBodyLog {
+		excerpt = excerpt[:maxBodyLog] + "...(truncated)"
+	}
+	errMsg := fmt.Sprintf("M360 %s returned %d: %s", endpoint, resp.StatusCode, excerpt)
+	// 408 (Request Timeout) and 429 (Too Many Requests) are retryable.
+	if resp.StatusCode >= 400 && resp.StatusCode < 500 &&
+		resp.StatusCode != http.StatusRequestTimeout &&
+		resp.StatusCode != http.StatusTooManyRequests {
+		return &adapters.NonRetryableError{Err: errors.New(errMsg)}
+	}
+	return errors.New(errMsg)
+}
+
+// healthCheck verifies connectivity to the M360 API.
+func (c *m360Client) healthCheck(ctx context.Context) error {
+	url := fmt.Sprintf("%s/api/%s/external/run", c.baseURL, c.apiVersion)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("create health check request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("M360 health check: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MB cap
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	return fmt.Errorf("M360 health check returned %d", resp.StatusCode)
+}
+
+// logResponse extracts event_id from a successful M360 response for debug logging.
+func (c *m360Client) logResponse(body []byte) {
+	var resp struct {
+		Output struct {
+			EventID string `json:"event_id"`
+		} `json:"output"`
+	}
+	if err := json.Unmarshal(body, &resp); err == nil && resp.Output.EventID != "" {
+		c.logger.V(1).Info("M360 event accepted", "m360_event_id", resp.Output.EventID)
+	}
+}

--- a/osac-metering/adapters/cmd/m360-adapter/client_test.go
+++ b/osac-metering/adapters/cmd/m360-adapter/client_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/osac-project/osac-metering/adapters"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("m360Client", func() {
+	var (
+		server *httptest.Server
+		client *m360Client
+	)
+
+	AfterEach(func() {
+		if server != nil {
+			server.Close()
+		}
+	})
+
+	Describe("post", func() {
+		It("sends POST with correct URL, auth header, and body", func() {
+			var capturedReq *http.Request
+			var capturedBody []byte
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedReq = r
+				capturedBody, _ = io.ReadAll(r.Body)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"output":{"event_id":"m360-ev-1"}}`))
+			}))
+			client = newM360Client(server.URL, "v1", "test-api-key")
+
+			payload := map[string]any{"event_id": "ce-123", "resource_type": "compute_instance"}
+			err := client.post(context.Background(), "/vmaas/event", payload)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(capturedReq.Method).To(Equal("POST"))
+			Expect(capturedReq.URL.Path).To(Equal("/api/v1/external/run/vmaas/event"))
+			Expect(capturedReq.Header.Get("Authorization")).To(Equal("Bearer test-api-key"))
+			Expect(capturedReq.Header.Get("Content-Type")).To(Equal("application/json"))
+
+			var body map[string]any
+			Expect(json.Unmarshal(capturedBody, &body)).To(Succeed())
+			Expect(body["event_id"]).To(Equal("ce-123"))
+		})
+
+		It("uses configurable API version in URL", func() {
+			var capturedPath string
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedPath = r.URL.Path
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"output":{"event_id":"ev-1"}}`))
+			}))
+			client = newM360Client(server.URL, "v2", "key")
+
+			err := client.post(context.Background(), "/caas/event", map[string]any{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(capturedPath).To(Equal("/api/v2/external/run/caas/event"))
+		})
+
+		It("returns NonRetryableError on 400", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":"bad request"}`))
+			}))
+			client = newM360Client(server.URL, "v1", "key")
+
+			err := client.post(context.Background(), "/vmaas/event", map[string]any{})
+
+			Expect(err).To(HaveOccurred())
+			var nonRetryable *adapters.NonRetryableError
+			Expect(errors.As(err, &nonRetryable)).To(BeTrue())
+		})
+
+		It("returns NonRetryableError on 401", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			}))
+			client = newM360Client(server.URL, "v1", "bad-key")
+
+			err := client.post(context.Background(), "/vmaas/event", map[string]any{})
+
+			var nonRetryable *adapters.NonRetryableError
+			Expect(errors.As(err, &nonRetryable)).To(BeTrue())
+		})
+
+		It("returns retryable error on 408", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusRequestTimeout)
+			}))
+			client = newM360Client(server.URL, "v1", "key")
+
+			err := client.post(context.Background(), "/vmaas/event", map[string]any{})
+
+			Expect(err).To(HaveOccurred())
+			var nonRetryable *adapters.NonRetryableError
+			Expect(errors.As(err, &nonRetryable)).To(BeFalse())
+		})
+
+		It("returns retryable error on 429", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusTooManyRequests)
+			}))
+			client = newM360Client(server.URL, "v1", "key")
+
+			err := client.post(context.Background(), "/vmaas/event", map[string]any{})
+
+			Expect(err).To(HaveOccurred())
+			var nonRetryable *adapters.NonRetryableError
+			Expect(errors.As(err, &nonRetryable)).To(BeFalse())
+		})
+
+		It("returns retryable error on 500", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+			client = newM360Client(server.URL, "v1", "key")
+
+			err := client.post(context.Background(), "/vmaas/event", map[string]any{})
+
+			Expect(err).To(HaveOccurred())
+			var nonRetryable *adapters.NonRetryableError
+			Expect(errors.As(err, &nonRetryable)).To(BeFalse())
+		})
+
+		It("returns error when context is cancelled", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			client = newM360Client(server.URL, "v1", "key")
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel() // cancel immediately
+
+			err := client.post(ctx, "/vmaas/event", map[string]any{})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("healthCheck", func() {
+		It("returns nil on 200", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			client = newM360Client(server.URL, "v1", "key")
+
+			err := client.healthCheck(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns error on non-2xx", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+			}))
+			client = newM360Client(server.URL, "v1", "key")
+
+			err := client.healthCheck(context.Background())
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/osac-metering/adapters/cmd/m360-adapter/m360_adapter_suite_test.go
+++ b/osac-metering/adapters/cmd/m360-adapter/m360_adapter_suite_test.go
@@ -1,0 +1,22 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestM360Adapter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "M360 Adapter Suite")
+}

--- a/osac-metering/adapters/cmd/m360-adapter/main.go
+++ b/osac-metering/adapters/cmd/m360-adapter/main.go
@@ -1,0 +1,197 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+// m360-adapter consumes OSAC metering CloudEvents from Kafka and
+// forwards them to the Monetize360 (M360) Usage API via REST.
+//
+// Usage:
+//
+//	export KAFKA_BROKERS="localhost:9092"
+//	export M360_API_URL="https://m360.example.com"
+//	export M360_API_KEY_FILE="/path/to/api-key"
+//	go run ./cmd/m360-adapter/
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/go-logr/stdr"
+	"github.com/osac-project/osac-metering/adapters"
+)
+
+type m360Adapter struct {
+	client *m360Client
+}
+
+func (a *m360Adapter) Name() string { return "m360" }
+
+func (a *m360Adapter) Submit(ctx context.Context, event adapters.MeteringEvent) error {
+	endpoint, payload, err := translateEvent(event.CloudEvent)
+	if err != nil {
+		return err
+	}
+	return a.client.post(ctx, endpoint, payload)
+}
+
+func (a *m360Adapter) Flush(_ context.Context) (adapters.SubmitResult, error) {
+	return adapters.SubmitResult{Idempotent: true}, nil
+}
+
+func (a *m360Adapter) HealthCheck(ctx context.Context) error {
+	return a.client.healthCheck(ctx)
+}
+
+func (a *m360Adapter) Close() error { return nil }
+
+func main() {
+	brokers := requireEnv("KAFKA_BROKERS")
+	m360URL := requireEnv("M360_API_URL")
+	apiKeyFile := requireEnv("M360_API_KEY_FILE")
+
+	apiKey := readFileOrFatal(apiKeyFile)
+	apiVersion := envOrDefault("M360_API_VERSION", "v1")
+
+	topics := adapters.AllTopics
+	if v := os.Getenv("KAFKA_TOPICS"); v != "" {
+		topics = splitAndTrim(v, ",")
+		if len(topics) == 0 {
+			log.Fatal("KAFKA_TOPICS must contain at least one topic")
+		}
+	}
+
+	group := envOrDefault("KAFKA_CONSUMER_GROUP", "m360-adapter")
+
+	var flushInterval time.Duration
+	if v := os.Getenv("FLUSH_INTERVAL"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			log.Fatalf("invalid FLUSH_INTERVAL %q: %v", v, err)
+		}
+		if d < 0 {
+			log.Fatalf("FLUSH_INTERVAL must be non-negative, got %s", d)
+		}
+		flushInterval = d
+	}
+
+	metricsAddr := envOrDefault("METRICS_ADDR", ":2112")
+
+	// TLS defaults to true (!= "false") — safer for production.
+	// Note: echo-adapter uses == "true" (defaults off) since it runs in
+	// development/CI where Kafka may not have TLS configured.
+	tlsEnabled := os.Getenv("KAFKA_TLS_ENABLED") != "false"
+
+	logger := stdr.New(log.New(os.Stderr, "", log.LstdFlags))
+
+	client := newM360Client(m360URL, apiVersion, apiKey)
+	client.logger = logger
+
+	adapter := &m360Adapter{client: client}
+	runner := adapters.NewRunner(adapter, adapters.RunnerConfig{
+		Brokers:       brokers,
+		ConsumerGroup: group,
+		Topics:        topics,
+		FlushInterval: flushInterval,
+		Kafka: adapters.KafkaConfig{
+			TLSEnabled:   tlsEnabled,
+			TLSCACert:    os.Getenv("KAFKA_TLS_CA_CERT"),
+			SASLUser:     os.Getenv("KAFKA_SASL_USERNAME"),
+			SASLPassFile: os.Getenv("KAFKA_SASL_PASSWORD_FILE"),
+		},
+	}, logger)
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", runner.MetricsHandler())
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		if err := adapter.HealthCheck(r.Context()); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	httpServer := &http.Server{
+		Addr:              metricsAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	go func() {
+		log.Print("HTTP server listening")
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("metrics server error: %v", err)
+		}
+	}()
+
+	ctx, cancel := signal.NotifyContext(context.Background(),
+		syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	log.Printf("starting m360 adapter: topics=%v group=%s api_version=%s flush=%s",
+		topics, group, apiVersion, flushInterval)
+
+	runErr := runner.Run(ctx)
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer shutdownCancel()
+	if err := httpServer.Shutdown(shutdownCtx); err != nil {
+		log.Printf("HTTP server shutdown error: %v", err)
+	}
+
+	if runErr != nil {
+		log.Fatalf("runner error: %v", runErr)
+	}
+
+	log.Print("m360 adapter shut down cleanly")
+}
+
+func requireEnv(key string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		log.Fatalf("%s is required", key)
+	}
+	return v
+}
+
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func readFileOrFatal(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatalf("reading %s: %v", path, err)
+	}
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		log.Fatalf("%s is empty", path)
+	}
+	return trimmed
+}
+
+func splitAndTrim(s, sep string) []string {
+	parts := strings.Split(s, sep)
+	result := parts[:0]
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}

--- a/osac-metering/adapters/cmd/m360-adapter/translate.go
+++ b/osac-metering/adapters/cmd/m360-adapter/translate.go
@@ -1,0 +1,128 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/osac-project/osac-metering/adapters"
+)
+
+// resourceTypeEndpoints maps OSAC resource types to M360 API endpoints.
+var resourceTypeEndpoints = map[string]string{
+	"compute_instance": "/vmaas/event",
+	"cluster_order":    "/caas/event",
+	"maas_inference":   "/maas/event",
+}
+
+// spaceString is the M360 convention for non-applicable fields.
+const spaceString = " "
+
+// translateEvent converts a canonical OSAC CloudEvent to a flat M360
+// Usage API payload and returns the target endpoint path.
+func translateEvent(ce cloudevents.Event) (string, map[string]any, error) {
+	if ce.ID() == "" {
+		return "", nil, &adapters.NonRetryableError{
+			Err: errors.New("CloudEvent has empty ID"),
+		}
+	}
+	if ce.Time().IsZero() {
+		return "", nil, &adapters.NonRetryableError{
+			Err: errors.New("CloudEvent has zero timestamp"),
+		}
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(ce.Data(), &data); err != nil {
+		return "", nil, &adapters.NonRetryableError{
+			Err: fmt.Errorf("unmarshal CloudEvent data: %w", err),
+		}
+	}
+
+	resourceType, _ := data["resource_type"].(string)
+	endpoint, ok := resourceTypeEndpoints[resourceType]
+	if !ok {
+		return "", nil, &adapters.NonRetryableError{
+			Err: fmt.Errorf("unknown resource_type %q", resourceType),
+		}
+	}
+
+	payload := map[string]any{
+		"specversion":     ce.SpecVersion(),
+		"type":            ce.Type(),
+		"source":          ce.Source(),
+		"subject":         ce.Subject(),
+		"event_time":      ce.Time().UTC().Format("2006-01-02T15:04:05Z"),
+		"datacontenttype": ce.DataContentType(),
+		"event_id":        ce.ID(),
+	}
+
+	// Copy data fields to top level.
+	dataFields := []string{
+		"resource_id", "resource_type", "tenant_id", "project_id",
+		"catalog_item_id", "template_id", "previous_state", "current_state",
+		"transition_time", "duration_seconds", "schema_version",
+	}
+	for _, key := range dataFields {
+		payload[key] = nullToSpace(data[key])
+	}
+
+	// Merge billing_dimensions to top level, skipping non-billable
+	// (nil, empty string, zero) values and protecting canonical fields
+	// from being overwritten.
+	if rawDims, hasDims := data["billing_dimensions"]; hasDims && rawDims != nil {
+		dims, ok := rawDims.(map[string]any)
+		if !ok {
+			return "", nil, &adapters.NonRetryableError{
+				Err: errors.New("billing_dimensions is not a map"),
+			}
+		}
+		for k, v := range dims {
+			if isZeroValue(v) {
+				continue
+			}
+			if _, exists := payload[k]; exists {
+				continue
+			}
+			payload[k] = v
+		}
+	}
+
+	return endpoint, payload, nil
+}
+
+// nullToSpace replaces nil and empty string with the M360 space string.
+func nullToSpace(v any) any {
+	if v == nil {
+		return spaceString
+	}
+	if s, ok := v.(string); ok && s == "" {
+		return spaceString
+	}
+	return v
+}
+
+// isZeroValue returns true for nil, empty string, and numeric zero.
+// JSON numbers are always decoded as float64 by encoding/json.
+func isZeroValue(v any) bool {
+	if v == nil {
+		return true
+	}
+	switch val := v.(type) {
+	case string:
+		return val == ""
+	case float64:
+		return val == 0
+	}
+	return false
+}

--- a/osac-metering/adapters/cmd/m360-adapter/translate_test.go
+++ b/osac-metering/adapters/cmd/m360-adapter/translate_test.go
@@ -1,0 +1,343 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package main
+
+import (
+	"errors"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/osac-project/osac-metering/adapters"
+)
+
+// helper to build a CloudEvent from the canonical format
+func buildCloudEvent(
+	id, ceType, resourceID, resourceType, tenantID, projectID string,
+	billingDimensions map[string]any,
+) cloudevents.Event {
+	ce := cloudevents.NewEvent()
+	ce.SetSpecVersion("1.0")
+	ce.SetID(id)
+	ce.SetType(ceType)
+	ce.SetSource("osac-metering-service")
+	ce.SetSubject(resourceType + "/" + resourceID)
+	ce.SetTime(time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC))
+	ce.SetDataContentType("application/json")
+
+	data := map[string]any{
+		"resource_id":      resourceID,
+		"resource_type":    resourceType,
+		"tenant_id":        tenantID,
+		"project_id":       projectID,
+		"catalog_item_id":  "ci-rhel10-gpu",
+		"template_id":      "tmpl-rhel10-large-gpu",
+		"previous_state":   nil,
+		"current_state":    "STARTING",
+		"transition_time":  "2026-07-20T10:00:00Z",
+		"duration_seconds": 0,
+		"schema_version":   "v1",
+	}
+	if billingDimensions != nil {
+		data["billing_dimensions"] = billingDimensions
+	}
+	ExpectWithOffset(1, ce.SetData(cloudevents.ApplicationJSON, data)).To(Succeed())
+	return ce
+}
+
+var _ = Describe("translateEvent", func() {
+	Describe("VMaaS events", func() {
+		It("translates a compute_instance event to flat M360 payload", func() {
+			ce := buildCloudEvent(
+				"ce-abc123",
+				"osac.resource.created.v1",
+				"vm-001",
+				"compute_instance",
+				"tenant-acme",
+				"project-gpu",
+				map[string]any{
+					"instance_type":      "large-gpu",
+					"image_ref":          "rhel-10.2-x86_64",
+					"boot_disk_size_gib": 100,
+				},
+			)
+
+			endpoint, payload, err := translateEvent(ce)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(endpoint).To(Equal("/vmaas/event"))
+			Expect(payload["event_id"]).To(Equal("ce-abc123"))
+			Expect(payload["event_time"]).To(Equal("2026-07-20T10:00:00Z"))
+			Expect(payload["resource_type"]).To(Equal("compute_instance"))
+			Expect(payload["instance_type"]).To(Equal("large-gpu"))
+			Expect(payload["image_ref"]).To(Equal("rhel-10.2-x86_64"))
+			Expect(payload["boot_disk_size_gib"]).To(BeEquivalentTo(100))
+		})
+
+		It("replaces nil previous_state with space string", func() {
+			ce := buildCloudEvent(
+				"ce-nil-test",
+				"osac.resource.created.v1",
+				"vm-002",
+				"compute_instance",
+				"tenant-acme",
+				"project-gpu",
+				map[string]any{"instance_type": "medium"},
+			)
+
+			_, payload, err := translateEvent(ce)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(payload["previous_state"]).To(Equal(" "))
+		})
+
+		It("replaces empty string fields with space string", func() {
+			ce := buildCloudEvent(
+				"ce-empty-test",
+				"osac.resource.created.v1",
+				"vm-003",
+				"compute_instance",
+				"tenant-acme",
+				"",
+				map[string]any{"instance_type": "medium"},
+			)
+
+			_, payload, err := translateEvent(ce)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(payload["project_id"]).To(Equal(" "))
+		})
+
+		It("handles missing billing_dimensions gracefully", func() {
+			ce := buildCloudEvent(
+				"ce-no-dims",
+				"osac.resource.created.v1",
+				"vm-004",
+				"compute_instance",
+				"tenant-acme",
+				"project-test",
+				nil,
+			)
+
+			endpoint, payload, err := translateEvent(ce)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(endpoint).To(Equal("/vmaas/event"))
+			Expect(payload).NotTo(HaveKey("instance_type"))
+		})
+
+		It("skips non-billable billing_dimensions (nil, empty, zero)", func() {
+			ce := buildCloudEvent(
+				"ce-zero-dims",
+				"osac.resource.created.v1",
+				"vm-005",
+				"compute_instance",
+				"tenant-acme",
+				"project-test",
+				map[string]any{
+					"instance_type":      "large-gpu",
+					"image_ref":          "",
+					"boot_disk_size_gib": 0,
+					"extra_field":        nil,
+				},
+			)
+
+			_, payload, err := translateEvent(ce)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(payload["instance_type"]).To(Equal("large-gpu"))
+			Expect(payload).NotTo(HaveKey("image_ref"))
+			Expect(payload).NotTo(HaveKey("boot_disk_size_gib"))
+			Expect(payload).NotTo(HaveKey("extra_field"))
+		})
+
+		It("prevents billing_dimensions from overwriting canonical fields", func() {
+			ce := buildCloudEvent(
+				"ce-overwrite",
+				"osac.resource.created.v1",
+				"vm-006",
+				"compute_instance",
+				"tenant-acme",
+				"project-test",
+				map[string]any{
+					"event_id":      "injected-id",
+					"resource_type": "injected-type",
+					"instance_type": "large-gpu",
+				},
+			)
+
+			_, payload, err := translateEvent(ce)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(payload["event_id"]).To(Equal("ce-overwrite"))
+			Expect(payload["resource_type"]).To(Equal("compute_instance"))
+			Expect(payload["instance_type"]).To(Equal("large-gpu"))
+		})
+	})
+
+	Describe("CaaS events", func() {
+		It("translates a cluster_order event to /caas/event", func() {
+			ce := buildCloudEvent(
+				"ce-caas-001",
+				"osac.resource.created.v1",
+				"cluster-001",
+				"cluster_order",
+				"tenant-acme",
+				"project-ml",
+				map[string]any{
+					"cluster_template": "ocp-ci-small",
+					"release_image":    "quay.io/openshift-release-dev/ocp-release:4.17.0-x86_64",
+					"component":        "control_plane",
+					"host_type":        "_control_plane",
+					"node_count":       1,
+				},
+			)
+
+			endpoint, payload, err := translateEvent(ce)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(endpoint).To(Equal("/caas/event"))
+			Expect(payload["cluster_template"]).To(Equal("ocp-ci-small"))
+			Expect(payload["component"]).To(Equal("control_plane"))
+			Expect(payload["node_count"]).To(BeEquivalentTo(1))
+		})
+	})
+
+	Describe("MaaS events", func() {
+		It("translates a maas_inference event to /maas/event", func() {
+			ce := buildCloudEvent(
+				"ce-maas-001",
+				"osac.inference.usage.v1",
+				"req-001",
+				"maas_inference",
+				"tenant-acme",
+				"project-nlp",
+				map[string]any{
+					"provider":              "anthropic",
+					"model":                 "claude-sonnet-4-20250514",
+					"prompt_tokens":         1500,
+					"completion_tokens":     800,
+					"total_tokens":          2300,
+					"cached_input_tokens":   200,
+					"cache_creation_tokens": 0,
+					"reasoning_tokens":      150,
+					"duration_ms":           3200,
+					"organization_id":       "acme-corp",
+					"cost_center":           "engineering",
+					"subscription":          "acme-premium-sub",
+				},
+			)
+
+			endpoint, payload, err := translateEvent(ce)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(endpoint).To(Equal("/maas/event"))
+			Expect(payload["provider"]).To(Equal("anthropic"))
+			Expect(payload["prompt_tokens"]).To(BeEquivalentTo(1500))
+			Expect(payload["total_tokens"]).To(BeEquivalentTo(2300))
+		})
+	})
+
+	Describe("error cases", func() {
+		It("returns NonRetryableError for unknown resource_type", func() {
+			ce := buildCloudEvent(
+				"ce-unknown",
+				"osac.resource.created.v1",
+				"res-001",
+				"unknown_type",
+				"tenant-acme",
+				"project-x",
+				nil,
+			)
+
+			_, _, err := translateEvent(ce)
+
+			Expect(err).To(HaveOccurred())
+			var nonRetryable *adapters.NonRetryableError
+			Expect(errors.As(err, &nonRetryable)).To(BeTrue())
+		})
+
+		It("returns NonRetryableError for empty CloudEvent ID", func() {
+			ce := buildCloudEvent(
+				"",
+				"osac.resource.created.v1",
+				"vm-001",
+				"compute_instance",
+				"tenant-acme",
+				"project-test",
+				nil,
+			)
+
+			_, _, err := translateEvent(ce)
+
+			Expect(err).To(HaveOccurred())
+			var nonRetryable *adapters.NonRetryableError
+			Expect(errors.As(err, &nonRetryable)).To(BeTrue())
+		})
+
+		It("returns NonRetryableError for zero CloudEvent timestamp", func() {
+			ce := cloudevents.NewEvent()
+			ce.SetID("ce-zero-time")
+			ce.SetType("osac.resource.created.v1")
+			ce.SetSource("osac-metering-service")
+			// Deliberately not setting time — ce.Time() returns zero value.
+			ce.SetDataContentType("application/json")
+			ExpectWithOffset(0, ce.SetData(cloudevents.ApplicationJSON, map[string]any{
+				"resource_type": "compute_instance",
+			})).To(Succeed())
+
+			_, _, err := translateEvent(ce)
+
+			Expect(err).To(HaveOccurred())
+			var nonRetryable *adapters.NonRetryableError
+			Expect(errors.As(err, &nonRetryable)).To(BeTrue())
+		})
+
+		It("returns NonRetryableError for malformed billing_dimensions", func() {
+			ce := cloudevents.NewEvent()
+			ce.SetID("ce-bad-dims")
+			ce.SetType("osac.resource.created.v1")
+			ce.SetSource("osac-metering-service")
+			ce.SetSubject("compute_instance/vm-001")
+			ce.SetTime(time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC))
+			ce.SetDataContentType("application/json")
+			ExpectWithOffset(0, ce.SetData(cloudevents.ApplicationJSON, map[string]any{
+				"resource_type":      "compute_instance",
+				"resource_id":        "vm-001",
+				"tenant_id":          "tenant-acme",
+				"billing_dimensions": "not-a-map",
+			})).To(Succeed())
+
+			_, _, err := translateEvent(ce)
+
+			Expect(err).To(HaveOccurred())
+			var nonRetryable *adapters.NonRetryableError
+			Expect(errors.As(err, &nonRetryable)).To(BeTrue())
+		})
+
+		It("returns NonRetryableError for malformed data", func() {
+			ce := cloudevents.NewEvent()
+			ce.SetID("ce-bad")
+			ce.SetType("osac.resource.created.v1")
+			ce.SetSource("osac-metering-service")
+			ce.SetTime(time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC))
+			// Set invalid JSON data
+			ce.DataEncoded = []byte("not-json{{{")
+			ce.SetDataContentType("application/json")
+
+			_, _, err := translateEvent(ce)
+
+			Expect(err).To(HaveOccurred())
+			var nonRetryable *adapters.NonRetryableError
+			Expect(errors.As(err, &nonRetryable)).To(BeTrue())
+		})
+	})
+})

--- a/osac-metering/charts/osac-metering/templates/kafka-secrets-rbac.yaml
+++ b/osac-metering/charts/osac-metering/templates/kafka-secrets-rbac.yaml
@@ -17,6 +17,9 @@ rules:
       {{- if .Values.echoAdapter.enabled }}
       - osac-metering-echo-adapter
       {{- end }}
+      {{- if .Values.m360Adapter.enabled }}
+      - osac-metering-m360-adapter
+      {{- end }}
     verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/osac-metering/charts/osac-metering/templates/m360-adapter-deployment.yaml
+++ b/osac-metering/charts/osac-metering/templates/m360-adapter-deployment.yaml
@@ -1,0 +1,156 @@
+{{- if .Values.m360Adapter.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "osac-metering.fullname" . }}-m360-adapter
+  labels:
+    {{- include "osac-metering.labels" . | nindent 4 }}
+    app.kubernetes.io/component: m360-adapter
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "osac-metering.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: m360-adapter
+  template:
+    metadata:
+      labels:
+        {{- include "osac-metering.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: m360-adapter
+    spec:
+      serviceAccountName: {{ include "osac-metering.fullname" . }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: kafka-secrets
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Mi
+        - name: m360-api-key
+          secret:
+            secretName: {{ required "m360Adapter.m360.apiKeySecret is required when m360Adapter is enabled" .Values.m360Adapter.m360.apiKeySecret }}
+        - name: tmp
+          emptyDir:
+            sizeLimit: 10Mi
+      initContainers:
+        - name: fetch-kafka-secrets
+          image: {{ .Values.cliImage | default "quay.io/openshift/origin-cli:4.20.0" }}
+          env:
+            - name: HOME
+              value: /tmp
+            - name: SOURCE_NS
+              value: {{ include "osac-metering.kafkaClusterNamespace" . }}
+            - name: SASL_SECRET
+              value: osac-metering-m360-adapter
+            - name: CA_SECRET
+              value: {{ include "osac-metering.kafkaCaSecret" . }}
+          volumeMounts:
+            - name: kafka-secrets
+              mountPath: /etc/kafka-secrets
+            - name: tmp
+              mountPath: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          command:
+            - /bin/bash
+            - -euo
+            - pipefail
+            - -c
+            - |
+              DEADLINE=$((SECONDS + 300))
+              wait_for_secret() {
+                local name=$1 ns=$2
+                echo "Waiting for secret ${name} in ${ns} (timeout 5m)..."
+                until oc get secret "${name}" -n "${ns}" > /dev/null 2>&1; do
+                  if [ $SECONDS -ge $DEADLINE ]; then
+                    echo "Timed out waiting for secret ${name} in ${ns}"
+                    exit 1
+                  fi
+                  sleep 5
+                done
+              }
+
+              wait_for_secret "${SASL_SECRET}" "${SOURCE_NS}"
+              wait_for_secret "${CA_SECRET}" "${SOURCE_NS}"
+
+              oc get secret "${SASL_SECRET}" -n "${SOURCE_NS}" -o jsonpath='{.data.password}' | base64 -d > /etc/kafka-secrets/password
+              oc get secret "${CA_SECRET}" -n "${SOURCE_NS}" -o jsonpath='{.data.ca\.crt}' | base64 -d > /etc/kafka-secrets/ca.crt
+              echo "Kafka secrets fetched."
+      containers:
+        - name: m360-adapter
+          image: "{{ required "m360Adapter.image.repository is required when m360Adapter is enabled" .Values.m360Adapter.image.repository }}:{{ required "m360Adapter.image.tag is required when m360Adapter is enabled" .Values.m360Adapter.image.tag }}"
+          imagePullPolicy: {{ .Values.m360Adapter.image.pullPolicy | default "Always" }}
+          env:
+            - name: KAFKA_BROKERS
+              value: {{ include "osac-metering.kafkaBrokers" . | quote }}
+            - name: KAFKA_TLS_ENABLED
+              value: "true"
+            - name: KAFKA_TLS_CA_CERT
+              value: /etc/kafka-secrets/ca.crt
+            - name: KAFKA_SASL_USERNAME
+              value: osac-metering-m360-adapter
+            - name: KAFKA_CONSUMER_GROUP
+              value: osac-metering-m360-adapter
+            - name: KAFKA_SASL_PASSWORD_FILE
+              value: /etc/kafka-secrets/password
+            - name: M360_API_URL
+              value: {{ required "m360Adapter.m360.apiUrl is required when m360Adapter is enabled" .Values.m360Adapter.m360.apiUrl | quote }}
+            - name: M360_API_KEY_FILE
+              value: /etc/m360/api-key
+            - name: M360_API_VERSION
+              value: {{ .Values.m360Adapter.m360.apiVersion | default "v1" | quote }}
+            - name: METRICS_ADDR
+              value: ":8080"
+          volumeMounts:
+            - name: kafka-secrets
+              mountPath: /etc/kafka-secrets
+              readOnly: true
+            - name: m360-api-key
+              mountPath: /etc/m360
+              readOnly: true
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+{{- end }}

--- a/osac-metering/charts/osac-metering/templates/m360-adapter-kafka-user.yaml
+++ b/osac-metering/charts/osac-metering/templates/m360-adapter-kafka-user.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.m360Adapter.enabled }}
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  name: osac-metering-m360-adapter
+  namespace: {{ include "osac-metering.kafkaClusterNamespace" . }}
+  labels:
+    strimzi.io/cluster: {{ include "osac-metering.kafkaClusterName" . }}
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: osac.metering.
+          patternType: prefix
+        operations:
+          - Read
+          - Describe
+        host: "*"
+      - resource:
+          type: group
+          name: osac-metering-m360-adapter
+          patternType: literal
+        operations:
+          - Read
+        host: "*"
+{{- end }}

--- a/osac-metering/charts/osac-metering/templates/m360-adapter-service.yaml
+++ b/osac-metering/charts/osac-metering/templates/m360-adapter-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.m360Adapter.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "osac-metering.fullname" . }}-m360-adapter
+  labels:
+    {{- include "osac-metering.labels" . | nindent 4 }}
+    app.kubernetes.io/component: m360-adapter
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "osac-metering.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: m360-adapter
+{{- end }}

--- a/osac-metering/charts/osac-metering/values.yaml
+++ b/osac-metering/charts/osac-metering/values.yaml
@@ -35,3 +35,15 @@ echoAdapter:
   #   repository: ghcr.io/osac-project/metering-echo-adapter
   #   tag: latest
   #   pullPolicy: Always
+
+## M360 adapter — forwards metering events to Monetize360 Usage API.
+m360Adapter:
+  enabled: false
+  image:
+    repository: ghcr.io/osac-project/metering-m360-adapter
+    tag: latest
+    pullPolicy: Always
+  m360:
+    apiUrl: ""
+    apiKeySecret: ""     # name of K8s Secret with key "api-key"
+    apiVersion: "v1"


### PR DESCRIPTION
## Description

Standalone Go binary that consumes OSAC metering CloudEvents from Kafka and
forwards them to the Monetize360 (M360) Usage API via REST. Implements the
`ProviderAdapter` interface using the existing adapter Runner framework
(Kafka consumption, dedup, retry, offset management all handled by the Runner).

The adapter translates nested CloudEvents to M360's flat payload format and
routes to the correct M360 endpoint by resource type:

| Resource Type | M360 Endpoint |
|---------------|---------------|
| `compute_instance` (VMaaS) | `POST /vmaas/event` |
| `cluster_order` (CaaS) | `POST /caas/event` |
| `maas_inference` (MaaS) | `POST /maas/event` |

Key behaviors:
- Per-event submit (M360 API is per-event; no batch endpoint)
- Defaults to `adapters.AllTopics` (lifecycle, heartbeat, corrections, inference); overridable via `KAFKA_TOPICS` env var (rejects empty override)
- Bearer token auth from K8s Secret file mount
- Error classification: 4xx → non-retryable (except 408/429), 5xx → retryable by Runner
- HTTP 408 (Request Timeout) and 429 (Too Many Requests) treated as retryable
- Null/empty fields replaced with `" "` (space string) per M360 convention
- Non-billable billing_dimensions (nil, empty, zero) are skipped
- billing_dimensions cannot overwrite canonical CloudEvent/data fields
- Malformed billing_dimensions (non-nil, non-map) returns NonRetryableError
- Validates CloudEvent ID (non-empty) and timestamp (non-zero) before translation
- Response body truncated to 256 bytes in error messages to prevent log leakage
- Flush interval uses framework default (10s) — configurable via `FLUSH_INTERVAL` env var
- Rejects negative `FLUSH_INTERVAL` values (prevents `time.NewTicker` panic)
- TLS enabled by default, configurable API version (default `v1`)
- `GET /healthz` — liveness probe (always 200)
- `GET /readyz` — readiness probe (M360 connectivity check, `timeoutSeconds: 5` to accommodate upstream latency)
- Helm deployment gated by `m360Adapter.enabled: false` (disabled by default)
- Helm `required` checks for `apiKeySecret`, `apiUrl`, `image.repository`, `image.tag`
- Graceful HTTP server shutdown on SIGTERM with `ReadHeaderTimeout`
- CI image-build workflow (`build-metering-m360-adapter-image.yaml`) — mirrors echo-adapter workflow

### Files

| File | Purpose |
|------|---------|
| `adapters/cmd/m360-adapter/translate.go` | CloudEvent → flat M360 payload, endpoint routing |
| `adapters/cmd/m360-adapter/client.go` | HTTP client, Bearer auth, error classification |
| `adapters/cmd/m360-adapter/main.go` | Entry point, env config, health/metrics server |
| `adapters/cmd/m360-adapter/m360_adapter_suite_test.go` | Ginkgo suite bootstrap |
| `adapters/Containerfile.m360-adapter` | Multi-stage UBI 10 container build |
| `adapters/Makefile` | `all` default target, `build-m360-adapter`, recursive test/lint |
| `.github/workflows/build-metering-m360-adapter-image.yaml` | CI image build workflow |
| `charts/osac-metering/templates/m360-adapter-*` | Deployment, KafkaUser, Service |
| `charts/osac-metering/templates/kafka-secrets-rbac.yaml` | RBAC for m360-adapter Kafka secret |
| `charts/osac-metering/values.yaml` | `m360Adapter` config section |

## Jira

- [OSAC-3424](https://redhat.atlassian.net/browse/OSAC-3424) — [DEV] Implement M360 adapter
- Epic: [OSAC-3413](https://redhat.atlassian.net/browse/OSAC-3413) — M360 Adapter
- Feature: [OSAC-985](https://redhat.atlassian.net/browse/OSAC-985) — Metering and Usage Tracking

## Not Included

- **Kafka-based ingestion to M360** — deferred to a follow-up story; this PR
  uses REST API only
- **Batch/bulk event submission** — M360 API is per-event, no batch endpoint
  exists
- **M360 account/tenant provisioning** — out of scope
- **DLQ handling** — handled by the Runner framework (no adapter-level changes)
- **Shared schema package** — adapter intentionally decouples from
  metering-service's Go module, depending only on CloudEvents SDK and
  M360 API contract; track as fast-follow if schema drift becomes a concern
- **SHA-pinned Actions / cosign signing** — all repo workflows use floating
  version tags; pinning and signing should be a repo-wide effort, not
  introduced in a single adapter PR
- **Configurable Secret key name** in Helm chart — the adapter expects the
  Secret to have a key named `api-key` (documented in values.yaml); making
  this configurable is a follow-up enhancement
- **`automountServiceAccountToken: false`** — valid security hardening, but
  should be applied consistently across all chart deployments (metering-service,
  echo-adapter, m360-adapter) in a dedicated follow-up

## References

- Metering design: [osac-project/enhancement-proposals/enhancements/OSAC-985-metering-and-usage-tracking/design.md](https://github.com/osac-project/enhancement-proposals/blob/main/enhancements/OSAC-985-metering-and-usage-tracking/design.md)
- M360 API contract (as part of the simulator code): [masayag/osac-m360-integration/](https://github.com/masayag/osac-m360-integration)
- Echo adapter (reference implementation): [adapters/cmd/echo-adapter/](https://github.com/osac-project/osac/tree/main/osac-metering/adapters/cmd/echo-adapter)

## How Has This Been Tested?

23 Ginkgo unit tests across 3 suites (105 total specs):
- **Translation** (13 tests): VMaaS/CaaS/MaaS event translation, null→space
  conversion, empty string→space conversion, `nil` `billing_dimensions` handling,
  non-billable billing_dimensions filtering, malformed billing_dimensions (non-map)
  error, canonical field overwrite protection, unknown `resource_type` error,
  empty CloudEvent ID error, zero timestamp error, malformed CloudEvent error
- **HTTP client** (10 tests): POST with correct URL/auth/body, configurable API
  version, `NonRetryableError` on 400/401, retryable error on 408/429, retryable
  error on 500, context cancellation, health check success/failure

```bash
cd osac-metering/adapters
make test   # 105 specs across 3 suites (Adapters 67, Echo 15, M360 23)
make lint   # 0 issues (recursive ./...)
```

Manual end-to-end testing (adapter → M360 UAT/simulator) to be performed
during deployment validation.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work