### PR TITLE
OSAC-3873: re-enable latest tag on fulfillment-service image publish

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -94,7 +94,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=sha
-          # type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
## Summary

- `ghcr.io/osac-project/fulfillment-service:latest` has been frozen on a build from 2026-07-15 for weeks, silently running stale code wherever it's deployed (e.g. `osac-installer/values/demo/values.yaml`), while `main`/sha-tagged builds keep advancing normally.
- Root cause: in `.github/workflows/publish-image.yaml`, the `docker/metadata-action` tag rule that generates the `latest` tag on push to `main` was commented out. No other rule in that workflow's `tags:` block produces a `latest` tag — `docker/metadata-action` does not auto-generate one on default-branch pushes unless this kind of explicit `type=raw` rule is enabled. This was the only image-publishing workflow in the mono-repo with the rule disabled.
- Fix: re-enable the rule. This required more than deleting the `# ` prefix — the commented line was indented to sit *outside* the `tags: |` literal block scalar (as a true YAML comment, at the same indent level as the `tags:` key itself), so a byte-literal "just remove the comment marker" edit drops the line out of the block and produces invalid YAML (confirmed locally: yamllint fails with `could not find expected ':'`). The fix re-indents the line to match the block's content lines, making it both syntactically valid and byte-for-byte identical in content *and* structure to the already-working rule in all 6 sibling image-publish workflows.
- This surfaced now because #78 ([OSAC-3367](https://redhat.atlassian.net/browse/OSAC-3367)) removed fulfillment-service's explicit image-tag pinning/sync step during the mono-repo migration, so values files started floating on `:latest` assuming CI kept it fresh.
- Downstream symptom (not fixed here, just explained): a demo install on the stale `:latest` server predates the `host_type` typed-reference migration ([OSAC-1330](https://redhat.atlassian.net/browse/OSAC-1330) / #85) and rejects osac-aap's `publish_templates` POSTs with `proto: invalid value for string field hostType` / HTTP 400. That migration is correct and working as intended for `main`/sha-tagged deployments — it's purely a symptom of this frozen tag.

## Verification

Repo-wide audit of every image-publishing workflow (`grep -rl "docker/metadata-action" .github/workflows/`, 7 files) — all now show an active `type=raw,value=latest,enable=...` rule:

```
--- .github/workflows/build-bmf-image.yaml ---
120:            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
--- .github/workflows/build-image.yaml ---
129:            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
--- .github/workflows/build-metering-echo-adapter-image.yaml ---
68:            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
--- .github/workflows/build-metering-service-image.yaml ---
68:            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
--- .github/workflows/execution-environment.yml ---
96:            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
--- .github/workflows/publish-csi-driver-image.yaml ---
101:            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
--- .github/workflows/publish-image.yaml ---
97:            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
```

The other 6 workflows are unchanged (already correct) — this PR touches only `publish-image.yaml`.

## Test plan

This is a GitHub Actions workflow config change with no application-level unit test; it can't be exercised from a PR context since the `image` job only triggers on push to `main`/release tags, not on `pull_request`. Verified instead by:

- [x] `git diff` against `main` is exactly one file, one changed line (`.github/workflows/publish-image.yaml`)
- [x] `pre-commit run --files .github/workflows/publish-image.yaml` passes (yamllint and all other hooks green)
- [x] Parsed the resulting YAML with `PyYAML` and confirmed the `tags:` step input resolves to the same 7-line list, in the same order, as the equivalent already-working step in `build-image.yaml` (both end with the same `type=raw,value=latest,enable=...` entry)
- [x] Repo-wide grep re-check above — all 7 image-publishing workflows now have the rule active

Follow-up (can't be verified pre-merge): once this merges to `main`, spot-check that the tag actually advances, e.g. `skopeo inspect docker://ghcr.io/osac-project/fulfillment-service:latest` or `podman image inspect ghcr.io/osac-project/fulfillment-service:latest | grep -i created`.

Fixes: https://redhat.atlassian.net/browse/OSAC-3873

Assisted-by: Claude Code <noreply@anthropic.com>