### PR TITLE
OSAC-3954: populate Name on resolved ClusterTemplateReference and HostTypeReference

### DIFF
--- a/fulfillment-service/internal/servers/private_clusters_server.go
+++ b/fulfillment-service/internal/servers/private_clusters_server.go
@@ -944,6 +944,11 @@ func (s *PrivateClustersServer) validateAndTransformCatalogItem(ctx context.Cont
 		return grpcstatus.Errorf(grpccodes.InvalidArgument, "template '%s' has been deleted", templateRefStr)
 	}
 
+	resolvedTemplateRef := &privatev1.ClusterTemplateReference{}
+	resolvedTemplateRef.SetId(template.GetId())
+	resolvedTemplateRef.SetName(template.GetMetadata().GetName())
+	cluster.GetSpec().SetTemplate(resolvedTemplateRef)
+
 	// Apply spec defaults from the template (user and field_definition values take precedence):
 	utils.ApplyClusterSpecDefaults(cluster.GetSpec(), template.GetSpecDefaults())
 

--- a/fulfillment-service/internal/servers/private_clusters_server.go
+++ b/fulfillment-service/internal/servers/private_clusters_server.go
@@ -196,6 +196,7 @@ func (s *PrivateClustersServer) Create(ctx context.Context,
 		if hostType != nil {
 			hostTypeRef := &privatev1.HostTypeReference{}
 			hostTypeRef.SetId(hostType.GetId())
+			hostTypeRef.SetName(hostType.GetMetadata().GetName())
 			nodeSet.SetHostType(hostTypeRef)
 		}
 	}
@@ -755,16 +756,19 @@ func (s *PrivateClustersServer) validateAndTransformCluster(ctx context.Context,
 	)
 	cluster.GetSpec().SetTemplateParameters(actualClusterParameters)
 
-	// Make sure that the template and the host types of the node sets are referenced by their identifiers, as
-	// that is what we want to save to the database.
+	// Make sure that the template and the host types of the node sets are referenced by their identifiers and
+	// names, as that is what we want to save to the database. Both fields are needed: id for lookups, name for
+	// display and billing dimensions (metering reads the name).
 	resolvedTemplateRef := &privatev1.ClusterTemplateReference{}
 	resolvedTemplateRef.SetId(template.GetId())
+	resolvedTemplateRef.SetName(template.GetMetadata().GetName())
 	cluster.GetSpec().SetTemplate(resolvedTemplateRef)
 	for _, clusterNodeSet := range cluster.GetSpec().GetNodeSets() {
 		hostType := hostTypes[refKey(clusterNodeSet.GetHostType())]
 		if hostType != nil {
 			resolvedHostTypeRef := &privatev1.HostTypeReference{}
 			resolvedHostTypeRef.SetId(hostType.GetId())
+			resolvedHostTypeRef.SetName(hostType.GetMetadata().GetName())
 			clusterNodeSet.SetHostType(resolvedHostTypeRef)
 		}
 	}
@@ -982,6 +986,7 @@ func (s *PrivateClustersServer) validateAndTransformCatalogItem(ctx context.Cont
 		if hostType != nil {
 			resolvedHostTypeRef := &privatev1.HostTypeReference{}
 			resolvedHostTypeRef.SetId(hostType.GetId())
+			resolvedHostTypeRef.SetName(hostType.GetMetadata().GetName())
 			clusterNodeSet.SetHostType(resolvedHostTypeRef)
 		}
 	}

