### PR TITLE
OSAC-3872: Add hairpin MASQUERADE for ingress DNAT on tenant VLAN

### DIFF
--- a/osac-aap/collections/ansible_collections/agentless_net/steps/roles/external_access/playbooks/l3_create_dnat.yaml
+++ b/osac-aap/collections/ansible_collections/agentless_net/steps/roles/external_access/playbooks/l3_create_dnat.yaml
@@ -28,3 +28,31 @@
         -o {{ _dnat_veth_iface }} -j MASQUERADE
       when: _veth_masq_check.rc != 0
       changed_when: true
+
+    - name: Find VLAN sub-interface in namespace {{ dnat_router_name }}
+      ansible.builtin.raw: >-
+        ip netns exec {{ dnat_router_name }}
+        ip -o link show type vlan 2>/dev/null | awk -F'[ :]+' '{split($2,a,"@"); print a[1]}' | head -1
+      register: _hairpin_vlan_iface
+      changed_when: false
+      failed_when: false
+
+    - name: Check if hairpin MASQUERADE exists on VLAN sub-interface
+      ansible.builtin.raw: >-
+        ip netns exec {{ dnat_router_name }}
+        iptables -t nat -C POSTROUTING
+        -o {{ _hairpin_vlan_iface.stdout | trim }} -j MASQUERADE 2>/dev/null
+      register: _hairpin_masq_check
+      changed_when: false
+      failed_when: false
+      when: _hairpin_vlan_iface.stdout | trim | length > 0
+
+    - name: Add MASQUERADE on VLAN sub-interface for hairpin NAT (namespace {{ dnat_router_name }})
+      ansible.builtin.raw: >-
+        ip netns exec {{ dnat_router_name }}
+        iptables -t nat -A POSTROUTING
+        -o {{ _hairpin_vlan_iface.stdout | trim }} -j MASQUERADE
+      when:
+        - _hairpin_vlan_iface.stdout | trim | length > 0
+        - _hairpin_masq_check.rc | default(1) != 0
+      changed_when: true


### PR DESCRIPTION
When the DNAT target (MetalLB ingress VIP) is on the same VLAN subnet
as the source worker, the packet hairpins back out the VLAN sub-interface
without hitting the veth MASQUERADE. The response bypasses the namespace
conntrack and the DNAT is never reversed, breaking the console operator
health check and any pod-to-ingress traffic via the public IP.

Add a MASQUERADE rule on the VLAN sub-interface inside each per-cluster
namespace so the source is rewritten to the gateway IP, forcing the
response back through the namespace where conntrack can reverse the DNAT.

Assisted-by: Claude Code <noreply@anthropic.com>

---

/assign @danmanor 