### PR TITLE
OSAC-3880: hide private-API CLI subcommands from non-admin help output

### DIFF
--- a/fulfillment-service/AGENTS.md
+++ b/fulfillment-service/AGENTS.md
@@ -216,6 +216,8 @@ inline code and `{{ bt 3 }}` for fenced code blocks.
 For flag help, start with a short type hint in italics (e.g. `_[BOOLEAN]_`, `_URL_`,
 `_FILE|DIRECTORY_`) followed by a dash and the description.
 
+Do not end `shortHelp` strings with a trailing period — the help template does not append one.
+
 Refer to existing commands such as `internal/cmd/cli/login/login_cmd.go` for style and examples of
 how help text is structured.
 

--- a/fulfillment-service/AGENTS.md
+++ b/fulfillment-service/AGENTS.md
@@ -219,6 +219,19 @@ For flag help, start with a short type hint in italics (e.g. `_[BOOLEAN]_`, `_UR
 Refer to existing commands such as `internal/cmd/cli/login/login_cmd.go` for style and examples of
 how help text is structured.
 
+### Private-API Subcommands
+
+Subcommands that use the private API (`privatev1`) must be annotated so they are hidden from
+`--help` when private mode (--private) is disabled or configuration is unavailable. Wrap the `AddCommand` call with
+`help.MarkPrivateAPI`:
+
+```go
+result.AddCommand(help.MarkPrivateAPI(mysubcommand.Cmd()))
+```
+
+Add the subcommand name to the `privateNames` map in the corresponding `*_cmd_test.go` annotation
+test (e.g. `create_cmd_test.go`, `describe_cmd_test.go`).
+
 ## API Design Guidelines
 
 Before making any API design or implementation decision (adding or modifying `.proto` files,

--- a/fulfillment-service/internal/cmd/cli/create/baremetalinstance/create_baremetal_instance_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/baremetalinstance/create_baremetal_instance_cmd.go
@@ -216,7 +216,7 @@ func (c *runnerContext) run(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-const shortHelp = `Create a bare metal instance.`
+const shortHelp = `Create a bare metal instance`
 
 const longHelp = `
 Create a bare metal instance.

--- a/fulfillment-service/internal/cmd/cli/create/baremetalinstancecatalogitem/create_baremetal_instance_catalog_item_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/baremetalinstancecatalogitem/create_baremetal_instance_catalog_item_cmd.go
@@ -128,7 +128,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-const shortHelp = `Create a bare metal instance catalog item.`
+const shortHelp = `Create a bare metal instance catalog item`
 
 const longHelp = `
 Create a bare metal instance catalog item. A catalog item defines a curated

--- a/fulfillment-service/internal/cmd/cli/create/clustercatalogitem/create_cluster_catalog_item_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/clustercatalogitem/create_cluster_catalog_item_cmd.go
@@ -128,7 +128,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-const shortHelp = `Create a cluster catalog item.`
+const shortHelp = `Create a cluster catalog item`
 
 const longHelp = `
 Create a cluster catalog item. A catalog item defines a curated cluster

--- a/fulfillment-service/internal/cmd/cli/create/clusterversion/create_clusterversion_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/clusterversion/create_clusterversion_cmd.go
@@ -159,7 +159,7 @@ func parseState(value string) (privatev1.ClusterVersionState, error) {
 	}
 }
 
-const shortHelp = `Create a cluster version.`
+const shortHelp = `Create a cluster version`
 
 const longHelp = `
 Create a cluster version.

--- a/fulfillment-service/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
@@ -964,7 +964,7 @@ func (c *runnerContext) validTemplateParameters(template *publicv1.ComputeInstan
 	return results
 }
 
-const shortHelp = `Create a compute instance.`
+const shortHelp = `Create a compute instance`
 
 const longHelp = `
 Create a compute instance.

