### PR TITLE
OSAC-3468: Correct status for project deletion when projectmembership exists

### DIFF
--- a/fulfillment-service/internal/controllers/project/project_reconciler_function.go
+++ b/fulfillment-service/internal/controllers/project/project_reconciler_function.go
@@ -369,8 +369,18 @@ func (t *task) delete(ctx context.Context) error {
 	}
 
 	// Cascade-delete ProjectMemberships scoped to this project
-	if err := t.deleteProjectMemberships(ctx); err != nil {
+	existingMemberships, err := t.deleteProjectMemberships(ctx)
+	if err != nil {
 		return err
+	}
+
+	if existingMemberships {
+		if !t.project.HasStatus() {
+			t.project.SetStatus(&privatev1.ProjectStatus{})
+		}
+		t.project.GetStatus().SetState(privatev1.ProjectState_PROJECT_STATE_DELETING)
+		t.project.GetStatus().SetMessage("Pending ProjectMembership deletion prior to project deletion")
+		return nil
 	}
 
 	// Clean up Keycloak groups
@@ -401,7 +411,7 @@ func (t *task) delete(ctx context.Context) error {
 // deleteProjectMemberships lists all ProjectMemberships scoped to this project, marks each for
 // deletion, and waits for them to be fully removed before returning. This prevents orphaned
 // memberships and ensures the project can complete its own deletion.
-func (t *task) deleteProjectMemberships(ctx context.Context) error {
+func (t *task) deleteProjectMemberships(ctx context.Context) (bool, error) {
 	projectName := t.project.GetMetadata().GetName()
 	tenant := t.project.GetMetadata().GetTenant()
 
@@ -413,7 +423,11 @@ func (t *task) deleteProjectMemberships(ctx context.Context) error {
 		Filter: new(membershipFilter),
 	}.Build())
 	if err != nil {
-		return fmt.Errorf("failed to query for project memberships: %w", err)
+		return false, fmt.Errorf("failed to query for project memberships: %w", err)
+	}
+
+	if listResp.GetTotal() == 0 {
+		return false, nil
 	}
 
 	for _, membership := range listResp.GetItems() {
@@ -428,15 +442,11 @@ func (t *task) deleteProjectMemberships(ctx context.Context) error {
 			Id: membership.GetId(),
 		}.Build())
 		if err != nil && status.Code(err) != codes.NotFound {
-			return fmt.Errorf("failed to delete project membership %s: %w", membership.GetId(), err)
+			return true, fmt.Errorf("failed to delete project membership %s: %w", membership.GetId(), err)
 		}
 	}
 
-	if listResp.GetTotal() > 0 {
-		return fmt.Errorf("project still has %d project membership(s) pending deletion", listResp.GetTotal())
-	}
-
-	return nil
+	return true, nil
 }
 
 // setDefaults sets default values for the project.

--- a/fulfillment-service/internal/controllers/project/project_reconciler_function_test.go
+++ b/fulfillment-service/internal/controllers/project/project_reconciler_function_test.go
@@ -1217,9 +1217,9 @@ var _ = Describe("Deletion Cleanup", func() {
 			}
 
 			err := task.delete(ctx)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("project still has 1 project membership(s) pending deletion"))
-			Expect(project.GetMetadata().GetFinalizers()).To(ContainElement(finalizers.Controller))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(project.GetStatus().GetState()).To(Equal(privatev1.ProjectState_PROJECT_STATE_DELETING))
+			Expect(project.GetStatus().GetMessage()).To(Equal("Pending ProjectMembership deletion prior to project deletion"))
 		})
 
 		It("should proceed with deletion when all memberships are gone", func() {
@@ -1301,8 +1301,9 @@ var _ = Describe("Deletion Cleanup", func() {
 			}
 
 			err := task.delete(ctx)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("project still has 1 project membership(s) pending deletion"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(project.GetStatus().GetState()).To(Equal(privatev1.ProjectState_PROJECT_STATE_DELETING))
+			Expect(project.GetStatus().GetMessage()).To(Equal("Pending ProjectMembership deletion prior to project deletion"))
 		})
 
 		It("should return error when querying for memberships fails", func() {
@@ -1388,8 +1389,9 @@ var _ = Describe("Deletion Cleanup", func() {
 			}
 
 			err := task.delete(ctx)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("project still has 2 project membership(s) pending deletion"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(project.GetStatus().GetState()).To(Equal(privatev1.ProjectState_PROJECT_STATE_DELETING))
+			Expect(project.GetStatus().GetMessage()).To(Equal("Pending ProjectMembership deletion prior to project deletion"))
 		})
 
 		It("should handle NotFound during membership deletion gracefully", func() {
@@ -1435,8 +1437,9 @@ var _ = Describe("Deletion Cleanup", func() {
 			}
 
 			err := task.delete(ctx)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("project still has 1 project membership(s) pending deletion"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(project.GetStatus().GetState()).To(Equal(privatev1.ProjectState_PROJECT_STATE_DELETING))
+			Expect(project.GetStatus().GetMessage()).To(Equal("Pending ProjectMembership deletion prior to project deletion"))
 		})
 	})
 })


### PR DESCRIPTION
The project controller returned an error if there was any existing projectmembership despite the projectmemberships getting marked for deletion.

This makes it seem as if there was an error removing the projectmembership and it didn't update the project's status to show that the projectmemberships were getting removed.

This ensures that the project status is updated with the correct information:
1. shows that the projectmemberships are pending removal prior to the project getting deleted.
2. adds an error message if there was a failure to delete the projectmemberships

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project deletion now removes associated memberships before completing cleanup.
  * Deletion waits for membership cleanup to finish, preventing premature removal of project groups.
  * Projects remain clearly marked as **DELETING** while cleanup is still in progress.
  * Already-deleting or missing memberships are handled without blocking project deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->