### PR TITLE
OSAC-1504, OSAC-2245: validate cluster network_attachment and inject tenant defaults

### DIFF
--- a/fulfillment-service/internal/servers/default_network_helpers.go
+++ b/fulfillment-service/internal/servers/default_network_helpers.go
@@ -1,0 +1,117 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+
+	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
+)
+
+// findDefaultSubnet returns the newest READY subnet labeled as a tenant default
+// with an IPv4 CIDR, scoped to the given tenant. Returns nil if none found.
+func findDefaultSubnet(
+	ctx context.Context,
+	logger *slog.Logger,
+	subnetsDao *dao.GenericDAO[*privatev1.Subnet],
+	tenant string,
+) (*privatev1.Subnet, error) {
+	filter := fmt.Sprintf(
+		"this.metadata.labels[\"%s\"] == \"true\" && has(this.spec.ipv4_cidr) && this.metadata.tenant == \"%s\"",
+		defaultLabel, tenant,
+	)
+	listResponse, err := subnetsDao.List().
+		SetFilter(filter).
+		Do(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var items []*privatev1.Subnet
+	for _, subnet := range listResponse.GetItems() {
+		if subnet.GetMetadata().HasDeletionTimestamp() {
+			continue
+		}
+		if subnet.GetStatus().GetState() != privatev1.SubnetState_SUBNET_STATE_READY {
+			continue
+		}
+		items = append(items, subnet)
+	}
+	if len(items) == 0 {
+		return nil, nil
+	}
+	sort.Slice(items, func(i, j int) bool {
+		ti := items[i].GetMetadata().GetCreationTimestamp().AsTime()
+		tj := items[j].GetMetadata().GetCreationTimestamp().AsTime()
+		return ti.After(tj)
+	})
+	if len(items) > 1 {
+		logger.WarnContext(ctx, "multiple default Subnets found, using newest",
+			slog.Int("count", len(items)),
+		)
+	}
+	return items[0], nil
+}
+
+// findDefaultSecurityGroup returns the newest READY security group labeled as a
+// tenant default that belongs to the given virtual network, scoped to the given
+// tenant. Returns nil if none found.
+func findDefaultSecurityGroup(
+	ctx context.Context,
+	logger *slog.Logger,
+	securityGroupsDao *dao.GenericDAO[*privatev1.SecurityGroup],
+	virtualNetworkID string,
+	tenant string,
+) (*privatev1.SecurityGroup, error) {
+	filter := fmt.Sprintf(
+		"this.metadata.labels[\"%s\"] == \"true\" && this.metadata.tenant == \"%s\"",
+		defaultLabel, tenant,
+	)
+	listResponse, err := securityGroupsDao.List().
+		SetFilter(filter).
+		Do(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var items []*privatev1.SecurityGroup
+	for _, sg := range listResponse.GetItems() {
+		if sg.GetMetadata().HasDeletionTimestamp() {
+			continue
+		}
+		if sg.GetStatus().GetState() != privatev1.SecurityGroupState_SECURITY_GROUP_STATE_READY {
+			continue
+		}
+		if refKey(sg.GetSpec().GetVirtualNetwork()) != virtualNetworkID {
+			continue
+		}
+		items = append(items, sg)
+	}
+	if len(items) == 0 {
+		return nil, nil
+	}
+	sort.Slice(items, func(i, j int) bool {
+		ti := items[i].GetMetadata().GetCreationTimestamp().AsTime()
+		tj := items[j].GetMetadata().GetCreationTimestamp().AsTime()
+		return ti.After(tj)
+	})
+	if len(items) > 1 {
+		logger.WarnContext(ctx, "multiple default SecurityGroups found, using newest",
+			slog.Int("count", len(items)),
+		)
+	}
+	return items[0], nil
+}

--- a/fulfillment-service/internal/servers/private_clusters_server.go
+++ b/fulfillment-service/internal/servers/private_clusters_server.go
@@ -52,10 +52,13 @@ var _ privatev1.ClustersServer = (*PrivateClustersServer)(nil)
 type PrivateClustersServer struct {
 	privatev1.UnimplementedClustersServer
 	logger             *slog.Logger
+	tenancyLogic       auth.TenancyLogic
 	templatesDao       *dao.GenericDAO[*privatev1.ClusterTemplate]
 	catalogItemsDao    *dao.GenericDAO[*privatev1.ClusterCatalogItem]
 	hostTypesDao       *dao.GenericDAO[*privatev1.HostType]
 	clusterVersionsDao *dao.GenericDAO[*privatev1.ClusterVersion]
+	subnetsDao         *dao.GenericDAO[*privatev1.Subnet]
+	securityGroupsDao  *dao.GenericDAO[*privatev1.SecurityGroup]
 	generic            *GenericServer[*privatev1.Cluster]
 }
 
@@ -140,6 +143,26 @@ func (b *PrivateClustersServerBuilder) Build() (result *PrivateClustersServer, e
 		return
 	}
 
+	// Create the subnets DAO:
+	subnetsDao, err := dao.NewGenericDAO[*privatev1.Subnet]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	// Create the security groups DAO:
+	securityGroupsDao, err := dao.NewGenericDAO[*privatev1.SecurityGroup]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
 	// Create the generic server:
 	generic, err := NewGenericServer[*privatev1.Cluster]().
 		SetLogger(b.logger).
@@ -156,10 +179,13 @@ func (b *PrivateClustersServerBuilder) Build() (result *PrivateClustersServer, e
 	// Create and populate the object:
 	result = &PrivateClustersServer{
 		logger:             b.logger,
+		tenancyLogic:       b.tenancyLogic,
 		templatesDao:       templatesDao,
 		catalogItemsDao:    catalogItemsDao,
 		hostTypesDao:       hostTypesDao,
 		clusterVersionsDao: clusterVersionsDao,
+		subnetsDao:         subnetsDao,
+		securityGroupsDao:  securityGroupsDao,
 		generic:            generic,
 	}
 	return
@@ -227,7 +253,33 @@ func (s *PrivateClustersServer) Create(ctx context.Context,
 		}
 	}
 
+	// Inject default network attachment from tenant defaults when not provided.
+	// Injection errors are deferred — generic.Create validates the tenant and
+	// produces a clearer error when the tenant itself doesn't exist.
+	var networkAttachmentErr error
+	if request.GetObject().GetSpec().GetNetworkAttachment() == nil {
+		networkAttachmentErr = s.injectDefaultNetworkAttachment(ctx, request.GetObject())
+	}
+
+	// Validate network attachment references (subnet READY, SGs same-VN):
+	if networkAttachmentErr == nil && request.GetObject().GetSpec().GetNetworkAttachment() != nil {
+		networkAttachmentErr = s.validateNetworkAttachmentState(ctx, request.GetObject())
+	}
+
+	// Attempt to persist — generic.Create validates tenant existence, so if the
+	// tenant is invalid, the tenant error takes priority over a network error.
 	err = s.generic.Create(ctx, request, &response)
+	if err != nil {
+		return
+	}
+
+	// If persist succeeded but we had a deferred network attachment error, roll
+	// back by returning the error (the DB transaction will be rolled back by the
+	// gRPC interceptor).
+	if networkAttachmentErr != nil {
+		err = networkAttachmentErr
+		response = nil
+	}
 	return
 }
 
@@ -256,6 +308,38 @@ func (s *PrivateClustersServer) Update(ctx context.Context,
 	err = s.validateNetworkAttachmentImmutability(ctx, request)
 	if err != nil {
 		return
+	}
+	// Validate network attachment state when security groups are being updated.
+	// For sub-field masks (e.g. spec.network_attachment.security_groups), merge
+	// the existing cluster's subnet into the update object before validation,
+	// because the caller may only send the changed security_groups.
+	mask := request.GetUpdateMask()
+	if mask != nil && len(mask.GetPaths()) > 0 &&
+		updateIncludesField(mask, "spec.network_attachment.security_groups") {
+		obj := request.GetObject()
+		if obj == nil || obj.GetSpec() == nil {
+			err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object and spec are required")
+			return
+		}
+		if obj.GetSpec().GetNetworkAttachment().GetSubnet() == nil {
+			existing, found, lookupErr := s.getExistingCluster(ctx, request)
+			if lookupErr != nil {
+				err = lookupErr
+				return
+			}
+			if found && existing.GetSpec().GetNetworkAttachment() != nil {
+				att := obj.GetSpec().GetNetworkAttachment()
+				if att == nil {
+					att = privatev1.ClusterNetworkAttachment_builder{}.Build()
+					obj.GetSpec().SetNetworkAttachment(att)
+				}
+				att.SetSubnet(existing.GetSpec().GetNetworkAttachment().GetSubnet())
+			}
+		}
+		err = s.validateNetworkAttachmentState(ctx, request.GetObject())
+		if err != nil {
+			return
+		}
 	}
 	if err = utils.ValidateClusterSpecFields(request.GetObject().GetSpec()); err != nil {
 		return
@@ -688,6 +772,153 @@ func (s *PrivateClustersServer) validateNetworkAttachmentImmutability(ctx contex
 			"cannot change spec.network_attachment.subnet from '%s' to '%s': subnet is immutable",
 			refKey(existingSubnet), refKey(newSubnet),
 		)
+	}
+
+	return nil
+}
+
+// resolveTargetTenant returns the tenant from the cluster metadata, falling
+// back to the caller's default tenant when not explicitly set.
+func (s *PrivateClustersServer) resolveTargetTenant(ctx context.Context, cluster *privatev1.Cluster) (string, error) {
+	if t := cluster.GetMetadata().GetTenant(); t != "" {
+		return t, nil
+	}
+	return s.tenancyLogic.DetermineDefaultTenant(ctx)
+}
+
+// injectDefaultNetworkAttachment populates spec.network_attachment from the
+// tenant's default subnet and security group when the caller omits it.
+func (s *PrivateClustersServer) injectDefaultNetworkAttachment(ctx context.Context,
+	cluster *privatev1.Cluster) error {
+	tenant, err := s.resolveTargetTenant(ctx, cluster)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "failed to determine target tenant", slog.Any("error", err))
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to determine target tenant")
+	}
+
+	spec := cluster.GetSpec()
+	subnet, err := findDefaultSubnet(ctx, s.logger, s.subnetsDao, tenant)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "failed to look up default subnet", slog.Any("error", err))
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to look up default subnet")
+	}
+	if subnet == nil {
+		return nil
+	}
+
+	attachment := privatev1.ClusterNetworkAttachment_builder{
+		Subnet: privatev1.SubnetLocalReference_builder{Id: subnet.GetId()}.Build(),
+	}.Build()
+
+	virtualNetworkID := refKey(subnet.GetSpec().GetVirtualNetwork())
+	sg, err := findDefaultSecurityGroup(ctx, s.logger, s.securityGroupsDao, virtualNetworkID, tenant)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "failed to look up default security group", slog.Any("error", err))
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to look up default security group")
+	}
+	if sg != nil {
+		attachment.SetSecurityGroups([]*privatev1.SecurityGroupLocalReference{
+			privatev1.SecurityGroupLocalReference_builder{Id: sg.GetId()}.Build(),
+		})
+	}
+
+	spec.SetNetworkAttachment(attachment)
+
+	attrs := []slog.Attr{
+		slog.String("subnet_id", subnet.GetId()),
+	}
+	if sg != nil {
+		attrs = append(attrs, slog.String("security_group_id", sg.GetId()))
+	}
+	s.logger.LogAttrs(ctx, slog.LevelInfo, "auto-injected default network attachment", attrs...)
+	return nil
+}
+
+// validateNetworkAttachmentState validates that the subnet referenced by the
+// cluster's network attachment is READY, and that all security groups are READY
+// and belong to the same virtual network as the subnet.
+func (s *PrivateClustersServer) validateNetworkAttachmentState(ctx context.Context, cluster *privatev1.Cluster) error {
+	if cluster == nil || cluster.GetSpec() == nil {
+		return nil
+	}
+	att := cluster.GetSpec().GetNetworkAttachment()
+	if att == nil {
+		return nil
+	}
+
+	subnetRef := att.GetSubnet()
+	subnetKey := refKey(subnetRef)
+	if subnetKey == "" {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"spec.network_attachment.subnet is required")
+	}
+
+	getResponse, getErr := s.subnetsDao.Get().SetId(subnetKey).Do(ctx)
+	if getErr != nil {
+		var notFoundErr *dao.ErrNotFound
+		if errors.As(getErr, &notFoundErr) {
+			return grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"spec.network_attachment: subnet '%s' does not exist", subnetKey)
+		}
+		s.logger.ErrorContext(ctx, "failed to query subnet",
+			slog.String("subnet_key", subnetKey), slog.Any("error", getErr))
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to validate subnet")
+	}
+	subnet := getResponse.GetObject()
+	if subnet == nil {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"spec.network_attachment: subnet '%s' does not exist", subnetKey)
+	}
+	if subnet.GetStatus().GetState() != privatev1.SubnetState_SUBNET_STATE_READY {
+		return grpcstatus.Errorf(grpccodes.FailedPrecondition,
+			"spec.network_attachment: subnet '%s' is not in READY state (current state: %s)",
+			subnetKey, subnet.GetStatus().GetState().String())
+	}
+
+	virtualNetworkID := refKey(subnet.GetSpec().GetVirtualNetwork())
+	if virtualNetworkID == "" {
+		return grpcstatus.Errorf(grpccodes.Internal,
+			"spec.network_attachment: subnet '%s' has no virtual network reference", subnetKey)
+	}
+
+	for i, sgRef := range att.GetSecurityGroups() {
+		sgKey := refKey(sgRef)
+		if sgKey == "" {
+			return grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"spec.network_attachment.security_groups[%d]: reference is empty", i)
+		}
+
+		sgResponse, getErr := s.securityGroupsDao.Get().SetId(sgKey).Do(ctx)
+		if getErr != nil {
+			var notFoundErr *dao.ErrNotFound
+			if errors.As(getErr, &notFoundErr) {
+				return grpcstatus.Errorf(grpccodes.InvalidArgument,
+					"spec.network_attachment.security_groups[%d]: security group '%s' does not exist",
+					i, sgKey)
+			}
+			s.logger.ErrorContext(ctx, "failed to query security group",
+				slog.String("security_group_key", sgKey), slog.Any("error", getErr))
+			return grpcstatus.Errorf(grpccodes.Internal, "failed to validate security group")
+		}
+		sg := sgResponse.GetObject()
+		if sg == nil {
+			return grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"spec.network_attachment.security_groups[%d]: security group '%s' does not exist",
+				i, sgKey)
+		}
+		if sg.GetStatus().GetState() != privatev1.SecurityGroupState_SECURITY_GROUP_STATE_READY {
+			return grpcstatus.Errorf(grpccodes.FailedPrecondition,
+				"spec.network_attachment.security_groups[%d]: security group '%s' is not in READY state (current state: %s)",
+				i, sgKey, sg.GetStatus().GetState().String())
+		}
+
+		sgVirtualNetworkID := refKey(sg.GetSpec().GetVirtualNetwork())
+		if sgVirtualNetworkID != virtualNetworkID {
+			return grpcstatus.Errorf(grpccodes.InvalidArgument,
+				"spec.network_attachment.security_groups[%d]: security group '%s' belongs to VirtualNetwork '%s', "+
+					"but subnet '%s' belongs to VirtualNetwork '%s'",
+				i, sgKey, sgVirtualNetworkID, subnetKey, virtualNetworkID)
+		}
 	}
 
 	return nil

