### PR TITLE
fix: auto-queue re-enables auto-merge on ejected PRs

### DIFF
--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -5,9 +5,12 @@ on:
   pull_request_target:
     types: [opened, reopened, ready_for_review, synchronize, labeled, unlabeled]
     branches: [main]
+  schedule:
+    - cron: "*/10 * * * *"
 
 jobs:
   enable-auto-merge:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - name: Check repo collaborator
@@ -59,3 +62,25 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.MERGE_QUEUE_TOKEN }}
         run: gh pr merge ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --disable-auto
+
+  requeue-eligible-prs:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-enable auto-merge on eligible PRs
+        env:
+          GH_TOKEN: ${{ secrets.MERGE_QUEUE_TOKEN }}
+        run: |
+          echo "Scanning for eligible PRs without auto-merge..."
+          gh pr list --repo "${{ github.repository }}" --state open --json number,isDraft,labels,autoMergeRequest --jq '
+            .[] | select(
+              .isDraft == false
+              and .autoMergeRequest == null
+              and ([.labels[].name] | contains(["lgtm","approved","jira/valid-reference"]))
+              and ([.labels[].name] | any(. == "do-not-merge/hold" or . == "needs-rebase") | not)
+            ) | .number
+          ' | while read -r pr; do
+            echo "Re-enabling auto-merge on PR #$pr"
+            gh pr merge "$pr" --repo "${{ github.repository }}" --auto --rebase || echo "Failed to enable auto-merge on PR #$pr"
+          done
+          echo "Scan complete."

--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -71,15 +71,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.MERGE_QUEUE_TOKEN }}
         run: |
+          set -euo pipefail
           echo "Scanning for eligible PRs without auto-merge..."
-          gh pr list --repo "${{ github.repository }}" --state open --json number,isDraft,labels,autoMergeRequest --jq '
-            .[] | select(
+          prs=$(gh pr list --repo "${{ github.repository }}" --state open --limit 200 --json number,isDraft,labels,autoMergeRequest --jq '
+            [.[] | select(
               .isDraft == false
               and .autoMergeRequest == null
               and ([.labels[].name] | contains(["lgtm","approved","jira/valid-reference"]))
               and ([.labels[].name] | any(. == "do-not-merge/hold" or . == "needs-rebase") | not)
-            ) | .number
-          ' | while read -r pr; do
+            ) | .number]')
+          echo "Eligible PRs: $prs"
+          for pr in $(echo "$prs" | jq -r '.[]'); do
             echo "Re-enabling auto-merge on PR #$pr"
             gh pr merge "$pr" --repo "${{ github.repository }}" --auto --rebase || echo "Failed to enable auto-merge on PR #$pr"
           done

--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -83,6 +83,6 @@ jobs:
           echo "Eligible PRs: $prs"
           for pr in $(echo "$prs" | jq -r '.[]'); do
             echo "Re-enabling auto-merge on PR #$pr"
-            gh pr merge "$pr" --repo "${{ github.repository }}" --auto --rebase || echo "Failed to enable auto-merge on PR #$pr"
+            gh pr merge "$pr" --repo "${{ github.repository }}" --auto --rebase
           done
           echo "Scan complete."


### PR DESCRIPTION
## Summary

When the merge queue ejects a PR (timeout, failed checks, conflicts), GitHub disables auto-merge. No PR event fires, so the event-driven auto-queue never re-enables it — ejected PRs sit dead.

Adds a scheduled job (every 10 min) that scans for open PRs with:
- All required labels (lgtm, approved, jira/valid-reference)
- No blocking labels (do-not-merge/hold, needs-rebase)
- Not draft
- Auto-merge not currently enabled

Re-enables auto-merge with `--rebase` on each match.

## Test plan

- [ ] Eject a PR from the queue manually, verify it gets re-enqueued within 10 min
- [ ] Verify PRs with blocking labels are not re-queued
- [ ] Verify draft PRs are not re-queued

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Automation**
  * Added periodic checks to identify eligible open pull requests.
  * Automatically re-enables pull request auto-merge when required approvals are present and no blocking conditions apply.
  * Preserves existing event-based auto-merge behavior while excluding scheduled runs.
  * Logs individual failures without stopping processing of other pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->