### PR TITLE
[wip] investigate: Revert storage-tier changes (#256, #159) to diagnose BMaaS CI degradation

### DIFF
--- a/osac-operator/api/v1alpha1/computeinstance_types_test.go
+++ b/osac-operator/api/v1alpha1/computeinstance_types_test.go
@@ -28,8 +28,7 @@ var _ = Describe("ComputeInstanceSpec", func() {
 				Cores:     4,
 				MemoryGiB: 8,
 				BootDisk: v1alpha1.DiskSpec{
-					SizeGiB:     30,
-					StorageTier: "standard",
+					SizeGiB: 30,
 				},
 				RunStrategy: v1alpha1.RunStrategyAlways,
 			}
@@ -52,7 +51,7 @@ var _ = Describe("ComputeInstanceSpec", func() {
 				},
 				Cores:       1,
 				MemoryGiB:   1,
-				BootDisk:    v1alpha1.DiskSpec{SizeGiB: 1, StorageTier: "standard"},
+				BootDisk:    v1alpha1.DiskSpec{SizeGiB: 1},
 				RunStrategy: v1alpha1.RunStrategyAlways,
 			}
 
@@ -71,11 +70,11 @@ var _ = Describe("ComputeInstanceSpec", func() {
 				},
 				Cores:     2,
 				MemoryGiB: 4,
-				BootDisk:  v1alpha1.DiskSpec{SizeGiB: 10, StorageTier: "standard"},
+				BootDisk:  v1alpha1.DiskSpec{SizeGiB: 10},
 				AdditionalDisks: []v1alpha1.DiskSpec{
-					{SizeGiB: 50, StorageTier: "standard"},
-					{SizeGiB: 100, StorageTier: "standard"},
-					{SizeGiB: 200, StorageTier: "standard"},
+					{SizeGiB: 50},
+					{SizeGiB: 100},
+					{SizeGiB: 200},
 				},
 				RunStrategy: v1alpha1.RunStrategyAlways,
 			}
@@ -95,7 +94,7 @@ var _ = Describe("ComputeInstanceSpec", func() {
 				},
 				Cores:     2,
 				MemoryGiB: 4,
-				BootDisk:  v1alpha1.DiskSpec{SizeGiB: 10, StorageTier: "standard"},
+				BootDisk:  v1alpha1.DiskSpec{SizeGiB: 10},
 				UserDataSecretRef: &corev1.LocalObjectReference{
 					Name: "my-cloud-init",
 				},
@@ -116,7 +115,7 @@ var _ = Describe("ComputeInstanceSpec", func() {
 				},
 				Cores:       2,
 				MemoryGiB:   4,
-				BootDisk:    v1alpha1.DiskSpec{SizeGiB: 10, StorageTier: "standard"},
+				BootDisk:    v1alpha1.DiskSpec{SizeGiB: 10},
 				SSHKey:      sshKey,
 				RunStrategy: v1alpha1.RunStrategyAlways,
 			}
@@ -184,7 +183,7 @@ var _ = Describe("ComputeInstance", func() {
 				},
 				Cores:       2,
 				MemoryGiB:   4,
-				BootDisk:    v1alpha1.DiskSpec{SizeGiB: 10, StorageTier: "standard"},
+				BootDisk:    v1alpha1.DiskSpec{SizeGiB: 10},
 				RunStrategy: v1alpha1.RunStrategyAlways,
 				NetworkAttachments: []v1alpha1.NetworkAttachment{
 					{
@@ -208,7 +207,7 @@ var _ = Describe("ComputeInstance", func() {
 				},
 				Cores:       2,
 				MemoryGiB:   4,
-				BootDisk:    v1alpha1.DiskSpec{SizeGiB: 10, StorageTier: "standard"},
+				BootDisk:    v1alpha1.DiskSpec{SizeGiB: 10},
 				RunStrategy: v1alpha1.RunStrategyAlways,
 				NetworkAttachments: []v1alpha1.NetworkAttachment{
 					{SubnetRef: "subnet-A", SecurityGroupRefs: []string{"web-sg"}},
@@ -232,7 +231,7 @@ var _ = Describe("ComputeInstance", func() {
 				},
 				Cores:       2,
 				MemoryGiB:   4,
-				BootDisk:    v1alpha1.DiskSpec{SizeGiB: 10, StorageTier: "standard"},
+				BootDisk:    v1alpha1.DiskSpec{SizeGiB: 10},
 				RunStrategy: v1alpha1.RunStrategyAlways,
 				NetworkAttachments: []v1alpha1.NetworkAttachment{
 					{SubnetRef: "subnet-A"},
@@ -256,7 +255,7 @@ var _ = Describe("ComputeInstance", func() {
 				},
 				Cores:       2,
 				MemoryGiB:   4,
-				BootDisk:    v1alpha1.DiskSpec{SizeGiB: 10, StorageTier: "standard"},
+				BootDisk:    v1alpha1.DiskSpec{SizeGiB: 10},
 				RunStrategy: v1alpha1.RunStrategyAlways,
 				NetworkAttachments: []v1alpha1.NetworkAttachment{
 					{SubnetRef: "subnet-A", SecurityGroupRefs: []string{"sg-1"}},

--- a/osac-operator/charts/operator/values.yaml
+++ b/osac-operator/charts/operator/values.yaml
@@ -55,6 +55,9 @@ certs:
     kind: ClusterIssuer
     name: default-ca
 
+bootstrap:
+  cliImage: quay.io/openshift/origin-cli:4.20.0
+
 hubAccess:
   enabled: false
 

--- a/osac-operator/internal/controller/computeinstance_validation_test.go
+++ b/osac-operator/internal/controller/computeinstance_validation_test.go
@@ -69,7 +69,7 @@ var _ = Describe("ComputeInstance CEL Validation", func() {
 				},
 				Cores:       2,
 				MemoryGiB:   4,
-				BootDisk:    osacv1alpha1.DiskSpec{SizeGiB: 20, StorageTier: "standard"},
+				BootDisk:    osacv1alpha1.DiskSpec{SizeGiB: 20},
 				RunStrategy: osacv1alpha1.RunStrategyAlways,
 			},
 		}
@@ -265,7 +265,7 @@ var _ = Describe("ComputeInstance CEL Validation", func() {
 		It("should reject changing additionalDisks", func() {
 			instance := createValidInstance("test-additionaldisks-immutable")
 			instance.Spec.AdditionalDisks = []osacv1alpha1.DiskSpec{
-				{SizeGiB: 100, StorageTier: "standard"},
+				{SizeGiB: 100},
 			}
 			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
 
@@ -283,7 +283,7 @@ var _ = Describe("ComputeInstance CEL Validation", func() {
 		It("should reject adding additionalDisks", func() {
 			instance := createValidInstance("test-add-disk-immutable")
 			instance.Spec.AdditionalDisks = []osacv1alpha1.DiskSpec{
-				{SizeGiB: 100, StorageTier: "standard"},
+				{SizeGiB: 100},
 			}
 			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
 
@@ -292,7 +292,7 @@ var _ = Describe("ComputeInstance CEL Validation", func() {
 
 			// Try to add another disk
 			instance.Spec.AdditionalDisks = append(instance.Spec.AdditionalDisks,
-				osacv1alpha1.DiskSpec{SizeGiB: 200, StorageTier: "standard"},
+				osacv1alpha1.DiskSpec{SizeGiB: 200},
 			)
 			err := k8sClient.Update(ctx, instance)
 			Expect(err).To(HaveOccurred())

--- a/osac-operator/internal/controller/suite_test.go
+++ b/osac-operator/internal/controller/suite_test.go
@@ -171,8 +171,7 @@ func newTestComputeInstanceSpec(templateID string) osacv1alpha1.ComputeInstanceS
 		Cores:     4,
 		MemoryGiB: 8,
 		BootDisk: osacv1alpha1.DiskSpec{
-			SizeGiB:     30,
-			StorageTier: "standard",
+			SizeGiB: 30,
 		},
 		RunStrategy: osacv1alpha1.RunStrategyAlways,
 	}

--- a/osac-operator/test/integration/console_proxy_test.go
+++ b/osac-operator/test/integration/console_proxy_test.go
@@ -190,7 +190,6 @@ spec:
   memoryGiB: 4
   bootDisk:
     sizeGiB: 20
-    storageTier: standard
   runStrategy: Always
 `, name, namespace)
 	return strings.NewReader(yaml)


### PR DESCRIPTION
## Summary

Diagnostic PR to determine whether PRs #256 and #159 are causing the BMaaS CI degradation observed starting Aug 11 20:17 UTC (coinciding with release v0.0.85).

This PR reverts:
- **PR #256** (`c8d822a4`): [OSAC-3886](https://redhat.atlassian.net/browse/OSAC-3886) — deleted a StorageClass labeling Helm hook
- **PR #159** (`3e9b25c0`): [OSAC-3629](https://redhat.atlassian.net/browse/OSAC-3629) — added `storage_tier` to the CRD/reconciler and updated test fixtures

## Rationale

The CI degradation timeline correlates with the v0.0.85 release. These two PRs modified storage-related infrastructure and are the most likely candidates for the regression. Reverting them in isolation lets us confirm or rule out causation before investing in a targeted fix.

## Test plan

- [ ] Merge this PR and monitor BMaaS CI pipeline runs for stabilization
- [ ] If CI stabilizes, narrow down which of the two PRs is the actual culprit by re-applying them individually
- [ ] If CI does not stabilize, close this PR and investigate other changes in v0.0.85

🤖 Generated with [Claude Code](https://claude.com/claude-code)