### PR TITLE
OSAC-3975: extract shared envutil package for adapter env parsing

### DIFF
--- a/osac-metering/adapters/cmd/echo-adapter/main.go
+++ b/osac-metering/adapters/cmd/echo-adapter/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/go-logr/stdr"
 
 	"github.com/osac-project/osac-metering/adapters"
+	"github.com/osac-project/osac-metering/adapters/envutil"
 )
 
 // echoAdapter logs every event to stdout, stores it in a ring buffer
@@ -86,15 +87,9 @@ func (a *echoAdapter) Close() error {
 }
 
 func main() {
-	brokers := os.Getenv("KAFKA_BROKERS")
-	if brokers == "" {
-		log.Fatal("KAFKA_BROKERS is required (comma-separated broker list)")
-	}
+	brokers := envutil.RequireEnv("KAFKA_BROKERS")
 
-	group := os.Getenv("KAFKA_CONSUMER_GROUP")
-	if group == "" {
-		group = "echo-adapter-smoke-test"
-	}
+	group := envutil.EnvOrDefault("KAFKA_CONSUMER_GROUP", "echo-adapter-smoke-test")
 
 	flushInterval := 5 * time.Second
 	if v := os.Getenv("FLUSH_INTERVAL"); v != "" {
@@ -105,10 +100,7 @@ func main() {
 		flushInterval = d
 	}
 
-	metricsAddr := os.Getenv("METRICS_ADDR")
-	if metricsAddr == "" {
-		metricsAddr = ":2112"
-	}
+	metricsAddr := envutil.EnvOrDefault("METRICS_ADDR", ":2112")
 
 	bufferSize := defaultMaxEvents
 	if v := os.Getenv("ECHO_BUFFER_SIZE"); v != "" {

--- a/osac-metering/adapters/cmd/m360-adapter/main.go
+++ b/osac-metering/adapters/cmd/m360-adapter/main.go
@@ -24,12 +24,12 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
 	"github.com/go-logr/stdr"
 	"github.com/osac-project/osac-metering/adapters"
+	"github.com/osac-project/osac-metering/adapters/envutil"
 )
 
 type m360Adapter struct {
@@ -57,22 +57,22 @@ func (a *m360Adapter) HealthCheck(ctx context.Context) error {
 func (a *m360Adapter) Close() error { return nil }
 
 func main() {
-	brokers := requireEnv("KAFKA_BROKERS")
-	m360URL := requireEnv("M360_API_URL")
-	apiKeyFile := requireEnv("M360_API_KEY_FILE")
+	brokers := envutil.RequireEnv("KAFKA_BROKERS")
+	m360URL := envutil.RequireEnv("M360_API_URL")
+	apiKeyFile := envutil.RequireEnv("M360_API_KEY_FILE")
 
-	apiKey := readFileOrFatal(apiKeyFile)
-	apiVersion := envOrDefault("M360_API_VERSION", "v1")
+	apiKey := envutil.ReadFileOrFatal(apiKeyFile)
+	apiVersion := envutil.EnvOrDefault("M360_API_VERSION", "v1")
 
 	topics := adapters.AllTopics
 	if v := os.Getenv("KAFKA_TOPICS"); v != "" {
-		topics = splitAndTrim(v, ",")
+		topics = envutil.SplitAndTrim(v, ",")
 		if len(topics) == 0 {
 			log.Fatal("KAFKA_TOPICS must contain at least one topic")
 		}
 	}
 
-	group := envOrDefault("KAFKA_CONSUMER_GROUP", "m360-adapter")
+	group := envutil.EnvOrDefault("KAFKA_CONSUMER_GROUP", "m360-adapter")
 
 	var flushInterval time.Duration
 	if v := os.Getenv("FLUSH_INTERVAL"); v != "" {
@@ -86,7 +86,7 @@ func main() {
 		flushInterval = d
 	}
 
-	metricsAddr := envOrDefault("METRICS_ADDR", ":2112")
+	metricsAddr := envutil.EnvOrDefault("METRICS_ADDR", ":2112")
 
 	// TLS defaults to true (!= "false") — safer for production.
 	// Note: echo-adapter uses == "true" (defaults off) since it runs in
@@ -156,42 +156,4 @@ func main() {
 	}
 
 	log.Print("m360 adapter shut down cleanly")
-}
-
-func requireEnv(key string) string {
-	v := os.Getenv(key)
-	if v == "" {
-		log.Fatalf("%s is required", key)
-	}
-	return v
-}
-
-func envOrDefault(key, fallback string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return fallback
-}
-
-func readFileOrFatal(path string) string {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		log.Fatalf("reading %s: %v", path, err)
-	}
-	trimmed := strings.TrimSpace(string(data))
-	if trimmed == "" {
-		log.Fatalf("%s is empty", path)
-	}
-	return trimmed
-}
-
-func splitAndTrim(s, sep string) []string {
-	parts := strings.Split(s, sep)
-	result := parts[:0]
-	for _, p := range parts {
-		if trimmed := strings.TrimSpace(p); trimmed != "" {
-			result = append(result, trimmed)
-		}
-	}
-	return result
 }

--- a/osac-metering/adapters/envutil/envutil.go
+++ b/osac-metering/adapters/envutil/envutil.go
@@ -1,0 +1,67 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+// Package envutil provides common environment variable and file-reading
+// helpers for adapter main functions. All functions that encounter an
+// error call log.Fatalf, making them suitable for use during process
+// startup only.
+package envutil
+
+import (
+	"log"
+	"os"
+	"strings"
+)
+
+// RequireEnv returns the value of the named environment variable or
+// terminates the process if it is empty or unset.
+func RequireEnv(key string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		log.Fatalf("%s is required", key)
+	}
+	return v
+}
+
+// EnvOrDefault returns the value of the named environment variable, or
+// fallback if the variable is empty or unset.
+func EnvOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// ReadFileOrFatal reads the file at path, trims whitespace, and returns
+// the result. It terminates the process if the file cannot be read or
+// is empty after trimming.
+func ReadFileOrFatal(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatalf("reading %s: %v", path, err)
+	}
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		log.Fatalf("%s is empty", path)
+	}
+	return trimmed
+}
+
+// SplitAndTrim splits s by sep, trims whitespace from each part, and
+// returns only the non-empty parts.
+func SplitAndTrim(s, sep string) []string {
+	parts := strings.Split(s, sep)
+	var result []string
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}

--- a/osac-metering/adapters/envutil/envutil_test.go
+++ b/osac-metering/adapters/envutil/envutil_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package envutil_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/osac-project/osac-metering/adapters/envutil"
+)
+
+func TestEnvutil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Envutil Suite")
+}
+
+var _ = Describe("RequireEnv", func() {
+	It("returns the value when set", func() {
+		GinkgoT().Setenv("TEST_REQUIRE_ENV_KEY", "hello")
+		Expect(envutil.RequireEnv("TEST_REQUIRE_ENV_KEY")).To(Equal("hello"))
+	})
+})
+
+var _ = Describe("EnvOrDefault", func() {
+	It("returns the env value when set", func() {
+		GinkgoT().Setenv("TEST_ENV_OR_DEFAULT_KEY", "custom")
+		Expect(envutil.EnvOrDefault("TEST_ENV_OR_DEFAULT_KEY", "fallback")).To(Equal("custom"))
+	})
+
+	It("returns the fallback when unset", func() {
+		Expect(envutil.EnvOrDefault("TEST_ENV_OR_DEFAULT_UNSET", "fallback")).To(Equal("fallback"))
+	})
+
+	It("returns the fallback when empty", func() {
+		GinkgoT().Setenv("TEST_ENV_OR_DEFAULT_KEY", "")
+		Expect(envutil.EnvOrDefault("TEST_ENV_OR_DEFAULT_KEY", "fallback")).To(Equal("fallback"))
+	})
+})
+
+var _ = Describe("ReadFileOrFatal", func() {
+	It("reads and trims file content", func() {
+		dir := GinkgoT().TempDir()
+		path := filepath.Join(dir, "secret")
+		Expect(os.WriteFile(path, []byte("  my-secret\n"), 0o600)).To(Succeed())
+		Expect(envutil.ReadFileOrFatal(path)).To(Equal("my-secret"))
+	})
+})
+
+var _ = Describe("SplitAndTrim", func() {
+	It("splits and trims a comma-separated string", func() {
+		Expect(envutil.SplitAndTrim(" a , b , c ", ",")).To(Equal([]string{"a", "b", "c"}))
+	})
+
+	It("drops empty segments", func() {
+		Expect(envutil.SplitAndTrim("a,,b,", ",")).To(Equal([]string{"a", "b"}))
+	})
+
+	It("returns empty slice for whitespace-only input", func() {
+		Expect(envutil.SplitAndTrim("  ,  , ", ",")).To(BeEmpty())
+	})
+
+	It("handles a single value", func() {
+		Expect(envutil.SplitAndTrim("solo", ",")).To(Equal([]string{"solo"}))
+	})
+})


