### PR TITLE
OSAC-3610: parameterize hardcoded Keycloak credentials in osac-installer

### DIFF
--- a/osac-installer/Makefile
+++ b/osac-installer/Makefile
@@ -136,4 +136,5 @@ helm-validate: helm-lint ## Validate all charts (lint + template)
 		helm template osac-operators charts/osac-operators/ --values "$$f" > /dev/null; \
 		helm template osac-prereqs charts/osac-prereqs/ --values "$$f" > /dev/null; \
 	done
+	./scripts/validate-keycloak-credentials.sh
 	@echo "Validation passed."

--- a/osac-installer/charts/osac-prereqs/files/hooks/resolve-realm-secrets.sh
+++ b/osac-installer/charts/osac-prereqs/files/hooks/resolve-realm-secrets.sh
@@ -26,12 +26,14 @@ REALM_ADMIN_PASSWORD="${REALM_ADMIN_PASSWORD:?REALM_ADMIN_PASSWORD must be set}"
 
 # REALM_ADMIN_USERNAME/PASSWORD are user-supplied Helm values (unlike the
 # auto-generated base64 client secrets above) substituted into JSON string
-# values, so each needs two escaping passes: first JSON string-escaping
-# (backslash, then quote) since the raw value lands inside a JSON string,
-# then sed replacement-escaping (backslash, ampersand, and the s### delimiter)
-# so sed doesn't reinterpret characters introduced by the JSON escaping.
+# values, so each needs two escaping passes: first full JSON string escaping
+# (via python3's json.dumps, so control characters like tabs/newlines are
+# handled correctly, not just backslash/quote) since the raw value lands
+# inside a JSON string, then sed replacement-escaping (backslash, ampersand,
+# and the s### delimiter) so sed doesn't reinterpret characters introduced
+# by the JSON escaping.
 json_escape_string() {
-    printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+    python3 -c "import json,sys; print(json.dumps(sys.argv[1])[1:-1])" "$1"
 }
 
 escape_sed_replacement() {

--- a/osac-installer/charts/osac-prereqs/files/hooks/resolve-realm-secrets.sh
+++ b/osac-installer/charts/osac-prereqs/files/hooks/resolve-realm-secrets.sh
@@ -21,9 +21,28 @@ ADMIN_SECRET=$(oc get secret "${SECRET_NAME}" -n "${NAMESPACE}" -o jsonpath='{.d
 [[ -n "${CONTROLLER_SECRET}" ]] || { echo "ERROR: ${SECRET_NAME} missing osac-controller key" >&2; exit 1; }
 [[ -n "${ADMIN_SECRET}" ]] || { echo "ERROR: ${SECRET_NAME} missing osac-admin key" >&2; exit 1; }
 
+REALM_ADMIN_USERNAME="${REALM_ADMIN_USERNAME:-admin}"
+REALM_ADMIN_PASSWORD="${REALM_ADMIN_PASSWORD:?REALM_ADMIN_PASSWORD must be set}"
+
+# REALM_ADMIN_USERNAME/PASSWORD are user-supplied Helm values (unlike the
+# auto-generated base64 client secrets above) substituted into JSON string
+# values, so each needs two escaping passes: first JSON string-escaping
+# (backslash, then quote) since the raw value lands inside a JSON string,
+# then sed replacement-escaping (backslash, ampersand, and the s### delimiter)
+# so sed doesn't reinterpret characters introduced by the JSON escaping.
+json_escape_string() {
+    printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+escape_sed_replacement() {
+    printf '%s' "$1" | sed -e 's/[\&#]/\\&/g'
+}
+
 sed \
     -e "s#__OSAC_CONTROLLER_CLIENT_SECRET__#${CONTROLLER_SECRET}#" \
     -e "s#__OSAC_ADMIN_CLIENT_SECRET__#${ADMIN_SECRET}#" \
+    -e "s#__OSAC_REALM_ADMIN_USERNAME__#$(escape_sed_replacement "$(json_escape_string "${REALM_ADMIN_USERNAME}")")#" \
+    -e "s#__OSAC_REALM_ADMIN_PASSWORD__#$(escape_sed_replacement "$(json_escape_string "${REALM_ADMIN_PASSWORD}")")#" \
     "${RAW_REALM}" > "${RESOLVED_REALM}"
 
 echo "Realm secrets resolved -> ${RESOLVED_REALM}"

--- a/osac-installer/charts/osac-prereqs/files/realm.json
+++ b/osac-installer/charts/osac-prereqs/files/realm.json
@@ -537,7 +537,7 @@
   "users": [
     {
       "id": "7aa83fea-6fcd-4167-a8cf-80ed4c3221b7",
-      "username": "admin",
+      "username": "__OSAC_REALM_ADMIN_USERNAME__",
       "firstName": "Administrator",
       "lastName": "User",
       "email": "admin@example.com",
@@ -547,12 +547,9 @@
       "totp": false,
       "credentials": [
         {
-          "id": "85ac82fc-bbcc-49a0-a709-1ac82d9fb37f",
           "type": "password",
-          "userLabel": "My password",
-          "createdDate": 1757683819334,
-          "secretData": "{\"value\":\"ETe90wgj32P+Q1rPLulfMazdek0nF+op9EFkdZllsnE=\",\"salt\":\"QhTSTs3ZpWedDP/H7S7UCg==\",\"additionalParameters\":{}}",
-          "credentialData": "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+          "value": "__OSAC_REALM_ADMIN_PASSWORD__",
+          "temporary": false
         }
       ],
       "disableableCredentialTypes": [],

--- a/osac-installer/charts/osac-prereqs/templates/keycloak/resources.yaml
+++ b/osac-installer/charts/osac-prereqs/templates/keycloak/resources.yaml
@@ -372,6 +372,10 @@ spec:
           value: /realm-raw/realm.json
         - name: REALM_OUTPUT_PATH
           value: /realm/realm.json
+        - name: REALM_ADMIN_USERNAME
+          value: {{ .Values.keycloak.adminUsername | quote }}
+        - name: REALM_ADMIN_PASSWORD
+          value: {{ .Values.keycloak.adminPassword | quote }}
         volumeMounts:
         - name: scripts
           mountPath: /scripts
@@ -397,9 +401,9 @@ spec:
           readOnly: true
         env:
         - name: KEYCLOAK_ADMIN
-          value: admin
+          value: {{ .Values.keycloak.adminUsername | quote }}
         - name: KEYCLOAK_ADMIN_PASSWORD
-          value: admin
+          value: {{ .Values.keycloak.adminPassword | quote }}
         - name: KC_HTTP_ENABLED
           value: "false"
         - name: KC_HTTPS_ENABLED
@@ -499,33 +503,38 @@ data:
         -H 'Content-Type: application/x-www-form-urlencoded' \
         -d 'grant_type=password' \
         -d 'client_id=admin-cli' \
-        -d 'username=admin' \
-        -d 'password=admin' | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+        --data-urlencode "username=${ADMIN_USERNAME}" \
+        --data-urlencode "password=${ADMIN_PASSWORD}" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
       [[ -n "${TOKEN}" ]] || { echo "ERROR: Could not get admin token"; return 1; }
 
       USER_ID=$(curl -k -sf -X GET "https://keycloak:443/admin/realms/osac/users?username=$username" \
         -H "Authorization: Bearer $TOKEN" | python3 -c "import sys,json; print(json.load(sys.stdin)[0]['id'])")
       [[ -n "${USER_ID}" ]] || { echo "ERROR: Could not find user: $username"; return 1; }
 
+      # Build the JSON body with python3 (already used above for parsing)
+      # rather than hand-rolled bash string interpolation, so $password can
+      # safely contain quotes, backslashes, or other JSON-significant chars.
+      PAYLOAD=$(python3 -c "import json,sys; print(json.dumps({'type': 'password', 'value': sys.argv[1], 'temporary': False}))" "$password")
+
       curl -k -sf -X PUT "https://keycloak:443/admin/realms/osac/users/$USER_ID/reset-password" \
         -H "Authorization: Bearer $TOKEN" \
         -H "Content-Type: application/json" \
-        -d "{\"type\":\"password\",\"value\":\"$password\",\"temporary\":false}"
+        -d "$PAYLOAD"
 
       echo "Set password for $username"
     }
 
     # Set all passwords
     echo "Setting passwords for all tenant users..."
-    set_password "tenant1_admin" "foobar"
-    set_password "tenant1_user" "foobar"
-    set_password "tenant2_admin" "foobar"
-    set_password "tenant2_user" "foobar"
-    set_password "twotenant" "foobar"
-    set_password "my_user" "foobar"
-    set_password "your_user" "foobar"
+    set_password "tenant1_admin" "${DEFAULT_USER_PASSWORD}"
+    set_password "tenant1_user" "${DEFAULT_USER_PASSWORD}"
+    set_password "tenant2_admin" "${DEFAULT_USER_PASSWORD}"
+    set_password "tenant2_user" "${DEFAULT_USER_PASSWORD}"
+    set_password "twotenant" "${DEFAULT_USER_PASSWORD}"
+    set_password "my_user" "${DEFAULT_USER_PASSWORD}"
+    set_password "your_user" "${DEFAULT_USER_PASSWORD}"
 
-    echo "All passwords set to 'foobar'"
+    echo "All demo-user passwords set"
 ---
 apiVersion: batch/v1
 kind: Job
@@ -554,6 +563,12 @@ spec:
         env:
         - name: HOME
           value: /tmp
+        - name: ADMIN_USERNAME
+          value: {{ .Values.keycloak.adminUsername | quote }}
+        - name: ADMIN_PASSWORD
+          value: {{ .Values.keycloak.adminPassword | quote }}
+        - name: DEFAULT_USER_PASSWORD
+          value: {{ .Values.keycloak.defaultUserPassword | quote }}
         resources:
           requests:
             cpu: 50m

--- a/osac-installer/charts/osac-prereqs/templates/keycloak/resources.yaml
+++ b/osac-installer/charts/osac-prereqs/templates/keycloak/resources.yaml
@@ -136,6 +136,19 @@ data:
 {{ $.Files.Get "files/hooks/resolve-realm-secrets.sh" | indent 4 }}
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-admin-credentials
+  namespace: keycloak
+  labels:
+    {{- include "osac-prereqs.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  admin-username: {{ .Values.keycloak.adminUsername | quote }}
+  admin-password: {{ .Values.keycloak.adminPassword | quote }}
+  default-user-password: {{ .Values.keycloak.defaultUserPassword | quote }}
+---
+apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: keycloak-database
@@ -373,9 +386,15 @@ spec:
         - name: REALM_OUTPUT_PATH
           value: /realm/realm.json
         - name: REALM_ADMIN_USERNAME
-          value: {{ .Values.keycloak.adminUsername | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: keycloak-admin-credentials
+              key: admin-username
         - name: REALM_ADMIN_PASSWORD
-          value: {{ .Values.keycloak.adminPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: keycloak-admin-credentials
+              key: admin-password
         volumeMounts:
         - name: scripts
           mountPath: /scripts
@@ -401,9 +420,15 @@ spec:
           readOnly: true
         env:
         - name: KEYCLOAK_ADMIN
-          value: {{ .Values.keycloak.adminUsername | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: keycloak-admin-credentials
+              key: admin-username
         - name: KEYCLOAK_ADMIN_PASSWORD
-          value: {{ .Values.keycloak.adminPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: keycloak-admin-credentials
+              key: admin-password
         - name: KC_HTTP_ENABLED
           value: "false"
         - name: KC_HTTPS_ENABLED
@@ -564,11 +589,20 @@ spec:
         - name: HOME
           value: /tmp
         - name: ADMIN_USERNAME
-          value: {{ .Values.keycloak.adminUsername | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: keycloak-admin-credentials
+              key: admin-username
         - name: ADMIN_PASSWORD
-          value: {{ .Values.keycloak.adminPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: keycloak-admin-credentials
+              key: admin-password
         - name: DEFAULT_USER_PASSWORD
-          value: {{ .Values.keycloak.defaultUserPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: keycloak-admin-credentials
+              key: default-user-password
         resources:
           requests:
             cpu: 50m

--- a/osac-installer/charts/osac-prereqs/values.yaml
+++ b/osac-installer/charts/osac-prereqs/values.yaml
@@ -15,6 +15,9 @@ keycloak:
   enabled: true
   realmOverwrite: true
   hostname: "keycloak.keycloak.svc.cluster.local"
+  adminUsername: admin
+  adminPassword: admin
+  defaultUserPassword: foobar
   route:
     hostname: ""
   images:

--- a/osac-installer/prerequisites/keycloak/service/deployment.yaml
+++ b/osac-installer/prerequisites/keycloak/service/deployment.yaml
@@ -73,7 +73,7 @@ spec:
           ADMIN_SECRET=$(oc get secret keycloak-client-secrets -o jsonpath='{.data.osac-admin}' | base64 -d)
           [[ -n "${CONTROLLER_SECRET}" && -n "${ADMIN_SECRET}" ]] || { echo "ERROR: keycloak-client-secrets is missing osac-controller or osac-admin" >&2; exit 1; }
           [[ -n "${REALM_ADMIN_USERNAME}" && -n "${REALM_ADMIN_PASSWORD}" ]] || { echo "ERROR: keycloak-admin-credentials is missing admin-username or admin-password" >&2; exit 1; }
-          json_escape_string() { printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'; }
+          json_escape_string() { python3 -c "import json,sys; print(json.dumps(sys.argv[1])[1:-1])" "$1"; }
           escape_sed_replacement() { printf '%s' "$1" | sed -e 's/[\&#]/\\&/g'; }
           sed \
             -e "s#__OSAC_CONTROLLER_CLIENT_SECRET__#${CONTROLLER_SECRET}#" \

--- a/osac-installer/prerequisites/keycloak/service/deployment.yaml
+++ b/osac-installer/prerequisites/keycloak/service/deployment.yaml
@@ -10,6 +10,11 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 #
+# Prerequisite: create the keycloak-admin-credentials secret before applying, e.g.:
+#   oc create secret generic keycloak-admin-credentials -n keycloak \
+#     --from-literal=admin-username=<your-admin-username> \
+#     --from-literal=admin-password=<your-admin-password> \
+#     --from-literal=default-user-password=<your-default-user-password>
 
 apiVersion: apps/v1
 kind: Deployment
@@ -67,10 +72,26 @@ spec:
           CONTROLLER_SECRET=$(oc get secret keycloak-client-secrets -o jsonpath='{.data.osac-controller}' | base64 -d)
           ADMIN_SECRET=$(oc get secret keycloak-client-secrets -o jsonpath='{.data.osac-admin}' | base64 -d)
           [[ -n "${CONTROLLER_SECRET}" && -n "${ADMIN_SECRET}" ]] || { echo "ERROR: keycloak-client-secrets is missing osac-controller or osac-admin" >&2; exit 1; }
+          [[ -n "${REALM_ADMIN_USERNAME}" && -n "${REALM_ADMIN_PASSWORD}" ]] || { echo "ERROR: keycloak-admin-credentials is missing admin-username or admin-password" >&2; exit 1; }
+          json_escape_string() { printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'; }
+          escape_sed_replacement() { printf '%s' "$1" | sed -e 's/[\&#]/\\&/g'; }
           sed \
             -e "s#__OSAC_CONTROLLER_CLIENT_SECRET__#${CONTROLLER_SECRET}#" \
             -e "s#__OSAC_ADMIN_CLIENT_SECRET__#${ADMIN_SECRET}#" \
+            -e "s#__OSAC_REALM_ADMIN_USERNAME__#$(escape_sed_replacement "$(json_escape_string "${REALM_ADMIN_USERNAME}")")#" \
+            -e "s#__OSAC_REALM_ADMIN_PASSWORD__#$(escape_sed_replacement "$(json_escape_string "${REALM_ADMIN_PASSWORD}")")#" \
             /realm-raw/realm.json > /realm/realm.json
+        env:
+        - name: REALM_ADMIN_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: keycloak-admin-credentials
+              key: admin-username
+        - name: REALM_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: keycloak-admin-credentials
+              key: admin-password
         volumeMounts:
         - name: realm-raw
           mountPath: /realm-raw
@@ -93,9 +114,15 @@ spec:
           readOnly: true
         env:
         - name: KEYCLOAK_ADMIN
-          value: admin
+          valueFrom:
+            secretKeyRef:
+              name: keycloak-admin-credentials
+              key: admin-username
         - name: KEYCLOAK_ADMIN_PASSWORD
-          value: admin
+          valueFrom:
+            secretKeyRef:
+              name: keycloak-admin-credentials
+              key: admin-password
         - name: KC_HOSTNAME_STRICT
           value: "true"
         - name: KC_HOSTNAME_STRICT_HTTPS

--- a/osac-installer/prerequisites/keycloak/service/files/realm.json
+++ b/osac-installer/prerequisites/keycloak/service/files/realm.json
@@ -537,7 +537,7 @@
   "users": [
     {
       "id": "7aa83fea-6fcd-4167-a8cf-80ed4c3221b7",
-      "username": "admin",
+      "username": "__OSAC_REALM_ADMIN_USERNAME__",
       "firstName": "Administrator",
       "lastName": "User",
       "email": "admin@example.com",
@@ -547,12 +547,9 @@
       "totp": false,
       "credentials": [
         {
-          "id": "85ac82fc-bbcc-49a0-a709-1ac82d9fb37f",
           "type": "password",
-          "userLabel": "My password",
-          "createdDate": 1757683819334,
-          "secretData": "{\"value\":\"ETe90wgj32P+Q1rPLulfMazdek0nF+op9EFkdZllsnE=\",\"salt\":\"QhTSTs3ZpWedDP/H7S7UCg==\",\"additionalParameters\":{}}",
-          "credentialData": "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+          "value": "__OSAC_REALM_ADMIN_PASSWORD__",
+          "temporary": false
         }
       ],
       "disableableCredentialTypes": [],

--- a/osac-installer/prerequisites/keycloak/service/password-setup-job.yaml
+++ b/osac-installer/prerequisites/keycloak/service/password-setup-job.yaml
@@ -54,14 +54,15 @@ data:
         return 1
       fi
 
-      # Set password. JSON-escape $password (backslash, then quote) before
-      # interpolating -- it's a configurable value, not a fixed literal, and
-      # could otherwise break the request body or inject into it.
-      ESCAPED_PASSWORD=$(printf '%s' "$password" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+      # Build the JSON body with python3 rather than hand-rolled bash string
+      # escaping, so $password can safely contain quotes, backslashes,
+      # control characters, or other JSON-significant chars -- it's a
+      # configurable value now, not a fixed literal.
+      PAYLOAD=$(python3 -c "import json,sys; print(json.dumps({'type': 'password', 'value': sys.argv[1], 'temporary': False}))" "$password")
       curl -k -s -X PUT "https://keycloak:443/admin/realms/osac/users/$USER_ID/reset-password" \
         -H "Authorization: Bearer $TOKEN" \
         -H "Content-Type: application/json" \
-        -d "{\"type\":\"password\",\"value\":\"$ESCAPED_PASSWORD\",\"temporary\":false}" 2>/dev/null
+        -d "$PAYLOAD" 2>/dev/null
 
       echo "✓ Set password for $username"
     }

--- a/osac-installer/prerequisites/keycloak/service/password-setup-job.yaml
+++ b/osac-installer/prerequisites/keycloak/service/password-setup-job.yaml
@@ -59,10 +59,10 @@ data:
       # control characters, or other JSON-significant chars -- it's a
       # configurable value now, not a fixed literal.
       PAYLOAD=$(python3 -c "import json,sys; print(json.dumps({'type': 'password', 'value': sys.argv[1], 'temporary': False}))" "$password")
-      curl -k -s -X PUT "https://keycloak:443/admin/realms/osac/users/$USER_ID/reset-password" \
+      curl -k -fsS -X PUT "https://keycloak:443/admin/realms/osac/users/$USER_ID/reset-password" \
         -H "Authorization: Bearer $TOKEN" \
         -H "Content-Type: application/json" \
-        -d "$PAYLOAD" 2>/dev/null
+        -d "$PAYLOAD"
 
       echo "✓ Set password for $username"
     }

--- a/osac-installer/prerequisites/keycloak/service/password-setup-job.yaml
+++ b/osac-installer/prerequisites/keycloak/service/password-setup-job.yaml
@@ -10,6 +10,7 @@
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 #
+# Prerequisite: create the keycloak-admin-credentials secret before applying (see deployment.yaml).
 
 apiVersion: v1
 kind: ConfigMap
@@ -36,8 +37,8 @@ data:
         -H 'Content-Type: application/x-www-form-urlencoded' \
         -d 'grant_type=password' \
         -d 'client_id=admin-cli' \
-        -d 'username=admin' \
-        -d 'password=admin' 2>/dev/null | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)
+        --data-urlencode "username=${ADMIN_USERNAME}" \
+        --data-urlencode "password=${ADMIN_PASSWORD}" 2>/dev/null | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)
 
       if [ -z "$TOKEN" ]; then
         echo "Could not get admin token"
@@ -53,26 +54,29 @@ data:
         return 1
       fi
 
-      # Set password
+      # Set password. JSON-escape $password (backslash, then quote) before
+      # interpolating -- it's a configurable value, not a fixed literal, and
+      # could otherwise break the request body or inject into it.
+      ESCAPED_PASSWORD=$(printf '%s' "$password" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
       curl -k -s -X PUT "https://keycloak:443/admin/realms/osac/users/$USER_ID/reset-password" \
         -H "Authorization: Bearer $TOKEN" \
         -H "Content-Type: application/json" \
-        -d "{\"type\":\"password\",\"value\":\"$password\",\"temporary\":false}" 2>/dev/null
+        -d "{\"type\":\"password\",\"value\":\"$ESCAPED_PASSWORD\",\"temporary\":false}" 2>/dev/null
 
       echo "✓ Set password for $username"
     }
 
     # Set all passwords
     echo "Setting passwords for all tenant users..."
-    set_password "tenant1_admin" "foobar"
-    set_password "tenant1_user" "foobar"
-    set_password "tenant2_admin" "foobar"
-    set_password "tenant2_user" "foobar"
-    set_password "twotenant" "foobar"
-    set_password "my_user" "foobar"
-    set_password "your_user" "foobar"
+    set_password "tenant1_admin" "${DEFAULT_USER_PASSWORD}"
+    set_password "tenant1_user" "${DEFAULT_USER_PASSWORD}"
+    set_password "tenant2_admin" "${DEFAULT_USER_PASSWORD}"
+    set_password "tenant2_user" "${DEFAULT_USER_PASSWORD}"
+    set_password "twotenant" "${DEFAULT_USER_PASSWORD}"
+    set_password "my_user" "${DEFAULT_USER_PASSWORD}"
+    set_password "your_user" "${DEFAULT_USER_PASSWORD}"
 
-    echo "✓ All passwords set to 'foobar'"
+    echo "✓ All demo-user passwords set"
 ---
 apiVersion: batch/v1
 kind: Job
@@ -89,6 +93,22 @@ spec:
         command:
         - /bin/bash
         - /scripts/set-passwords.sh
+        env:
+        - name: ADMIN_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: keycloak-admin-credentials
+              key: admin-username
+        - name: ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: keycloak-admin-credentials
+              key: admin-password
+        - name: DEFAULT_USER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: keycloak-admin-credentials
+              key: default-user-password
         volumeMounts:
         - name: scripts
           mountPath: /scripts

--- a/osac-installer/scripts/validate-keycloak-credentials.sh
+++ b/osac-installer/scripts/validate-keycloak-credentials.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Regression test for OSAC-3610: Keycloak admin/demo-user credentials must be
+# overridable via Helm values, not hardcoded. Verifies:
+#   1. Defaults render as today's literals (admin/admin/foobar) -- no
+#      behavior change for installs that don't override anything.
+#   2. --set overrides actually propagate into the rendered manifests --
+#      this is the core regression: before the fix, no override existed.
+#   3. resolve-realm-secrets.sh's sed substitution handles passwords
+#      containing sed/regex metacharacters without corrupting the JSON.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="${SCRIPT_DIR}/../charts/osac-prereqs"
+FAILURES=0
+
+fail() {
+    echo "FAIL: $1" >&2
+    FAILURES=$((FAILURES + 1))
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" description="$3"
+    if ! grep -qF -- "${needle}" <<<"${haystack}"; then
+        fail "${description} -- expected to find: ${needle}"
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" description="$3"
+    if grep -qF -- "${needle}" <<<"${haystack}"; then
+        fail "${description} -- did not expect to find: ${needle}"
+    fi
+}
+
+echo "=== Test 1: defaults preserve today's literals ==="
+DEFAULT_RENDER=$(helm template "${CHART_DIR}")
+assert_contains "${DEFAULT_RENDER}" 'name: KEYCLOAK_ADMIN
+          value: "admin"' "Default KEYCLOAK_ADMIN"
+assert_contains "${DEFAULT_RENDER}" 'name: KEYCLOAK_ADMIN_PASSWORD
+          value: "admin"' "Default KEYCLOAK_ADMIN_PASSWORD"
+assert_contains "${DEFAULT_RENDER}" 'name: DEFAULT_USER_PASSWORD
+          value: "foobar"' "Default DEFAULT_USER_PASSWORD"
+
+echo "=== Test 2: --set overrides propagate (the actual regression) ==="
+OVERRIDE_RENDER=$(helm template "${CHART_DIR}" \
+    --set keycloak.adminUsername=demo-admin \
+    --set keycloak.adminPassword=SuperSecret123 \
+    --set keycloak.defaultUserPassword=DemoUserPass456)
+assert_contains "${OVERRIDE_RENDER}" 'name: KEYCLOAK_ADMIN
+          value: "demo-admin"' "Overridden KEYCLOAK_ADMIN"
+assert_contains "${OVERRIDE_RENDER}" 'name: KEYCLOAK_ADMIN_PASSWORD
+          value: "SuperSecret123"' "Overridden KEYCLOAK_ADMIN_PASSWORD"
+assert_contains "${OVERRIDE_RENDER}" 'name: DEFAULT_USER_PASSWORD
+          value: "DemoUserPass456"' "Overridden DEFAULT_USER_PASSWORD"
+assert_not_contains "${OVERRIDE_RENDER}" 'value: "admin"' "Overridden render must not retain hardcoded admin literal"
+assert_not_contains "${OVERRIDE_RENDER}" 'value: "foobar"' "Overridden render must not retain hardcoded foobar literal"
+
+echo "=== Test 3: realm.json placeholders present, no baked-in credential hash ==="
+assert_contains "${DEFAULT_RENDER}" '__OSAC_REALM_ADMIN_USERNAME__' "realm.json admin username placeholder"
+assert_contains "${DEFAULT_RENDER}" '__OSAC_REALM_ADMIN_PASSWORD__' "realm.json admin password placeholder"
+assert_not_contains "${DEFAULT_RENDER}" 'ETe90wgj32P' "Static argon2 password hash must be removed from realm.json"
+
+echo "=== Test 4: resolve-realm-secrets.sh substitution survives special characters ==="
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+cat >"${TMP_DIR}/realm-raw.json" <<'EOF'
+{"username": "__OSAC_REALM_ADMIN_USERNAME__", "credentials": [{"type": "password", "value": "__OSAC_REALM_ADMIN_PASSWORD__", "temporary": false}]}
+EOF
+
+# Stub `oc` so the hook script's client-secret bootstrap path is exercised
+# without a real cluster: existence check reports "not found" once (forcing
+# the generate branch), then jsonpath lookups return fixed base64 values.
+mkdir -p "${TMP_DIR}/bin"
+cat >"${TMP_DIR}/bin/oc" <<'EOF'
+#!/usr/bin/env bash
+args="$*"
+case "${args}" in
+  *"-o jsonpath="*osac-controller*) printf '%s' "$(printf 'controller-secret' | base64)" ;;
+  *"-o jsonpath="*osac-admin*)      printf '%s' "$(printf 'admin-secret' | base64)" ;;
+  *"create secret"*)                exit 0 ;;
+  *"get secret"*)                   exit 1 ;;  # existence check: force the "generate" branch
+  *)                                exit 0 ;;
+esac
+EOF
+chmod +x "${TMP_DIR}/bin/oc"
+
+PATH="${TMP_DIR}/bin:${PATH}" \
+REALM_RAW_PATH="${TMP_DIR}/realm-raw.json" \
+REALM_OUTPUT_PATH="${TMP_DIR}/realm-resolved.json" \
+REALM_ADMIN_USERNAME="demo-admin" \
+REALM_ADMIN_PASSWORD='test-p@ss#word&with\slash/chars' \
+    bash "${CHART_DIR}/files/hooks/resolve-realm-secrets.sh" >/dev/null 2>&1 || {
+        fail "resolve-realm-secrets.sh exited non-zero"
+    }
+
+if [[ -f "${TMP_DIR}/realm-resolved.json" ]]; then
+    RESOLVED=$(cat "${TMP_DIR}/realm-resolved.json")
+    DECODED_PASSWORD=$(python3 -c "import json; print(json.load(open('${TMP_DIR}/realm-resolved.json'))['credentials'][0]['value'])" 2>/dev/null) || {
+        fail "Resolved realm.json is not valid JSON after substituting a password with sed/JSON metacharacters"
+    }
+    # Compare the JSON-decoded value, not the raw file text -- valid JSON
+    # necessarily re-escapes the backslash as \\, so the raw bytes never
+    # contain the password's literal backslash form.
+    if [[ "${DECODED_PASSWORD}" != 'test-p@ss#word&with\slash/chars' ]]; then
+        fail "Resolved realm.json's decoded password does not match the original -- got: ${DECODED_PASSWORD}"
+    fi
+    assert_not_contains "${RESOLVED}" '__OSAC_REALM_ADMIN_PASSWORD__' "Placeholder must be fully substituted"
+else
+    fail "resolve-realm-secrets.sh did not produce ${TMP_DIR}/realm-resolved.json"
+fi
+
+echo "=== Test 5: demo-user reset-password JSON body handles quote/backslash chars ==="
+# Extracts and executes the ACTUAL embedded set-passwords.sh scripts (not a
+# reimplementation) against a stubbed curl, so a future edit to either
+# script's escaping logic is caught here rather than silently regressing.
+DEMO_PASSWORD='pass"with\backslash'
+
+mkdir -p "${TMP_DIR}/curlbin"
+CAPTURE_FILE="${TMP_DIR}/captured_reset_password_payload.json"
+cat >"${TMP_DIR}/curlbin/curl" <<EOF
+#!/usr/bin/env bash
+args="\$*"
+case "\${args}" in
+  *"reset-password"*)
+    # Most specific match first: find the argument immediately following -d
+    # and capture it, before any less-specific pattern below can match.
+    prev=""
+    for a in "\$@"; do
+      if [[ "\${prev}" == "-d" ]]; then
+        printf '%s' "\${a}" > "${CAPTURE_FILE}"
+      fi
+      prev="\${a}"
+    done
+    exit 0
+    ;;
+  *"protocol/openid-connect/token"*) echo '{"access_token":"fake-token"}' ;;
+  *"/users?username="*) echo '[{"id":"fake-user-id"}]' ;;
+  *) exit 0 ;;  # bare readiness-check GET (https://keycloak:443/realms/osac, no distinguishing flag)
+esac
+EOF
+chmod +x "${TMP_DIR}/curlbin/curl"
+
+run_set_password_script() {
+    local script_content="$1"
+    rm -f "${CAPTURE_FILE}"
+    echo "${script_content}" > "${TMP_DIR}/extracted-set-passwords.sh"
+    PATH="${TMP_DIR}/curlbin:${PATH}" \
+    ADMIN_USERNAME="demo-admin" \
+    ADMIN_PASSWORD="admin-pw" \
+    DEFAULT_USER_PASSWORD="${DEMO_PASSWORD}" \
+        bash "${TMP_DIR}/extracted-set-passwords.sh" >/dev/null 2>&1 || true
+}
+
+# --- Chart Job's actual embedded script, extracted from the real rendered manifest ---
+CHART_SCRIPT=$(python3 -c "
+import yaml, sys
+docs = yaml.safe_load_all(sys.stdin.read())
+for d in docs:
+    if d and d.get('kind') == 'ConfigMap' and d.get('metadata', {}).get('name') == 'keycloak-password-setup' and d.get('metadata', {}).get('namespace') == 'keycloak':
+        print(d['data']['set-passwords.sh'])
+        break
+" <<<"${DEFAULT_RENDER}")
+[[ -n "${CHART_SCRIPT}" ]] || fail "Could not extract set-passwords.sh from the rendered chart manifest"
+
+if [[ -n "${CHART_SCRIPT}" ]]; then
+    run_set_password_script "${CHART_SCRIPT}"
+    if [[ -f "${CAPTURE_FILE}" ]]; then
+        DECODED=$(python3 -c "import json; print(json.load(open('${CAPTURE_FILE}'))['value'])" 2>/dev/null) || {
+            fail "Chart Job's actual set-passwords.sh produced an invalid JSON reset-password body for a password with quote/backslash"
+        }
+        [[ "${DECODED}" == "${DEMO_PASSWORD}" ]] || fail "Chart Job's actual set-passwords.sh reset-password body does not round-trip the password -- got: ${DECODED}"
+    else
+        fail "Chart Job's actual set-passwords.sh never reached the reset-password call"
+    fi
+fi
+
+# --- Static reference manifest's actual embedded script, extracted directly from the YAML file ---
+STATIC_SCRIPT=$(python3 -c "
+import yaml
+with open('${SCRIPT_DIR}/../prerequisites/keycloak/service/password-setup-job.yaml') as f:
+    docs = list(yaml.safe_load_all(f))
+for d in docs:
+    if d and d.get('kind') == 'ConfigMap' and d.get('metadata', {}).get('name') == 'keycloak-password-setup':
+        print(d['data']['set-passwords.sh'])
+        break
+")
+[[ -n "${STATIC_SCRIPT}" ]] || fail "Could not extract set-passwords.sh from the static reference manifest"
+
+if [[ -n "${STATIC_SCRIPT}" ]]; then
+    run_set_password_script "${STATIC_SCRIPT}"
+    if [[ -f "${CAPTURE_FILE}" ]]; then
+        DECODED=$(python3 -c "import json; print(json.load(open('${CAPTURE_FILE}'))['value'])" 2>/dev/null) || {
+            fail "Static reference manifest's actual set-passwords.sh produced an invalid JSON reset-password body for a password with quote/backslash"
+        }
+        [[ "${DECODED}" == "${DEMO_PASSWORD}" ]] || fail "Static reference manifest's actual set-passwords.sh reset-password body does not round-trip the password -- got: ${DECODED}"
+    else
+        fail "Static reference manifest's actual set-passwords.sh never reached the reset-password call"
+    fi
+fi
+
+echo
+if [[ "${FAILURES}" -gt 0 ]]; then
+    echo "${FAILURES} check(s) failed."
+    exit 1
+fi
+echo "All Keycloak credential parameterization checks passed."

--- a/osac-installer/scripts/validate-keycloak-credentials.sh
+++ b/osac-installer/scripts/validate-keycloak-credentials.sh
@@ -9,6 +9,14 @@
 #      containing sed/regex metacharacters without corrupting the JSON.
 set -euo pipefail
 
+python3 -c "import yaml" 2>/dev/null || {
+    echo "ERROR: PyYAML is required to run this script (used to extract embedded" >&2
+    echo "scripts and structural fields from rendered/static manifests)." >&2
+    echo "Install it with: pip install pyyaml  (already present in the workspace's" >&2
+    echo "documented dev Containerfile via python3-pyyaml)." >&2
+    exit 1
+}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHART_DIR="${SCRIPT_DIR}/../charts/osac-prereqs"
 FAILURES=0
@@ -32,28 +40,62 @@ assert_not_contains() {
     fi
 }
 
-echo "=== Test 1: defaults preserve today's literals ==="
-DEFAULT_RENDER=$(helm template "${CHART_DIR}")
-assert_contains "${DEFAULT_RENDER}" 'name: KEYCLOAK_ADMIN
-          value: "admin"' "Default KEYCLOAK_ADMIN"
-assert_contains "${DEFAULT_RENDER}" 'name: KEYCLOAK_ADMIN_PASSWORD
-          value: "admin"' "Default KEYCLOAK_ADMIN_PASSWORD"
-assert_contains "${DEFAULT_RENDER}" 'name: DEFAULT_USER_PASSWORD
-          value: "foobar"' "Default DEFAULT_USER_PASSWORD"
+# Structural check: does the given Deployment/Job's named container/
+# initContainer have an env var sourced from the expected Secret name/key
+# (not a plaintext `value:`)? Uses PyYAML for a real structural check rather
+# than brittle multi-line grep -F (which silently splits multi-line needles
+# into OR'd single-line alternatives -- see Test 7's comment below).
+assert_secret_key_ref() {
+    local render="$1" kind="$2" resource_name="$3" container_name="$4" env_name="$5" expected_secret="$6" expected_key="$7" description="$8"
+    python3 -c "
+import yaml, sys
+docs = list(yaml.safe_load_all(sys.stdin.read()))
+for d in docs:
+    if not d or d.get('kind') != '${kind}' or d.get('metadata', {}).get('name') != '${resource_name}':
+        continue
+    spec = d['spec']['template']['spec']
+    for c in spec.get('containers', []) + spec.get('initContainers', []):
+        if c.get('name') != '${container_name}':
+            continue
+        for e in c.get('env', []):
+            if e.get('name') == '${env_name}':
+                ref = e.get('valueFrom', {}).get('secretKeyRef', {})
+                sys.exit(0 if ref.get('name') == '${expected_secret}' and ref.get('key') == '${expected_key}' else 1)
+sys.exit(1)
+" <<<"${render}" || fail "${description}"
+}
 
-echo "=== Test 2: --set overrides propagate (the actual regression) ==="
+echo "=== Test 1: defaults preserve today's literals (via the keycloak-admin-credentials Secret) ==="
+DEFAULT_RENDER=$(helm template "${CHART_DIR}")
+assert_contains "${DEFAULT_RENDER}" 'admin-username: "admin"' "Default admin-username in keycloak-admin-credentials Secret"
+assert_contains "${DEFAULT_RENDER}" 'admin-password: "admin"' "Default admin-password in keycloak-admin-credentials Secret"
+assert_contains "${DEFAULT_RENDER}" 'default-user-password: "foobar"' "Default default-user-password in keycloak-admin-credentials Secret"
+assert_secret_key_ref "${DEFAULT_RENDER}" Deployment keycloak-service keycloak KEYCLOAK_ADMIN keycloak-admin-credentials admin-username "Deployment's KEYCLOAK_ADMIN must source from keycloak-admin-credentials/admin-username"
+assert_secret_key_ref "${DEFAULT_RENDER}" Deployment keycloak-service keycloak KEYCLOAK_ADMIN_PASSWORD keycloak-admin-credentials admin-password "Deployment's KEYCLOAK_ADMIN_PASSWORD must source from keycloak-admin-credentials/admin-password"
+assert_secret_key_ref "${DEFAULT_RENDER}" Deployment keycloak-service resolve-realm-secrets REALM_ADMIN_USERNAME keycloak-admin-credentials admin-username "resolve-realm-secrets init container's REALM_ADMIN_USERNAME must source from the Secret"
+assert_secret_key_ref "${DEFAULT_RENDER}" Deployment keycloak-service resolve-realm-secrets REALM_ADMIN_PASSWORD keycloak-admin-credentials admin-password "resolve-realm-secrets init container's REALM_ADMIN_PASSWORD must source from the Secret"
+assert_secret_key_ref "${DEFAULT_RENDER}" Job keycloak-set-passwords set-passwords ADMIN_USERNAME keycloak-admin-credentials admin-username "keycloak-set-passwords Job's ADMIN_USERNAME must source from the Secret"
+assert_secret_key_ref "${DEFAULT_RENDER}" Job keycloak-set-passwords set-passwords ADMIN_PASSWORD keycloak-admin-credentials admin-password "keycloak-set-passwords Job's ADMIN_PASSWORD must source from the Secret"
+assert_secret_key_ref "${DEFAULT_RENDER}" Job keycloak-set-passwords set-passwords DEFAULT_USER_PASSWORD keycloak-admin-credentials default-user-password "keycloak-set-passwords Job's DEFAULT_USER_PASSWORD must source from the Secret"
+
+echo "=== Test 2: --set overrides propagate into the Secret (the actual regression) ==="
 OVERRIDE_RENDER=$(helm template "${CHART_DIR}" \
     --set keycloak.adminUsername=demo-admin \
     --set keycloak.adminPassword=SuperSecret123 \
     --set keycloak.defaultUserPassword=DemoUserPass456)
-assert_contains "${OVERRIDE_RENDER}" 'name: KEYCLOAK_ADMIN
-          value: "demo-admin"' "Overridden KEYCLOAK_ADMIN"
-assert_contains "${OVERRIDE_RENDER}" 'name: KEYCLOAK_ADMIN_PASSWORD
-          value: "SuperSecret123"' "Overridden KEYCLOAK_ADMIN_PASSWORD"
-assert_contains "${OVERRIDE_RENDER}" 'name: DEFAULT_USER_PASSWORD
-          value: "DemoUserPass456"' "Overridden DEFAULT_USER_PASSWORD"
-assert_not_contains "${OVERRIDE_RENDER}" 'value: "admin"' "Overridden render must not retain hardcoded admin literal"
-assert_not_contains "${OVERRIDE_RENDER}" 'value: "foobar"' "Overridden render must not retain hardcoded foobar literal"
+assert_contains "${OVERRIDE_RENDER}" 'admin-username: "demo-admin"' "Overridden admin-username in Secret"
+assert_contains "${OVERRIDE_RENDER}" 'admin-password: "SuperSecret123"' "Overridden admin-password in Secret"
+assert_contains "${OVERRIDE_RENDER}" 'default-user-password: "DemoUserPass456"' "Overridden default-user-password in Secret"
+assert_not_contains "${OVERRIDE_RENDER}" 'admin-username: "admin"' "Overridden Secret must not retain the hardcoded admin-username default"
+assert_not_contains "${OVERRIDE_RENDER}" 'admin-password: "admin"' "Overridden Secret must not retain the hardcoded admin-password default"
+assert_not_contains "${OVERRIDE_RENDER}" 'default-user-password: "foobar"' "Overridden Secret must not retain the hardcoded default-user-password default"
+
+echo "=== Test 2b: pod specs never carry credentials as plaintext, only via secretKeyRef ==="
+assert_not_contains "${DEFAULT_RENDER}" '          value: "admin"' "Default render must have no plaintext admin literal in any pod spec env"
+assert_not_contains "${DEFAULT_RENDER}" '          value: "foobar"' "Default render must have no plaintext foobar literal in any pod spec env"
+assert_not_contains "${OVERRIDE_RENDER}" '          value: "demo-admin"' "Overridden render must have no plaintext admin-username literal in any pod spec env"
+assert_not_contains "${OVERRIDE_RENDER}" '          value: "SuperSecret123"' "Overridden render must have no plaintext admin-password literal in any pod spec env"
+assert_not_contains "${OVERRIDE_RENDER}" '          value: "DemoUserPass456"' "Overridden render must have no plaintext default-user-password literal in any pod spec env"
 
 echo "=== Test 3: realm.json placeholders present, no baked-in credential hash ==="
 assert_contains "${DEFAULT_RENDER}" '__OSAC_REALM_ADMIN_USERNAME__' "realm.json admin username placeholder"
@@ -198,6 +240,72 @@ if [[ -n "${STATIC_SCRIPT}" ]]; then
         fail "Static reference manifest's actual set-passwords.sh never reached the reset-password call"
     fi
 fi
+
+echo "=== Test 6: static reference manifest's realm.json and resolve-realm-secrets coverage ==="
+# Tests 3/4 only cover the chart's copies. The static prerequisites/
+# manifest has its own hand-maintained duplicates of both realm.json and
+# the resolve-realm-secrets logic (deployment.yaml has no shared script
+# file to reference), so they need their own direct coverage -- otherwise
+# a future edit to the static copy alone could silently diverge unnoticed.
+
+STATIC_REALM_JSON=$(cat "${SCRIPT_DIR}/../prerequisites/keycloak/service/files/realm.json")
+assert_contains "${STATIC_REALM_JSON}" '__OSAC_REALM_ADMIN_USERNAME__' "Static realm.json admin username placeholder"
+assert_contains "${STATIC_REALM_JSON}" '__OSAC_REALM_ADMIN_PASSWORD__' "Static realm.json admin password placeholder"
+assert_not_contains "${STATIC_REALM_JSON}" 'ETe90wgj32P' "Static reference manifest's realm.json must not retain the static argon2 password hash"
+
+STATIC_RESOLVE_SCRIPT=$(python3 -c "
+import yaml
+with open('${SCRIPT_DIR}/../prerequisites/keycloak/service/deployment.yaml') as f:
+    docs = list(yaml.safe_load_all(f))
+for d in docs:
+    if d and d.get('kind') == 'Deployment':
+        for c in d['spec']['template']['spec']['initContainers']:
+            if c.get('name') == 'resolve-realm-secrets':
+                print(c['command'][2])
+                break
+        break
+")
+[[ -n "${STATIC_RESOLVE_SCRIPT}" ]] || fail "Could not extract resolve-realm-secrets init container script from the static Deployment manifest"
+
+if [[ -n "${STATIC_RESOLVE_SCRIPT}" ]]; then
+    # Unlike the chart's copy (which takes paths via REALM_RAW_PATH/
+    # REALM_OUTPUT_PATH env vars), this script hardcodes /realm-raw/realm.json
+    # and /realm/realm.json -- redirect them to TMP_DIR paths for this test
+    # run only; the committed file is never touched.
+    STATIC_RESOLVE_REDIRECTED=$(printf '%s' "${STATIC_RESOLVE_SCRIPT}" | sed \
+        -e "s#/realm-raw/realm\.json#${TMP_DIR}/static-realm-raw.json#g" \
+        -e "s#/realm/realm\.json#${TMP_DIR}/static-realm-resolved.json#g")
+    cp "${TMP_DIR}/realm-raw.json" "${TMP_DIR}/static-realm-raw.json"
+    echo "${STATIC_RESOLVE_REDIRECTED}" > "${TMP_DIR}/extracted-static-resolve.sh"
+    rm -f "${TMP_DIR}/static-realm-resolved.json"
+
+    PATH="${TMP_DIR}/bin:${PATH}" \
+    REALM_ADMIN_USERNAME="demo-admin" \
+    REALM_ADMIN_PASSWORD=$'test-p@ss#word&with\\slash/chars\tand\ttabs\nand\nnewlines' \
+        bash "${TMP_DIR}/extracted-static-resolve.sh" >/dev/null 2>&1 || {
+            fail "Static reference manifest's resolve-realm-secrets init container script exited non-zero"
+        }
+
+    if [[ -f "${TMP_DIR}/static-realm-resolved.json" ]]; then
+        STATIC_DECODED_PASSWORD=$(python3 -c "import json; print(json.load(open('${TMP_DIR}/static-realm-resolved.json'))['credentials'][0]['value'])" 2>/dev/null) || {
+            fail "Static reference manifest's resolved realm.json is not valid JSON after substituting a password with sed/JSON metacharacters"
+        }
+        if [[ "${STATIC_DECODED_PASSWORD}" != $'test-p@ss#word&with\\slash/chars\tand\ttabs\nand\nnewlines' ]]; then
+            fail "Static reference manifest's resolved realm.json decoded password does not match the original"
+        fi
+    else
+        fail "Static reference manifest's resolve-realm-secrets script did not produce a resolved realm.json"
+    fi
+fi
+
+echo "=== Test 7: static deployment.yaml sources credentials via secretKeyRef, not literals ==="
+STATIC_DEPLOYMENT=$(cat "${SCRIPT_DIR}/../prerequisites/keycloak/service/deployment.yaml")
+assert_contains "${STATIC_DEPLOYMENT}" 'name: keycloak-admin-credentials' "deployment.yaml must reference the keycloak-admin-credentials Secret"
+# A single-line needle, not a multi-line one: grep -F splits multi-line
+# patterns into OR'd single-line alternatives, which would make a
+# "name: KEYCLOAK_ADMIN\n  value: admin" needle match on the (harmless,
+# always-present) variable-name line alone and produce a false failure.
+assert_not_contains "${STATIC_DEPLOYMENT}" '          value: admin' "deployment.yaml must not hardcode a literal admin credential value"
 
 echo
 if [[ "${FAILURES}" -gt 0 ]]; then

--- a/osac-installer/scripts/validate-keycloak-credentials.sh
+++ b/osac-installer/scripts/validate-keycloak-credentials.sh
@@ -89,7 +89,7 @@ PATH="${TMP_DIR}/bin:${PATH}" \
 REALM_RAW_PATH="${TMP_DIR}/realm-raw.json" \
 REALM_OUTPUT_PATH="${TMP_DIR}/realm-resolved.json" \
 REALM_ADMIN_USERNAME="demo-admin" \
-REALM_ADMIN_PASSWORD='test-p@ss#word&with\slash/chars' \
+REALM_ADMIN_PASSWORD=$'test-p@ss#word&with\\slash/chars\tand\ttabs\nand\nnewlines' \
     bash "${CHART_DIR}/files/hooks/resolve-realm-secrets.sh" >/dev/null 2>&1 || {
         fail "resolve-realm-secrets.sh exited non-zero"
     }
@@ -102,8 +102,8 @@ if [[ -f "${TMP_DIR}/realm-resolved.json" ]]; then
     # Compare the JSON-decoded value, not the raw file text -- valid JSON
     # necessarily re-escapes the backslash as \\, so the raw bytes never
     # contain the password's literal backslash form.
-    if [[ "${DECODED_PASSWORD}" != 'test-p@ss#word&with\slash/chars' ]]; then
-        fail "Resolved realm.json's decoded password does not match the original -- got: ${DECODED_PASSWORD}"
+    if [[ "${DECODED_PASSWORD}" != $'test-p@ss#word&with\\slash/chars\tand\ttabs\nand\nnewlines' ]]; then
+        fail "Resolved realm.json's decoded password does not match the original"
     fi
     assert_not_contains "${RESOLVED}" '__OSAC_REALM_ADMIN_PASSWORD__' "Placeholder must be fully substituted"
 else
@@ -169,7 +169,7 @@ if [[ -n "${CHART_SCRIPT}" ]]; then
         DECODED=$(python3 -c "import json; print(json.load(open('${CAPTURE_FILE}'))['value'])" 2>/dev/null) || {
             fail "Chart Job's actual set-passwords.sh produced an invalid JSON reset-password body for a password with quote/backslash"
         }
-        [[ "${DECODED}" == "${DEMO_PASSWORD}" ]] || fail "Chart Job's actual set-passwords.sh reset-password body does not round-trip the password -- got: ${DECODED}"
+        [[ "${DECODED}" == "${DEMO_PASSWORD}" ]] || fail "Chart Job's actual set-passwords.sh reset-password body does not round-trip the password"
     else
         fail "Chart Job's actual set-passwords.sh never reached the reset-password call"
     fi
@@ -193,7 +193,7 @@ if [[ -n "${STATIC_SCRIPT}" ]]; then
         DECODED=$(python3 -c "import json; print(json.load(open('${CAPTURE_FILE}'))['value'])" 2>/dev/null) || {
             fail "Static reference manifest's actual set-passwords.sh produced an invalid JSON reset-password body for a password with quote/backslash"
         }
-        [[ "${DECODED}" == "${DEMO_PASSWORD}" ]] || fail "Static reference manifest's actual set-passwords.sh reset-password body does not round-trip the password -- got: ${DECODED}"
+        [[ "${DECODED}" == "${DEMO_PASSWORD}" ]] || fail "Static reference manifest's actual set-passwords.sh reset-password body does not round-trip the password"
     else
         fail "Static reference manifest's actual set-passwords.sh never reached the reset-password call"
     fi

--- a/osac-installer/scripts/validate-keycloak-credentials.sh
+++ b/osac-installer/scripts/validate-keycloak-credentials.sh
@@ -29,14 +29,14 @@ fail() {
 assert_contains() {
     local haystack="$1" needle="$2" description="$3"
     if ! grep -qF -- "${needle}" <<<"${haystack}"; then
-        fail "${description} -- expected to find: ${needle}"
+        fail "${description} -- expected value not found"
     fi
 }
 
 assert_not_contains() {
     local haystack="$1" needle="$2" description="$3"
     if grep -qF -- "${needle}" <<<"${haystack}"; then
-        fail "${description} -- did not expect to find: ${needle}"
+        fail "${description} -- unexpected value was found"
     fi
 }
 

--- a/osac-installer/scripts/validate-keycloak-credentials.sh
+++ b/osac-installer/scripts/validate-keycloak-credentials.sh
@@ -241,6 +241,14 @@ if [[ -n "${STATIC_SCRIPT}" ]]; then
     fi
 fi
 
+# Test 5 above only proves the extracted script's logic works when given
+# credentials via env vars -- it doesn't prove the Job manifest actually
+# wires those env vars to the Secret. Check that structurally too.
+STATIC_PASSWORD_JOB=$(cat "${SCRIPT_DIR}/../prerequisites/keycloak/service/password-setup-job.yaml")
+assert_secret_key_ref "${STATIC_PASSWORD_JOB}" Job keycloak-set-passwords set-passwords ADMIN_USERNAME keycloak-admin-credentials admin-username "Static password-setup-job.yaml's ADMIN_USERNAME must source from keycloak-admin-credentials/admin-username"
+assert_secret_key_ref "${STATIC_PASSWORD_JOB}" Job keycloak-set-passwords set-passwords ADMIN_PASSWORD keycloak-admin-credentials admin-password "Static password-setup-job.yaml's ADMIN_PASSWORD must source from keycloak-admin-credentials/admin-password"
+assert_secret_key_ref "${STATIC_PASSWORD_JOB}" Job keycloak-set-passwords set-passwords DEFAULT_USER_PASSWORD keycloak-admin-credentials default-user-password "Static password-setup-job.yaml's DEFAULT_USER_PASSWORD must source from keycloak-admin-credentials/default-user-password"
+
 echo "=== Test 6: static reference manifest's realm.json and resolve-realm-secrets coverage ==="
 # Tests 3/4 only cover the chart's copies. The static prerequisites/
 # manifest has its own hand-maintained duplicates of both realm.json and
@@ -299,13 +307,16 @@ if [[ -n "${STATIC_RESOLVE_SCRIPT}" ]]; then
 fi
 
 echo "=== Test 7: static deployment.yaml sources credentials via secretKeyRef, not literals ==="
+# Structural checks per env var (assert_secret_key_ref), not a substring
+# search: "name: keycloak-admin-credentials" appearing *somewhere* in the
+# file doesn't prove any specific env var points at the right secret/key --
+# e.g. KEYCLOAK_ADMIN could be wired to the wrong key and this would have
+# still passed under the old string-based check.
 STATIC_DEPLOYMENT=$(cat "${SCRIPT_DIR}/../prerequisites/keycloak/service/deployment.yaml")
-assert_contains "${STATIC_DEPLOYMENT}" 'name: keycloak-admin-credentials' "deployment.yaml must reference the keycloak-admin-credentials Secret"
-# A single-line needle, not a multi-line one: grep -F splits multi-line
-# patterns into OR'd single-line alternatives, which would make a
-# "name: KEYCLOAK_ADMIN\n  value: admin" needle match on the (harmless,
-# always-present) variable-name line alone and produce a false failure.
-assert_not_contains "${STATIC_DEPLOYMENT}" '          value: admin' "deployment.yaml must not hardcode a literal admin credential value"
+assert_secret_key_ref "${STATIC_DEPLOYMENT}" Deployment keycloak-service keycloak KEYCLOAK_ADMIN keycloak-admin-credentials admin-username "Static deployment.yaml's KEYCLOAK_ADMIN must source from keycloak-admin-credentials/admin-username"
+assert_secret_key_ref "${STATIC_DEPLOYMENT}" Deployment keycloak-service keycloak KEYCLOAK_ADMIN_PASSWORD keycloak-admin-credentials admin-password "Static deployment.yaml's KEYCLOAK_ADMIN_PASSWORD must source from keycloak-admin-credentials/admin-password"
+assert_secret_key_ref "${STATIC_DEPLOYMENT}" Deployment keycloak-service resolve-realm-secrets REALM_ADMIN_USERNAME keycloak-admin-credentials admin-username "Static deployment.yaml's REALM_ADMIN_USERNAME must source from keycloak-admin-credentials/admin-username"
+assert_secret_key_ref "${STATIC_DEPLOYMENT}" Deployment keycloak-service resolve-realm-secrets REALM_ADMIN_PASSWORD keycloak-admin-credentials admin-password "Static deployment.yaml's REALM_ADMIN_PASSWORD must source from keycloak-admin-credentials/admin-password"
 
 echo
 if [[ "${FAILURES}" -gt 0 ]]; then

--- a/osac-installer/scripts/validate-keycloak-credentials.sh
+++ b/osac-installer/scripts/validate-keycloak-credentials.sh
@@ -131,22 +131,29 @@ PATH="${TMP_DIR}/bin:${PATH}" \
 REALM_RAW_PATH="${TMP_DIR}/realm-raw.json" \
 REALM_OUTPUT_PATH="${TMP_DIR}/realm-resolved.json" \
 REALM_ADMIN_USERNAME="demo-admin" \
-REALM_ADMIN_PASSWORD=$'test-p@ss#word&with\\slash/chars\tand\ttabs\nand\nnewlines' \
+REALM_ADMIN_PASSWORD=$'test-p@ss#word&with\\slash/chars\tand\ttabs\nand\nnewlines\n' \
     bash "${CHART_DIR}/files/hooks/resolve-realm-secrets.sh" >/dev/null 2>&1 || {
         fail "resolve-realm-secrets.sh exited non-zero"
     }
 
 if [[ -f "${TMP_DIR}/realm-resolved.json" ]]; then
     RESOLVED=$(cat "${TMP_DIR}/realm-resolved.json")
-    DECODED_PASSWORD=$(python3 -c "import json; print(json.load(open('${TMP_DIR}/realm-resolved.json'))['credentials'][0]['value'])" 2>/dev/null) || {
-        fail "Resolved realm.json is not valid JSON after substituting a password with sed/JSON metacharacters"
-    }
-    # Compare the JSON-decoded value, not the raw file text -- valid JSON
-    # necessarily re-escapes the backslash as \\, so the raw bytes never
-    # contain the password's literal backslash form.
-    if [[ "${DECODED_PASSWORD}" != $'test-p@ss#word&with\\slash/chars\tand\ttabs\nand\nnewlines' ]]; then
-        fail "Resolved realm.json's decoded password does not match the original"
-    fi
+    # Compare byte-for-byte inside Python via the environment, not through a
+    # $(...) capture -- command substitution silently strips trailing
+    # newlines, which would hide a real bug for passwords ending in "\n".
+    EXPECTED_REALM_PASSWORD=$'test-p@ss#word&with\\slash/chars\tand\ttabs\nand\nnewlines\n' \
+        python3 -c "
+import json, os, sys
+try:
+    decoded = json.load(open('${TMP_DIR}/realm-resolved.json'))['credentials'][0]['value']
+except Exception:
+    sys.exit(2)
+sys.exit(0 if decoded == os.environ['EXPECTED_REALM_PASSWORD'] else 1)
+"
+    case $? in
+        2) fail "Resolved realm.json is not valid JSON after substituting a password with sed/JSON metacharacters" ;;
+        1) fail "Resolved realm.json's decoded password does not match the original" ;;
+    esac
     assert_not_contains "${RESOLVED}" '__OSAC_REALM_ADMIN_PASSWORD__' "Placeholder must be fully substituted"
 else
     fail "resolve-realm-secrets.sh did not produce ${TMP_DIR}/realm-resolved.json"
@@ -289,18 +296,27 @@ if [[ -n "${STATIC_RESOLVE_SCRIPT}" ]]; then
 
     PATH="${TMP_DIR}/bin:${PATH}" \
     REALM_ADMIN_USERNAME="demo-admin" \
-    REALM_ADMIN_PASSWORD=$'test-p@ss#word&with\\slash/chars\tand\ttabs\nand\nnewlines' \
+    REALM_ADMIN_PASSWORD=$'test-p@ss#word&with\\slash/chars\tand\ttabs\nand\nnewlines\n' \
         bash "${TMP_DIR}/extracted-static-resolve.sh" >/dev/null 2>&1 || {
             fail "Static reference manifest's resolve-realm-secrets init container script exited non-zero"
         }
 
     if [[ -f "${TMP_DIR}/static-realm-resolved.json" ]]; then
-        STATIC_DECODED_PASSWORD=$(python3 -c "import json; print(json.load(open('${TMP_DIR}/static-realm-resolved.json'))['credentials'][0]['value'])" 2>/dev/null) || {
-            fail "Static reference manifest's resolved realm.json is not valid JSON after substituting a password with sed/JSON metacharacters"
-        }
-        if [[ "${STATIC_DECODED_PASSWORD}" != $'test-p@ss#word&with\\slash/chars\tand\ttabs\nand\nnewlines' ]]; then
-            fail "Static reference manifest's resolved realm.json decoded password does not match the original"
-        fi
+        # See the chart resolver test above for why this avoids a $(...)
+        # capture: it would silently strip a trailing "\n" from the password.
+        EXPECTED_REALM_PASSWORD=$'test-p@ss#word&with\\slash/chars\tand\ttabs\nand\nnewlines\n' \
+            python3 -c "
+import json, os, sys
+try:
+    decoded = json.load(open('${TMP_DIR}/static-realm-resolved.json'))['credentials'][0]['value']
+except Exception:
+    sys.exit(2)
+sys.exit(0 if decoded == os.environ['EXPECTED_REALM_PASSWORD'] else 1)
+"
+        case $? in
+            2) fail "Static reference manifest's resolved realm.json is not valid JSON after substituting a password with sed/JSON metacharacters" ;;
+            1) fail "Static reference manifest's resolved realm.json decoded password does not match the original" ;;
+        esac
     else
         fail "Static reference manifest's resolve-realm-secrets script did not produce a resolved realm.json"
     fi


### PR DESCRIPTION
## Summary

- `osac-prereqs` shipped Keycloak with hardcoded admin (`admin`/`admin`) and demo tenant user (`foobar`) credentials with no way to override them — a blocker for standing up Red Hat Demo Platform environments without publicly-known credentials.
- Adds `keycloak.adminUsername`, `keycloak.adminPassword`, and `keycloak.defaultUserPassword` Helm values, defaulting to today's literals. Per agreed direction with Wolfgang, [OSAC-3610](https://redhat.atlassian.net/browse/OSAC-3610) ticket reporter: values are overridable but **not required** — `osac-test-infra`'s e2e suite and existing CI values files are unaffected, and Demo Platform's own deploy automation is responsible for overriding with a generated value.
- Reuses the existing `resolve-realm-secrets.sh` placeholder-substitution hook (previously used only for OIDC client secrets) to set the realm-admin's password at Keycloak import time, replacing a static baked-in argon2 credential hash.
- **Sources credentials via a chart-managed `keycloak-admin-credentials` Secret (`secretKeyRef`), not plaintext in pod specs.** Added in response to a CodeRabbit security finding — the chart materializes `values.yaml`'s existing `adminUsername`/`adminPassword`/`defaultUserPassword` into a Secret and every consumer (`KEYCLOAK_ADMIN`, `KEYCLOAK_ADMIN_PASSWORD`, `REALM_ADMIN_USERNAME`, `REALM_ADMIN_PASSWORD`, `ADMIN_USERNAME`, `ADMIN_PASSWORD`, `DEFAULT_USER_PASSWORD`) reads from it via `secretKeyRef`. This is backward-compatible: the Helm values, defaults, and override mechanism are unchanged — `osac-test-infra`/CI values files are unaffected — only the in-pod delivery mechanism changed (no longer visible via `oc get deployment -o yaml`, only via `oc get secret`). Matches the pattern already used by the static `prerequisites/keycloak/service/` manifests below.
- Applies the equivalent change to the static `prerequisites/keycloak/service/` reference manifests via the same `keycloak-admin-credentials` Secret (operator-created prerequisite — see header comment in `deployment.yaml`).
- Fixes escaping bugs surfaced across two rounds of testing/review: the realm.json placeholder substitution didn't JSON-escape passwords containing backslashes or control characters (tabs/newlines), and the demo-user `reset-password` API call interpolated the password into a JSON body with no escaping at all (both previously safe only because the values were fixed literals) — replaced hand-rolled sed escaping with `python3 json.dumps` everywhere. Also fixed a `curl` call in the static manifest that silently swallowed HTTP errors (missing `-f`).
- Adds `scripts/validate-keycloak-credentials.sh` as a regression test (8 checks, covering both the chart and static-manifest paths), wired into `make helm-validate`.

## ✅ Live-Cluster Verification — Complete (re-verified after the Secret-based rework)

Originally flagged as a required pre-merge blocker (the realm-admin's plaintext `"value"` credential relies on Keycloak's `--import-realm` bootstrap accepting an unhashed password at import time — a new code path for this codebase, since every other user's password is set post-import via the Admin REST API instead). **Verified against a live kind cluster, then re-verified after adding the `keycloak-admin-credentials` Secret / `secretKeyRef` rework:**

- `resolve-realm-secrets.sh`'s init container ran cleanly; the imported `realm.json` showed the correctly-resolved plaintext admin credential.
- Keycloak logs: `Realm 'osac' imported` / `Import finished successfully` — no errors on the plaintext credential.
- **Positive control:** `admin`/`admin` login against the `osac` realm returned a valid access token — confirmed both before and after the Secret-based rework.
- **Negative control:** a wrong password correctly returned `invalid_grant`.
- The `keycloak-set-passwords` Job completed successfully for all 7 demo users (now also `secretKeyRef`-sourced); verified `tenant1_admin`/`foobar` also authenticates.
- Confirmed via `kubectl get deployment -o jsonpath` that the pod spec now shows `secretKeyRef` (not a plaintext value) for all credential env vars, and via `kubectl get secret -o jsonpath | base64 -d` that the Secret itself holds the expected values.

No fallback to the originally-considered Job-based Admin REST API approach is needed — the sed-substitution reuse works as designed. 

## Jira

https://redhat.atlassian.net/browse/OSAC-3610

## Test plan

- [x] `helm lint charts/osac-operators/` and `helm lint charts/osac-prereqs/` pass
- [x] `helm template` against all 5 real values files (`bmaas-ci`, `caas-ci`, `development`, `full-ci`, `vmaas-ci`) for `osac-operators`, `osac-prereqs`, and `osac` (umbrella, with the documented `--set service.externalHostname=...`/`internalHostname=...` workaround for the pre-existing schema requirement)
- [x] New regression suite (`scripts/validate-keycloak-credentials.sh`, wired into `make helm-validate`, 8 checks): defaults preserved (via the Secret), `--set` overrides propagate into the Secret correctly, pod specs never carry plaintext credentials, `realm.json`/resolve-realm-secrets coverage for both the chart and static-manifest paths, all JSON-escaping fixes verified against the actual production scripts (not reimplementations) — including deliberately reverting each fix and confirming the test catches the regression, then restoring it
- [x] `pre-commit run --all-files` passes (three pre-existing, unrelated failures: missing `buf`/`golangci-lint` binaries in this environment — no Go/proto files touched by this change)
- [x] Live-cluster verification — **complete, re-verified after the Secret rework, see above**

## Confidence

High — the core parameterization is thoroughly verified structurally and via live-cluster testing (twice, before and after the Secret-based rework), all escaping bugs found during testing/review now have genuine regression coverage, and the previously-unverified realm-import behavior is confirmed working end-to-end.

## Rollback

Revert this commit. Since all new Helm values default to today's hardcoded literals, no data migration or state cleanup is needed — a rollback returns exactly to the pre-fix hardcoded-credential behavior.

## Risk Assessment

Low — changes are contained to the `osac-prereqs` chart, its files, and the static `prerequisites/keycloak/service/` reference manifests. No controller code, CRDs, or other charts touched. The previously-open live-cluster risk is now closed, re-verified after the Secret-based credential delivery was added.

---

_This PR description was drafted with AI assistance ([create-pr](https://github.com/osac-project/osac-workspace/tree/main/skills/create-pr) v0.1.0). Review for accuracy_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Keycloak administrator and default user credentials can be configured through Helm values and deployment secrets.
- Realm initialization and demo-user password setup now use the configured credentials.
- Credentials containing special characters are handled safely.

## Bug Fixes
- Replaced fixed credential handling with Secret-based configuration for more reliable deployments.

## Tests
- Added automated validation for default, customized, Secret-based, and special-character credentials.
- Helm validation now checks credential configuration during chart validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->