### PR TITLE
OSAC-3974: move Kafka TLS default into framework KafkaConfigFromEnv

### DIFF
--- a/osac-metering/AGENTS.md
+++ b/osac-metering/AGENTS.md
@@ -90,7 +90,7 @@ The `adapters/` package is a standalone Go module that provides everything a bil
 - `NonRetryableError` / `RetryableError` error classification
 - Graceful shutdown: final flush with 30s timeout, adapter close with 10s timeout
 
-**Kafka configuration** (`kafka.go`) — TLS with custom CA, SASL/SCRAM-SHA-512 authentication
+**Kafka configuration** (`kafka.go`, `kafka_env.go`) — TLS with custom CA, SASL/SCRAM-SHA-512 authentication; `KafkaConfigFromEnv()` reads `KAFKA_*` env vars with TLS enabled by default
 
 **Prometheus metrics** (`metrics.go`):
 - `osac_adapter_events_submitted_total` (provider, topic)
@@ -111,6 +111,8 @@ The `adapters/` package is a standalone Go module that provides everything a bil
 - `DELETE /events` — clear stored events
 - `GET /healthz` — health check
 - `GET /metrics` — Prometheus metrics
+
+Kafka TLS is enabled by default (via `KafkaConfigFromEnv()`); set `KAFKA_TLS_ENABLED=false` for local development without TLS.
 
 Deployed via Helm with `echoAdapter.enabled: true` (disabled by default; enabled in CI values profiles).
 

--- a/osac-metering/adapters/cmd/echo-adapter/main.go
+++ b/osac-metering/adapters/cmd/echo-adapter/main.go
@@ -21,9 +21,12 @@ in compliance with the License. You may obtain a copy of the License at
 //	export KAFKA_BROKERS="localhost:9092"
 //	go run ./cmd/echo-adapter/
 //
+// TLS is enabled by default. For local development without TLS:
+//
+//	export KAFKA_TLS_ENABLED="false"
+//
 // Optional TLS/SASL (for cluster-deployed Kafka):
 //
-//	export KAFKA_TLS_ENABLED="true"
 //	export KAFKA_TLS_CA_CERT="/path/to/ca.crt"
 //	export KAFKA_SASL_USERNAME="metering-user"
 //	export KAFKA_SASL_PASSWORD_FILE="/path/to/password"
@@ -120,12 +123,7 @@ func main() {
 		ConsumerGroup: group,
 		Topics:        adapters.AllTopics,
 		FlushInterval: flushInterval,
-		Kafka: adapters.KafkaConfig{
-			TLSEnabled:   os.Getenv("KAFKA_TLS_ENABLED") == "true",
-			TLSCACert:    os.Getenv("KAFKA_TLS_CA_CERT"),
-			SASLUser:     os.Getenv("KAFKA_SASL_USERNAME"),
-			SASLPassFile: os.Getenv("KAFKA_SASL_PASSWORD_FILE"),
-		},
+		Kafka:         adapters.KafkaConfigFromEnv(),
 	}, logger)
 
 	// Serve metrics, health, and event query endpoints.

--- a/osac-metering/adapters/cmd/m360-adapter/main.go
+++ b/osac-metering/adapters/cmd/m360-adapter/main.go
@@ -88,11 +88,6 @@ func main() {
 
 	metricsAddr := envutil.EnvOrDefault("METRICS_ADDR", ":2112")
 
-	// TLS defaults to true (!= "false") — safer for production.
-	// Note: echo-adapter uses == "true" (defaults off) since it runs in
-	// development/CI where Kafka may not have TLS configured.
-	tlsEnabled := os.Getenv("KAFKA_TLS_ENABLED") != "false"
-
 	logger := stdr.New(log.New(os.Stderr, "", log.LstdFlags))
 
 	client := newM360Client(m360URL, apiVersion, apiKey)
@@ -104,12 +99,7 @@ func main() {
 		ConsumerGroup: group,
 		Topics:        topics,
 		FlushInterval: flushInterval,
-		Kafka: adapters.KafkaConfig{
-			TLSEnabled:   tlsEnabled,
-			TLSCACert:    os.Getenv("KAFKA_TLS_CA_CERT"),
-			SASLUser:     os.Getenv("KAFKA_SASL_USERNAME"),
-			SASLPassFile: os.Getenv("KAFKA_SASL_PASSWORD_FILE"),
-		},
+		Kafka:         adapters.KafkaConfigFromEnv(),
 	}, logger)
 
 	mux := http.NewServeMux()

--- a/osac-metering/adapters/kafka_env.go
+++ b/osac-metering/adapters/kafka_env.go
@@ -1,0 +1,31 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package adapters
+
+import "os"
+
+// KafkaConfigFromEnv reads Kafka connection configuration from environment
+// variables. TLS is enabled by default; set KAFKA_TLS_ENABLED=false to
+// disable it.
+//
+// Environment variables:
+//
+//   - KAFKA_TLS_ENABLED       — "false" to disable TLS (default: enabled)
+//   - KAFKA_TLS_CA_CERT       — path to CA certificate file (default: system CAs)
+//   - KAFKA_SASL_USERNAME     — SASL/SCRAM username (default: disabled)
+//   - KAFKA_SASL_PASSWORD_FILE — path to file containing SASL password
+func KafkaConfigFromEnv() KafkaConfig {
+	return KafkaConfig{
+		TLSEnabled:   os.Getenv("KAFKA_TLS_ENABLED") != "false",
+		TLSCACert:    os.Getenv("KAFKA_TLS_CA_CERT"),
+		SASLUser:     os.Getenv("KAFKA_SASL_USERNAME"),
+		SASLPassFile: os.Getenv("KAFKA_SASL_PASSWORD_FILE"),
+	}
+}

