### PR TITLE
OSAC-3843: Add NMStateConfig to agentless_net cluster_infra

### DIFF
--- a/osac-aap/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/tasks/create.yaml
+++ b/osac-aap/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/tasks/create.yaml
@@ -1,4 +1,12 @@
 ---
+- name: Validate agentless-net interface configuration
+  ansible.builtin.assert:
+    that:
+      - agentless_net_data_interface | length > 0
+      - agentless_net_mgmt_interface | length > 0
+    fail_msg: >-
+      AGENTLESS_NET_DATA_INTERFACE and AGENTLESS_NET_MGMT_INTERFACE must be set.
+
 - name: Load agentless-net inventory hosts
   ansible.builtin.include_vars:
     file: "{{ agentless_net_inventory_file }}"
@@ -263,6 +271,47 @@
       -e snat_external_subnet={{ cluster_infra_external_peer_ip | ansible.utils.ipaddr('network/prefix') }}
       -e snat_external_interface={{ agentless_net_external_interface }}
       {{ role_path }}/playbooks/l3_create_snat.yaml
+
+# --- Configure worker NICs via NMStateConfig ---
+#
+# The worker has two NICs: a data NIC (switch fabric, VLAN access port) and a
+# management NIC (libvirt bridge, flat L2). NMStateConfig tells the assisted-
+# installer how to configure both NICs during RHCOS installation:
+#   Data NIC:  static IP on the VLAN subnet, net-node as default gateway
+#   Mgmt NIC:  DHCP (libvirt), specific route to management subnet
+
+- name: Create NMStateConfig CRs and apply live to agents
+  ansible.builtin.include_role:
+    name: osac.service.nmstate_config
+  vars:
+    nmstate_config_state: present
+    nmstate_config_cluster_name: "{{ cluster_infra_name }}"
+    nmstate_config_agents: "{{ cluster_infra_selected_agents.resources }}"
+    nmstate_config_gateway_cidr: "{{ cluster_infra_subnet_gateway }}/{{ agentless_net_subnet_cidr | ansible.utils.ipaddr('prefix') }}"
+    nmstate_config_interface_names:
+      - "{{ agentless_net_data_interface }}"
+    nmstate_config_server_interfaces:
+      - "{{ agentless_net_data_interface }}"
+    nmstate_config_mgmt_interface: "{{ agentless_net_mgmt_interface }}"
+
+# Shared namespace-wide label instead of netris's per-cluster label pattern.
+# The assisted-installer matches NMStateConfigs to agents by MAC address, so
+# matching all configs is safe. merge_type: merge replaces the entire matchLabels
+# map, so per-cluster labels would overwrite each other on concurrent pipelines.
+- name: Set InfraEnv nmStateConfigLabelSelector to match all NMStateConfigs
+  kubernetes.core.k8s:
+    state: present
+    merge_type: merge
+    definition:
+      apiVersion: agent-install.openshift.io/v1beta1
+      kind: InfraEnv
+      metadata:
+        name: "{{ hosted_cluster_default_infraenv }}"
+        namespace: "{{ default_agent_namespace }}"
+      spec:
+        nmStateConfigLabelSelector:
+          matchLabels:
+            infraenv: "{{ default_agent_namespace }}"
 
 # --- Approve agents and attach to cluster ---
 

--- a/osac-aap/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/tasks/delete.yaml
+++ b/osac-aap/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/tasks/delete.yaml
@@ -31,6 +31,13 @@
   loop_control:
     label: "{{ item.key }}"
 
+- name: Delete NMStateConfig CRs for cluster agents
+  ansible.builtin.include_role:
+    name: osac.service.nmstate_config
+  vars:
+    nmstate_config_state: absent
+    nmstate_config_cluster_name: "{{ cluster_infra_name }}"
+
 - name: Detach agents from cluster
   ansible.builtin.include_role:
     name: osac.service.manage_agents

