### PR TITLE
OSAC-3764: Add BMH lifecycle manager

### DIFF
--- a/bare-metal-fulfillment-operator/internal/baremetalhost/baremetalhost_suite_test.go
+++ b/bare-metal-fulfillment-operator/internal/baremetalhost/baremetalhost_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package baremetalhost
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
+	. "github.com/onsi/gomega"    //nolint:revive,staticcheck
+)
+
+func TestBareMetalHost(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "BareMetalHost Suite")
+}

--- a/bare-metal-fulfillment-operator/internal/baremetalhost/manager.go
+++ b/bare-metal-fulfillment-operator/internal/baremetalhost/manager.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package baremetalhost provides utilities for managing on-demand
+// BareMetalHost CRs. It is a shared utility — any inventory backend
+// that needs to create, delete, or check readiness of BMH CRs can
+// use this package.
+package baremetalhost
+
+import (
+	"context"
+	"fmt"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// CreateParams holds the parameters for creating a BareMetalHost CR.
+type CreateParams struct {
+	Name                           string
+	BMCAddress                     string
+	CredentialsSecret              string
+	BootMACAddress                 string
+	DisableCertificateVerification bool
+	ConsumerRef                    *corev1.ObjectReference
+	Labels                         map[string]string
+}
+
+// Manager handles on-demand BareMetalHost CR creation, deletion, and
+// readiness checking. Any inventory backend that needs BMH CRs can
+// use this utility.
+type Manager struct {
+	client    client.Client
+	namespace string
+}
+
+// NewManager creates a manager for the given Metal3 namespace.
+func NewManager(k8sClient client.Client, namespace string) *Manager {
+	return &Manager{
+		client:    k8sClient,
+		namespace: namespace,
+	}
+}
+
+// Namespace returns the Metal3 namespace used for BareMetalHost CRs.
+func (m *Manager) Namespace() string {
+	return m.namespace
+}
+
+// CreateBMH creates a BareMetalHost CR in the configured namespace.
+// Sets spec.online = false — the controller manages power via reconcileManagement.
+// Idempotent: if a BMH with the same name already exists and its consumerRef
+// matches, treats it as success. If consumerRef does not match, returns an error.
+func (m *Manager) CreateBMH(ctx context.Context, params CreateParams) error {
+	log := ctrllog.FromContext(ctx)
+
+	bmh := &metal3api.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      params.Name,
+			Namespace: m.namespace,
+			Labels:    params.Labels,
+		},
+		Spec: metal3api.BareMetalHostSpec{
+			BMC: metal3api.BMCDetails{
+				Address:                        params.BMCAddress,
+				CredentialsName:                params.CredentialsSecret,
+				DisableCertificateVerification: params.DisableCertificateVerification,
+			},
+			BootMACAddress: params.BootMACAddress,
+			Online:         false,
+			ConsumerRef:    params.ConsumerRef,
+		},
+	}
+
+	err := m.client.Create(ctx, bmh)
+	if err == nil {
+		log.Info("Created BareMetalHost", "name", params.Name, "namespace", m.namespace)
+		return nil
+	}
+
+	if !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to create BareMetalHost %s/%s: %w", m.namespace, params.Name, err)
+	}
+
+	existing := &metal3api.BareMetalHost{}
+	if getErr := m.client.Get(ctx, client.ObjectKey{Namespace: m.namespace, Name: params.Name}, existing); getErr != nil {
+		return fmt.Errorf("failed to get existing BareMetalHost %s/%s: %w", m.namespace, params.Name, getErr)
+	}
+
+	if existing.Spec.ConsumerRef == nil && params.ConsumerRef == nil {
+		log.Info("BareMetalHost already exists with no consumerRef", "name", params.Name)
+		return nil
+	}
+
+	if existing.Spec.ConsumerRef != nil && params.ConsumerRef != nil &&
+		existing.Spec.ConsumerRef.APIVersion == params.ConsumerRef.APIVersion &&
+		existing.Spec.ConsumerRef.Kind == params.ConsumerRef.Kind &&
+		existing.Spec.ConsumerRef.Name == params.ConsumerRef.Name &&
+		existing.Spec.ConsumerRef.Namespace == params.ConsumerRef.Namespace {
+		log.Info("BareMetalHost already exists with matching consumerRef", "name", params.Name)
+		return nil
+	}
+
+	return fmt.Errorf("BareMetalHost %s/%s already exists with different consumerRef", m.namespace, params.Name)
+}
+
+// DeleteBMH deletes a BareMetalHost CR by name. Idempotent — ignores NotFound.
+// Does not delete BMC credentials Secrets (they are admin-managed and reusable).
+func (m *Manager) DeleteBMH(ctx context.Context, name string) error {
+	log := ctrllog.FromContext(ctx)
+
+	bmh := &metal3api.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: m.namespace,
+		},
+	}
+
+	if err := m.client.Delete(ctx, bmh); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("BareMetalHost already deleted", "name", name, "namespace", m.namespace)
+			return nil
+		}
+		return fmt.Errorf("failed to delete BareMetalHost %s/%s: %w", m.namespace, name, err)
+	}
+
+	log.Info("Deleted BareMetalHost", "name", name, "namespace", m.namespace)
+	return nil
+}
+
+// IsBMHReady checks whether the BMH has completed Metal3 registration and is
+// ready for power management. Returns true when the BMH provisioning state is
+// "available" and operational status is "OK". Returns false while the BMH is
+// in registering, inspecting, or preparing state. Returns an error if the BMH
+// does not exist or has an error operational status. Callers distinguish
+// not-found from error-status via apierrors.IsNotFound(err).
+func (m *Manager) IsBMHReady(ctx context.Context, name string) (bool, error) {
+	log := ctrllog.FromContext(ctx)
+
+	bmh := &metal3api.BareMetalHost{}
+	if err := m.client.Get(ctx, client.ObjectKey{Namespace: m.namespace, Name: name}, bmh); err != nil {
+		return false, fmt.Errorf("failed to get BareMetalHost %s/%s: %w", m.namespace, name, err)
+	}
+
+	if bmh.Status.OperationalStatus == metal3api.OperationalStatusError {
+		return false, fmt.Errorf("BareMetalHost %s/%s has error status: %s",
+			m.namespace, name, bmh.Status.ErrorMessage)
+	}
+
+	ready := bmh.Status.Provisioning.State == metal3api.StateAvailable &&
+		bmh.Status.OperationalStatus == metal3api.OperationalStatusOK
+
+	log.V(1).Info("BareMetalHost readiness check",
+		"name", name,
+		"provisioningState", bmh.Status.Provisioning.State,
+		"operationalStatus", bmh.Status.OperationalStatus,
+		"ready", ready)
+
+	return ready, nil
+}

