### PR TITLE
OSAC-3879: honor E2E path-ignore on merge queue

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -41,12 +41,23 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
-      should-run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+      # Same ignore list for pull_request and merge_group (OSAC-3879).
+      # schedule / workflow_dispatch always run. e2e-*-gate still if: always()
+      # so ruleset-required checks report when expensive E2E is skipped.
+      should-run: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || steps.filter.outputs.code == 'true' }}
     steps:
+      # dorny/paths-filter uses git diff on merge_group (not the PR Files API),
+      # so the repo must be checked out with enough history for base..head.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        if: github.event_name == 'merge_group'
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         id: filter
         with:
           predicate-quantifier: 'every'

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -41,12 +41,23 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
-      should-run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+      # Same ignore list for pull_request and merge_group (OSAC-3879).
+      # schedule / workflow_dispatch always run. e2e-*-gate still if: always()
+      # so ruleset-required checks report when expensive E2E is skipped.
+      should-run: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || steps.filter.outputs.code == 'true' }}
     steps:
+      # dorny/paths-filter uses git diff on merge_group (not the PR Files API),
+      # so the repo must be checked out with enough history for base..head.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        if: github.event_name == 'merge_group'
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         id: filter
         with:
           predicate-quantifier: 'every'

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -41,12 +41,23 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
-      should-run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+      # Same ignore list for pull_request and merge_group (OSAC-3879).
+      # schedule / workflow_dispatch always run. e2e-*-gate still if: always()
+      # so ruleset-required checks report when expensive E2E is skipped.
+      should-run: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || steps.filter.outputs.code == 'true' }}
     steps:
+      # dorny/paths-filter uses git diff on merge_group (not the PR Files API),
+      # so the repo must be checked out with enough history for base..head.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        if: github.event_name == 'merge_group'
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         id: filter
         with:
           predicate-quantifier: 'every'


### PR DESCRIPTION
## Summary
- Apply the same docs/non-code path filter on `merge_group` as on `pull_request`, so merge-queue entries no longer always run full bmaas+caas+vmaas E2E
- Keep `schedule` / `workflow_dispatch` always-on; keep `e2e-*-gate` with `if: always()` so required ruleset checks still report when E2E is skipped
- Checkout with `fetch-depth: 0` and `persist-credentials: false` for merge_group (dorny/paths-filter uses git diff)

## Jira
https://redhat.atlassian.net/browse/OSAC-3879

## Test plan
- [ ] Docs-only PR: expensive E2E skipped; gates pass
- [ ] Docs-only merge-queue entry: expensive E2E skipped; gates pass (no "Expected forever")
- [ ] Code PR / MQ entry: E2E still runs; gates reflect result
- [ ] `schedule` / `workflow_dispatch`: E2E still always runs
- [ ] Bugbot / security / CodeRabbit local reviews clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD**
  * End-to-end installation checks now run for merge-group events.
  * Pull request and merge-group changes are filtered to determine when relevant checks should run.
  * Scheduled and manually triggered workflows continue to run without path filtering.
  * Improved repository history handling for merge-group validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->