--- a/osac-aap/collections/ansible_collections/agentless_net/steps/roles/external_access/tasks/create.yaml
+++ b/osac-aap/collections/ansible_collections/agentless_net/steps/roles/external_access/tasks/create.yaml
@@ -284,4 +284,3 @@
       -e dnat_internal_port=443
       -e dnat_protocol=tcp
       {{ role_path }}/playbooks/l3_create_dnat.yaml
-

--- a/osac-aap/collections/ansible_collections/osac/config_as_code/README.md
+++ b/osac-aap/collections/ansible_collections/osac/config_as_code/README.md
@@ -58,8 +58,8 @@ use case, e.g.:
 - `OS_*`: OpenStack credentials
 - ...whatever in needed
 - `NETRIS_PASSWORD`: Netris password
-- `SERVER_SSH_KEY`: Private key used to SSH into bare-metal servers via the bastion (base64-encoded)
-- `SERVER_SSH_BASTION_KEY`: Private key used to SSH into the bastion host (base64-encoded)
+- `SERVER_SSH_KEY`: Private key used to SSH into bare-metal servers (base64-encoded)
+- `SERVER_SSH_BASTION_KEY`: Private key used to SSH into the bastion host (base64-encoded). Required only when `SERVER_SSH_BASTION_HOST` is configured
 
 These variables must be defined in a secret named: `cluster-fulfillment-ig` in
 the namespace where AAP is deployed.

--- a/osac-aap/collections/ansible_collections/osac/service/roles/nmstate_config/meta/argument_specs.yaml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/nmstate_config/meta/argument_specs.yaml
@@ -121,16 +121,19 @@ argument_specs:
         description: "Route metric for the VPC default route."
       nmstate_config_ssh_bastion_host:
         type: str
-        required: true
-        description: "Bastion host to proxy SSH through to reach agent mgmt IPs."
+        required: false
+        default: ""
+        description: "Bastion host to proxy SSH through to reach agent mgmt IPs. When empty, SSH connects directly."
       nmstate_config_ssh_bastion_user:
         type: str
-        required: true
+        required: false
+        default: ""
         description: "SSH user for the bastion host."
       nmstate_config_ssh_bastion_key:
         type: str
-        required: true
-        description: "SSH private key file for local -> bastion connection."
+        required: false
+        default: ""
+        description: "SSH private key file for the local -> bastion proxy hop. Required only when nmstate_config_ssh_bastion_host is set."
       nmstate_config_ssh_user:
         type: str
         default: core
@@ -138,7 +141,7 @@ argument_specs:
       nmstate_config_ssh_key:
         type: str
         required: true
-        description: "SSH private key file for bastion -> agent connection."
+        description: "SSH private key file for authenticating to agents (used for both direct and bastion-proxied connections)."
 
   delete:
     options:

--- a/osac-aap/collections/ansible_collections/osac/service/roles/nmstate_config/tasks/apply_single.yaml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/nmstate_config/tasks/apply_single.yaml
@@ -1,4 +1,14 @@
 ---
+- name: Validate bastion configuration
+  ansible.builtin.assert:
+    that:
+      - nmstate_config_ssh_bastion_user | length > 0
+      - nmstate_config_ssh_bastion_key | length > 0
+    fail_msg: >-
+      nmstate_config_ssh_bastion_user and nmstate_config_ssh_bastion_key
+      must be set when nmstate_config_ssh_bastion_host is configured.
+  when: nmstate_config_ssh_bastion_host | default('') | length > 0
+
 - name: "Get management IP for agent {{ _nmstate_apply_assignment.agent.metadata.name }}"
   ansible.builtin.set_fact:
     _nmstate_apply_mgmt_ip: "{{ _nmstate_apply_assignment.agent | osac.service.agent_mgmt_ip(nmstate_config_mgmt_interface) }}"
