### PR TITLE
OSAC-3985: requeue instead of firing CaaS storage job when no tier definitions registered

### DIFF
--- a/osac-operator/internal/controller/storage_controller.go
+++ b/osac-operator/internal/controller/storage_controller.go
@@ -370,9 +370,9 @@ func (r *StorageReconciler) handleUpdate(ctx context.Context, instance *v1alpha1
 				{ClusterName: clusterName, Ready: false, Reason: v1alpha1.TenantReasonNotFound},
 			}
 
-			if r.TiersClient != nil && len(tierDefinitions) == 0 {
+			if r.TiersClient != nil && r.BackendsClient != nil && len(tierDefinitions) == 0 {
 				log.Info("no storage tier definitions registered yet, requeueing",
-					"tenant", tenantName, "requeueAfter", r.StatusPollInterval)
+					"tenant", tenantName)
 				return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
 			}
 

--- a/osac-operator/internal/controller/storage_controller.go
+++ b/osac-operator/internal/controller/storage_controller.go
@@ -370,6 +370,12 @@ func (r *StorageReconciler) handleUpdate(ctx context.Context, instance *v1alpha1
 				{ClusterName: clusterName, Ready: false, Reason: v1alpha1.TenantReasonNotFound},
 			}
 
+			if r.TiersClient != nil && len(tierDefinitions) == 0 {
+				log.Info("no storage tier definitions registered yet, requeueing",
+					"tenant", tenantName, "requeueAfter", r.StatusPollInterval)
+				return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
+			}
+
 			return r.handleClusterStorageProvisioning(ctx, instance, hubSecretReady)
 		}
 

--- a/osac-operator/internal/controller/storage_controller_test.go
+++ b/osac-operator/internal/controller/storage_controller_test.go
@@ -482,6 +482,34 @@ var _ = Describe("Storage Controller", func() {
 			Expect(clusterCond.Status).To(Equal(metav1.ConditionFalse))
 		})
 
+		It("should requeue without firing a job when TiersClient is set but tier resolution fails", func() {
+			name := "storage-test-tier-error"
+			createReadyTenantForStorage(ctx, name, testNamespace)
+			createHubSecret(ctx, name, secretsNamespace)
+
+			clusterProvider := &mockProvisioningProvider{name: "cluster-storage-mock"}
+			r := NewStorageReconciler(
+				testMcManager, testNamespace, mcmanager.LocalCluster,
+				nil, clusterProvider, pollInterval,
+				provisioning.DefaultMaxJobHistory,
+			)
+			r.TiersClient = &mockStorageTiersLister{
+				listFunc: func(_ context.Context, _ *privatev1.StorageTiersListRequest, _ ...grpc.CallOption) (*privatev1.StorageTiersListResponse, error) {
+					return nil, fmt.Errorf("tiers API unavailable")
+				},
+			}
+			r.BackendsClient = registeredBackendsClient(1)
+
+			nn := types.NamespacedName{Name: name, Namespace: testNamespace}
+			result, err := r.Reconcile(ctx, storageReconcileRequest(nn))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(pollInterval))
+
+			tenant := &v1alpha1.Tenant{}
+			Expect(k8sClient.Get(ctx, nn, tenant)).To(Succeed())
+			Expect(tenant.Status.ClusterStorageJobs).To(BeEmpty())
+		})
+
 		It("should trigger cluster storage provisioning when Stage 1 complete but no SCs", func() {
 			name := "storage-test-no-sc"
 			createReadyTenantForStorage(ctx, name, testNamespace)

--- a/osac-operator/internal/controller/storage_controller_test.go
+++ b/osac-operator/internal/controller/storage_controller_test.go
@@ -450,6 +450,38 @@ var _ = Describe("Storage Controller", func() {
 	})
 
 	Context("Stage 2: Cluster storage provisioning", func() {
+		It("should requeue without firing a job when TiersClient is set but no tier definitions are registered", func() {
+			name := "storage-test-no-tiers"
+			createReadyTenantForStorage(ctx, name, testNamespace)
+			createHubSecret(ctx, name, secretsNamespace)
+
+			clusterProvider := &mockProvisioningProvider{name: "cluster-storage-mock"}
+			r := NewStorageReconciler(
+				testMcManager, testNamespace, mcmanager.LocalCluster,
+				nil, clusterProvider, pollInterval,
+				provisioning.DefaultMaxJobHistory,
+			)
+			r.TiersClient = &mockStorageTiersLister{
+				listFunc: func(_ context.Context, _ *privatev1.StorageTiersListRequest, _ ...grpc.CallOption) (*privatev1.StorageTiersListResponse, error) {
+					return &privatev1.StorageTiersListResponse{}, nil
+				},
+			}
+			r.BackendsClient = registeredBackendsClient(1)
+
+			nn := types.NamespacedName{Name: name, Namespace: testNamespace}
+			result, err := r.Reconcile(ctx, storageReconcileRequest(nn))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(pollInterval))
+
+			tenant := &v1alpha1.Tenant{}
+			Expect(k8sClient.Get(ctx, nn, tenant)).To(Succeed())
+			Expect(tenant.Status.ClusterStorageJobs).To(BeEmpty())
+
+			clusterCond := tenant.GetStatusCondition(v1alpha1.TenantConditionClusterStorageReady)
+			Expect(clusterCond).NotTo(BeNil())
+			Expect(clusterCond.Status).To(Equal(metav1.ConditionFalse))
+		})
+
 		It("should trigger cluster storage provisioning when Stage 1 complete but no SCs", func() {
 			name := "storage-test-no-sc"
 			createReadyTenantForStorage(ctx, name, testNamespace)


### PR DESCRIPTION
## Summary

- On fresh install, `osac-create-tenant-cluster-storage` fired before any StorageTiers were registered, producing a predictable AAP job failure (`storage_tier_definitions must be non-empty`). Self-healed on retry but generated noise.
- Add a 4-line guard in `handleUpdate()`: if `TiersClient` is configured but tier definitions are empty, requeue with `StatusPollInterval` instead of firing the job.
- New test case in Stage 2 context: verifies no job is fired and `RequeueAfter = pollInterval` when TiersClient returns empty tier list.

Fixes: [OSAC-3985](https://redhat.atlassian.net/browse/OSAC-3985)

## Test plan

- [x] `make test` — 633 passed, 0 failed
- [x] `make lint` — 0 issues
- [ ] Observed on fresh install: no failed AAP job before StorageTiers register

## Breaking changes

- [ ] This PR does not introduce breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage provisioning when tenant-specific storage tier definitions are unavailable.
  * The system now periodically retries instead of starting cluster-storage provisioning prematurely.
  * Prevents cluster-storage jobs from being created until required tier information is available.
  * Handles missing tier definitions and tier-resolution failures without reporting a reconciliation error.
  * Improves recovery as tier information becomes available or fulfillment services resume.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->