### PR TITLE
fix: auto-queue uses collaborators endpoint for access check

### DIFF
--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -10,7 +10,7 @@ jobs:
   enable-auto-merge:
     runs-on: ubuntu-latest
     steps:
-      - name: Check org membership
+      - name: Check repo collaborator
         id: org-check
         env:
           GH_TOKEN: ${{ secrets.MERGE_QUEUE_TOKEN }}
@@ -18,7 +18,7 @@ jobs:
           author="${{ github.event.pull_request.user.login }}"
           echo "author=$author"
           echo "draft=${{ github.event.pull_request.draft }}"
-          if gh api "orgs/osac-project/members/$author"; then
+          if gh api "repos/${{ github.repository }}/collaborators/$author"; then
             echo "org_member=true"
             echo "org_member=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary

- Switch from `/orgs/{org}/members/{username}` to `/repos/{owner}/{repo}/collaborators/{username}` for the auto-queue access check
- Org members endpoint requires `read:org` scope (classic PAT) or "Members" org permission (fine-grained) which may not be available
- Collaborators endpoint works with `repo` scope (classic) or "Administration: read" (fine-grained) — no token changes needed

## Test plan

- [ ] Verify auto-queue enables auto-merge for org member PRs
- [ ] Verify auto-queue skips non-collaborator PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)