@@ -11,6 +21,13 @@
       Check that the agent has a '{{ nmstate_config_mgmt_interface }}' interface
       with an IPv4 address in status.inventory.interfaces.
   when: _nmstate_apply_mgmt_ip is none or _nmstate_apply_mgmt_ip == ""
+
+- name: "Build SSH proxy args for agent {{ _nmstate_apply_assignment.agent.metadata.name }}"
+  ansible.builtin.set_fact:
+    _nmstate_apply_ssh_proxy_args: >-
+      {% if nmstate_config_ssh_bastion_host | default('') | length > 0 %}
+      -o 'ProxyCommand=ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=30 -i {{ nmstate_config_ssh_bastion_key }} -W %h:%p {{ nmstate_config_ssh_bastion_user }}@{{ nmstate_config_ssh_bastion_host }}'
+      {% endif %}
 
 - name: "Calculate static IP for agent {{ _nmstate_apply_assignment.agent.metadata.name }}"
   ansible.builtin.set_fact:
@@ -41,7 +58,7 @@
   ansible.builtin.shell:
     cmd: |
       ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=30 \
-        -o 'ProxyCommand=ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=30 -i {{ nmstate_config_ssh_bastion_key }} -W %h:%p {{ nmstate_config_ssh_bastion_user }}@{{ nmstate_config_ssh_bastion_host }}' \
+        {{ _nmstate_apply_ssh_proxy_args }} \
         -i {{ nmstate_config_ssh_key }} \
         {{ nmstate_config_ssh_user }}@{{ _nmstate_apply_mgmt_ip }} \
         'sudo sysctl -qw net.ipv4.conf.all.rp_filter=0 net.ipv4.conf.{{ nmstate_config_mgmt_interface }}.rp_filter=0'
@@ -52,7 +69,7 @@
   ansible.builtin.shell:
     cmd: |
       scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=30 \
-        -o 'ProxyCommand=ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=30 -i {{ nmstate_config_ssh_bastion_key }} -W %h:%p {{ nmstate_config_ssh_bastion_user }}@{{ nmstate_config_ssh_bastion_host }}' \
+        {{ _nmstate_apply_ssh_proxy_args }} \
         -i {{ nmstate_config_ssh_key }} \
         /tmp/nmstate-{{ _nmstate_apply_assignment.agent.metadata.name }}.yaml \
         {{ nmstate_config_ssh_user }}@{{ _nmstate_apply_mgmt_ip }}:/tmp/nmstate-config.yaml
@@ -63,7 +80,7 @@
   ansible.builtin.shell:
     cmd: |
       ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=30 \
-        -o 'ProxyCommand=ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=30 -i {{ nmstate_config_ssh_bastion_key }} -W %h:%p {{ nmstate_config_ssh_bastion_user }}@{{ nmstate_config_ssh_bastion_host }}' \
+        {{ _nmstate_apply_ssh_proxy_args }} \
         -i {{ nmstate_config_ssh_key }} \
         {{ nmstate_config_ssh_user }}@{{ _nmstate_apply_mgmt_ip }} \
         'nohup sudo nmstatectl apply /tmp/nmstate-config.yaml > /tmp/nmstate-apply.log 2>&1 &'

--- a/osac-aap/collections/ansible_collections/osac/service/roles/write_ssh_keys/tasks/main.yml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/write_ssh_keys/tasks/main.yml
@@ -12,8 +12,14 @@
   ansible.builtin.assert:
     that:
       - lookup('env', 'SERVER_SSH_KEY') | length > 0
+    fail_msg: "SERVER_SSH_KEY env var is empty"
+
+- name: Validate bastion SSH key env var
+  ansible.builtin.assert:
+    that:
       - lookup('env', 'SERVER_SSH_BASTION_KEY') | length > 0
-    fail_msg: "SERVER_SSH_KEY and/or SERVER_SSH_BASTION_KEY env vars are empty"
+    fail_msg: "SERVER_SSH_BASTION_KEY env var is empty (required when SERVER_SSH_BASTION_HOST is set)"
+  when: lookup('env', 'SERVER_SSH_BASTION_HOST') | length > 0
 
 - name: Write server SSH key from env var
   ansible.builtin.copy:
