### PR TITLE
OSAC-3182: stamp GPU fields from InstanceType onto ComputeInstance CR

### DIFF
--- a/fulfillment-service/internal/controllers/computeinstance/computeinstance_reconciler_function.go
+++ b/fulfillment-service/internal/controllers/computeinstance/computeinstance_reconciler_function.go
@@ -705,6 +705,13 @@ func (t *task) addExplicitFields(ctx context.Context, spec *osacv1alpha1.Compute
 	itSpec := response.GetObject().GetSpec()
 	spec.Cores = itSpec.GetCores()
 	spec.MemoryGiB = itSpec.GetMemoryGib()
+	if gpu := itSpec.GetGpu(); gpu != nil {
+		spec.Gpu = &osacv1alpha1.GpuSpec{
+			PciDeviceSelector: gpu.GetPciDeviceSelector(),
+			ResourceName:      gpu.GetResourceName(),
+			Count:             gpu.GetCount(),
+		}
+	}
 	if ciSpec.HasRunStrategy() {
 		spec.RunStrategy = osacv1alpha1.RunStrategyType(ciSpec.GetRunStrategy())
 	}

--- a/fulfillment-service/internal/controllers/computeinstance/computeinstance_reconciler_function_test.go
+++ b/fulfillment-service/internal/controllers/computeinstance/computeinstance_reconciler_function_test.go
@@ -1909,6 +1909,144 @@ var _ = Describe("instance_type resolution in reconciler", func() {
 		Expect(spec.MemoryGiB).To(Equal(int32(8)))
 	})
 
+	It("resolves instance_type gpu fields onto CR spec", func() {
+		mockInstanceTypesClient := NewMockInstanceTypesClient(ctrl)
+		mockInstanceTypesClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(privatev1.InstanceTypesGetResponse_builder{
+				Object: privatev1.InstanceType_builder{
+					Id: "gpu-a100-8core",
+					Spec: privatev1.InstanceTypeSpec_builder{
+						Cores:     8,
+						MemoryGib: 64,
+						Gpu: privatev1.GpuSpec_builder{
+							PciDeviceSelector: "10DE:20B0",
+							ResourceName:      "nvidia.com/A100",
+							Count:             1,
+						}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build(), nil)
+
+		t := &task{
+			r: &function{
+				logger:              logger,
+				instanceTypesClient: mockInstanceTypesClient,
+			},
+			computeInstance: privatev1.ComputeInstance_builder{
+				Id: "test-gpu-instance",
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					Template:     &privatev1.ComputeInstanceTemplateReference{Name: "osac.templates.ocp_virt_vm"},
+					InstanceType: &privatev1.InstanceTypeReference{Name: "gpu-a100-8core"},
+					NetworkAttachments: []*privatev1.NetworkAttachment{
+						privatev1.NetworkAttachment_builder{Subnet: &privatev1.SubnetLocalReference{Id: subnetID}}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+			hubNamespace: hubNamespace,
+			hubClient:    fakeClient,
+		}
+
+		spec, err := t.buildSpec(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(spec.Cores).To(Equal(int32(8)))
+		Expect(spec.MemoryGiB).To(Equal(int32(64)))
+		Expect(spec.Gpu).ToNot(BeNil())
+		Expect(spec.Gpu.PciDeviceSelector).To(Equal("10DE:20B0"))
+		Expect(spec.Gpu.ResourceName).To(Equal("nvidia.com/A100"))
+		Expect(spec.Gpu.Count).To(Equal(int32(1)))
+	})
+
+	It("leaves gpu nil when InstanceType has no gpu", func() {
+		mockInstanceTypesClient := NewMockInstanceTypesClient(ctrl)
+		mockInstanceTypesClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(privatev1.InstanceTypesGetResponse_builder{
+				Object: privatev1.InstanceType_builder{
+					Id: "standard-4-8",
+					Spec: privatev1.InstanceTypeSpec_builder{
+						Cores:     4,
+						MemoryGib: 8,
+					}.Build(),
+				}.Build(),
+			}.Build(), nil)
+
+		t := &task{
+			r: &function{
+				logger:              logger,
+				instanceTypesClient: mockInstanceTypesClient,
+			},
+			computeInstance: privatev1.ComputeInstance_builder{
+				Id: "test-no-gpu-instance",
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					Template:     &privatev1.ComputeInstanceTemplateReference{Name: "osac.templates.ocp_virt_vm"},
+					InstanceType: &privatev1.InstanceTypeReference{Name: "standard-4-8"},
+					NetworkAttachments: []*privatev1.NetworkAttachment{
+						privatev1.NetworkAttachment_builder{Subnet: &privatev1.SubnetLocalReference{Id: subnetID}}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+			hubNamespace: hubNamespace,
+			hubClient:    fakeClient,
+		}
+
+		spec, err := t.buildSpec(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(spec.Cores).To(Equal(int32(4)))
+		Expect(spec.MemoryGiB).To(Equal(int32(8)))
+		Expect(spec.Gpu).To(BeNil())
+	})
+
+	It("gpu stamping is idempotent", func() {
+		mockInstanceTypesClient := NewMockInstanceTypesClient(ctrl)
+		mockInstanceTypesClient.EXPECT().
+			Get(gomock.Any(), gomock.Any()).
+			Return(privatev1.InstanceTypesGetResponse_builder{
+				Object: privatev1.InstanceType_builder{
+					Id: "gpu-a100-8core",
+					Spec: privatev1.InstanceTypeSpec_builder{
+						Cores:     8,
+						MemoryGib: 64,
+						Gpu: privatev1.GpuSpec_builder{
+							PciDeviceSelector: "10DE:20B0",
+							ResourceName:      "nvidia.com/A100",
+							Count:             2,
+						}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build(), nil).
+			Times(2)
+
+		t := &task{
+			r: &function{
+				logger:              logger,
+				instanceTypesClient: mockInstanceTypesClient,
+			},
+			computeInstance: privatev1.ComputeInstance_builder{
+				Id: "test-idempotent-gpu",
+				Spec: privatev1.ComputeInstanceSpec_builder{
+					Template:     &privatev1.ComputeInstanceTemplateReference{Name: "osac.templates.ocp_virt_vm"},
+					InstanceType: &privatev1.InstanceTypeReference{Name: "gpu-a100-8core"},
+					NetworkAttachments: []*privatev1.NetworkAttachment{
+						privatev1.NetworkAttachment_builder{Subnet: &privatev1.SubnetLocalReference{Id: subnetID}}.Build(),
+					},
+				}.Build(),
+			}.Build(),
+			hubNamespace: hubNamespace,
+			hubClient:    fakeClient,
+		}
+
+		spec1, err := t.buildSpec(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		spec2, err := t.buildSpec(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(spec1.Gpu).ToNot(BeNil())
+		Expect(spec2.Gpu).ToNot(BeNil())
+		Expect(*spec1.Gpu).To(Equal(*spec2.Gpu))
+	})
+
 	It("returns error when instance_type is empty", func() {
 		t := &task{
 			r: &function{


### PR DESCRIPTION
## [OSAC-3182](https://redhat.atlassian.net/browse/OSAC-3182): stamp GPU fields from InstanceType onto ComputeInstance CR

**Jira:** [OSAC-3182](https://redhat.atlassian.net/browse/OSAC-3182)
**Story type:** [DEV]
**Depends on:** osac-project/osac#217 ([OSAC-3162](https://redhat.atlassian.net/browse/OSAC-3162) — GpuSpec CRD type)

### Summary

Extends the ComputeInstance reconciler's `addExplicitFields` method to read GPU data from the resolved InstanceType and stamp it onto the K8s ComputeInstance CR spec. Follows the same pattern as the existing cores/memory stamping. When the InstanceType has no GPU, the CR's gpu field remains nil.

### Changes

- **`fulfillment-service/internal/controllers/computeinstance/computeinstance_reconciler_function.go`**
  - Added GPU nil-check and `osacv1alpha1.GpuSpec` construction after cores/memory assignment in `addExplicitFields`

- **`fulfillment-service/internal/controllers/computeinstance/computeinstance_reconciler_function_test.go`**
  - Added 3 unit tests in the "instance_type resolution in reconciler" describe block:
    - "resolves instance_type gpu fields onto CR spec" — verifies all 3 GPU fields
    - "leaves gpu nil when InstanceType has no gpu" — verifies nil preservation
    - "gpu stamping is idempotent" — verifies repeated calls produce identical results

### Testing

- **Unit tests:** 3 new Ginkgo tests covering GPU present, GPU absent, and idempotency
- **Integration tests:** Deferred to [OSAC-3184](https://redhat.atlassian.net/browse/OSAC-3184) (QE story)
- **Coverage:** All behavioral paths through the GPU stamping code are exercised through the public `buildSpec` interface

### Acceptance Criteria

- [ ] AC-1: GPU-enabled InstanceType → reconciler stamps gpu struct (pciDeviceSelector, resourceName, count) onto CR
- [ ] AC-2: Non-GPU InstanceType → CR gpu field remains nil
- [ ] AC-3: GPU stamping is idempotent — re-reconciliation produces no change
- [ ] AC-4: GPU ComputeInstances carry the same tenant isolation metadata as non-GPU instances


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compute instances now support optional GPU passthrough configuration.
  * GPU settings include device selection, resource name, and device count.
  * GPU configurations are validated, limited to 1–16 devices, and immutable after creation.
  * GPU settings are automatically applied when resolving GPU-enabled instance types.

* **Bug Fixes**
  * Ensured GPU settings remain consistent when compute instance specifications are rebuilt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->