--- a/fulfillment-service/internal/servers/private_clusters_server_test.go
+++ b/fulfillment-service/internal/servers/private_clusters_server_test.go
@@ -345,11 +345,12 @@ var _ = Describe("Private clusters server", func() {
 			Expect(object).ToNot(BeNil())
 			Expect(object.GetId()).ToNot(BeEmpty())
 
-			// Verify that the host type name was replaced by the identifier:
+			// Verify that the host type name was replaced by the identifier and name is preserved:
 			nodeSets := object.GetSpec().GetNodeSets()
 			Expect(nodeSets).To(HaveKey("compute"))
 			nodeSet := nodeSets["compute"]
 			Expect(nodeSet.GetHostType().GetId()).To(Equal("acme-1ti-id"))
+			Expect(nodeSet.GetHostType().GetName()).To(Equal("acme-1ti-name"))
 		})
 
 		It("Creates object with host type specified by identifier in node set", func() {
@@ -379,11 +380,12 @@ var _ = Describe("Private clusters server", func() {
 			Expect(object).ToNot(BeNil())
 			Expect(object.GetId()).ToNot(BeEmpty())
 
-			// Verify that the host type identifier is preserved:
+			// Verify that the host type identifier is preserved and name is resolved:
 			nodeSets := object.GetSpec().GetNodeSets()
 			Expect(nodeSets).To(HaveKey("compute"))
 			nodeSet := nodeSets["compute"]
 			Expect(nodeSet.GetHostType().GetId()).To(Equal("acme-1ti-id"))
+			Expect(nodeSet.GetHostType().GetName()).To(Equal("acme-1ti-name"))
 		})
 
 		It("Creates object with template and host type specified by name", func() {
@@ -413,7 +415,7 @@ var _ = Describe("Private clusters server", func() {
 			Expect(object).ToNot(BeNil())
 			Expect(object.GetId()).ToNot(BeEmpty())
 
-			// Verify that the the template and host type names were replaced by the identifiers
+			// Verify that the template and host type names were replaced by the identifiers
 			// and metadata names are preserved on the resolved references:
 			Expect(object.GetSpec().GetTemplate().GetId()).To(Equal("my-template-id"))
 			Expect(object.GetSpec().GetTemplate().GetName()).To(Equal("my-template-name"))
@@ -1592,6 +1594,7 @@ var _ = Describe("Private clusters server", func() {
 				Expect(object).ToNot(BeNil())
 				Expect(object.GetId()).ToNot(BeEmpty())
 				Expect(object.GetSpec().GetTemplate().GetId()).To(Equal("my-template-id"))
+				Expect(object.GetSpec().GetTemplate().GetName()).To(Equal("my-template-name"))
 				Expect(object.GetSpec().GetCatalogItem().GetId()).To(Equal("cat-happy"))
 
 				// Verify node sets are populated from the template:
@@ -1599,9 +1602,11 @@ var _ = Describe("Private clusters server", func() {
 				Expect(nodeSets).To(HaveLen(2))
 				Expect(nodeSets).To(HaveKey("compute"))
 				Expect(nodeSets["compute"].GetHostType().GetId()).To(Equal("acme-1ti-id"))
+				Expect(nodeSets["compute"].GetHostType().GetName()).To(Equal("acme-1ti-name"))
 				Expect(nodeSets["compute"].GetSize()).To(Equal(int32(3)))
 				Expect(nodeSets).To(HaveKey("gpu"))
 				Expect(nodeSets["gpu"].GetHostType().GetId()).To(Equal("acme-gpu-id"))
+				Expect(nodeSets["gpu"].GetHostType().GetName()).To(Equal("acme-gpu-name"))
 				Expect(nodeSets["gpu"].GetSize()).To(Equal(int32(1)))
 			})
 

--- a/fulfillment-service/internal/servers/private_clusters_server_test.go
+++ b/fulfillment-service/internal/servers/private_clusters_server_test.go
@@ -290,8 +290,9 @@ var _ = Describe("Private clusters server", func() {
 			Expect(object).ToNot(BeNil())
 			Expect(object.GetId()).ToNot(BeEmpty())
 
-			// Verify that the template name was replaced by the identifier:
+			// Verify that the template name was replaced by the identifier and name is preserved:
 			Expect(object.GetSpec().GetTemplate().GetId()).To(Equal("my-template-id"))
+			Expect(object.GetSpec().GetTemplate().GetName()).To(Equal("my-template-name"))
 		})
 
 		It("Fails when creating object with non-existent template name", func() {
@@ -412,12 +413,15 @@ var _ = Describe("Private clusters server", func() {
 			Expect(object).ToNot(BeNil())
 			Expect(object.GetId()).ToNot(BeEmpty())
 
-			// Verify that the the template and host type names were replaced by the identifiers:
+			// Verify that the the template and host type names were replaced by the identifiers
+			// and metadata names are preserved on the resolved references:
 			Expect(object.GetSpec().GetTemplate().GetId()).To(Equal("my-template-id"))
+			Expect(object.GetSpec().GetTemplate().GetName()).To(Equal("my-template-name"))
 			nodeSets := object.GetSpec().GetNodeSets()
 			Expect(nodeSets).To(HaveKey("compute"))
 			nodeSet := nodeSets["compute"]
 			Expect(nodeSet.GetHostType().GetId()).To(Equal("acme-1ti-id"))
+			Expect(nodeSet.GetHostType().GetName()).To(Equal("acme-1ti-name"))
 		})
 
 		It("Fails when creating object with non-existent host type name", func() {


### PR DESCRIPTION
## Summary

- Set `Name` (from `metadata.name`) alongside `Id` on resolved `ClusterTemplateReference` and `HostTypeReference` in `validateAndTransformCluster`
- Previously only `Id` was set, leaving `Name` empty — metering reads `Name` for the `cluster_template` billing dimension, which was always `""`
- Fix covers all three resolution sites: create path (line 760), signal/update path (line 198), and update validation path (line 986)
- Added test assertions verifying `Name` is preserved after reference resolution

## Root Cause

`private_clusters_server.go` resolves user-provided template/host-type references to their canonical form (by ID). The resolved `ClusterTemplateReference` was constructed with only `SetId()`, dropping the `Name` field. Downstream, `osac-metering`'s `ClusterBillingDimensions()` reads `spec.GetTemplate().GetName()` for the `cluster_template` billing dimension — always empty.

## Test plan

- [x] Existing cluster tests pass (`ginkgo run --focus="Cluster" internal/servers` — 115 passed)
- [x] Added assertions in "Creates object with template specified by name" and "Creates object with template and host type specified by name" tests verifying `GetName()` returns expected value after resolution
- [ ] CaaS metering E2E tests (osac-test-infra PR #349) should pass once this lands in the image

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Private cluster creation now consistently retains the names of selected templates and host types, whether chosen by name, ID, or through a catalog item.
  * Catalog-item-based creation now correctly records the resolved template details before applying defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->