@@ -28,3 +34,4 @@
     dest: "{{ server_ssh_bastion_key }}"
     mode: "0400"
   no_log: true
+  when: lookup('env', 'SERVER_SSH_BASTION_HOST') | length > 0

--- a/osac-aap/group_vars/all/agentless_net.yaml
+++ b/osac-aap/group_vars/all/agentless_net.yaml
@@ -15,6 +15,8 @@ agentless_net_trunk_interface: "{{ lookup('env', 'AGENTLESS_NET_TRUNK_INTERFACE'
 agentless_net_external_interface: "{{ lookup('env', 'AGENTLESS_NET_EXTERNAL_INTERFACE', default='eth0') }}"
 agentless_net_external_gateway: "{{ lookup('env', 'AGENTLESS_NET_EXTERNAL_GATEWAY', default='') }}"
 agentless_net_subnet_cidr: "{{ lookup('env', 'AGENTLESS_NET_SUBNET_CIDR', default='') }}"
+agentless_net_data_interface: "{{ lookup('env', 'AGENTLESS_NET_DATA_INTERFACE') }}"
+agentless_net_mgmt_interface: "{{ lookup('env', 'AGENTLESS_NET_MGMT_INTERFACE') }}"
 
 # external_access role
 agentless_net_public_ip_pool_start: "{{ lookup('env', 'AGENTLESS_NET_PUBLIC_IP_POOL_START', default='') }}"

--- a/osac-aap/playbook_osac_create_hosted_cluster.yml
+++ b/osac-aap/playbook_osac_create_hosted_cluster.yml
@@ -11,7 +11,7 @@
       ansible.builtin.include_role:
         name: osac.service.write_ssh_keys
       when:
-        - network_class | default('') == 'netris'
+        - network_class | default('') in ['netris', 'agentless_net']
         - lookup('env', 'SERVER_SSH_KEY') | length > 0
 
     - name: Set cluster order name


### PR DESCRIPTION
The worker's data NIC (switch fabric) has no IP because nothing configures it. Add NMStateConfig CR creation, live apply, and deletion to cluster_infra so the assisted-installer configures both NICs during RHCOS installation:

  Data NIC:  static IP on the VLAN subnet, net-node as default gateway
  Mgmt NIC:  DHCP, specific route to management subnet

The NMState config is embedded in the discovery ISO at generation time. Since agents boot before NMStateConfigs are created, the live apply step SSHs into each running discovery agent and runs nmstatectl apply so the installer carries the config over when writing RHCOS to disk.

Use a shared label (infraenv: <namespace>) for the InfraEnv nmStateConfigLabelSelector so all NMStateConfigs are matched regardless of cluster — the assisted-installer matches each one to the right agent by MAC address. A per-cluster label would be overwritten by concurrent pipelines sharing a single InfraEnv.

Support direct SSH (no bastion) in the shared nmstate_config role: when SERVER_SSH_BASTION_HOST is empty, SSH connects directly to agents without a ProxyCommand hop. Also make write_ssh_keys bastion-aware — only require the bastion key when a bastion host is configured.

New env vars (AGENTLESS_NET_DATA_INTERFACE,
AGENTLESS_NET_MGMT_INTERFACE)
control the NIC names — no defaults since names are hardware-dependent.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for separate management and data interfaces for agentless network workers.
  - Automatically creates and applies network configuration, including VLAN data networking and DHCP management networking.
  - Added environment-based interface configuration.
  - SSH key setup now supports both network classes and direct server connections.

- **Bug Fixes**
  - Improved SSH and SCP connectivity through optional bastion hosts.
  - Added validation for required network settings and SSH credentials.

- **Chores**
  - Added cleanup of network configuration resources when removing cluster agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->