### PR TITLE
OSAC-3610: document configurable Keycloak credential Helm values

### DIFF
--- a/fulfillment-service/docs/AUTH.md
+++ b/fulfillment-service/docs/AUTH.md
@@ -119,6 +119,9 @@ helm install keycloak oci://ghcr.io/osac/charts/keycloak \
 | `certs.issuerRef.name` | The name of the cert-manager issuer for TLS certificates | **Yes** | None |
 | `images.keycloak` | The Keycloak container image | No | `quay.io/keycloak/keycloak:26.3` |
 | `images.postgres` | The PostgreSQL container image | No | `quay.io/sclorg/postgresql-18-c10s:latest` |
+| `keycloak.adminUsername` | Realm admin username | No | `admin` |
+| `keycloak.adminPassword` | Realm admin password | No | `admin` |
+| `keycloak.defaultUserPassword` | Default password for pre-configured example users | No | `foobar` |
 
 ### Important Notes
 
@@ -126,10 +129,25 @@ helm install keycloak oci://ghcr.io/osac/charts/keycloak \
   reference itself, meaning that when Keycloak redirects users, or generates an URL for itself, it
   will use this host name. This is also used for token issuer URLs.
 
-- The default admin credentials are:
-  - Username: `admin`
-  - Password: `admin`
-  - **Important**: Change these credentials in production environments!
+- The realm admin credentials are configurable via Helm values in
+  `charts/osac-prereqs/values.yaml`:
+
+  | Value | Description | Default |
+  |-------|-------------|---------|
+  | `keycloak.adminUsername` | Realm admin username | `admin` |
+  | `keycloak.adminPassword` | Realm admin password | `admin` |
+  | `keycloak.defaultUserPassword` | Default password for example users | `foobar` |
+
+  Override at install time:
+
+  ```bash
+  helm install osac-prereqs charts/osac-prereqs/ \
+    --set keycloak.adminUsername=my-admin \
+    --set keycloak.adminPassword='<strong-password>' \
+    --set keycloak.defaultUserPassword='<user-password>'
+  ```
+
+  **Important**: Always override these defaults in production environments!
 
 ## Keycloak Configuration
 
@@ -192,8 +210,8 @@ To access the Keycloak Admin Console:
 
 2. **Login**:
 
-   - Username: `admin`
-   - Password: `admin`
+   - Username: the value of `keycloak.adminUsername` (default: `admin`)
+   - Password: the value of `keycloak.adminPassword` (default: `admin`)
 
 3. **Select the realm**:
 

--- a/osac-installer/docs/helm-deployment-guide.md
+++ b/osac-installer/docs/helm-deployment-guide.md
@@ -48,6 +48,10 @@ CA certificates, trust-manager Bundle, Keycloak (realm with OVERWRITE
 strategy), LVMCluster, HyperConverged, MetalLB IPAddressPool, and
 controller credentials (read from Keycloak, written to OSAC namespace).
 
+Keycloak realm admin credentials are configurable via `keycloak.adminUsername`,
+`keycloak.adminPassword`, and `keycloak.defaultUserPassword` in the prereqs
+values file (defaults: `admin`/`admin`/`foobar`).
+
 Uses `--wait-for-jobs` to avoid circular dependencies between hook Jobs
 and template resources.
 
@@ -108,6 +112,9 @@ Key settings:
 | `service.internalHostname` | Required. Set automatically by `make install-osac`. |
 | `service.auth.issuerUrl` | Keycloak realm URL (default works for in-cluster Keycloak) |
 | `operator.controllers.*` | Enable/disable individual controllers |
+| `keycloak.adminUsername` | Keycloak realm admin username (default: `admin`) |
+| `keycloak.adminPassword` | Keycloak realm admin password (default: `admin`) |
+| `keycloak.defaultUserPassword` | Default password for example users (default: `foobar`) |
 
 ## CI/Dev-Only Features
 
@@ -117,6 +124,27 @@ These are top-level values, disabled by default. Enable only in CI/dev:
 |-------|-------------|
 | `hubAccess.enabled` | Creates hub-access SA/RBAC and registers local cluster as a hub. Only for environments where fulfillment-service and hub are the same cluster. |
 | `bundledPostgres.enabled` | Deploys a single-pod ephemeral PostgreSQL. Uses `fsync=off` and `emptyDir` — data lost on restart. Not for production. |
+
+## Keycloak Credential Configuration
+
+The `osac-prereqs` chart ships with default Keycloak credentials for
+development convenience. **Override these in any non-dev environment:**
+
+```yaml
+# In your values file:
+keycloak:
+  adminUsername: my-admin
+  adminPassword: <strong-password>
+  defaultUserPassword: <user-password>
+```
+
+Or via `--set` flags on `make install-prereqs`:
+
+```bash
+helm install osac-prereqs charts/osac-prereqs/ \
+  --set keycloak.adminUsername=my-admin \
+  --set keycloak.adminPassword='<strong-password>'
+```
 
 ## Makefile Targets
 


### PR DESCRIPTION
## Summary

This documentation-only PR updates fulfillment-service/docs/AUTH.md.

    Documents the configurable Helm values for Keycloak credentials:
        keycloak.adminUsername
        keycloak.adminPassword
        keycloak.defaultUserPassword
    Lists the default values for these settings.
    Adds a helm install example that overrides the default credentials.
    Updates the Keycloak Admin Console login instructions to reference the Helm values.
    States that production deployments must override the default credentials.

The PR does not change Helm chart behavior or application code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Documented configurable Keycloak admin and example-user credentials for Helm deployments.
  - Added default values, configuration locations, installation-time overrides, and production security guidance.
  - Updated Admin Console login instructions to use the configured credentials.
  - Added Helm values reference entries and configuration examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->