### PR TITLE
OSAC-3116: update docs for typed resource references

### DIFF
--- a/fulfillment-service/docs/API.md
+++ b/fulfillment-service/docs/API.md
@@ -431,7 +431,7 @@ The URL space must never be deeper than a collection and its members. For exampl
 belongs to a `VirtualNetwork`, do not define a nested URL like
 `/api/fulfillment/v1/virtual_networks/123/subnets`. Instead, `Subnet` has its own top-level
 collection at `/api/fulfillment/v1/subnets`, and users find the subnets of a virtual network using
-the filter capability with a CEL expression like `this.spec.virtual_network == "123"`.
+the filter capability with a CEL expression like `this.spec.virtual_network.name == "my-vnet"`.
 
 ### HTTP verb mapping
 
@@ -492,30 +492,170 @@ top-level `state` enum.
 
 ## Object references
 
-When an object needs to reference another object, define a `string` field named after the
-relationship or the type of the referenced object. The value of the field is the unique identifier
-of the referenced object.
+When an object needs to reference another object, the API uses typed reference messages instead of
+plain string fields. Each referenced type has its own message, giving the schema full type safety
+and enabling automatic server-side validation and resolution.
 
-For example, when a `Cluster` references a template:
+There are two kinds of references:
+
+### Full references
+
+Full references can point to resources in a different project or in the shared tenant. They have
+four fields:
 
 ```protobuf
-message ClusterSpec {
-  string template = 1;
+message ClusterTemplateReference {
+  string id = 1;
+  string name = 2;
+  string project = 3;
+  bool shared = 4;
 }
 ```
 