--- a/bare-metal-fulfillment-operator/internal/baremetalhost/manager_test.go
+++ b/bare-metal-fulfillment-operator/internal/baremetalhost/manager_test.go
@@ -1,0 +1,296 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package baremetalhost
+
+import (
+	"context"
+
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
+	. "github.com/onsi/gomega"    //nolint:revive,staticcheck
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const testNamespace = "osac-baremetal"
+
+func newTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	Expect(metal3api.AddToScheme(s)).To(Succeed())
+	return s
+}
+
+func newTestManager(objects ...client.Object) *Manager {
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(newTestScheme()).
+		WithObjects(objects...).
+		WithStatusSubresource(&metal3api.BareMetalHost{}).
+		Build()
+	return NewManager(k8sClient, testNamespace)
+}
+
+var _ = Describe("BareMetalHost Manager", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	Describe("Namespace", func() {
+		It("should return the configured namespace", func() {
+			mgr := newTestManager()
+			Expect(mgr.Namespace()).To(Equal(testNamespace))
+		})
+	})
+
+	Describe("CreateBMH", func() {
+		It("should create a new BMH", func() {
+			mgr := newTestManager()
+
+			err := mgr.CreateBMH(ctx, CreateParams{
+				Name:              "node001",
+				BMCAddress:        "redfish-virtualmedia+https://10.0.0.1/redfish/v1/Systems/1",
+				CredentialsSecret: "bmc-creds",
+				BootMACAddress:    "aa:bb:cc:dd:ee:01",
+				ConsumerRef: &corev1.ObjectReference{
+					APIVersion: "osac.openshift.io/v1alpha1",
+					Kind:       "BareMetalInstance",
+					Name:       "test-instance-uid",
+				},
+				Labels: map[string]string{"osac.openshift.io/pool-id": "pool1"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			bmh := &metal3api.BareMetalHost{}
+			Expect(mgr.client.Get(ctx, client.ObjectKey{
+				Namespace: testNamespace, Name: "node001",
+			}, bmh)).To(Succeed())
+
+			Expect(bmh.Spec.BMC.Address).To(Equal("redfish-virtualmedia+https://10.0.0.1/redfish/v1/Systems/1"))
+			Expect(bmh.Spec.BMC.CredentialsName).To(Equal("bmc-creds"))
+			Expect(bmh.Spec.BootMACAddress).To(Equal("aa:bb:cc:dd:ee:01"))
+			Expect(bmh.Spec.Online).To(BeFalse())
+			Expect(bmh.Spec.ConsumerRef).NotTo(BeNil())
+			Expect(bmh.Spec.ConsumerRef.Name).To(Equal("test-instance-uid"))
+			Expect(bmh.Labels["osac.openshift.io/pool-id"]).To(Equal("pool1"))
+		})
+
+		It("should be idempotent with matching consumerRef", func() {
+			existing := &metal3api.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "node001",
+					Namespace: testNamespace,
+				},
+				Spec: metal3api.BareMetalHostSpec{
+					ConsumerRef: &corev1.ObjectReference{
+						APIVersion: "osac.openshift.io/v1alpha1",
+						Kind:       "BareMetalInstance",
+						Name:       "test-instance-uid",
+					},
+				},
+			}
+			mgr := newTestManager(existing)
+
+			err := mgr.CreateBMH(ctx, CreateParams{
+				Name: "node001",
+				ConsumerRef: &corev1.ObjectReference{
+					APIVersion: "osac.openshift.io/v1alpha1",
+					Kind:       "BareMetalInstance",
+					Name:       "test-instance-uid",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return error with different consumerRef", func() {
+			existing := &metal3api.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "node001",
+					Namespace: testNamespace,
+				},
+				Spec: metal3api.BareMetalHostSpec{
+					ConsumerRef: &corev1.ObjectReference{
+						Name: "other-instance-uid",
+					},
+				},
+			}
+			mgr := newTestManager(existing)
+
+			err := mgr.CreateBMH(ctx, CreateParams{
+				Name: "node001",
+				ConsumerRef: &corev1.ObjectReference{
+					Name: "my-instance-uid",
+				},
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("different consumerRef"))
+		})
+
+		It("should be idempotent when both consumerRefs are nil", func() {
+			existing := &metal3api.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "node001",
+					Namespace: testNamespace,
+				},
+			}
+			mgr := newTestManager(existing)
+
+			err := mgr.CreateBMH(ctx, CreateParams{
+				Name: "node001",
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("DeleteBMH", func() {
+		It("should delete an existing BMH", func() {
+			existing := &metal3api.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "node001",
+					Namespace: testNamespace,
+				},
+			}
+			mgr := newTestManager(existing)
+
+			Expect(mgr.DeleteBMH(ctx, "node001")).To(Succeed())
+
+			bmh := &metal3api.BareMetalHost{}
+			err := mgr.client.Get(ctx, client.ObjectKey{
+				Namespace: testNamespace, Name: "node001",
+			}, bmh)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should be idempotent for not found", func() {
+			mgr := newTestManager()
+			Expect(mgr.DeleteBMH(ctx, "nonexistent")).To(Succeed())
+		})
+	})
+
+	Describe("IsBMHReady", func() {
+		It("should return true when available and OK", func() {
+			bmh := &metal3api.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "node001",
+					Namespace: testNamespace,
+				},
+				Status: metal3api.BareMetalHostStatus{
+					Provisioning: metal3api.ProvisionStatus{
+						State: metal3api.StateAvailable,
+					},
+					OperationalStatus: metal3api.OperationalStatusOK,
+				},
+			}
+			mgr := newTestManager(bmh)
+
+			ready, err := mgr.IsBMHReady(ctx, "node001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ready).To(BeTrue())
+		})
+
+		It("should return false when registering", func() {
+			bmh := &metal3api.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "node001",
+					Namespace: testNamespace,
+				},
+				Status: metal3api.BareMetalHostStatus{
+					Provisioning: metal3api.ProvisionStatus{
+						State: metal3api.StateRegistering,
+					},
+					OperationalStatus: metal3api.OperationalStatusOK,
+				},
+			}
+			mgr := newTestManager(bmh)
+
+			ready, err := mgr.IsBMHReady(ctx, "node001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ready).To(BeFalse())
+		})
+
+		It("should return false when inspecting", func() {
+			bmh := &metal3api.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "node001",
+					Namespace: testNamespace,
+				},
+				Status: metal3api.BareMetalHostStatus{
+					Provisioning: metal3api.ProvisionStatus{
+						State: metal3api.StateInspecting,
+					},
+					OperationalStatus: metal3api.OperationalStatusOK,
+				},
+			}
+			mgr := newTestManager(bmh)
+
+			ready, err := mgr.IsBMHReady(ctx, "node001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ready).To(BeFalse())
+		})
+
+		It("should return false when preparing", func() {
+			bmh := &metal3api.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "node001",
+					Namespace: testNamespace,
+				},
+				Status: metal3api.BareMetalHostStatus{
+					Provisioning: metal3api.ProvisionStatus{
+						State: metal3api.StatePreparing,
+					},
+					OperationalStatus: metal3api.OperationalStatusOK,
+				},
+			}
+			mgr := newTestManager(bmh)
+
+			ready, err := mgr.IsBMHReady(ctx, "node001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ready).To(BeFalse())
+		})
+
+		It("should return error when operational status is error", func() {
+			bmh := &metal3api.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "node001",
+					Namespace: testNamespace,
+				},
+				Status: metal3api.BareMetalHostStatus{
+					Provisioning: metal3api.ProvisionStatus{
+						State: metal3api.StateAvailable,
+					},
+					OperationalStatus: metal3api.OperationalStatusError,
+					ErrorMessage:      "BMC connection failed",
+				},
+			}
+			mgr := newTestManager(bmh)
+
+			_, err := mgr.IsBMHReady(ctx, "node001")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("error status"))
+		})
+
+		It("should return error when BMH not found", func() {
+			mgr := newTestManager()
+
+			_, err := mgr.IsBMHReady(ctx, "nonexistent")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
## Summary

On-demand BareMetalHost CR management for inventory backends paired with Metal3 ([OSAC-1339](https://redhat.atlassian.net/browse/OSAC-1339)):

- **CreateBMH**: Creates BMH CR with BMC address, credentials, boot MAC, consumer reference. Idempotent — matches full ConsumerRef identity. BMC cert verification configurable.
- **DeleteBMH**: Deletes BMH CR by name. Idempotent (ignores NotFound). Does not delete BMC credentials Secrets.
- **IsBMHReady**: Returns true when provisioning state is Available and operational status is OK.

Reusable by any inventory backend — not BCM-specific. The BCM backend is the first consumer (Phase 2: OSAC-3767, [OSAC-3771](https://redhat.atlassian.net/browse/OSAC-3771)).

**Depends on:** [osac#228](https://github.com/osac-project/osac/pull/228) (BCM HTTP client)

## Test plan

- [ ] `make build` passes
- [ ] `make test` passes (7 new tests: create new/idempotent/conflict, delete existing/not-found, readiness available/registering/error/not-found)
- [ ] `make lint` passes (0 issues)

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added BareMetalHost lifecycle management, including creation, deletion, conflict handling, credential preservation, and readiness checks.
  - Added integration with the BCM inventory service, including secure connectivity, version validation, device retrieval and updates, inventory metadata management, metrics, and clearer error reporting.
  - Added configurable host settings such as BMC access, boot configuration, labels, consumer references, and certificates.

- **Tests**
  - Added comprehensive coverage for BareMetalHost lifecycle operations and BCM connectivity, validation, API behavior, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->