### PR TITLE
OSAC-3632: per-disk StorageClass resolution in AAP

### DIFF
--- a/osac-aap/collections/ansible_collections/osac/service/roles/tenant_storage_class/meta/argument_specs.yaml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/tenant_storage_class/meta/argument_specs.yaml
@@ -23,3 +23,11 @@ argument_specs:
           The role matches this against the tier field in the injected
           storageClasses list and fails if no matching tier is found,
           listing the available tiers.
+      tenant_storage_class_disk_label:
+        type: str
+        required: false
+        default: ""
+        description: >-
+          Human-readable disk label (e.g. "boot disk", "additional disk 2")
+          included in error messages to identify which disk failed tier
+          resolution.

--- a/osac-aap/collections/ansible_collections/osac/service/roles/tenant_storage_class/tasks/main.yaml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/tenant_storage_class/tasks/main.yaml
@@ -10,9 +10,10 @@
   ansible.builtin.fail:
     msg: >-
       No resolved storage tiers available for tenant
-      "{{ tenant_storage_class_tenant_name }}". The storageClasses list
-      injected by the ComputeInstance controller is empty. Check the
-      Tenant StorageClassReady condition.
+      "{{ tenant_storage_class_tenant_name }}"
+      {{ ('(resolving ' + tenant_storage_class_disk_label + ')') if tenant_storage_class_disk_label | length > 0 else '' }}.
+      The storageClasses list injected by the ComputeInstance controller
+      is empty. Check the Tenant StorageClassReady condition.
   when: tenant_storage_class_storage_classes | length == 0
 
 - name: Resolve StorageClass for requested tier
@@ -24,7 +25,8 @@
   ansible.builtin.fail:
     msg: >-
       Storage tier "{{ tenant_storage_class_storage_tier }}" is not available
-      for tenant "{{ tenant_storage_class_tenant_name }}".
+      for tenant "{{ tenant_storage_class_tenant_name }}"
+      {{ ('(resolving ' + tenant_storage_class_disk_label + ')') if tenant_storage_class_disk_label | length > 0 else '' }}.
       Available tiers: {{ _tenant_sc_available_tiers }}.
   when: _tenant_sc_match | length == 0
 

--- a/osac-aap/collections/ansible_collections/osac/service/roles/tenant_storage_class/tests/test.yml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/tenant_storage_class/tests/test.yml
@@ -18,6 +18,9 @@
 #
 #   Test 4 (duplicate tiers -- first-match semantics):
 #     ansible-playbook ... -e test_duplicate_tier=true
+#
+#   Test 5 (disk label appears in tier-not-available error):
+#     ansible-playbook ... -e test_disk_label=true
 
 # ──────────────────────────────────────────────────────────────
 # Test 1: Resolve requested tier (happy path)
@@ -151,3 +154,39 @@
         fail_msg: "Expected 'ceph-fast-primary' but got '{{ tenant_storage_class_name | default('undefined') }}'"
         success_msg: "First-match semantics confirmed: {{ tenant_storage_class_name }}"
       when: test_duplicate_tier | default(false) | bool
+
+# ──────────────────────────────────────────────────────────────
+# Test 5: Disk label included in tier-not-available error
+# Expected: role fails with message containing the disk label
+# ──────────────────────────────────────────────────────────────
+- name: Test tenant_storage_class role -- disk label in error message
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run disk-label error test
+      when: test_disk_label | default(false) | bool
+      block:
+        - name: Attempt to discover StorageClass with disk label (expected to fail)
+          ansible.builtin.include_role:
+            name: osac.service.tenant_storage_class
+          vars:
+            tenant_storage_class_tenant_name: "tenant-acme"
+            tenant_storage_class_storage_classes:
+              - name: "ceph-acme-default"
+                tier: "default"
+            tenant_storage_class_storage_tier: "fast"
+            tenant_storage_class_disk_label: "additional disk 2"
+
+        - name: This task should not be reached -- role should have failed
+          ansible.builtin.fail:
+            msg: "Role did not fail as expected when tier is not available"
+
+      rescue:
+        - name: Verify error message includes disk label
+          ansible.builtin.assert:
+            that:
+              - "'additional disk 2' in ansible_failed_result.msg"
+              - "'is not available' in ansible_failed_result.msg"
+            fail_msg: "Error message missing disk label: {{ ansible_failed_result.msg }}"
+            success_msg: "Disk label found in error: {{ ansible_failed_result.msg }}"

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_resources.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_resources.yaml
@@ -1,19 +1,33 @@
 ---
-- name: Resolve StorageClass for this template's storage tier
+# Phase 1: Resolve all storage tiers before creating any resources.
+
+- name: Resolve StorageClass for boot disk tier
   ansible.builtin.include_role:
     name: osac.service.tenant_storage_class
   vars:
-    # 'local' matches the only tier every current environment actually registers
-    # (see playbook_osac_create_compute_instance.yml's _requested_storage_tier).
-    tenant_storage_class_storage_tier: "{{ _requested_storage_tier | default('local') }}"
+    tenant_storage_class_storage_tier: "{{ compute_instance.spec.bootDisk.storageTier }}"
+    tenant_storage_class_disk_label: "boot disk"
 
-- name: Set storage_class from tenant StorageClass
+- name: Set boot disk StorageClass
   ansible.builtin.set_fact:
-    storage_class: "{{ tenant_storage_class_name }}"
+    boot_disk_storage_class: "{{ tenant_storage_class_name }}"
 
-- name: Using tenant storage_class
+- name: Initialize additional disk StorageClasses list
+  ansible.builtin.set_fact:
+    additional_disk_storage_classes: []
+
+- name: Resolve StorageClass for each additional disk
+  ansible.builtin.include_tasks: resolve_additional_disk.yaml
+  loop: "{{ vm_additional_disks }}"
+  loop_control:
+    index_var: resolve_disk_index
+  when: vm_additional_disks | length > 0
+
+- name: Display resolved StorageClasses
   ansible.builtin.debug:
-    var: storage_class
+    msg: "Resolved StorageClasses for boot disk + {{ additional_disk_storage_classes | length }} additional disk(s)"
+
+# Phase 2: Create resources using resolved StorageClasses.
 
 - name: Create DataVolume for VM root disk
   kubernetes.core.k8s:
@@ -36,7 +50,7 @@
           resources:
             requests:
               storage: "{{ vm_boot_disk_size }}"
-          storageClassName: "{{ storage_class }}"
+          storageClassName: "{{ boot_disk_storage_class }}"
     state: present
 
 - name: Create DataVolumes for additional disks
@@ -59,7 +73,7 @@
           resources:
             requests:
               storage: "{{ item.sizeGiB }}Gi"
-          storageClassName: "{{ storage_class }}"
+          storageClassName: "{{ additional_disk_storage_classes[idx] }}"
     state: present
   loop: "{{ vm_additional_disks }}"
   loop_control:

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/resolve_additional_disk.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/resolve_additional_disk.yaml
@@ -1,0 +1,11 @@
+---
+- name: Resolve StorageClass for additional disk {{ resolve_disk_index + 1 }}
+  ansible.builtin.include_role:
+    name: osac.service.tenant_storage_class
+  vars:
+    tenant_storage_class_storage_tier: "{{ item.storageTier }}"
+    tenant_storage_class_disk_label: "additional disk {{ resolve_disk_index + 1 }}"
+
+- name: Append resolved StorageClass for additional disk {{ resolve_disk_index + 1 }}
+  ansible.builtin.set_fact:
+    additional_disk_storage_classes: "{{ additional_disk_storage_classes + [tenant_storage_class_name] }}"

--- a/osac-aap/collections/ansible_collections/osac/workflows/playbooks/compute_instance/create.yml
+++ b/osac-aap/collections/ansible_collections/osac/workflows/playbooks/compute_instance/create.yml
@@ -72,14 +72,15 @@
     # This workflow is an internal implementation detail invoked via import_playbook — JIT storage
     # provisioning only runs in the top-level playbook (playbook_osac_create_compute_instance.yml).
     # Direct invocation of this workflow bypasses JIT, so this guard catches that case explicitly.
-    - name: Fail if tenant_storage_class_name is not set before template call
+    - name: Fail if tenant_storage_class_storage_classes is not set before template call
       ansible.builtin.fail:
         msg: >-
-          tenant_storage_class_name is not defined or empty. Direct invocation of this workflow
-          bypasses JIT storage provisioning (osac.service.storage_provider ensure_storage_class).
-          Either invoke via playbook_osac_create_compute_instance.yml (recommended) or set
-          tenant_storage_class_name explicitly before calling this workflow.
-      when: tenant_storage_class_name is not defined or tenant_storage_class_name | length == 0
+          tenant_storage_class_storage_classes is not defined or empty. Direct invocation of
+          this workflow bypasses JIT storage provisioning (osac.service.storage_provider
+          ensure_storage_class). Either invoke via playbook_osac_create_compute_instance.yml
+          (recommended) or set tenant_storage_class_storage_classes explicitly before calling
+          this workflow.
+      when: tenant_storage_class_storage_classes is not defined or tenant_storage_class_storage_classes | length == 0
 
     - name: Display compute instance information
       ansible.builtin.debug:

--- a/osac-aap/playbook_osac_create_compute_instance.yml
+++ b/osac-aap/playbook_osac_create_compute_instance.yml
@@ -9,11 +9,6 @@
     template_id: "{{ osac_job_vars.resource.spec.templateID }}"
     template_parameters: {}
     tenant_storage_classes: "{{ osac_job_vars.tenant_storage_classes | default([]) }}"
-    # 'local' matches the only tier every current environment actually registers
-    # (register-local-storage.yaml's LVMS-backed StorageTier, see osac-installer).
-    # No environment defines a tier literally named 'default' -- that name only
-    # ever appeared in storage_provider's own VAST-oriented unit test fixtures.
-    _requested_storage_tier: "{{ lookup('env', 'STORAGE_REQUESTED_TIER') | default('local', true) }}"
 
   pre_tasks:
     - name: Show resource metadata
@@ -52,19 +47,27 @@
          osac_job_vars.storage_tier_definitions is string or
          osac_job_vars.storage_tier_definitions is mapping)
 
-    - name: Filter storage tier definitions to the requested tier for JIT storage
+    - name: Collect unique storage tiers from CR payload
+      ansible.builtin.set_fact:
+        _cr_requested_tiers: >-
+          {{ ([compute_instance.spec.bootDisk.storageTier | default('')]
+              + (compute_instance.spec.additionalDisks | default([]) | map(attribute='storageTier', default='') | list))
+             | select | unique | list }}
+
+    - name: Filter storage tier definitions to requested tiers for JIT storage
       when: (osac_job_vars.storage_tier_definitions | default([])) | length > 0
       block:
-        - name: Filter to only the requested tier
+        - name: Filter to only the requested tiers
           ansible.builtin.set_fact:
             _jit_storage_tiers: >-
               {{ osac_job_vars.storage_tier_definitions
-                 | selectattr('name', 'equalto', _requested_storage_tier) | list }}
+                 | selectattr('name', 'in', _cr_requested_tiers) | list }}
 
-        - name: Warn if requested tier not found in storage_tier_definitions
+        - name: Warn if no requested tiers found in storage_tier_definitions
           ansible.builtin.debug:
             msg: >-
-              Requested storage tier '{{ _requested_storage_tier }}' not found in storage_tier_definitions.
+              None of the requested storage tiers {{ _cr_requested_tiers | to_json }}
+              found in storage_tier_definitions.
               Available tiers: {{ osac_job_vars.storage_tier_definitions | map(attribute='name') | list | to_json }}.
               JIT storage provisioning will be skipped.
           when: _jit_storage_tiers | length == 0

--- a/osac-aap/tests/integration/fixtures/computeinstance-test.yaml
+++ b/osac-aap/tests/integration/fixtures/computeinstance-test.yaml
@@ -12,6 +12,7 @@ spec:
   memoryGiB: 4
   bootDisk:
     sizeGiB: 20
+    storageTier: local
   image:
     sourceType: registry
     sourceRef: "quay.io/containerdisks/fedora:latest"

--- a/osac-aap/tests/integration/fixtures/computeinstance-with-gpu-test.yaml
+++ b/osac-aap/tests/integration/fixtures/computeinstance-with-gpu-test.yaml
@@ -12,6 +12,7 @@ spec:
   memoryGiB: 4
   bootDisk:
     sizeGiB: 20
+    storageTier: local
   image:
     sourceType: registry
     sourceRef: "quay.io/containerdisks/fedora:latest"

--- a/osac-aap/tests/integration/targets/compute_instance_create/tasks/baseline.yml
+++ b/osac-aap/tests/integration/targets/compute_instance_create/tasks/baseline.yml
@@ -15,7 +15,9 @@
         osac_job_vars:
           resource: "{{ test_compute_instance }}"
         tenant_target_namespace: "computeinstance-test-vm-work"
-        tenant_storage_class_name: "test-storage-class"
+        tenant_storage_class_storage_classes:
+          - name: "test-storage-class"
+            tier: "local"
         # Override only resource creation to prevent actual VM/DataVolume creation
         create_step_resources_override:
           name: osac.workflows.workflow_helpers

--- a/osac-aap/tests/integration/targets/compute_instance_create/tasks/overrides.yml
+++ b/osac-aap/tests/integration/targets/compute_instance_create/tasks/overrides.yml
@@ -25,7 +25,9 @@
         osac_job_vars:
           resource: "{{ test_compute_instance }}"
         tenant_target_namespace: "computeinstance-test-vm-work"
-        tenant_storage_class_name: "test-storage-class"
+        tenant_storage_class_storage_classes:
+          - name: "test-storage-class"
+            tier: "local"
 
         # Override 3 workflow extension points
         hook_workflow_start:

--- a/osac-aap/tests/integration/targets/compute_instance_with_gpu_create/tasks/baseline.yml
+++ b/osac-aap/tests/integration/targets/compute_instance_with_gpu_create/tasks/baseline.yml
@@ -15,7 +15,9 @@
         osac_job_vars:
           resource: "{{ test_compute_instance }}"
         tenant_target_namespace: "computeinstance-test-vm-gpu-work"
-        tenant_storage_class_name: "test-storage-class"
+        tenant_storage_class_storage_classes:
+          - name: "test-storage-class"
+            tier: "local"
         create_step_resources_override:
           name: osac.workflows.workflow_helpers
           tasks_from: noop.yml

--- a/osac-aap/tests/test-windows-golden-image.yml
+++ b/osac-aap/tests/test-windows-golden-image.yml
@@ -26,6 +26,7 @@
         memoryGiB: 8
         bootDisk:
           sizeGiB: 80
+          storageTier: default
         image:
           sourceRef: "{{ golden_image_ref }}"
         runStrategy: "Always"


### PR DESCRIPTION
## [OSAC-3632](https://redhat.atlassian.net/browse/OSAC-3632): per-disk StorageClass resolution in AAP

**Jira:** [OSAC-3632](https://redhat.atlassian.net/browse/OSAC-3632)
**Story type:** [DEV]

### Summary

Replaces the single global `STORAGE_REQUESTED_TIER` environment variable with per-disk StorageClass resolution from the CR payload's `storageTier` field. Each disk (boot + additional) now resolves its StorageClass independently via the `tenant_storage_class` role, with all resolution completing before any DataVolumes are created.

Part of [OSAC-1710](https://redhat.atlassian.net/browse/OSAC-1710) (design §7a, §7b, §7c).

### Dependencies

Removing the `STORAGE_REQUESTED_TIER` fallback makes a resolvable `storageTier` mandatory at provisioning time. The `e2e-vmaas-full-install` job stays red until the E2E environment seeds a `StorageTier` and passes `--boot-disk-storage-tier`:

- Depends on osac-project/osac-test-infra#367 ([OSAC-3633](https://redhat.atlassian.net/browse/OSAC-3633): adds per-disk storage-tier E2E tests and StorageTier seeding). Its vmaas/bmaas/caas e2e runs are green; once it merges, this PR's `e2e-vmaas` will pass on a fresh run.

### Changes

**Per-disk resolution (`osac-aap/`):**
- Removed `_requested_storage_tier` variable and `STORAGE_REQUESTED_TIER` env var from `playbook_osac_create_compute_instance.yml`
- Refactored `create_resources.yaml` into two phases: (1) resolve all storage tiers, (2) create DataVolumes with per-disk StorageClasses
- Added `resolve_additional_disk.yaml` to resolve each additional disk's tier in a loop
- Updated JIT storage provisioning to collect unique tiers from CR payload instead of using a single env var
- Updated workflow guard in `compute_instance/create.yml` to check `tenant_storage_class_storage_classes` list

**Role enhancement:**
- Added optional `tenant_storage_class_disk_label` parameter to `tenant_storage_class` role for disk-identifying error messages

**Test updates:**
- Added `storageTier: local` to test fixtures (`computeinstance-test.yaml`, `computeinstance-with-gpu-test.yaml`)
- Updated integration test baselines/overrides to use `tenant_storage_class_storage_classes` list instead of `tenant_storage_class_name`
- Added role test for disk label inclusion in error messages
- Changed `setup_test_env.sh` to use local mono-repo CRDs instead of cloning upstream

### Testing
- **Role tests:** 5 tests pass (happy path, tier not available, empty list, duplicate tiers, disk label in errors)
- **Integration tests:** Baselines and overrides updated for per-disk resolution pattern
- **Coverage:** All behavioral contracts of the `tenant_storage_class` role tested through public interfaces

### Acceptance Criteria

- [x] AC-1: `STORAGE_REQUESTED_TIER` env var and `_requested_storage_tier` variable removed
- [x] AC-2: Boot disk storageTier read from CR payload and resolved via `tenant_storage_class` role
- [x] AC-3: Each additional disk storageTier resolved independently
- [x] AC-4: All tier resolution completes before any DataVolumes are created
- [x] AC-5: Boot disk DataVolume uses `boot_disk_storage_class`; additional disks use `additional_disk_storage_classes[idx]`
- [x] AC-6: Tier resolution failure messages identify the affected disk



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compute instances can resolve storage classes independently for boot and additional disks.
  * Storage provisioning now supports all storage tiers requested by the instance configuration.
  * Storage resolution errors can identify the affected disk by label.

* **Bug Fixes**
  * Prevented additional disks from incorrectly sharing the boot disk’s storage class.
  * Improved validation and guidance when storage class configuration is missing or incomplete.
  * Improved error messages when requested storage tiers are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->