### PR TITLE
fix: dismiss changes-requested reviews and remove lgtm on push

### DIFF
--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -14,6 +14,27 @@ jobs:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
+      - name: Remove lgtm on new push
+        if: github.event.action == 'synchronize'
+        env:
+          GH_TOKEN: ${{ secrets.MERGE_QUEUE_TOKEN }}
+        run: |
+          pr=${{ github.event.pull_request.number }}
+          if gh pr view "$pr" --repo "${{ github.repository }}" --json labels --jq '[.labels[].name]' | jq -e 'index("lgtm")' > /dev/null; then
+            echo "Removing lgtm label from PR #$pr after new push"
+            gh pr edit "$pr" --repo "${{ github.repository }}" --remove-label lgtm
+          fi
+
+      - name: Dismiss changes-requested reviews
+        env:
+          GH_TOKEN: ${{ secrets.MERGE_QUEUE_TOKEN }}
+        run: |
+          pr=${{ github.event.pull_request.number }}
+          gh api "repos/${{ github.repository }}/pulls/$pr/reviews" --jq '.[] | select(.state == "CHANGES_REQUESTED") | .id' | while read -r review_id; do
+            echo "Dismissing review $review_id on PR #$pr"
+            gh api "repos/${{ github.repository }}/pulls/$pr/reviews/$review_id/dismissals" -X PUT -f message="Auto-dismissed: only Prow labels gate merging"
+          done
+
       - name: Check repo collaborator
         id: org-check
         env:

--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -5,13 +5,15 @@ on:
   pull_request_target:
     types: [opened, reopened, ready_for_review, synchronize, labeled, unlabeled]
     branches: [main]
+  pull_request_review:
+    types: [submitted]
   schedule:
     - cron: "*/10 * * * *"
   workflow_dispatch:
 
 jobs:
   enable-auto-merge:
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review'
     runs-on: ubuntu-latest
     steps:
       - name: Remove lgtm on new push


### PR DESCRIPTION
## Summary

- **Dismiss all CHANGES_REQUESTED reviews** on every PR event — only Prow labels (lgtm/approved) gate merging, not native GitHub reviews. Unblocks re-enabling the `pull_request` ruleset rule for direct push protection.
- **Remove lgtm label on new push/rebase** (synchronize event) — forces re-review after code changes, matching Prow behavior.

## Test plan

- [ ] Push to a PR with CodeRabbit CHANGES_REQUESTED — verify review is auto-dismissed
- [ ] Push to a PR with lgtm label — verify lgtm is removed
- [ ] Verify lgtm is NOT removed on label/unlabel events (only on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)