### PR TITLE
OSAC-3438: enable metering in CaaS CI values

### DIFF
--- a/osac-installer/values/caas-ci/values.yaml
+++ b/osac-installer/values/caas-ci/values.yaml
@@ -150,6 +150,36 @@ aap:
 validation:
   enabled: true
 
+# --- Kafka (metering infrastructure) ---
+kafka:
+  enabled: true
+
+# --- Metering ---
+metering:
+  enabled: true
+  echoAdapter:
+    enabled: true
+    image:
+      repository: ghcr.io/osac-project/metering-echo-adapter
+      tag: latest
+      pullPolicy: Always
+  database:
+    connection:
+    - secret:
+        name: metering-db
+        items:
+        - key: url
+          param: url
+    - secret:
+        name: postgres-client-cert-metering
+        items:
+        - key: tls.crt
+          param: sslcert
+        - key: tls.key
+          param: sslkey
+        - key: ca.crt
+          param: sslrootcert
+
 # --- Bare Metal Fulfillment Operator ---
 bmf:
   enabled: false


### PR DESCRIPTION
## Summary

- Enable Kafka, metering-service, and echo-adapter in `values/caas-ci/values.yaml`
- Matches the existing `values/vmaas-ci/values.yaml` metering config
- Required for CaaS metering E2E tests (osac-test-infra#349)

## Test plan

- [x] CaaS CI deployment will install AMQ Streams operator, Kafka cluster, metering-service, and echo-adapter
- [ ] CaaS E2E metering tests pass (depends on osac-test-infra#349)

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Kafka integration.
  * Added metering configuration with an echo adapter.
  * Added secure PostgreSQL connections using client certificates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->