### PR TITLE
OSAC-3954: fix stale comment — reference resolution now sets Id and Name

### DIFF
--- a/fulfillment-service/internal/servers/private_clusters_server.go
+++ b/fulfillment-service/internal/servers/private_clusters_server.go
@@ -596,8 +596,7 @@ func (s *PrivateClustersServer) validateTemplateImmutability(ctx context.Context
 	}
 
 	// Check if template has changed. Compare by refKey (Id) rather than proto.Equal because
-	// validateAndTransformCluster normalizes the stored reference to Id-only, while the
-	// reference validator interceptor may backfill Name on incoming requests.
+	// the reference validator interceptor may backfill additional fields on incoming requests.
 	if updatingTemplate && refKey(existingSpec.GetTemplate()) != refKey(newSpec.GetTemplate()) {
 		return grpcstatus.Errorf(
 			grpccodes.InvalidArgument,


### PR DESCRIPTION
## Summary

- Fix stale comment in `validateTemplateImmutability` that claimed `validateAndTransformCluster` normalizes references to Id-only — no longer true after #277

Follow-up from [masayag's review](https://github.com/osac-project/osac/pull/277#pullrequestreview-3101095282) on #277.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal validation behavior in a code comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->