### PR TITLE
OSAC-3915: Make pull_secret an optional template parameter

### DIFF
--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_small_nico/meta/osac.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_4_20_small_nico/meta/osac.yaml
@@ -28,8 +28,10 @@ parameters:
     title: Pull Secret
     description: >
       The pull secret contains credentials for authenticating to image repositories.
+      Resolved automatically from spec.pullSecret or the provider default Secret
+      when not provided as a template parameter.
     type: string
-    required: true
+    required: false
   - name: ssh_public_key
     title: SSH Public Key
     description: >

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_ci_small/meta/osac.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_ci_small/meta/osac.yaml
@@ -20,8 +20,10 @@ parameters:
     title: Pull Secret
     description: >
       The pull secret contains credentials for authenticating to image repositories.
+      Resolved automatically from spec.pullSecret or the provider default Secret
+      when not provided as a template parameter.
     type: string
-    required: true
+    required: false
   - name: ssh_public_key
     title: SSH Public Key
     description: >


### PR DESCRIPTION
## Summary

Cluster creation from the UI always fails for `ocp_ci_small` and `ocp_4_20_small_nico` because `pull_secret` is declared as a **required** template parameter. The UI populates the dedicated `spec.pullSecret` field but has no way to populate `spec.template_parameters`, so `ValidateTemplateParameters` always rejects the request.

## Fix

Change `pull_secret` from `required: true` to `required: false` in both templates. The `cluster_settings` service role resolves credentials at runtime via a fallback chain (spec field > templateParameters > provider default Secret), so requiring it as a template parameter was never necessary. CLI users can still pass `-p pull_secret=...` if they choose to.

## Background

The `pull_secret` and `ssh_public_key` parameters were inherited from `argument_specs.yaml`. The working `ocp_small` and `ocp_4_20_ai_maas` templates never declared them as required.

## Test plan

- [x] `ansible-lint` passes
- [x] Unit tests pass
- [ ] CaaS E2E: existing tests still pass (they pass credentials via `-p`/`-f`, which remains valid since the parameters are still declared, just optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Made the pull secret configuration optional for the OpenShift 4.20 NICo and CI cluster templates.
  * Pull secrets can now be resolved automatically from the cluster specification or the provider’s default Secret when not supplied.
  * SSH public key configuration remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->