### PR TITLE
OSAC-3846: Wait for Konnectivity before installing MetalLB on hosted cluster

### DIFF
--- a/osac-aap/collections/ansible_collections/osac/service/roles/metallb_ingress/tasks/configure_metallb_ingress.yml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/metallb_ingress/tasks/configure_metallb_ingress.yml
@@ -4,6 +4,21 @@
   ansible.builtin.set_fact:
     metallb_namespace: metallb-system
 
+- name: Wait for pod-to-API connectivity on hosted cluster
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ metallb_ingress_admin_kubeconfig }}"
+    api_version: v1
+    kind: Pod
+    namespace: kube-system
+    label_selectors:
+      - app=konnectivity-agent
+  register: _konnectivity_check
+  until:
+    - _konnectivity_check.resources | length > 0
+    - _konnectivity_check.resources[0].status.phase == "Running"
+  retries: 60
+  delay: 10
+
 - name: Create metallb namespace
   kubernetes.core.k8s:
     state: present


### PR DESCRIPTION
The OLM bundle unpack Job calls the kube-apiserver to store extracted manifests. In HyperShift, pod-to-API connectivity requires Konnectivity to be ready. If the Subscription is created before Konnectivity is up, the unpack Job fails and OLM stops retrying.

Wait for the konnectivity-agent pod to be Running before creating the MetalLB namespace and Subscription.

Assisted-by: Claude Code <noreply@anthropic.com>

---

/assign @danmanor 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MetalLB ingress setup reliability by waiting for the hosted cluster’s connectivity agent to become operational before continuing configuration.
  - Added retry handling to accommodate startup delays and help prevent premature configuration failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->