### PR TITLE
NO-ISSUE: Make default cluster version setup idempotent in IT

### DIFF
--- a/fulfillment-service/it/it_suite_test.go
+++ b/fulfillment-service/it/it_suite_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/klog/v2"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
 
-	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/logging"
 )
 
@@ -127,22 +126,6 @@ var _ = BeforeSuite(func() {
 		err := tool.Cleanup(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	})
-
-	// Create a default cluster version for version resolution during cluster creation:
-	cvClient := privatev1.NewClusterVersionsClient(tool.InternalView().AdminConn())
-	_, err = cvClient.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
-		Object: privatev1.ClusterVersion_builder{
-			Metadata: privatev1.Metadata_builder{
-				Name: "default",
-			}.Build(),
-			Spec: privatev1.ClusterVersionSpec_builder{
-				Version:   "4.17.0",
-				Image:     "quay.io/openshift-release-dev/ocp-release:4.17.0-multi",
-				IsDefault: new(true),
-			}.Build(),
-		}.Build(),
-	}.Build())
-	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = Describe("Integration", func() {

--- a/fulfillment-service/it/it_tool.go
+++ b/fulfillment-service/it/it_tool.go
@@ -434,7 +434,14 @@ func (t *Tool) Setup(ctx context.Context) error {
 	}
 
 	// Register the hub:
-	if err = t.registerHub(ctx); err != nil {
+	err = t.ensureHub(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Ensure that a default cluster version is present:
+	err = t.ensureDefaultClusterVersion(ctx)
+	if err != nil {
 		return err
 	}
 
@@ -2258,7 +2265,7 @@ func (t *Tool) createHubNamespace(ctx context.Context) error {
 	return nil
 }
 
-func (t *Tool) registerHub(ctx context.Context) error {
+func (t *Tool) ensureHub(ctx context.Context) error {
 	t.logger.DebugContext(ctx, "Registering hub")
 
 	// Prepare the kubeconfig for the hub:
@@ -2311,6 +2318,28 @@ func (t *Tool) registerHub(ctx context.Context) error {
 		return fmt.Errorf("failed to create hub: %w", err)
 	}
 	return nil
+}
+
+// ensureDefaultClusterVersion ensures that a default cluster version is present for version resolution during cluster creation.
+func (t *Tool) ensureDefaultClusterVersion(ctx context.Context) error {
+	client := privatev1.NewClusterVersionsClient(t.internalView.adminConn)
+	_, err := client.Create(ctx, privatev1.ClusterVersionsCreateRequest_builder{
+		Object: privatev1.ClusterVersion_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name: "default",
+			}.Build(),
+			Spec: privatev1.ClusterVersionSpec_builder{
+				Version:   "4.17.0",
+				Image:     "quay.io/openshift-release-dev/ocp-release:4.17.0-multi",
+				IsDefault: new(true),
+			}.Build(),
+		}.Build(),
+	}.Build())
+	status, ok := grpcstatus.FromError(err)
+	if ok && status.Code() == grpccodes.AlreadyExists {
+		return nil
+	}
+	return fmt.Errorf("failed to create default cluster version: %w", err)
 }
 
 // buildCLI builds the osac CLI binary and stores its path for use in CLI integration tests.


### PR DESCRIPTION
## Summary

Move default cluster version creation from the test suite `BeforeSuite` hook into
`Tool.Setup` and treat `AlreadyExists` as success. This keeps integration tests
from failing on a subsequent run when the service is left running after the
previous run, for example with `IT_KEEP_SERVICE`.

## Test plan

- [x] Run integration tests with a fresh service deployment
- [x] Run integration tests again with `IT_KEEP_SERVICE` set and verify setup succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test setup by automatically ensuring required hub and cluster-version resources are available.
  * Added idempotent handling so existing resources do not cause setup failures.
  * Simplified test initialization by removing an unnecessary API client dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->