--- a/osac-metering/adapters/kafka_env_test.go
+++ b/osac-metering/adapters/kafka_env_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package adapters
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("KafkaConfigFromEnv", func() {
+	It("enables TLS by default when KAFKA_TLS_ENABLED is unset", func() {
+		GinkgoT().Setenv("KAFKA_TLS_ENABLED", "")
+		cfg := KafkaConfigFromEnv()
+		Expect(cfg.TLSEnabled).To(BeTrue())
+	})
+
+	It("disables TLS when KAFKA_TLS_ENABLED is 'false'", func() {
+		GinkgoT().Setenv("KAFKA_TLS_ENABLED", "false")
+		cfg := KafkaConfigFromEnv()
+		Expect(cfg.TLSEnabled).To(BeFalse())
+	})
+
+	It("enables TLS when KAFKA_TLS_ENABLED is 'true'", func() {
+		GinkgoT().Setenv("KAFKA_TLS_ENABLED", "true")
+		cfg := KafkaConfigFromEnv()
+		Expect(cfg.TLSEnabled).To(BeTrue())
+	})
+
+	It("enables TLS for any non-'false' value", func() {
+		GinkgoT().Setenv("KAFKA_TLS_ENABLED", "yes")
+		cfg := KafkaConfigFromEnv()
+		Expect(cfg.TLSEnabled).To(BeTrue())
+	})
+
+	It("reads KAFKA_TLS_CA_CERT", func() {
+		GinkgoT().Setenv("KAFKA_TLS_CA_CERT", "/etc/kafka/ca.crt")
+		cfg := KafkaConfigFromEnv()
+		Expect(cfg.TLSCACert).To(Equal("/etc/kafka/ca.crt"))
+	})
+
+	It("reads SASL configuration", func() {
+		GinkgoT().Setenv("KAFKA_SASL_USERNAME", "metering-user")
+		GinkgoT().Setenv("KAFKA_SASL_PASSWORD_FILE", "/run/secrets/kafka-password")
+		cfg := KafkaConfigFromEnv()
+		Expect(cfg.SASLUser).To(Equal("metering-user"))
+		Expect(cfg.SASLPassFile).To(Equal("/run/secrets/kafka-password"))
+	})
+
+	It("returns empty strings for unset optional fields", func() {
+		GinkgoT().Setenv("KAFKA_TLS_CA_CERT", "")
+		GinkgoT().Setenv("KAFKA_SASL_USERNAME", "")
+		GinkgoT().Setenv("KAFKA_SASL_PASSWORD_FILE", "")
+		cfg := KafkaConfigFromEnv()
+		Expect(cfg.TLSCACert).To(BeEmpty())
+		Expect(cfg.SASLUser).To(BeEmpty())
+		Expect(cfg.SASLPassFile).To(BeEmpty())
+	})
+})


### PR DESCRIPTION
## Summary

- Add `KafkaConfigFromEnv()` to the `adapters` package so the Kafka TLS default (enabled) is defined once in the framework, not per-adapter
- Update both `m360-adapter` and `echo-adapter` to call `adapters.KafkaConfigFromEnv()` instead of constructing `KafkaConfig` manually
- Add 7 Ginkgo specs for the new function

## Context

Identified during [PR #236](https://github.com/osac-project/osac/pull/236) review ([OSAC-3424](https://redhat.atlassian.net/browse/OSAC-3424)): `m360-adapter` parsed `KAFKA_TLS_ENABLED` with `!= "false"` (TLS on by default) while `echo-adapter` used `== "true"` (TLS off by default). The same env var produced opposite behavior depending on which adapter read it.

## Changes

| File | Change |
|------|--------|
| _adapters/kafka_env.go_ | New — `KafkaConfigFromEnv()` reads `KAFKA_TLS_*` and `KAFKA_SASL_*` env vars, TLS on by default |
| _adapters/kafka_env_test.go_ | 7 Ginkgo specs covering default, explicit true/false, non-"false" values, and optional fields |
| _adapters/cmd/m360-adapter/main.go_ | Replace inline `KafkaConfig{}` and `tlsEnabled` variable with `KafkaConfigFromEnv()` |
| _adapters/cmd/echo-adapter/main.go_ | Replace inline `KafkaConfig{}` with `KafkaConfigFromEnv()`, update doc comment for TLS-on default |

## Behavioral note

`echo-adapter`'s default changes from TLS off to TLS on when `KAFKA_TLS_ENABLED` is unset. Both Helm deployments already set `KAFKA_TLS_ENABLED=true` explicitly, so deployed behavior is unchanged. Local dev without TLS now requires `KAFKA_TLS_ENABLED=false`.

## Test plan

- [x] `make test` in `adapters/` — 112 specs pass (74 framework + 15 echo + 23 m360)
- [x] `make lint` in `adapters/` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Kafka connection settings are now consistently configured through environment variables across adapters.
  - Kafka TLS is enabled by default, with an option to disable it for local development.
  - Added support for configuring CA certificates and SASL credentials through environment variables.

- **Documentation**
  - Updated usage guidance to explain the default Kafka TLS behavior and how to disable it locally.

- **Tests**
  - Added coverage for default settings, TLS overrides, certificates, and SASL credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->