### PR TITLE
NO-ISSUE: fix FabricManager pointer type in controller tests

### DIFF
--- a/osac-aap/collections/ansible_collections/agentless_net/steps/roles/external_access/tasks/create.yaml
+++ b/osac-aap/collections/ansible_collections/agentless_net/steps/roles/external_access/tasks/create.yaml
@@ -284,4 +284,3 @@
       -e dnat_internal_port=443
       -e dnat_protocol=tcp
       {{ role_path }}/playbooks/l3_create_dnat.yaml
-

--- a/osac-operator/internal/controller/securitygroup_controller_test.go
+++ b/osac-operator/internal/controller/securitygroup_controller_test.go
@@ -698,7 +698,7 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			disc, err := networkmanager.NewDiscovery(fakeClient, "test-namespace")
 			Expect(err).NotTo(HaveOccurred())
 			reconciler.Resolver = dispatcher.NewResolver(dispatcheradapter.NewNetworkClassAdapter(newListingNetworkClassClient(
-				[]*privatev1.NetworkClass{{Id: "nc-dispatch", FabricManager: "netris"}}, &[]*privatev1.NetworkClass{},
+				[]*privatev1.NetworkClass{{Id: "nc-dispatch", FabricManager: ptr.To("netris")}}, &[]*privatev1.NetworkClass{},
 			)), disc)
 
 			vnet.Spec.NetworkClass = "nc-dispatch"
@@ -753,7 +753,7 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			disc, err := networkmanager.NewDiscovery(fakeClient, "test-namespace")
 			Expect(err).NotTo(HaveOccurred())
 			reconciler.Resolver = dispatcher.NewResolver(dispatcheradapter.NewNetworkClassAdapter(newListingNetworkClassClient(
-				[]*privatev1.NetworkClass{{Id: "nc-broken", FabricManager: "does-not-exist"}}, &[]*privatev1.NetworkClass{},
+				[]*privatev1.NetworkClass{{Id: "nc-broken", FabricManager: ptr.To("does-not-exist")}}, &[]*privatev1.NetworkClass{},
 			)), disc)
 
 			vnet.Spec.NetworkClass = "nc-broken"