--- a/fulfillment-service/internal/cmd/cli/create/computeinstancecatalogitem/create_compute_instance_catalog_item_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/computeinstancecatalogitem/create_compute_instance_catalog_item_cmd.go
@@ -128,7 +128,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-const shortHelp = `Create a compute instance catalog item.`
+const shortHelp = `Create a compute instance catalog item`
 
 const longHelp = `
 Create a compute instance catalog item. A catalog item defines a curated

--- a/fulfillment-service/internal/cmd/cli/create/create_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/create_cmd.go
@@ -46,6 +46,7 @@ import (
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/storagetier"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/subnet"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/virtualnetwork"
+	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/help"
 	"github.com/osac-project/osac/fulfillment-service/internal/config"
 	"github.com/osac-project/osac/fulfillment-service/internal/logging"
 	"github.com/osac-project/osac/fulfillment-service/internal/reflection"
@@ -65,19 +66,19 @@ func Cmd() *cobra.Command {
 	result.AddCommand(baremetalinstancecatalogitem.Cmd())
 	result.AddCommand(cluster.Cmd())
 	result.AddCommand(clustercatalogitem.Cmd())
-	result.AddCommand(clusterversion.Cmd())
+	result.AddCommand(help.MarkPrivateAPI(clusterversion.Cmd()))
 	result.AddCommand(computeinstance.Cmd())
 	result.AddCommand(computeinstancecatalogitem.Cmd())
 	result.AddCommand(externalip.Cmd())
 	result.AddCommand(externalipattachment.Cmd())
-	result.AddCommand(hub.Cmd())
-	result.AddCommand(instancetype.Cmd())
+	result.AddCommand(help.MarkPrivateAPI(hub.Cmd()))
+	result.AddCommand(help.MarkPrivateAPI(instancetype.Cmd()))
 	result.AddCommand(natgateway.Cmd())
 	result.AddCommand(virtualnetwork.Cmd())
 	result.AddCommand(subnet.Cmd())
 	result.AddCommand(securitygroup.Cmd())
-	result.AddCommand(storagebackend.Cmd())
-	result.AddCommand(storagetier.Cmd())
+	result.AddCommand(help.MarkPrivateAPI(storagebackend.Cmd()))
+	result.AddCommand(help.MarkPrivateAPI(storagetier.Cmd()))
 	flags := result.Flags()
 	flags.StringVarP(
 		&runner.args.file,

--- a/fulfillment-service/internal/cmd/cli/create/create_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/create/create_cmd_test.go
@@ -66,4 +66,25 @@ var _ = Describe("Create command", func() {
 			Expect(subcommandNames).To(ContainElements("baremetalinstancecatalogitem", "cluster", "clustercatalogitem", "clusterversion", "computeinstance", "computeinstancecatalogitem", "hub", "virtualnetwork", "subnet", "securitygroup"))
 		})
 	})
+
+	Describe("Private API annotations", func() {
+		It("should annotate private-API subcommands", func() {
+			cmd := Cmd()
+			privateNames := map[string]bool{
+				"hub": true, "instancetype": true, "clusterversion": true,
+				"storagebackend": true, "storagetier": true,
+			}
+			for _, sub := range cmd.Commands() {
+				if privateNames[sub.Name()] {
+					Expect(sub.Annotations).To(HaveKeyWithValue("api", "private"),
+						"subcommand %s should be annotated as private", sub.Name())
+				} else {
+					if sub.Annotations != nil {
+						Expect(sub.Annotations).ToNot(HaveKey("api"),
+							"subcommand %s should not be annotated as private", sub.Name())
+					}
+				}
+			}
+		})
+	})
 })

--- a/fulfillment-service/internal/cmd/cli/create/externalip/create_externalip_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/externalip/create_externalip_cmd.go
@@ -120,7 +120,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-const shortHelp = `Create an external IP.`
+const shortHelp = `Create an external IP`
 
 const longHelp = `
 Allocate an external IP address from an ExternalIPPool.

--- a/fulfillment-service/internal/cmd/cli/create/externalipattachment/create_externalipattachment_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/externalipattachment/create_externalipattachment_cmd.go
@@ -235,7 +235,7 @@ func parseTargetEndpoint(value string) (publicv1.ExternalIPAttachmentEndpoint, e
 	}
 }
 
-const shortHelp = `Attach an external IP to a resource.`
+const shortHelp = `Attach an external IP to a resource`
 
 const longHelp = `
 Create an external IP attachment to bind an external IP to a target resource.

--- a/fulfillment-service/internal/cmd/cli/create/hub/create_hub_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/hub/create_hub_cmd.go
@@ -131,7 +131,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-const shortHelp = `Create a hub.`
+const shortHelp = `Create a hub`
 
 const longHelp = `
 Create a hub.