-Note that the field name is `template`, not `template_id`. The convention is to name the field
-after the relationship, without an `_id` suffix.
+| Field     | Description |
+|-----------|-------------|
+| `id`      | Unique identifier of the referenced object. |
+| `name`    | Human-readable name of the referenced object. |
+| `project` | Project where the referenced object lives. Defaults to the caller's project when omitted. |
+| `shared`  | When `true`, the lookup targets the `shared` tenant (overrides the caller's tenant). |
 
-Other examples from the codebase:
+Callers may supply `id`, `name`, or both. When both are provided they must refer to the same
+object; otherwise the server returns `InvalidArgument`. The server auto-populates whichever field
+is missing after a successful lookup.
 
-- `SubnetSpec.virtual_network` references a `VirtualNetwork` by its `id`.
-- `RoleBindingSpec.role` references a `Role` by its `id`.
-- `ProjectSpec.parent` references a parent `Project` by its `id`.
+Full references are used when the target resource may live outside the caller's project — for
+example, cluster templates, catalog items, host types, instance types, network classes, IP pools,
+roles, and users.
 
-In the future the project plans to introduce a typed `Reference` message to make these references
-type-safe. Until then, references are plain `string` fields and the relationship must be documented
-in the proto comments.
+### Local references
+
+Local references are scoped to the same tenant and project as the parent object. They have only
+two fields:
+
+```protobuf
+message VirtualNetworkLocalReference {
+  string id = 1;
+  string name = 2;
+}
+```
+
+As with full references, callers may supply `id`, `name`, or both, and the server auto-populates
+the other.
+
+Local references are used when the target is always co-located — for example, a `Subnet`
+referencing its parent `VirtualNetwork`, or a `NetworkAttachment` referencing a `Subnet` and
+`SecurityGroup`.
+
+### Naming convention
+
+Each reference type is named `<TargetType>Reference` or `<TargetType>LocalReference` and is
+defined in the target type's `*_type.proto` file. The spec field that uses it is named after the
+relationship (e.g., `template`, `virtual_network`, `role`), not after the reference type itself.
+
+### Wire format (REST/JSON)
+
+In the REST/JSON representation, reference fields are nested objects:
+
+```json
+{
+  "spec": {
+    "template": { "name": "sandbox" },
+    "version": { "name": "4-17-0" }
+  }
+}
+```
+
+For local references the format is identical but without `project` and `shared`:
+
+```json
+{
+  "spec": {
+    "virtual_network": { "name": "my-vnet" }
+  }
+}
+```
+
+Repeated references (e.g., security groups in a network attachment) are arrays of objects:
+
+```json
+{
+  "subnet": { "name": "my-subnet" },
+  "security_groups": [
+    { "name": "sg-web" },
+    { "name": "sg-ssh" }
+  ]
+}
+```
+
+### Cross-project references
+
+To reference a resource in a different project within the same tenant, set the `project` field:
+
+```json
+{
+  "spec": {
+    "template": { "name": "shared-tpl", "project": "templates" }
+  }
+}
+```
+
+To reference a resource owned by the shared tenant (e.g., a globally available template), set
+`shared` to `true`:
+
+```json
+{
+  "spec": {
+    "template": { "name": "sandbox", "shared": true }
+  }
+}
+```
+
+### Server-side validation and resolution
+
+The server validates references automatically via a gRPC interceptor on `Create` and `Update`
+requests. For each reference field the interceptor:
+
+1. Determines the lookup scope (caller's tenant/project for local references; explicit
+   `project`/`shared` overrides for full references).
+2. Looks up the referenced object by `id`, `name`, or both.
+3. If both `id` and `name` are provided, verifies they refer to the same object.
+4. Auto-populates whichever of `id` or `name` was not provided by the caller.
+
+Invalid references produce an `InvalidArgument` error with `google.rpc.BadRequest` details
+containing one `FieldViolation` per invalid reference. The `field` value is the dot-separated
+path to the reference field (e.g., `object.spec.template`, `object.spec.network_attachments[0].subnet`).
+
+### Reference types in the API
+
+**Full references** (support cross-project via `project` and `shared`):
+
+| Reference type | Used by |
+|----------------|---------|
+| `ClusterTemplateReference` | `ClusterSpec.template`, `ClusterCatalogItem.template` |
+| `ClusterVersionReference` | `ClusterSpec.version` |
+| `ClusterCatalogItemReference` | `ClusterSpec.catalog_item` |
+| `ComputeInstanceTemplateReference` | `ComputeInstanceSpec.template`, `ComputeInstanceCatalogItem.template` |
+| `ComputeInstanceCatalogItemReference` | `ComputeInstanceSpec.catalog_item` |
+| `InstanceTypeReference` | `ComputeInstanceSpec.instance_type` |
+| `BareMetalInstanceTemplateReference` | `BareMetalInstanceCatalogItem.template` |
+| `BareMetalInstanceCatalogItemReference` | `BareMetalInstanceSpec.catalog_item` |
+| `HostTypeReference` | `ClusterTemplateNodeSet.host_type`, `ClusterNodeSet.host_type` |
+| `NetworkClassReference` | `VirtualNetworkSpec.network_class` |
+| `ExternalIPPoolReference` | `ExternalIPSpec.pool` |
+| `RoleReference` | `RoleBindingSpec.role` |
+| `UserReference` | `RoleBindingSpec.users`, `ProjectMembershipSpec.users` |
+
+**Local references** (same tenant and project only):
+
+| Reference type | Used by |
+|----------------|---------|
+| `VirtualNetworkLocalReference` | `SubnetSpec.virtual_network`, `SecurityGroupSpec.virtual_network`, `NATGatewaySpec.virtual_network` |
+| `SubnetLocalReference` | `NetworkAttachment.subnet` |
+| `SecurityGroupLocalReference` | `NetworkAttachment.security_groups` |
+| `ExternalIPLocalReference` | `ExternalIPAttachmentSpec.external_ip`, `NATGatewaySpec.external_ip` |
+| `ComputeInstanceLocalReference` | `ExternalIPAttachmentSpec.target.compute_instance` |
+| `ClusterLocalReference` | `ExternalIPAttachmentSpec.target.cluster` |
+| `BareMetalInstanceLocalReference` | `ExternalIPAttachmentSpec.target.baremetal_instance` |
 
 ## Documentation
 

--- a/fulfillment-service/docs/API.md
+++ b/fulfillment-service/docs/API.md
@@ -500,7 +500,7 @@ There are two kinds of references:
 
 ### Full references
 
-Full references can point to resources in a different project or in the shared tenant. They have
+Full references can point to objects in a different project or in the shared tenant. They have
 four fields:
 
 ```protobuf
@@ -523,7 +523,7 @@ Callers may supply `id`, `name`, or both. When both are provided they must refer
 object; otherwise the server returns `InvalidArgument`. The server auto-populates whichever field
 is missing after a successful lookup.
 
-Full references are used when the target resource may live outside the caller's project — for
+Full references are used when the target object may live outside the caller's project — for
 example, cluster templates, catalog items, host types, instance types, network classes, IP pools,
 roles, and users.
 
@@ -552,9 +552,9 @@ Each reference type is named `<TargetType>Reference` or `<TargetType>LocalRefere
 defined in the target type's `*_type.proto` file. The spec field that uses it is named after the
 relationship (e.g., `template`, `virtual_network`, `role`), not after the reference type itself.
 
-### Wire format (REST/JSON)
+### JSON representation
 
-In the REST/JSON representation, reference fields are nested objects:
+In the JSON representation used by the REST gateway, reference fields are nested objects:
 
 ```json
 {
@@ -589,7 +589,7 @@ Repeated references (e.g., security groups in a network attachment) are arrays o
 
 ### Cross-project references
 
-To reference a resource in a different project within the same tenant, set the `project` field:
+To reference an object in a different project within the same tenant, set the `project` field:
 
 ```json
 {
@@ -599,7 +599,7 @@ To reference a resource in a different project within the same tenant, set the `
 }
 ```
 
-To reference a resource owned by the shared tenant (e.g., a globally available template), set
+To reference an object owned by the shared tenant (e.g., a globally available template), set
 `shared` to `true`:
 
 ```json
@@ -624,38 +624,6 @@ requests. For each reference field the interceptor:
 Invalid references produce an `InvalidArgument` error with `google.rpc.BadRequest` details
 containing one `FieldViolation` per invalid reference. The `field` value is the dot-separated
 path to the reference field (e.g., `object.spec.template`, `object.spec.network_attachments[0].subnet`).
-
-### Reference types in the API
-
-**Full references** (support cross-project via `project` and `shared`):
-
-| Reference type | Used by |
-|----------------|---------|
-| `ClusterTemplateReference` | `ClusterSpec.template`, `ClusterCatalogItem.template` |
-| `ClusterVersionReference` | `ClusterSpec.version` |
-| `ClusterCatalogItemReference` | `ClusterSpec.catalog_item` |
-| `ComputeInstanceTemplateReference` | `ComputeInstanceSpec.template`, `ComputeInstanceCatalogItem.template` |
-| `ComputeInstanceCatalogItemReference` | `ComputeInstanceSpec.catalog_item` |
-| `InstanceTypeReference` | `ComputeInstanceSpec.instance_type` |
-| `BareMetalInstanceTemplateReference` | `BareMetalInstanceCatalogItem.template` |
-| `BareMetalInstanceCatalogItemReference` | `BareMetalInstanceSpec.catalog_item` |
-| `HostTypeReference` | `ClusterTemplateNodeSet.host_type`, `ClusterNodeSet.host_type` |
-| `NetworkClassReference` | `VirtualNetworkSpec.network_class` |
-| `ExternalIPPoolReference` | `ExternalIPSpec.pool` |
-| `RoleReference` | `RoleBindingSpec.role` |
-| `UserReference` | `RoleBindingSpec.users`, `ProjectMembershipSpec.users` |
-
-**Local references** (same tenant and project only):
-
-| Reference type | Used by |
-|----------------|---------|
-| `VirtualNetworkLocalReference` | `SubnetSpec.virtual_network`, `SecurityGroupSpec.virtual_network`, `NATGatewaySpec.virtual_network` |
-| `SubnetLocalReference` | `NetworkAttachment.subnet` |
-| `SecurityGroupLocalReference` | `NetworkAttachment.security_groups` |
-| `ExternalIPLocalReference` | `ExternalIPAttachmentSpec.external_ip`, `NATGatewaySpec.external_ip` |
-| `ComputeInstanceLocalReference` | `ExternalIPAttachmentSpec.target.compute_instance` |
-| `ClusterLocalReference` | `ExternalIPAttachmentSpec.target.cluster` |
-| `BareMetalInstanceLocalReference` | `ExternalIPAttachmentSpec.target.baremetal_instance` |
 
 ## Documentation
 

--- a/fulfillment-service/docs/CATALOG_ITEMS.md
+++ b/fulfillment-service/docs/CATALOG_ITEMS.md
@@ -102,7 +102,8 @@ title: Sandbox Cluster
 description: Small sandbox cluster template with networking parameters.
 node_sets:
   workers:
-    host_type: fc430
+    host_type:
+      name: fc430
     size: 1
 parameters:
   - name: vpc_id
@@ -131,7 +132,9 @@ metadata:
   name: sandbox
 title: Sandbox Cluster
 description: Small development cluster.
-template: "osac.templates.sandbox"
+template:
+  name: sandbox
+  shared: true
 published: true
 field_definitions:
   # Typed proto fields
@@ -193,7 +196,9 @@ metadata:
   name: standard-vm
 title: Standard Virtual Machine
 description: General-purpose virtual machine with KubeVirt.
-template: "osac.templates.ocp_virt_vm"
+template:
+  name: ocp_virt_vm
+  shared: true
 published: true
 field_definitions:
   - path: ssh_public_key

--- a/fulfillment-service/docs/FILTER.md
+++ b/fulfillment-service/docs/FILTER.md
@@ -113,6 +113,37 @@ field is present. The metadata fields `id`, `name` and `creation_timestamp` are 
 present. The `deletion_timestamp` field is considered present only when the object has actually
 been marked for deletion.
 
+## Filtering on reference fields
+
+Object references are typed messages (see [API.md — Object references](API.md#object-references)),
+so filter expressions must access their sub-fields rather than comparing the reference directly as
+a string. Every reference has at least `id` and `name`; full references additionally have `project`
+and `shared`.
+
+Select subnets belonging to a specific virtual network by name:
+
+```cel
+this.spec.virtual_network.name == "my-vnet"
+```
+
+Select subnets belonging to a specific virtual network by id:
+
+```cel
+this.spec.virtual_network.id == "672c0827-ef03-48d0-b825-689f83ff296b"
+```
+
+Select clusters using a specific catalog item:
+
+```cel
+this.spec.catalog_item.name == "dev-sandbox"
+```
+
+Select virtual networks using a specific network class:
+
+```cel
+this.spec.network_class.name == "default"
+```
+
 ## Examples
 
 Select objects whose name starts with `prod`:

--- a/osac-installer/OSAC-CLI-HOWTO.md
+++ b/osac-installer/OSAC-CLI-HOWTO.md
@@ -488,9 +488,12 @@ User-Agent: grpc-go/1.70.0
 
 # Request body (protobuf)
 {
-  "template": "simple",
-  "name": "cluster-001",
-  "parameters": {}
+  "spec": {
+    "template": { "name": "simple" }
+  },
+  "metadata": {
+    "name": "cluster-001"
+  }
 }
 
 # Response
@@ -501,8 +504,12 @@ grpc-status: 0
 # Response body (protobuf)
 {
   "id": "672c0827-ef03-48d0-b825-689f83ff296b",
-  "template": "simple",
-  "state": "PROVISIONING"
+  "spec": {
+    "template": { "id": "osac.templates.simple", "name": "simple" }
+  },
+  "status": {
+    "state": "CLUSTER_STATE_PROGRESSING"
+  }
 }
 ```
 


### PR DESCRIPTION
Summary

  - Replace stale "Object references" section in API.md that described references as plain string
  fields (and mentioned typed references as a "future plan") with comprehensive documentation covering
  full vs local references, wire format, cross-project lookups, server-side validation/resolution,
  error format, and complete reference type inventory
  - Add "Filtering on reference fields" section to FILTER.md with examples for
  this.spec.virtual_network.name, this.spec.catalog_item.name, etc.
  - Fix stale YAML examples in CATALOG_ITEMS.md — template: "osac.templates.sandbox" → template: { 
  name: sandbox, shared: true }, host_type: fc430 → host_type: { name: fc430 }
  - Fix stale gRPC request/response example in OSAC-CLI-HOWTO.md to use nested reference objects and
  proper spec/status structure

  Test plan

  - [x] Verify API.md reference type tables match current proto definitions
  - [x] Verify FILTER.md examples match actual CEL filter paths used in server code (confirmed against
  private_subnets_server.go, catalog_item_reference_checker.go)
  - [x] Verify CATALOG_ITEMS.md YAML examples are valid ProtoJSON for the current proto schema
  (confirmed ClusterTemplateReference, HostTypeReference, ComputeInstanceTemplateReference field
  shapes)
  - [x] Verify OSAC-CLI-HOWTO.md request/response example reflects actual wire format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API examples to use typed references, including names, IDs, projects, and shared scope.
  * Added guidance and examples for filtering typed reference fields.
  * Revised catalog item examples to use structured template and host type references.
  * Updated cluster creation and response examples to reflect nested specification and status fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->