### PR DESCRIPTION
## Summary

- Extract `requireEnv`, `envOrDefault`, `readFileOrFatal`, and `splitAndTrim` from _m360-adapter_ into a shared _adapters/envutil/_ package so all adapters use the same startup helpers
- Update both `m360-adapter` and `echo-adapter` to import `envutil` instead of re-implementing env parsing inline
- Add Ginkgo test suite for the new package (9 specs)

## Context

Identified during [PR #236](https://github.com/osac-project/osac/pull/236) review ([OSAC-3424](https://redhat.atlassian.net/browse/OSAC-3424)): `m360-adapter` extracted reusable helpers while echo-adapter used inline `os.Getenv` + `if` blocks. Without standardizing, each new adapter would copy one pattern or the other, compounding the inconsistency.

## Changes

| File | Change |
|------|--------|
| _adapters/envutil/envutil.go_ | New shared package: `RequireEnv`, `EnvOrDefault`, `ReadFileOrFatal`, `SplitAndTrim` |
| _adapters/envutil/envutil_test.go_ | Ginkgo tests (9 specs) |
| _adapters/cmd/m360-adapter/main.go_ | Replace local helpers with `envutil.*` imports, remove 37 lines |
| _adapters/cmd/echo-adapter/main.go_ | Replace 3 inline env-parsing blocks with `envutil.*` |

## Behavioral note

_echo-adapter_'s `KAFKA_BROKERS` error message changes from `"KAFKA_BROKERS is required (comma-separated broker list)"` to `"KAFKA_BROKERS is required"` (standardized via `RequireEnv`).

## Test plan

- [x] `make test` in `adapters/` — 114 specs pass (67 framework + 15 echo + 23 m360 + 9 envutil)
- [x] `make lint` in `adapters/` — 0 issues
- [x] No functional behavior change beyond the error message noted above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized startup configuration handling across metering adapters.
  * Added consistent support for required settings and configurable defaults.
  * Improved processing of file-based and comma-separated configuration values by trimming whitespace and ignoring empty entries.

* **Tests**
  * Added coverage for environment settings, default values, file input, and value splitting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->