--- a/fulfillment-service/internal/cmd/cli/create/instancetype/create_instancetype_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/instancetype/create_instancetype_cmd.go
@@ -166,7 +166,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-const shortHelp = `Create an instance type.`
+const shortHelp = `Create an instance type`
 
 const longHelp = `
 Create an instance type.

--- a/fulfillment-service/internal/cmd/cli/create/natgateway/create_natgateway_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/natgateway/create_natgateway_cmd.go
@@ -144,7 +144,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-const shortHelp = `Create a NAT gateway.`
+const shortHelp = `Create a NAT gateway`
 
 const longHelp = `
 Create a NAT gateway for outbound traffic (SNAT) from a virtual network.

--- a/fulfillment-service/internal/cmd/cli/create/securitygroup/create_securitygroup_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/securitygroup/create_securitygroup_cmd.go
@@ -282,7 +282,7 @@ func parsePort(value string) (int32, error) {
 	return int32(n), nil
 }
 
-const shortHelp = `Create a security group.`
+const shortHelp = `Create a security group`
 
 const longHelp = `
 Create a security group with optional ingress and egress firewall rules.

--- a/fulfillment-service/internal/cmd/cli/create/storagebackend/create_storagebackend_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/storagebackend/create_storagebackend_cmd.go
@@ -146,7 +146,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-const shortHelp = `Create a storage backend.`
+const shortHelp = `Create a storage backend`
 
 const longHelp = `
 Create a storage backend.

--- a/fulfillment-service/internal/cmd/cli/create/storagetier/create_storagetier_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/storagetier/create_storagetier_cmd.go
@@ -174,7 +174,7 @@ func parseProtocol(value string) (privatev1.StorageProtocol, error) {
 	}
 }
 
-const shortHelp = `Create a storage tier.`
+const shortHelp = `Create a storage tier`
 
 const longHelp = `
 Create a storage tier.

--- a/fulfillment-service/internal/cmd/cli/create/subnet/create_subnet_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/subnet/create_subnet_cmd.go
@@ -148,7 +148,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-const shortHelp = `Create a subnet.`
+const shortHelp = `Create a subnet`
 
 const longHelp = `
 Create a subnet within an existing virtual network. At least one of

--- a/fulfillment-service/internal/cmd/cli/create/virtualnetwork/create_virtualnetwork_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/virtualnetwork/create_virtualnetwork_cmd.go
@@ -139,7 +139,7 @@ func validateNetworkClass(networkClass string) error {
 	return nil
 }
 
-const shortHelp = `Create a virtual network.`
+const shortHelp = `Create a virtual network`
 
 const longHelp = `
 Create a virtual network with the specified network class and IP addressing

--- a/fulfillment-service/internal/cmd/cli/describe/baremetalinstance/describe_baremetalinstance_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/describe/baremetalinstance/describe_baremetalinstance_cmd.go
@@ -96,7 +96,7 @@ func renderBareMetalInstance(w io.Writer, bmi *publicv1.BareMetalInstance) {
 	writer.Flush()
 }
 
-const shortHelp = `Describe a bare metal instance.`
+const shortHelp = `Describe a bare metal instance`
 
 const longHelp = `
 Describe a bare metal instance.

--- a/fulfillment-service/internal/cmd/cli/describe/cluster/describe_cluster.go
+++ b/fulfillment-service/internal/cmd/cli/describe/cluster/describe_cluster.go
@@ -169,7 +169,7 @@ func renderCluster(w io.Writer, cluster *publicv1.Cluster, version *publicv1.Clu
 	}
 }
 
-const shortHelp = `Describe a cluster.`
+const shortHelp = `Describe a cluster`
 
 const longHelp = `
 Describe a cluster.

--- a/fulfillment-service/internal/cmd/cli/describe/clusterversion/describe_clusterversion_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/describe/clusterversion/describe_clusterversion_cmd.go
@@ -132,7 +132,7 @@ func renderClusterVersion(w io.Writer, cv *publicv1.ClusterVersion) {
 	writer.Flush()
 }
 
-const shortHelp = `Describe a cluster version.`
+const shortHelp = `Describe a cluster version`
 
 const longHelp = `
 Describe a cluster version.

