### PR TITLE
OSAC-3468: Signal project after project membership deletion

### DIFF
--- a/fulfillment-service/internal/controllers/projectmembership/project_membership_reconciler_function.go
+++ b/fulfillment-service/internal/controllers/projectmembership/project_membership_reconciler_function.go
@@ -603,6 +603,7 @@ func (t *task) delete(ctx context.Context) error {
 		if err := t.cleanupProjectMembership(ctx); err != nil {
 			return err
 		}
+		t.signalProject(ctx)
 	}
 
 	metadata.SetFinalizers(updated)
@@ -663,4 +664,32 @@ func (t *task) cleanupProjectMembership(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// signalProject looks up the project by name and signals it so that the
+// project reconciler re-runs. This is used when the project membership is deleted to
+// unblock the project's own deletion.
+func (t *task) signalProject(ctx context.Context) {
+	projectName := t.membership.GetMetadata().GetProject()
+	if projectName == "" {
+		return
+	}
+	project, err := t.getProjectByNameOrID(ctx, projectName)
+	if err != nil {
+		t.r.logger.WarnContext(ctx, "Failed to look up project for signaling",
+			slog.String("project_name", projectName),
+			slog.Any("error", err),
+		)
+		return
+	}
+
+	_, err = t.r.projectsClient.Signal(ctx, privatev1.ProjectsSignalRequest_builder{
+		Id: project.GetId(),
+	}.Build())
+	if err != nil {
+		t.r.logger.WarnContext(ctx, "Failed to signal project for membership deletion",
+			slog.String("project_name", projectName),
+			slog.Any("error", err),
+		)
+	}
 }

--- a/fulfillment-service/internal/controllers/projectmembership/project_membership_reconciler_function_test.go
+++ b/fulfillment-service/internal/controllers/projectmembership/project_membership_reconciler_function_test.go
@@ -1520,6 +1520,14 @@ var _ = Describe("Deletion Cleanup", func() {
 			RemoveUserFromGroup(gomock.Any(), "acme", "keycloak-alice-id", "group-id").
 			Return(nil)
 
+		mockProjectsClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(&privatev1.ProjectsGetResponse{Object: project}, nil)
+
+		mockProjectsClient.EXPECT().
+			Signal(gomock.Any(), gomock.Any()).
+			Return(privatev1.ProjectsSignalResponse_builder{}.Build(), nil)
+
 		task := &task{
 			r:          functionObj,
 			membership: membership,
@@ -1590,6 +1598,14 @@ var _ = Describe("Deletion Cleanup", func() {
 			RemoveUserFromGroup(gomock.Any(), "acme", "keycloak-alice-id", "group-id").
 			Return(nil)
 
+		mockProjectsClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(&privatev1.ProjectsGetResponse{Object: childProject}, nil)
+
+		mockProjectsClient.EXPECT().
+			Signal(gomock.Any(), gomock.Any()).
+			Return(privatev1.ProjectsSignalResponse_builder{}.Build(), nil)
+
 		task := &task{
 			r:          functionObj,
 			membership: membership,
@@ -1622,6 +1638,14 @@ var _ = Describe("Deletion Cleanup", func() {
 		mockProjectsClient.EXPECT().
 			List(gomock.Any(), gomock.Any()).
 			Return(&privatev1.ProjectsListResponse{Items: []*privatev1.Project{}}, nil)
+
+		// signalProject: project still not found by name
+		mockProjectsClient.EXPECT().
+			List(gomock.Any(), gomock.Any()).
+			Return(&privatev1.ProjectsListResponse{}, nil)
+		mockProjectsClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(nil, status.Error(codes.NotFound, "project not found"))
 
 		task := &task{
 			r:          functionObj,
@@ -1664,6 +1688,14 @@ var _ = Describe("Deletion Cleanup", func() {
 			GetGroupIDByPath(gomock.Any(), "acme", "/my-project/system:managers").
 			Return("", status.Error(codes.NotFound, "group not found"))
 
+		mockProjectsClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(&privatev1.ProjectsGetResponse{Object: project}, nil)
+
+		mockProjectsClient.EXPECT().
+			Signal(gomock.Any(), gomock.Any()).
+			Return(privatev1.ProjectsSignalResponse_builder{}.Build(), nil)
+
 		task := &task{
 			r:          functionObj,
 			membership: membership,
@@ -1704,6 +1736,155 @@ var _ = Describe("Deletion Cleanup", func() {
 		mockIdpClient.EXPECT().
 			GetGroupIDByPath(gomock.Any(), "acme", "/my-project/system:viewers").
 			Return("", fmt.Errorf("wrapped error: group not found in keycloak"))
+
+		mockProjectsClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(&privatev1.ProjectsGetResponse{Object: project}, nil)
+		mockProjectsClient.EXPECT().
+			Signal(gomock.Any(), gomock.Any()).
+			Return(privatev1.ProjectsSignalResponse_builder{}.Build(), nil)
+
+		task := &task{
+			r:          functionObj,
+			membership: membership,
+		}
+
+		err := task.delete(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(membership.GetMetadata().GetFinalizers()).ToNot(ContainElement(finalizers.ProjectMembershipFinalizer))
+	})
+})
+
+var _ = Describe("Signal Project on Deletion", func() {
+	var (
+		ctrl                         *gomock.Controller
+		mockProjectsClient           *MockProjectsClient
+		mockProjectMembershipsClient *MockProjectMembershipsClient
+		mockUsersClient              *MockUsersClient
+		mockIdpClient                *idp.MockClientInterface
+		ctx                          context.Context
+		functionObj                  *function
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockProjectsClient = NewMockProjectsClient(ctrl)
+		mockProjectMembershipsClient = NewMockProjectMembershipsClient(ctrl)
+		mockUsersClient = NewMockUsersClient(ctrl)
+		mockIdpClient = idp.NewMockClientInterface(ctrl)
+		ctx = context.Background()
+
+		functionObj = &function{
+			logger:                   logger,
+			projectMembershipsClient: mockProjectMembershipsClient,
+			projectsClient:           mockProjectsClient,
+			usersClient:              mockUsersClient,
+			idpClient:                mockIdpClient,
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	It("should not signal when project name is empty", func() {
+		membership := privatev1.ProjectMembership_builder{
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.ProjectMembershipFinalizer},
+			}.Build(),
+			Spec: privatev1.ProjectMembershipSpec_builder{
+				Role: privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_MANAGER,
+			}.Build(),
+		}.Build()
+
+		task := &task{
+			r:          functionObj,
+			membership: membership,
+		}
+
+		err := task.delete(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(membership.GetMetadata().GetFinalizers()).ToNot(ContainElement(finalizers.ProjectMembershipFinalizer))
+	})
+
+	It("should continue delete when project Get fails during signaling", func() {
+		membership := privatev1.ProjectMembership_builder{
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.ProjectMembershipFinalizer},
+				Project:    "my-project",
+			}.Build(),
+			Spec: privatev1.ProjectMembershipSpec_builder{
+				Role: privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_MANAGER,
+			}.Build(),
+		}.Build()
+
+		mockProjectsClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(nil, status.Errorf(codes.Unavailable, "service unavailable"))
+
+		task := &task{
+			r:          functionObj,
+			membership: membership,
+		}
+
+		err := task.delete(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(membership.GetMetadata().GetFinalizers()).ToNot(ContainElement(finalizers.ProjectMembershipFinalizer))
+	})
+
+	It("should skip signaling when project is not found by name", func() {
+		membership := privatev1.ProjectMembership_builder{
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.ProjectMembershipFinalizer},
+				Project:    "nonexistent-project",
+			}.Build(),
+			Spec: privatev1.ProjectMembershipSpec_builder{
+				Role: privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_MANAGER,
+			}.Build(),
+		}.Build()
+
+		mockProjectsClient.EXPECT().
+			List(gomock.Any(), gomock.Any()).
+			Return(&privatev1.ProjectsListResponse{}, nil)
+		mockProjectsClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(nil, status.Error(codes.NotFound, "project not found"))
+
+		task := &task{
+			r:          functionObj,
+			membership: membership,
+		}
+
+		err := task.delete(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(membership.GetMetadata().GetFinalizers()).ToNot(ContainElement(finalizers.ProjectMembershipFinalizer))
+	})
+
+	It("should continue delete when Signal RPC fails", func() {
+		project := privatev1.Project_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name:   "my-project",
+				Tenant: "acme",
+			}.Build(),
+			Spec: privatev1.ProjectSpec_builder{}.Build(),
+		}.Build()
+		membership := privatev1.ProjectMembership_builder{
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.ProjectMembershipFinalizer},
+				Project:    "my-project",
+			}.Build(),
+			Spec: privatev1.ProjectMembershipSpec_builder{
+				Role: privatev1.ProjectMembershipRole_PROJECT_MEMBERSHIP_ROLE_MANAGER,
+			}.Build(),
+		}.Build()
+
+		mockProjectsClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(&privatev1.ProjectsGetResponse{Object: project}, nil)
+
+		mockProjectsClient.EXPECT().
+			Signal(gomock.Any(), gomock.Any()).
+			Return(nil, status.Errorf(codes.Unavailable, "service unavailable"))
 
 		task := &task{
 			r:          functionObj,


### PR DESCRIPTION
Allows the project to be re-reconciled after a project membership is deleted to unblock the project's deletion.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Project membership deletion now notifies the associated project after cleanup.
  - Deletion completes successfully even when project lookup or notification encounters an error.
  - Notifications are handled for nested projects and memberships without authorization groups.
  - Notifications are skipped when no project name is available.
  - Membership finalizers are removed reliably in all supported deletion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->