### PR TITLE
OSAC-3845: Add MASQUERADE for DNAT return path in per-cluster namespace

### DIFF
--- a/osac-aap/collections/ansible_collections/agentless_net/steps/roles/external_access/playbooks/l3_create_dnat.yaml
+++ b/osac-aap/collections/ansible_collections/agentless_net/steps/roles/external_access/playbooks/l3_create_dnat.yaml
@@ -7,3 +7,24 @@
       ansible.builtin.include_role:
         name: agentless_net.l3.dnat
         tasks_from: create
+
+    - name: Derive veth interface name for namespace {{ dnat_router_name }}
+      ansible.builtin.set_fact:
+        _dnat_veth_iface: "v{{ dnat_router_name | hash('md5') | truncate(11, True, '') }}i"
+
+    - name: Check if veth MASQUERADE exists
+      ansible.builtin.raw: >-
+        ip netns exec {{ dnat_router_name }}
+        iptables -t nat -C POSTROUTING
+        -o {{ _dnat_veth_iface }} -j MASQUERADE 2>/dev/null
+      register: _veth_masq_check
+      changed_when: false
+      failed_when: false
+
+    - name: Add MASQUERADE on veth for DNAT return path (namespace {{ dnat_router_name }})
+      ansible.builtin.raw: >-
+        ip netns exec {{ dnat_router_name }}
+        iptables -t nat -A POSTROUTING
+        -o {{ _dnat_veth_iface }} -j MASQUERADE
+      when: _veth_masq_check.rc != 0
+      changed_when: true


### PR DESCRIPTION
DNAT translates the destination (public IP → MetalLB VIP) but the response from the kube-apiserver goes directly back to the source on the management network, bypassing the namespace. Conntrack never reverses the DNAT and the connection times out.

Add a broad MASQUERADE on the veth interface so the source IP becomes the namespace's veth IP. This forces the response back through the namespace where conntrack can reverse both the MASQUERADE and the DNAT.

Assisted-by: Claude Code <noreply@anthropic.com>

---

/assign @danmanor 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNAT setup by ensuring the required veth MASQUERADE rule is added when missing.
  * Prevented duplicate MASQUERADE rules by checking for existing configuration first.
  * Made the configuration check non-disruptive and resilient when no matching rule exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->