### PR TITLE
fix: add all blocking labels and manual dispatch to auto-queue

### DIFF
--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -7,10 +7,11 @@ on:
     branches: [main]
   schedule:
     - cron: "*/10 * * * *"
+  workflow_dispatch:
 
 jobs:
   enable-auto-merge:
-    if: github.event_name != 'schedule'
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
       - name: Check repo collaborator
@@ -37,7 +38,7 @@ jobs:
         run: |
           echo "labels=$LABELS"
           blocked=false
-          for label in "do-not-merge/hold" "needs-rebase"; do
+          for label in "do-not-merge/hold" "do-not-merge/work-in-progress" "do-not-merge/invalid-owners-file" "needs-rebase"; do
             if echo "$LABELS" | jq -e "index(\"$label\")" > /dev/null; then
               echo "Blocking label found: $label"
               blocked=true
@@ -64,7 +65,7 @@ jobs:
         run: gh pr merge ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --disable-auto
 
   requeue-eligible-prs:
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Re-enable auto-merge on eligible PRs
@@ -78,7 +79,7 @@ jobs:
               .isDraft == false
               and .autoMergeRequest == null
               and ([.labels[].name] | contains(["lgtm","approved","jira/valid-reference"]))
-              and ([.labels[].name] | any(. == "do-not-merge/hold" or . == "needs-rebase") | not)
+              and ([.labels[].name] | any(. == "do-not-merge/hold" or . == "do-not-merge/work-in-progress" or . == "do-not-merge/invalid-owners-file" or . == "needs-rebase") | not)
             ) | .number]')
           echo "Eligible PRs: $prs"
           for pr in $(echo "$prs" | jq -r '.[]'); do


### PR DESCRIPTION
## Summary

- Add missing blocking labels: `do-not-merge/work-in-progress`, `do-not-merge/invalid-owners-file` (both event-driven and scheduled jobs)
- Add `workflow_dispatch` trigger for manual re-queue runs (Actions > auto-queue > Run workflow)
- Supersedes #276

## Blocking labels (full list)

| Label | Effect |
|---|---|
| `do-not-merge/hold` | Disable auto-merge |
| `do-not-merge/work-in-progress` | Disable auto-merge |
| `do-not-merge/invalid-owners-file` | Disable auto-merge |
| `needs-rebase` | Disable auto-merge |

## Test plan

- [ ] PR with `do-not-merge/work-in-progress` label does not get auto-merge enabled
- [ ] Manual dispatch via Actions UI triggers requeue scan
- [ ] Scheduled run picks up ejected PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)