### PR TITLE
fix: auto-queue uses org membership check instead of author_association

### DIFF
--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -3,32 +3,33 @@ name: auto-queue
 
 on:
   pull_request_target:
-    types: [opened, ready_for_review]
+    types: [opened, reopened, ready_for_review]
     branches: [main]
 
 jobs:
   enable-auto-merge:
     runs-on: ubuntu-latest
     steps:
-      # Every run of this workflow has reported "skipped" since it was
-      # introduced (0/35+ runs actually reached the merge step) -- the old
-      # job-level `if:` below skipped the whole job before any step ran, so
-      # there was never a log line showing what the gate actually saw.
-      # This step is unconditional so we get that visibility on every event.
-      - name: Debug event payload
+      - name: Check org membership
+        id: org-check
+        env:
+          GH_TOKEN: ${{ secrets.MERGE_QUEUE_TOKEN }}
         run: |
-          echo "event_name=${{ github.event_name }}"
-          echo "action=${{ github.event.action }}"
-          echo "pr_number=${{ github.event.pull_request.number }}"
+          author="${{ github.event.pull_request.user.login }}"
+          echo "author=$author"
           echo "draft=${{ github.event.pull_request.draft }}"
-          echo "author=${{ github.event.pull_request.user.login }}"
-          echo "author_association=${{ github.event.pull_request.author_association }}"
-          echo "head_repo_fork=${{ github.event.pull_request.head.repo.fork }}"
-          echo "gate_would_pass=${{ github.event.pull_request.draft == false && contains(fromJSON('["MEMBER","COLLABORATOR","OWNER"]'), github.event.pull_request.author_association) }}"
+          if gh api "orgs/osac-project/members/$author"; then
+            echo "org_member=true"
+            echo "org_member=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "org_member=false"
+            echo "org_member=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Enable auto-merge
         if: >-
           github.event.pull_request.draft == false
-          && contains(fromJSON('["MEMBER","COLLABORATOR","OWNER"]'), github.event.pull_request.author_association)
+          && steps.org-check.outputs.org_member == 'true'
         env:
           GH_TOKEN: ${{ secrets.MERGE_QUEUE_TOKEN }}
         run: gh pr merge ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --auto --rebase


### PR DESCRIPTION
## Summary

- `author_association` returns `CONTRIBUTOR` for all fork-based PRs regardless of actual org membership, so auto-merge was never enabled — every run since introduction has silently skipped the merge step
- Replace the `author_association` gate with a GitHub API org membership check (`GET /orgs/osac-project/members/{username}`) that correctly distinguishes org members from outside contributors
- Add `reopened` trigger for PRs closed and reopened

## Test plan

- [ ] Open a test PR from an org member's fork — auto-merge should be enabled with `--rebase`
- [ ] Verify the workflow logs show `org_member=true` for org members
- [ ] Verify non-member fork PRs show `org_member=false` and auto-merge is not enabled
- [ ] Verify draft PRs from org members do not get auto-merge enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)