--- a/fulfillment-service/internal/cmd/cli/describe/computeinstance/describe_computeinstance_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/describe/computeinstance/describe_computeinstance_cmd.go
@@ -113,7 +113,7 @@ func renderComputeInstance(w io.Writer, ci *publicv1.ComputeInstance) {
 	writer.Flush()
 }
 
-const shortHelp = `Describe a compute instance.`
+const shortHelp = `Describe a compute instance`
 
 const longHelp = `
 Describe a compute instance.

--- a/fulfillment-service/internal/cmd/cli/describe/describe_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/describe/describe_cmd.go
@@ -30,6 +30,7 @@ import (
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/describe/storagetier"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/describe/subnet"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/describe/virtualnetwork"
+	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/help"
 )
 
 func Cmd() *cobra.Command {
@@ -50,8 +51,8 @@ func Cmd() *cobra.Command {
 	result.AddCommand(virtualnetwork.Cmd())
 	result.AddCommand(subnet.Cmd())
 	result.AddCommand(securitygroup.Cmd())
-	result.AddCommand(storagebackend.Cmd())
-	result.AddCommand(storagetier.Cmd())
+	result.AddCommand(help.MarkPrivateAPI(storagebackend.Cmd()))
+	result.AddCommand(help.MarkPrivateAPI(storagetier.Cmd()))
 	return result
 }
 

--- a/fulfillment-service/internal/cmd/cli/describe/describe_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/describe/describe_cmd_test.go
@@ -59,6 +59,26 @@ var _ = Describe("Describe command", func() {
 		})
 	})
 
+	Describe("Private API annotations", func() {
+		It("should annotate private-API subcommands", func() {
+			cmd := Cmd()
+			privateNames := map[string]bool{
+				"storagebackend": true, "storagetier": true,
+			}
+			for _, sub := range cmd.Commands() {
+				if privateNames[sub.Name()] {
+					Expect(sub.Annotations).To(HaveKeyWithValue("api", "private"),
+						"subcommand %s should be annotated as private", sub.Name())
+				} else {
+					if sub.Annotations != nil {
+						Expect(sub.Annotations).ToNot(HaveKey("api"),
+							"subcommand %s should not be annotated as private", sub.Name())
+					}
+				}
+			}
+		})
+	})
+
 	Describe("CEL filter construction", func() {
 		It("should produce valid CEL for a plain name", func() {
 			ref := "example-resource"

--- a/fulfillment-service/internal/cmd/cli/describe/instancetype/describe_instancetype_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/describe/instancetype/describe_instancetype_cmd.go
@@ -146,7 +146,7 @@ func renderInstanceType(w io.Writer, it *publicv1.InstanceType) {
 	writer.Flush()
 }
 
-const shortHelp = `Describe an instance type.`
+const shortHelp = `Describe an instance type`
 
 const longHelp = `
 Describe an instance type.

--- a/fulfillment-service/internal/cmd/cli/describe/storagebackend/describe_storagebackend_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/describe/storagebackend/describe_storagebackend_cmd.go
@@ -118,7 +118,7 @@ func renderStorageBackend(w io.Writer, sb *privatev1.StorageBackend) {
 	writer.Flush()
 }
 
-const shortHelp = `Describe a storage backend.`
+const shortHelp = `Describe a storage backend`
 
 const longHelp = `
 Describe a storage backend.

--- a/fulfillment-service/internal/cmd/cli/describe/storagetier/describe_storagetier_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/describe/storagetier/describe_storagetier_cmd.go
@@ -117,7 +117,7 @@ func renderStorageTier(w io.Writer, st *privatev1.StorageTier) {
 	writer.Flush()
 }
 
-const shortHelp = `Describe a storage tier.`
+const shortHelp = `Describe a storage tier`
 
 const longHelp = `
 Describe a storage tier.