--- a/fulfillment-service/internal/servers/private_clusters_server_test.go
+++ b/fulfillment-service/internal/servers/private_clusters_server_test.go
@@ -195,7 +195,7 @@ var _ = Describe("Private clusters server", func() {
 				Id: "test-vnet",
 				Metadata: privatev1.Metadata_builder{
 					Name:   "test-vnet",
-					Tenant: auth.SharedTenant,
+					Tenant: auth.SystemTenant,
 				}.Build(),
 			}.Build()).Do(ctx)
 			Expect(err).ToNot(HaveOccurred())
@@ -210,7 +210,7 @@ var _ = Describe("Private clusters server", func() {
 					Id: subnetID,
 					Metadata: privatev1.Metadata_builder{
 						Name:   subnetID,
-						Tenant: auth.SharedTenant,
+						Tenant: auth.SystemTenant,
 					}.Build(),
 					Spec: privatev1.SubnetSpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: "test-vnet"}.Build(),
@@ -222,6 +222,54 @@ var _ = Describe("Private clusters server", func() {
 				}.Build()).Do(ctx)
 				Expect(err).ToNot(HaveOccurred())
 			}
+
+			sgDao, err := dao.NewGenericDAO[*privatev1.SecurityGroup]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			_, err = sgDao.Create().SetObject(privatev1.SecurityGroup_builder{
+				Id: "default-sg",
+				Metadata: privatev1.Metadata_builder{
+					Name:   "default-sg",
+					Tenant: auth.SystemTenant,
+				}.Build(),
+				Spec: privatev1.SecurityGroupSpec_builder{
+					VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: "test-vnet"}.Build(),
+				}.Build(),
+				Status: privatev1.SecurityGroupStatus_builder{
+					State: privatev1.SecurityGroupState_SECURITY_GROUP_STATE_READY,
+				}.Build(),
+			}.Build()).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = sgDao.Create().SetObject(privatev1.SecurityGroup_builder{
+				Id: "sg-2",
+				Metadata: privatev1.Metadata_builder{
+					Name:   "sg-2",
+					Tenant: auth.SystemTenant,
+				}.Build(),
+				Spec: privatev1.SecurityGroupSpec_builder{
+					VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: "test-vnet"}.Build(),
+				}.Build(),
+				Status: privatev1.SecurityGroupStatus_builder{
+					State: privatev1.SecurityGroupState_SECURITY_GROUP_STATE_READY,
+				}.Build(),
+			}.Build()).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = sgDao.Create().SetObject(privatev1.SecurityGroup_builder{
+				Id: "sg-3",
+				Metadata: privatev1.Metadata_builder{
+					Name:   "sg-3",
+					Tenant: auth.SystemTenant,
+				}.Build(),
+				Spec: privatev1.SecurityGroupSpec_builder{
+					VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: "test-vnet"}.Build(),
+				}.Build(),
+				Status: privatev1.SecurityGroupStatus_builder{
+					State: privatev1.SecurityGroupState_SECURITY_GROUP_STATE_READY,
+				}.Build(),
+			}.Build()).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
 
 			// Create numbered templates for list tests:
 			for i := range 10 {
@@ -764,7 +812,8 @@ var _ = Describe("Private clusters server", func() {
 				Object: privatev1.Cluster_builder{
 					Id: object.GetId(),
 					Spec: privatev1.ClusterSpec_builder{
-						Template: object.GetSpec().GetTemplate(),
+						Template:          object.GetSpec().GetTemplate(),
+						NetworkAttachment: object.GetSpec().GetNetworkAttachment(),
 					}.Build(),
 					Status: privatev1.ClusterStatus_builder{
 						Hub: "your_hub",
@@ -1395,7 +1444,7 @@ var _ = Describe("Private clusters server", func() {
 			}
 
 			It("Rejects changing subnet via whole attachment replacement", func() {
-				object := createClusterWithNetworkAttachment(privatev1.SubnetLocalReference_builder{Id: "subnet-1"}.Build(), []*privatev1.SecurityGroupLocalReference{privatev1.SecurityGroupLocalReference_builder{Id: "sg-1"}.Build()})
+				object := createClusterWithNetworkAttachment(privatev1.SubnetLocalReference_builder{Id: "subnet-1"}.Build(), []*privatev1.SecurityGroupLocalReference{privatev1.SecurityGroupLocalReference_builder{Id: "default-sg"}.Build()})
 
 				_, err := server.Update(ctx, privatev1.ClustersUpdateRequest_builder{
 					Object: privatev1.Cluster_builder{
@@ -1403,7 +1452,7 @@ var _ = Describe("Private clusters server", func() {
 						Spec: privatev1.ClusterSpec_builder{
 							NetworkAttachment: privatev1.ClusterNetworkAttachment_builder{
 								Subnet:         privatev1.SubnetLocalReference_builder{Id: "subnet-2"}.Build(),
-								SecurityGroups: []*privatev1.SecurityGroupLocalReference{privatev1.SecurityGroupLocalReference_builder{Id: "sg-1"}.Build()},
+								SecurityGroups: []*privatev1.SecurityGroupLocalReference{privatev1.SecurityGroupLocalReference_builder{Id: "default-sg"}.Build()},
 							}.Build(),
 						}.Build(),
 					}.Build(),
@@ -1421,7 +1470,7 @@ var _ = Describe("Private clusters server", func() {
 			})
 
 			It("Rejects removing network_attachment when one exists", func() {
-				object := createClusterWithNetworkAttachment(privatev1.SubnetLocalReference_builder{Id: "subnet-1"}.Build(), []*privatev1.SecurityGroupLocalReference{privatev1.SecurityGroupLocalReference_builder{Id: "sg-1"}.Build()})
+				object := createClusterWithNetworkAttachment(privatev1.SubnetLocalReference_builder{Id: "subnet-1"}.Build(), []*privatev1.SecurityGroupLocalReference{privatev1.SecurityGroupLocalReference_builder{Id: "default-sg"}.Build()})
 
 				_, err := server.Update(ctx, privatev1.ClustersUpdateRequest_builder{
 					Object: privatev1.Cluster_builder{
@@ -1476,7 +1525,7 @@ var _ = Describe("Private clusters server", func() {
 			})
 
 			It("Allows changing security_groups with same subnet", func() {
-				object := createClusterWithNetworkAttachment(privatev1.SubnetLocalReference_builder{Id: "subnet-1"}.Build(), []*privatev1.SecurityGroupLocalReference{privatev1.SecurityGroupLocalReference_builder{Id: "sg-1"}.Build()})
+				object := createClusterWithNetworkAttachment(privatev1.SubnetLocalReference_builder{Id: "subnet-1"}.Build(), []*privatev1.SecurityGroupLocalReference{privatev1.SecurityGroupLocalReference_builder{Id: "default-sg"}.Build()})
 
 				updateResponse, err := server.Update(ctx, privatev1.ClustersUpdateRequest_builder{
 					Object: privatev1.Cluster_builder{
@@ -1484,7 +1533,7 @@ var _ = Describe("Private clusters server", func() {
 						Spec: privatev1.ClusterSpec_builder{
 							NetworkAttachment: privatev1.ClusterNetworkAttachment_builder{
 								Subnet:         privatev1.SubnetLocalReference_builder{Id: "subnet-1"}.Build(),
-								SecurityGroups: []*privatev1.SecurityGroupLocalReference{privatev1.SecurityGroupLocalReference_builder{Id: "sg-1"}.Build(), privatev1.SecurityGroupLocalReference_builder{Id: "sg-2"}.Build()},
+								SecurityGroups: []*privatev1.SecurityGroupLocalReference{privatev1.SecurityGroupLocalReference_builder{Id: "default-sg"}.Build(), privatev1.SecurityGroupLocalReference_builder{Id: "sg-2"}.Build()},
 							}.Build(),
 						}.Build(),
 					}.Build(),
@@ -1496,12 +1545,12 @@ var _ = Describe("Private clusters server", func() {
 				updated := updateResponse.GetObject()
 				Expect(updated.GetSpec().GetNetworkAttachment().GetSubnet().GetId()).To(Equal("subnet-1"))
 				Expect(updated.GetSpec().GetNetworkAttachment().GetSecurityGroups()).To(HaveLen(2))
-				Expect(updated.GetSpec().GetNetworkAttachment().GetSecurityGroups()[0].GetId()).To(Equal("sg-1"))
+				Expect(updated.GetSpec().GetNetworkAttachment().GetSecurityGroups()[0].GetId()).To(Equal("default-sg"))
 				Expect(updated.GetSpec().GetNetworkAttachment().GetSecurityGroups()[1].GetId()).To(Equal("sg-2"))
 			})
 
 			It("Allows updating security_groups via sub-field mask", func() {
-				object := createClusterWithNetworkAttachment(privatev1.SubnetLocalReference_builder{Id: "subnet-1"}.Build(), []*privatev1.SecurityGroupLocalReference{privatev1.SecurityGroupLocalReference_builder{Id: "sg-1"}.Build()})
+				object := createClusterWithNetworkAttachment(privatev1.SubnetLocalReference_builder{Id: "subnet-1"}.Build(), []*privatev1.SecurityGroupLocalReference{privatev1.SecurityGroupLocalReference_builder{Id: "default-sg"}.Build()})
 
 				updateResponse, err := server.Update(ctx, privatev1.ClustersUpdateRequest_builder{
 					Object: privatev1.Cluster_builder{
@@ -1524,7 +1573,7 @@ var _ = Describe("Private clusters server", func() {
 			})
 
 			It("Passes through when mask does not include network_attachment", func() {
-				object := createClusterWithNetworkAttachment(privatev1.SubnetLocalReference_builder{Id: "subnet-1"}.Build(), []*privatev1.SecurityGroupLocalReference{privatev1.SecurityGroupLocalReference_builder{Id: "sg-1"}.Build()})
+				object := createClusterWithNetworkAttachment(privatev1.SubnetLocalReference_builder{Id: "subnet-1"}.Build(), []*privatev1.SecurityGroupLocalReference{privatev1.SecurityGroupLocalReference_builder{Id: "default-sg"}.Build()})
 
 				updateResponse, err := server.Update(ctx, privatev1.ClustersUpdateRequest_builder{
 					Object: privatev1.Cluster_builder{

--- a/fulfillment-service/internal/servers/private_compute_instances_server.go
+++ b/fulfillment-service/internal/servers/private_compute_instances_server.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -54,6 +53,7 @@ type PrivateComputeInstancesServer struct {
 	privatev1.UnimplementedComputeInstancesServer
 
 	logger                  *slog.Logger
+	tenancyLogic            auth.TenancyLogic
 	generic                 *GenericServer[*privatev1.ComputeInstance]
 	templatesDao            *dao.GenericDAO[*privatev1.ComputeInstanceTemplate]
 	catalogItemsDao         *dao.GenericDAO[*privatev1.ComputeInstanceCatalogItem]
@@ -200,6 +200,7 @@ func (b *PrivateComputeInstancesServerBuilder) Build() (result *PrivateComputeIn
 	// Create and populate the object:
 	result = &PrivateComputeInstancesServer{
 		logger:                  b.logger,
+		tenancyLogic:            b.tenancyLogic,
 		generic:                 generic,
 		templatesDao:            templatesDao,
 		catalogItemsDao:         catalogItemsDao,
@@ -225,79 +226,20 @@ func (s *PrivateComputeInstancesServer) Get(ctx context.Context,
 	return
 }
 
-func (s *PrivateComputeInstancesServer) findDefaultSubnet(ctx context.Context) (*privatev1.Subnet, error) {
-	filter := fmt.Sprintf("this.metadata.labels[\"%s\"] == \"true\" && has(this.spec.ipv4_cidr)", defaultLabel)
-	listResponse, err := s.subnetsDao.List().
-		SetFilter(filter).
-		Do(ctx)
-	if err != nil {
-		return nil, err
-	}
-	var items []*privatev1.Subnet
-	for _, subnet := range listResponse.GetItems() {
-		if subnet.GetMetadata().HasDeletionTimestamp() {
-			continue
+func (s *PrivateComputeInstancesServer) injectDefaultNetworkAttachments(ctx context.Context,
+	vm *privatev1.ComputeInstance) error {
+	tenant := vm.GetMetadata().GetTenant()
+	if tenant == "" {
+		var tenantErr error
+		tenant, tenantErr = s.tenancyLogic.DetermineDefaultTenant(ctx)
+		if tenantErr != nil {
+			s.logger.ErrorContext(ctx, "failed to determine target tenant", slog.Any("error", tenantErr))
+			return grpcstatus.Errorf(grpccodes.Internal, "failed to determine target tenant")
 		}
-		if subnet.GetStatus().GetState() != privatev1.SubnetState_SUBNET_STATE_READY {
-			continue
-		}
-		items = append(items, subnet)
 	}
-	if len(items) == 0 {
-		return nil, nil
-	}
-	sort.Slice(items, func(i, j int) bool {
-		ti := items[i].GetMetadata().GetCreationTimestamp().AsTime()
-		tj := items[j].GetMetadata().GetCreationTimestamp().AsTime()
-		return ti.After(tj)
-	})
-	if len(items) > 1 {
-		s.logger.WarnContext(ctx, "multiple default Subnets found, using newest",
-			slog.Int("count", len(items)),
-		)
-	}
-	return items[0], nil
-}
 
-func (s *PrivateComputeInstancesServer) findDefaultSecurityGroup(ctx context.Context, virtualNetworkID string) (*privatev1.SecurityGroup, error) {
-	filter := fmt.Sprintf("this.metadata.labels[\"%s\"] == \"true\"", defaultLabel)
-	listResponse, err := s.securityGroupsDao.List().
-		SetFilter(filter).
-		Do(ctx)
-	if err != nil {
-		return nil, err
-	}
-	var items []*privatev1.SecurityGroup
-	for _, sg := range listResponse.GetItems() {
-		if sg.GetMetadata().HasDeletionTimestamp() {
-			continue
-		}
-		if sg.GetStatus().GetState() != privatev1.SecurityGroupState_SECURITY_GROUP_STATE_READY {
-			continue
-		}
-		if refKey(sg.GetSpec().GetVirtualNetwork()) != virtualNetworkID {
-			continue
-		}
-		items = append(items, sg)
-	}
-	if len(items) == 0 {
-		return nil, nil
-	}
-	sort.Slice(items, func(i, j int) bool {
-		ti := items[i].GetMetadata().GetCreationTimestamp().AsTime()
-		tj := items[j].GetMetadata().GetCreationTimestamp().AsTime()
-		return ti.After(tj)
-	})
-	if len(items) > 1 {
-		s.logger.WarnContext(ctx, "multiple default SecurityGroups found, using newest",
-			slog.Int("count", len(items)),
-		)
-	}
-	return items[0], nil
-}
-
-func (s *PrivateComputeInstancesServer) injectDefaultNetworkAttachments(ctx context.Context, spec *privatev1.ComputeInstanceSpec) error {
-	subnet, err := s.findDefaultSubnet(ctx)
+	spec := vm.GetSpec()
+	subnet, err := findDefaultSubnet(ctx, s.logger, s.subnetsDao, tenant)
 	if err != nil {
 		return grpcstatus.Errorf(grpccodes.Internal, "failed to look up default subnet: %v", err)
 	}
@@ -311,7 +253,7 @@ func (s *PrivateComputeInstancesServer) injectDefaultNetworkAttachments(ctx cont
 	}.Build()
 
 	virtualNetworkID := refKey(subnet.GetSpec().GetVirtualNetwork())
-	sg, err := s.findDefaultSecurityGroup(ctx, virtualNetworkID)
+	sg, err := findDefaultSecurityGroup(ctx, s.logger, s.securityGroupsDao, virtualNetworkID, tenant)
 	if err != nil {
 		return grpcstatus.Errorf(grpccodes.Internal, "failed to look up default security group: %v", err)
 	}
@@ -337,7 +279,7 @@ func (s *PrivateComputeInstancesServer) Create(ctx context.Context,
 	request *privatev1.ComputeInstancesCreateRequest) (response *privatev1.ComputeInstancesCreateResponse, err error) {
 	// Auto-inject default network attachments if none provided:
 	if len(request.GetObject().GetSpec().GetNetworkAttachments()) == 0 {
-		err = s.injectDefaultNetworkAttachments(ctx, request.GetObject().GetSpec())
+		err = s.injectDefaultNetworkAttachments(ctx, request.GetObject())
 		if err != nil {
 			return
 		}

--- a/fulfillment-service/internal/servers/private_compute_instances_server_test.go
+++ b/fulfillment-service/internal/servers/private_compute_instances_server_test.go
@@ -1789,7 +1789,7 @@ var _ = Describe("Private compute instances server", func() {
 				defaultSubnet := privatev1.Subnet_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   "test-default-subnet",
-						Tenant: auth.SharedTenant,
+						Tenant: auth.SystemTenant,
 						Labels: map[string]string{
 							"osac.openshift.io/default": "true",
 						},
@@ -1815,7 +1815,7 @@ var _ = Describe("Private compute instances server", func() {
 				defaultSG := privatev1.SecurityGroup_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   "test-default-sg",
-						Tenant: auth.SharedTenant,
+						Tenant: auth.SystemTenant,
 						Labels: map[string]string{
 							"osac.openshift.io/default": "true",
 						},
@@ -1863,7 +1863,7 @@ var _ = Describe("Private compute instances server", func() {
 				defaultSubnet := privatev1.Subnet_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   "test-default-subnet",
-						Tenant: auth.SharedTenant,
+						Tenant: auth.SystemTenant,
 						Labels: map[string]string{
 							"osac.openshift.io/default": "true",
 						},


### PR DESCRIPTION


Add subnet/security-group state validation to Cluster Create and Update: subnet must be READY, security groups must be READY and belong to the same virtual network as the subnet. When network_attachment is omitted on Create, the system auto-injects the tenant's default subnet and security group (labeled osac.openshift.io/default=true).

Extract findDefaultSubnet and findDefaultSecurityGroup into shared helpers so both Cluster and ComputeInstance servers use the same logic.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically applies the newest ready default subnet and security group when creating private clusters or compute instances without network attachments.
  * Supports tenant-specific default network settings.
* **Bug Fixes**
  * Rejects deleting, unavailable, nonexistent, or mismatched network resources.
  * Ensures subnets use IPv4 networks and security groups belong to the selected virtual network.
  * Preserves existing subnet settings during security-group-only updates.
  * Provides clearer handling when multiple default resources are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->