--- a/osac-operator/internal/controller/subnet_controller_test.go
+++ b/osac-operator/internal/controller/subnet_controller_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -393,7 +394,7 @@ var _ = Describe("SubnetReconciler", func() {
 			disc, err := networkmanager.NewDiscovery(fakeDiscoveryClient, "osac")
 			Expect(err).NotTo(HaveOccurred())
 			reconciler.Resolver = dispatcher.NewResolver(dispatcheradapter.NewNetworkClassAdapter(newListingNetworkClassClient(
-				[]*privatev1.NetworkClass{{Id: "nc-dispatch", FabricManager: "netris"}}, &[]*privatev1.NetworkClass{},
+				[]*privatev1.NetworkClass{{Id: "nc-dispatch", FabricManager: ptr.To("netris")}}, &[]*privatev1.NetworkClass{},
 			)), disc)
 
 			dispatchVnet := &osacv1alpha1.VirtualNetwork{
@@ -473,7 +474,7 @@ var _ = Describe("SubnetReconciler", func() {
 			disc, err := networkmanager.NewDiscovery(fakeDiscoveryClient, "osac")
 			Expect(err).NotTo(HaveOccurred())
 			reconciler.Resolver = dispatcher.NewResolver(dispatcheradapter.NewNetworkClassAdapter(newListingNetworkClassClient(
-				[]*privatev1.NetworkClass{{Id: "nc-broken", FabricManager: "does-not-exist"}}, &[]*privatev1.NetworkClass{},
+				[]*privatev1.NetworkClass{{Id: "nc-broken", FabricManager: ptr.To("does-not-exist")}}, &[]*privatev1.NetworkClass{},
 			)), disc)
 
 			dispatchVnet := &osacv1alpha1.VirtualNetwork{

--- a/osac-operator/internal/controller/virtualnetwork_controller_test.go
+++ b/osac-operator/internal/controller/virtualnetwork_controller_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -684,7 +685,7 @@ var _ = Describe("VirtualNetworkReconciler", func() {
 			disc, err := networkmanager.NewDiscovery(fakeDiscoveryClient, "osac")
 			Expect(err).NotTo(HaveOccurred())
 			reconciler.Resolver = dispatcher.NewResolver(dispatcheradapter.NewNetworkClassAdapter(newListingNetworkClassClient(
-				[]*privatev1.NetworkClass{{Id: "nc-dispatch", FabricManager: "netris"}}, &[]*privatev1.NetworkClass{},
+				[]*privatev1.NetworkClass{{Id: "nc-dispatch", FabricManager: ptr.To("netris")}}, &[]*privatev1.NetworkClass{},
 			)), disc)
 
 			vnet.Spec.NetworkClass = "nc-dispatch"
@@ -726,7 +727,7 @@ var _ = Describe("VirtualNetworkReconciler", func() {
 			disc, err := networkmanager.NewDiscovery(fakeDiscoveryClient, "osac")
 			Expect(err).NotTo(HaveOccurred())
 			reconciler.Resolver = dispatcher.NewResolver(dispatcheradapter.NewNetworkClassAdapter(newListingNetworkClassClient(
-				[]*privatev1.NetworkClass{{Id: "nc-broken", FabricManager: "does-not-exist"}}, &[]*privatev1.NetworkClass{},
+				[]*privatev1.NetworkClass{{Id: "nc-broken", FabricManager: ptr.To("does-not-exist")}}, &[]*privatev1.NetworkClass{},
 			)), disc)
 
 			vnet.Spec.NetworkClass = "nc-broken"
@@ -787,7 +788,7 @@ var _ = Describe("VirtualNetworkReconciler", func() {
 			// Simulate the NetworkClass being updated to register a fabricManager. The
 			// VirtualNetwork's spec is untouched — only the dynamically-resolved strategy changes.
 			reconciler.Resolver = dispatcher.NewResolver(dispatcheradapter.NewNetworkClassAdapter(newListingNetworkClassClient(
-				[]*privatev1.NetworkClass{{Id: "nc-dispatch", FabricManager: "netris"}}, &[]*privatev1.NetworkClass{},
+				[]*privatev1.NetworkClass{{Id: "nc-dispatch", FabricManager: ptr.To("netris")}}, &[]*privatev1.NetworkClass{},
 			)), disc)
 
 			// Third reconcile: updates the annotation to the newly-resolved manager and requeues.


### PR DESCRIPTION
## Summary

Fixes the main branch build broken by a merge race between the BSR v0.0.85 bump ([`1bc8491b`](https://github.com/osac-project/osac/commit/1bc8491b)) and the dispatcher wiring PR ([`3458fd8f`](https://github.com/osac-project/osac/commit/3458fd8f), [OSAC-1460](https://redhat.atlassian.net/browse/OSAC-1460)).

## Why

[OSAC-2068](https://github.com/osac-project/osac/commit/0b5be5b3) changed `NetworkClass.fabric_manager` from `string` to [`optional string`](https://github.com/osac-project/osac/blob/1bc8491bdf4309bd992ee1e4afdfd7b66515e3c5/fulfillment-service/proto/private/osac/private/v1/network_class_type.proto#L73-L77). In proto3, `optional` generates a pointer type (`*string`) in Go's opaque API instead of a value type (`string`). This change was picked up when the BSR was bumped to v0.0.85, regenerating the osac-operator gRPC client. The [OSAC-1460](https://redhat.atlassian.net/browse/OSAC-1460) tests used bare string literals (`FabricManager: "netris"`), which compiled against the old `string` field but fail against the new `*string`. Both PRs passed CI independently; the combination broke at merge time.

## Changes

Use `ptr.To("...")` for all `FabricManager` assignments in proto struct literals:
- `securitygroup_controller_test.go` (2 occurrences)
- `subnet_controller_test.go` (2 occurrences)
- `virtualnetwork_controller_test.go` (3 occurrences)

Also fixes a trailing newline in `osac-aap/.../create.yaml` that was failing the `end-of-file-fixer` pre-commit hook.

## Testing

```bash
cd osac-operator && make test  # all 12 packages pass, 0 vet errors
pre-commit run end-of-file-fixer --all-files  # passes
```

<br>

<small>Signed-off-by: akshaynadkarni <25892229+akshaynadkarni@users.noreply.github.com></small>
<small>Assisted-by: Cursor/Claude</small>