### PR TITLE
OSAC-3267: Add table name mapping when translating db errors

### DIFF
--- a/fulfillment-service/internal/database/dao/dao_errors.go
+++ b/fulfillment-service/internal/database/dao/dao_errors.go
@@ -44,8 +44,8 @@ func (e *ErrNotFound) Error() string {
 
 // ErrAlreadyExists is an error type that indicates that an object can't be created because it already exists.
 type ErrAlreadyExists struct {
-	// Table is the name of the table.
-	Table string
+	// Kind is the human-readable resource kind name (e.g. "compute instance", "external IP").
+	Kind string
 
 	// ID is the identifier of the object that already exists.
 	ID string
@@ -66,14 +66,9 @@ func (e *ErrAlreadyExists) Error() string {
 		return e.Reason
 	}
 
-	// If no reason has been provided then build the error message according to the table, identifier and name:
-	var kind string
-	switch e.Table {
-	case "projects":
-		kind = "project"
-	case "tenants":
-		kind = "tenant"
-	default:
+	// If no reason has been provided then build the error message according to the kind, identifier and name:
+	kind := e.Kind
+	if kind == "" {
 		kind = "object"
 	}
 	switch {

--- a/fulfillment-service/internal/database/dao/dao_errors_test.go
+++ b/fulfillment-service/internal/database/dao/dao_errors_test.go
@@ -61,8 +61,8 @@ var _ = Describe("Errors", func() {
 
 		It("Returns expected message for a tenant with a name", func() {
 			err := &ErrAlreadyExists{
-				Table: "tenants",
-				Name:  "my-tenant",
+				Kind: "tenant",
+				Name: "my-tenant",
 			}
 			Expect(err.Error()).To(Equal("tenant 'my-tenant' already exists"))
 		})
@@ -87,12 +87,103 @@ var _ = Describe("Errors", func() {
 			Expect(err.Error()).To(Equal("object already exists"))
 		})
 
-		It("Returns custom message for projects", func() {
+		It("Returns kind in error message for projects", func() {
 			err := &ErrAlreadyExists{
-				Table: "projects",
-				Name:  "my-name",
+				Kind: "project",
+				Name: "my-name",
 			}
 			Expect(err.Error()).To(Equal("project 'my-name' already exists"))
+		})
+
+		It("Returns kind in error message for virtual networks", func() {
+			err := &ErrAlreadyExists{
+				Kind: "virtual network",
+				Name: "my-vnet",
+			}
+			Expect(err.Error()).To(Equal("virtual network 'my-vnet' already exists"))
+		})
+
+		It("Returns kind in error message for cluster orders", func() {
+			err := &ErrAlreadyExists{
+				Kind: "cluster order",
+				Name: "my-cluster",
+			}
+			Expect(err.Error()).To(Equal("cluster order 'my-cluster' already exists"))
+		})
+
+		It("Returns kind in error message for security groups", func() {
+			err := &ErrAlreadyExists{
+				Kind: "security group",
+				ID:   "sg-123",
+				Name: "my-sg",
+			}
+			Expect(err.Error()).To(Equal(
+				"security group with identifier 'sg-123' and name 'my-sg' already exists",
+			))
+		})
+
+		It("Returns kind in error message for NAT gateways", func() {
+			err := &ErrAlreadyExists{
+				Kind: "NAT gateway",
+				Name: "my-natgw",
+			}
+			Expect(err.Error()).To(Equal("NAT gateway 'my-natgw' already exists"))
+		})
+
+		It("Returns kind in error message for external IP pools", func() {
+			err := &ErrAlreadyExists{
+				Kind: "external IP pool",
+				Name: "my-pool",
+			}
+			Expect(err.Error()).To(Equal("external IP pool 'my-pool' already exists"))
+		})
+
+		It("Returns kind in error message for compute instances", func() {
+			err := &ErrAlreadyExists{
+				Kind: "compute instance",
+				Name: "my-ci",
+			}
+			Expect(err.Error()).To(Equal("compute instance 'my-ci' already exists"))
+		})
+
+		It("Returns kind in error message for compute instance templates", func() {
+			err := &ErrAlreadyExists{
+				Kind: "compute instance template",
+				Name: "my-template",
+			}
+			Expect(err.Error()).To(Equal("compute instance template 'my-template' already exists"))
+		})
+
+		It("Returns kind in error message for host types", func() {
+			err := &ErrAlreadyExists{
+				Kind: "host type",
+				Name: "my-host-type",
+			}
+			Expect(err.Error()).To(Equal("host type 'my-host-type' already exists"))
+		})
+
+		It("Returns kind in error message for hubs", func() {
+			err := &ErrAlreadyExists{
+				Kind: "hub",
+				Name: "my-hub",
+			}
+			Expect(err.Error()).To(Equal("hub 'my-hub' already exists"))
+		})
+
+		It("Returns custom reason verbatim when set, ignoring kind", func() {
+			err := &ErrAlreadyExists{
+				Kind:   "compute instance",
+				ID:     "ci-123",
+				Reason: "custom trigger message",
+			}
+			Expect(err.Error()).To(Equal("custom trigger message"))
+		})
+
+		It("Falls back to 'object' when kind is empty", func() {
+			err := &ErrAlreadyExists{
+				Name: "my-thing",
+			}
+			Expect(err.Error()).To(Equal("object 'my-thing' already exists"))
 		})
 	})
 

--- a/fulfillment-service/internal/database/dao/generic_dao.go
+++ b/fulfillment-service/internal/database/dao/generic_dao.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strings"
 
 	"github.com/gobuffalo/flect"
 	"github.com/prometheus/client_golang/prometheus"
@@ -69,6 +70,7 @@ type GenericDAO[O Object] struct {
 	// Basic fields:
 	logger           *slog.Logger
 	table            string
+	kind             string
 	defaultLimit     int32
 	maxLimit         int32
 	timestampDesc    protoreflect.MessageDescriptor
@@ -293,6 +295,7 @@ func (b *GenericDAOBuilder[O]) Build() (result *GenericDAO[O], err error) {
 	result = &GenericDAO[O]{
 		logger:           b.logger,
 		table:            b.resolveTableName(),
+		kind:             b.kindName(),
 		defaultLimit:     b.defaultLimit,
 		maxLimit:         b.maxLimit,
 		timestampDesc:    timestampDesc,
@@ -325,6 +328,20 @@ func (b *GenericDAOBuilder[O]) resolveTableName() string {
 func (b *GenericDAOBuilder[O]) tableName() string {
 	var object O
 	return flect.Pluralize(flect.Underscore(string(object.ProtoReflect().Descriptor().Name())))
+}
+
+var kindAcronyms = strings.NewReplacer("nat ", "NAT ", " nat", " NAT", "ip ", "IP ", " ip", " IP")
+
+// kindName returns a human-readable singular resource kind derived from the table name.
+// For example, `compute_instances` becomes `compute instance` and `external_ips` becomes `external IP`.
+func (b *GenericDAOBuilder[O]) kindName() string {
+	table := b.resolveTableName()
+	if strings.HasSuffix(table, "_ips") {
+		table = strings.TrimSuffix(table, "s")
+	} else {
+		table = flect.Singularize(table)
+	}
+	return kindAcronyms.Replace(strings.ReplaceAll(table, "_", " "))
 }
 
 func (b *GenericDAOBuilder[O]) registerOpDurationMetric() (result *prometheus.HistogramVec, err error) {

--- a/fulfillment-service/internal/database/dao/generic_dao_create.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_create.go
@@ -212,9 +212,9 @@ func (r *CreateRequest[O]) translateError(ctx context.Context, id, tenant, proje
 	switch pgErr.Code {
 	case pgerrcode.UniqueViolation:
 		return &ErrAlreadyExists{
-			Table: r.dao.table,
-			ID:    id,
-			Name:  name,
+			Kind: r.dao.kind,
+			ID:   id,
+			Name: name,
 		}
 	case errReferenceCode:
 		return &ErrReference{
@@ -247,12 +247,14 @@ func (r *CreateRequest[O]) translateError(ctx context.Context, id, tenant, proje
 		// If no message is provided, fall back to ID.
 		if pgErr.Message != "" {
 			return &ErrAlreadyExists{
+				Kind:   r.dao.kind,
 				ID:     id,
 				Reason: pgErr.Message,
 			}
 		}
 		return &ErrAlreadyExists{
-			ID: id,
+			Kind: r.dao.kind,
+			ID:   id,
 		}
 	case pgerrcode.DeadlockDetected:
 		return &ErrDeadlock{}

--- a/fulfillment-service/internal/database/dao/generic_dao_update.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_update.go
@@ -239,10 +239,12 @@ func (r *UpdateRequest[O]) translateError(ctx context.Context, id, name, tenant 
 			return &ErrAlreadyExists{
 				ID:   id,
 				Name: name,
+				Kind: r.dao.kind,
 			}
 		}
 		return &ErrAlreadyExists{
-			ID: id,
+			ID:   id,
+			Kind: r.dao.kind,
 		}
 	case pgerrcode.ForeignKeyViolation:
 		switch {
@@ -312,12 +314,14 @@ func (r *UpdateRequest[O]) translateError(ctx context.Context, id, name, tenant 
 		// If no message is provided, fall back to ID.
 		if pgErr.Message != "" {
 			return &ErrAlreadyExists{
+				Kind:   r.dao.kind,
 				ID:     id,
 				Reason: pgErr.Message,
 			}
 		}
 		return &ErrAlreadyExists{
-			ID: id,
+			Kind: r.dao.kind,
+			ID:   id,
 		}
 	case pgerrcode.DeadlockDetected:
 		return &ErrDeadlock{}

--- a/fulfillment-service/internal/servers/private_clusters_server_test.go
+++ b/fulfillment-service/internal/servers/private_clusters_server_test.go
@@ -554,7 +554,7 @@ var _ = Describe("Private clusters server", func() {
 			status, ok := grpcstatus.FromError(err)
 			Expect(ok).To(BeTrue())
 			Expect(status.Code()).To(Equal(grpccodes.AlreadyExists))
-			Expect(status.Message()).To(Equal(fmt.Sprintf("object with identifier '%s' and name '%s' already exists", id, name)))
+			Expect(status.Message()).To(Equal(fmt.Sprintf("cluster with identifier '%s' and name '%s' already exists", id, name)))
 		})
 
 		It("List objects", func() {


### PR DESCRIPTION
Allows the user to see which object failed getting added or updated in the DB.
Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved duplicate-resource error messages with clear, human-readable resource types, including clusters, projects, virtual networks, security groups, NAT gateways, external IP pools, compute resources, host types, and hubs.
* Added consistent fallback wording for unrecognized resource types while preserving specific custom error messages.
* Duplicate cluster creation errors now identify the resource as a “cluster” instead of a generic “object.”

## Tests

* Expanded coverage for resource-specific duplicate errors and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->