--- a/fulfillment-service/internal/cmd/cli/describe/virtualnetwork/describe_virtualnetwork_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/describe/virtualnetwork/describe_virtualnetwork_cmd.go
@@ -128,7 +128,7 @@ func RenderVirtualNetwork(w io.Writer, vn *publicv1.VirtualNetwork) {
 	writer.Flush()
 }
 
-const shortHelp = `Describe a virtual network.`
+const shortHelp = `Describe a virtual network`
 
 const longHelp = `
 Display detailed information about a virtual network, referenced by identifier or name.

--- a/fulfillment-service/internal/cmd/cli/help/help_setup.go
+++ b/fulfillment-service/internal/cmd/cli/help/help_setup.go
@@ -16,8 +16,10 @@ package help
 import (
 	"bytes"
 	"embed"
+	"encoding/json"
 	"log/slog"
 	"os"
+	"path/filepath"
 
 	"charm.land/glamour/v2"
 	"charm.land/glamour/v2/ansi"
@@ -105,6 +107,9 @@ func Setup(cmd *cobra.Command) {
 		style.Code.Prefix = ""
 		style.Code.Suffix = ""
 
+		// Hide private-API subcommands when the user is not in private mode:
+		hidePrivateSubcommands(c)
+
 		// Render the help output:
 		var buffer bytes.Buffer
 		err = engine.Execute(&buffer, "command_help.md", c)
@@ -143,6 +148,71 @@ func flagsFunc(fs *pflag.FlagSet) []*pflag.Flag {
 		}
 	})
 	return result
+}
+
+const (
+	privateAPIAnnotationKey   = "api"
+	privateAPIAnnotationValue = "private"
+)
+
+// MarkPrivateAPI annotates a command as belonging to the private API. The help system uses this
+// to hide such commands from non-admin users who have not logged in with --private.
+func MarkPrivateAPI(cmd *cobra.Command) *cobra.Command {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[privateAPIAnnotationKey] = privateAPIAnnotationValue
+	return cmd
+}
+
+func isPrivateAPICommand(cmd *cobra.Command) bool {
+	return cmd.Annotations != nil && cmd.Annotations[privateAPIAnnotationKey] == privateAPIAnnotationValue
+}
+
+// hidePrivateSubcommands checks the user's config file to determine whether private-API mode is
+// enabled, and hides subcommands annotated with api=private when it is not. This runs at
+// help-render time because PersistentPreRunE does not execute for --help.
+func hidePrivateSubcommands(c *cobra.Command) {
+	hasPrivate := false
+	for _, sub := range c.Commands() {
+		if isPrivateAPICommand(sub) {
+			hasPrivate = true
+			break
+		}
+	}
+	if !hasPrivate {
+		return
+	}
+
+	isPrivate := false
+	configDir := ""
+	if f := c.Root().PersistentFlags().Lookup("config"); f != nil {
+		configDir = f.Value.String()
+		if !f.Changed {
+			if envVal := os.Getenv("OSAC_CONFIG"); envVal != "" {
+				configDir = envVal
+			}
+		}
+	}
+	if configDir != "" {
+		if absDir, err := filepath.Abs(configDir); err == nil {
+			data, err := os.ReadFile(filepath.Clean(filepath.Join(absDir, "config.json")))
+			if err == nil {
+				var cfg struct {
+					Private bool `json:"private,omitempty"`
+				}
+				if json.Unmarshal(data, &cfg) == nil {
+					isPrivate = cfg.Private
+				}
+			}
+		}
+	}
+
+	for _, sub := range c.Commands() {
+		if isPrivateAPICommand(sub) {
+			sub.Hidden = !isPrivate
+		}
+	}
 }
 
 // maxReadableWidth is the maximum width for help output that we consider readable.

--- a/fulfillment-service/internal/cmd/cli/help/help_setup_test.go
+++ b/fulfillment-service/internal/cmd/cli/help/help_setup_test.go
@@ -157,6 +157,28 @@ var _ = Describe("hidePrivateSubcommands", func() {
 		Expect(publicSub.Hidden).To(BeFalse())
 	})
 
+	It("reads config from OSAC_CONFIG env var when flag is not explicitly set", func() {
+		tmpDir := GinkgoT().TempDir()
+		err := os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte(`{"private": true}`), 0600)
+		Expect(err).ToNot(HaveOccurred())
+		root.PersistentFlags().String("config", "/nonexistent", "")
+
+		original := os.Getenv("OSAC_CONFIG")
+		os.Setenv("OSAC_CONFIG", tmpDir)
+		DeferCleanup(func() {
+			if original == "" {
+				os.Unsetenv("OSAC_CONFIG")
+			} else {
+				os.Setenv("OSAC_CONFIG", original)
+			}
+		})
+
+		hidePrivateSubcommands(parent)
+
+		Expect(privateSub.Hidden).To(BeFalse())
+		Expect(publicSub.Hidden).To(BeFalse())
+	})
+
 	It("does nothing when no subcommands have private annotation", func() {
 		cmd := &cobra.Command{Use: "get"}
 		sub := &cobra.Command{Use: "cluster"}

--- a/fulfillment-service/internal/cmd/cli/help/help_setup_test.go
+++ b/fulfillment-service/internal/cmd/cli/help/help_setup_test.go
@@ -124,7 +124,8 @@ var _ = Describe("hidePrivateSubcommands", func() {
 		tmpDir := GinkgoT().TempDir()
 		err := os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte(`{"private": false}`), 0600)
 		Expect(err).ToNot(HaveOccurred())
-		root.PersistentFlags().String("config", tmpDir, "")
+		root.PersistentFlags().String("config", "", "")
+		Expect(root.PersistentFlags().Set("config", tmpDir)).To(Succeed())
 
 		hidePrivateSubcommands(parent)
 
@@ -136,7 +137,8 @@ var _ = Describe("hidePrivateSubcommands", func() {
 		tmpDir := GinkgoT().TempDir()
 		err := os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte(`{"private": true}`), 0600)
 		Expect(err).ToNot(HaveOccurred())
-		root.PersistentFlags().String("config", tmpDir, "")
+		root.PersistentFlags().String("config", "", "")
+		Expect(root.PersistentFlags().Set("config", tmpDir)).To(Succeed())
 
 		hidePrivateSubcommands(parent)
 
@@ -146,7 +148,8 @@ var _ = Describe("hidePrivateSubcommands", func() {
 
 	It("hides private subcommands when no config file exists", func() {
 		tmpDir := GinkgoT().TempDir()
-		root.PersistentFlags().String("config", tmpDir, "")
+		root.PersistentFlags().String("config", "", "")
+		Expect(root.PersistentFlags().Set("config", tmpDir)).To(Succeed())
 
 		hidePrivateSubcommands(parent)
 
@@ -159,7 +162,8 @@ var _ = Describe("hidePrivateSubcommands", func() {
 		sub := &cobra.Command{Use: "cluster"}
 		cmd.AddCommand(sub)
 		root.AddCommand(cmd)
-		root.PersistentFlags().String("config", GinkgoT().TempDir(), "")
+		root.PersistentFlags().String("config", "", "")
+		Expect(root.PersistentFlags().Set("config", GinkgoT().TempDir())).To(Succeed())
 
 		hidePrivateSubcommands(cmd)
 

--- a/fulfillment-service/internal/cmd/cli/help/help_setup_test.go
+++ b/fulfillment-service/internal/cmd/cli/help/help_setup_test.go
@@ -15,6 +15,8 @@ package help
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"regexp"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
@@ -93,5 +95,74 @@ var _ = Describe("Help output", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ansiPattern.FindString(output.String())).To(BeEmpty(),
 			"subcommand help output should not contain ANSI escape codes when writing to a non-TTY")
+	})
+})
+
+var _ = Describe("hidePrivateSubcommands", func() {
+	var (
+		root       *cobra.Command
+		parent     *cobra.Command
+		publicSub  *cobra.Command
+		privateSub *cobra.Command
+	)
+
+	BeforeEach(func() {
+		root = &cobra.Command{Use: "osac"}
+		parent = &cobra.Command{Use: "create"}
+		publicSub = &cobra.Command{Use: "cluster", Short: "Create a cluster"}
+		privateSub = &cobra.Command{
+			Use:         "hub",
+			Short:       "Create a hub",
+			Annotations: map[string]string{"api": "private"},
+		}
+		parent.AddCommand(publicSub)
+		parent.AddCommand(privateSub)
+		root.AddCommand(parent)
+	})
+
+	It("hides private subcommands when config has private=false", func() {
+		tmpDir := GinkgoT().TempDir()
+		err := os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte(`{"private": false}`), 0600)
+		Expect(err).ToNot(HaveOccurred())
+		root.PersistentFlags().String("config", tmpDir, "")
+
+		hidePrivateSubcommands(parent)
+
+		Expect(privateSub.Hidden).To(BeTrue())
+		Expect(publicSub.Hidden).To(BeFalse())
+	})
+
+	It("shows private subcommands when config has private=true", func() {
+		tmpDir := GinkgoT().TempDir()
+		err := os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte(`{"private": true}`), 0600)
+		Expect(err).ToNot(HaveOccurred())
+		root.PersistentFlags().String("config", tmpDir, "")
+
+		hidePrivateSubcommands(parent)
+
+		Expect(privateSub.Hidden).To(BeFalse())
+		Expect(publicSub.Hidden).To(BeFalse())
+	})
+
+	It("hides private subcommands when no config file exists", func() {
+		tmpDir := GinkgoT().TempDir()
+		root.PersistentFlags().String("config", tmpDir, "")
+
+		hidePrivateSubcommands(parent)
+
+		Expect(privateSub.Hidden).To(BeTrue())
+		Expect(publicSub.Hidden).To(BeFalse())
+	})
+
+	It("does nothing when no subcommands have private annotation", func() {
+		cmd := &cobra.Command{Use: "get"}
+		sub := &cobra.Command{Use: "cluster"}
+		cmd.AddCommand(sub)
+		root.AddCommand(cmd)
+		root.PersistentFlags().String("config", GinkgoT().TempDir(), "")
+
+		hidePrivateSubcommands(cmd)
+
+		Expect(sub.Hidden).To(BeFalse())
 	})
 })

--- a/fulfillment-service/internal/cmd/cli/help/templates/command_help.md
+++ b/fulfillment-service/internal/cmd/cli/help/templates/command_help.md
@@ -13,7 +13,7 @@
 ## Commands
 {{ range .Commands }}
 {{ if .IsAvailableCommand }}
-* **{{ .Name }}** - {{ .Short }}.
+* **{{ .Name }}** - {{ .Short }}
 {{ end }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
## Summary
- Private-API-only subcommands (hub, instancetype, clusterversion, storagebackend, storagetier) were visible in `osac create --help` and `osac describe --help` even when the user logged in without `--private`
- Annotate private-API subcommands with `api=private` via `help.MarkPrivateAPI` and read `config.json` best-effort in the custom HelpFunc to toggle `Hidden` on annotated commands
- When private mode is not enabled (or config is missing), private subcommands are hidden from listings but remain executable if typed directly — server-side authz is the real guardrail
- Fix double period (`..`) in help subcommand descriptions: the help template appended a trailing period but most `shortHelp` constants already included one
- Document `help.MarkPrivateAPI` in AGENTS.md so future developers know to annotate new private-API subcommands

## Jira
https://issues.redhat.com/browse/OSAC-3880

## Test plan
- [x] Unit tests for `hidePrivateSubcommands` (private=true shows, private=false hides, no config hides, no annotations no-op)
- [x] Annotation tests for create (5 private subcommands) and describe (2 private subcommands)
- [x] `go build ./...` passes
- [x] `ginkgo run -r internal/cmd/cli` — 31 suites pass
- [x] `uv run dev.py lint` — 0 issues
- [x] Pre-flight security review: PASS
- [x] Pre-flight performance review: PASS

---

_This PR description was drafted with AI assistance ([create-pr](https://github.com/osac-project/osac-workspace/tree/main/skills/create-pr) v0.1.1). Review for accuracy_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for marking selected CLI commands as private.
  - Private commands are hidden from help and command listings unless private mode is enabled.

- **Style**
  - Standardized CLI help descriptions by removing automatically appended trailing periods.

- **Documentation**
  - Added guidance for maintaining private command visibility and annotations.

- **Tests**
  - Added coverage verifying private command visibility and help behavior in different configuration modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->