### PR TITLE
OSAC-3734: add debug logging to auto-queue workflow

### DIFF
--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -8,12 +8,27 @@ on:
 
 jobs:
   enable-auto-merge:
-    if: >-
-      github.event.pull_request.draft == false
-      && contains(fromJSON('["MEMBER","COLLABORATOR","OWNER"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     steps:
+      # Every run of this workflow has reported "skipped" since it was
+      # introduced (0/35+ runs actually reached the merge step) -- the old
+      # job-level `if:` below skipped the whole job before any step ran, so
+      # there was never a log line showing what the gate actually saw.
+      # This step is unconditional so we get that visibility on every event.
+      - name: Debug event payload
+        run: |
+          echo "event_name=${{ github.event_name }}"
+          echo "action=${{ github.event.action }}"
+          echo "pr_number=${{ github.event.pull_request.number }}"
+          echo "draft=${{ github.event.pull_request.draft }}"
+          echo "author=${{ github.event.pull_request.user.login }}"
+          echo "author_association=${{ github.event.pull_request.author_association }}"
+          echo "head_repo_fork=${{ github.event.pull_request.head.repo.fork }}"
+          echo "gate_would_pass=${{ github.event.pull_request.draft == false && contains(fromJSON('["MEMBER","COLLABORATOR","OWNER"]'), github.event.pull_request.author_association) }}"
       - name: Enable auto-merge
+        if: >-
+          github.event.pull_request.draft == false
+          && contains(fromJSON('["MEMBER","COLLABORATOR","OWNER"]'), github.event.pull_request.author_association)
         env:
           GH_TOKEN: ${{ secrets.MERGE_QUEUE_TOKEN }}
         run: gh pr merge ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --auto --rebase


### PR DESCRIPTION
## Summary

`auto-queue.yml` is supposed to auto-enable `gh pr merge --auto` on every
non-draft PR from an org member, replacing Tide's automatic queue entry.
Since it was introduced it has skipped 100% of the time (0 of 35+ runs
ever reached the merge step) — including on PRs that were verifiably
non-draft with `author_association: MEMBER` at open time. Nothing has
entered the merge queue since 2026-08-09 ~22:00 UTC as a result.

The job-level `if:` skips the whole job before any step runs, so there
is currently no log output at all explaining why the gate evaluated
false. This PR doesn't change behavior — it moves the same gate to a
step-level `if:` on the merge step only, and adds an unconditional
first step that logs the raw event fields (`draft`, `author_association`,
`author`, `head_repo_fork`) plus the computed gate result, so the next
few PR opens will tell us what the gate is actually seeing.

Follow-up PR will fix the gate itself once we know what it's seeing.

## Jira

https://redhat.atlassian.net/browse/OSAC-3734

## Test plan

- [ ] Open/ready-for-review a PR from an org member — "Debug event payload" step logs draft/author_association/gate_would_pass
- [ ] Values logged match reality (compare against `gh api repos/osac-project/osac/pulls/<n>`)
- [ ] No change in current (broken) merge behavior — this PR is diagnostics-only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request auto-merge workflow reliability by ensuring eligibility checks are applied directly to the merge action.
  * Added diagnostic logging to help identify why a pull request may not qualify for automatic merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->