### PR TITLE
fix: auto-queue reacts to rebases, label changes, and blocking labels

### DIFF
--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -3,7 +3,7 @@ name: auto-queue
 
 on:
   pull_request_target:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, synchronize, labeled, unlabeled]
     branches: [main]
 
 jobs:
@@ -26,10 +26,36 @@ jobs:
             echo "org_member=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Check blocking labels
+        if: steps.org-check.outputs.org_member == 'true'
+        id: label-check
+        env:
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          echo "labels=$LABELS"
+          blocked=false
+          for label in "do-not-merge/hold" "needs-rebase"; do
+            if echo "$LABELS" | jq -e "index(\"$label\")" > /dev/null; then
+              echo "Blocking label found: $label"
+              blocked=true
+            fi
+          done
+          echo "blocked=$blocked"
+          echo "blocked=$blocked" >> "$GITHUB_OUTPUT"
+
       - name: Enable auto-merge
         if: >-
           github.event.pull_request.draft == false
           && steps.org-check.outputs.org_member == 'true'
+          && steps.label-check.outputs.blocked == 'false'
         env:
           GH_TOKEN: ${{ secrets.MERGE_QUEUE_TOKEN }}
         run: gh pr merge ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --auto --rebase
+
+      - name: Disable auto-merge
+        if: >-
+          steps.org-check.outputs.org_member == 'true'
+          && steps.label-check.outputs.blocked == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.MERGE_QUEUE_TOKEN }}
+        run: gh pr merge ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --disable-auto


### PR DESCRIPTION
## Summary

- Add `synchronize`, `labeled`, `unlabeled` triggers so auto-merge is re-evaluated on pushes/rebases and label changes
- Check for `do-not-merge/hold` and `needs-rebase` labels — disable auto-merge when present, re-enable when removed
- Existing PRs opened before the org-membership fix will now get auto-merge on next push

## Test plan

- [ ] Push to an existing PR — verify auto-merge gets enabled
- [ ] Add `do-not-merge/hold` label — verify auto-merge gets disabled
- [ ] Remove `do-not-merge/hold` label — verify auto-merge gets re-enabled
- [ ] Add `needs-rebase` label — verify auto-merge gets disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)