### PR TITLE
NO-ISSUE: fix kind-dev setup failures on ARM64

### DIFF
--- a/kind-dev/setup.sh
+++ b/kind-dev/setup.sh
@@ -882,10 +882,15 @@ deploy_osac() {
     --namespace "${OSAC_NAMESPACE}"
     --create-namespace
     --values "${SCRIPT_DIR}/values-kind.yaml"
+    --timeout 15m
   )
   if [[ -n "${FULFILLMENT_IMAGE:-}" ]]; then
     helm_args+=(--set "service.images.service=${FULFILLMENT_IMAGE}")
     log "Using custom fulfillment image: ${FULFILLMENT_IMAGE}"
+  fi
+  if [[ "$(uname -m)" == "arm64" ]]; then
+    helm_args+=(--set "cliImage=bitnami/kubectl:latest")
+    log "ARM64 detected — using bitnami/kubectl for hook jobs"
   fi
   helm "${helm_args[@]}"
 

--- a/kind-dev/values-kind.yaml
+++ b/kind-dev/values-kind.yaml
@@ -23,7 +23,7 @@ operator:
     computeInstance: true
     tenant: true
     networking: true
-    bareMetalInstance: false
+    bareMetalInstance: true
   certs:
     issuerRef:
       name: default-ca

--- a/osac-installer/charts/osac/templates/hooks/create-hub.yaml
+++ b/osac-installer/charts/osac/templates/hooks/create-hub.yaml
@@ -70,7 +70,7 @@ spec:
             NAMESPACE="{{ .Release.Namespace }}"
 
             echo "Reading hub-access token..."
-            HUB_TOKEN=$(oc get secret hub-access -n "${NAMESPACE}" \
+            HUB_TOKEN=$(kubectl get secret hub-access -n "${NAMESPACE}" \
               -o jsonpath='{.data.token}' | base64 -d)
             [[ -n "${HUB_TOKEN}" ]] || { echo "ERROR: hub-access secret has no token"; exit 1; }
             echo "  hub-access token: ${#HUB_TOKEN} chars"

--- a/osac-installer/charts/osac/templates/hooks/pre-install-validate.yaml
+++ b/osac-installer/charts/osac/templates/hooks/pre-install-validate.yaml
@@ -30,7 +30,7 @@ spec:
 
           # Check that cert-manager CRDs exist
           echo "Checking for cert-manager CRDs..."
-          if oc get crd certificates.cert-manager.io >/dev/null; then
+          if kubectl get crd certificates.cert-manager.io >/dev/null; then
             echo "  cert-manager CRDs found."
           else
             echo "ERROR: cert-manager CRDs not found."
@@ -40,7 +40,7 @@ spec:
 
           # Check that a default StorageClass exists
           echo "Checking for default StorageClass..."
-          DEFAULT_SC=$(oc get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
+          DEFAULT_SC=$(kubectl get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
           if [ -n "$DEFAULT_SC" ]; then
             echo "  Default StorageClass found: $DEFAULT_SC"
           else

--- a/osac-installer/charts/osac/templates/hooks/publish-templates.yaml
+++ b/osac-installer/charts/osac/templates/hooks/publish-templates.yaml
@@ -29,7 +29,7 @@ spec:
           - pipefail
           - -c
           - |
-            AAP_TOKEN=$(oc get secret osac-aap-api-token -n {{ .Release.Namespace }} \
+            AAP_TOKEN=$(kubectl get secret osac-aap-api-token -n {{ .Release.Namespace }} \
               -o jsonpath='{.data.token}' | base64 -d)
             [[ -n "${AAP_TOKEN}" ]] || { echo "ERROR: osac-aap-api-token secret is empty"; exit 1; }
 


### PR DESCRIPTION
Summary

  Three issues prevent setup.sh from completing on ARM64 Macs:

  - Helm hook timeout: the fulfillment-create-hub post-install hook polls the fulfillment service for up to 10 minutes, but Helm's default timeout is 5 minutes. Add --timeout 15m to align with the Job's activeDeadlineSeconds.
  - Operator CrashLoopBackOff: the ExternalIPAttachmentReconciler unconditionally watches BareMetalInstance, requiring the type in the scheme, but bareMetalInstance was set to false in Kind values. Enable it so the scheme registers the type. The CRD chart is always deployed regardless.
  - Hook image pull failure: origin-cli is AMD64-only. Replace oc with kubectl in hook templates (drop-in for get/list commands) and override cliImage to bitnami/kubectl on ARM64 in setup.sh.

  Test plan

  - [x] ./kind-dev/teardown.sh && ./kind-dev/setup.sh completes on Apple Silicon Mac
  - [x] All pods in osac namespace reach Running/Ready (9/9)
  - [x] fulfillment-create-hub Job completes successfully (cleaned up by hook-succeeded policy)
  - [x] No regression on AMD64 — same origin-cli image used, kubectl is present in it

  Assisted-by: Claude Code noreply@anthropic.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled bare-metal instance management in the Kind development environment.
  * Added ARM64-specific support for deployment tooling.

* **Bug Fixes**
  * Improved installation and upgrade compatibility across Kubernetes-based environments.
  * Updated deployment validation, hub setup, and template publishing to use Kubernetes-native commands.
  * Added a 15-minute timeout to Helm deployments to support slower installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->