### PR TITLE
OSAC-4024: Add agentless_net to NETWORK_CLASS enum in Helm schema

### DIFF
--- a/osac-installer/charts/osac/values.schema.json
+++ b/osac-installer/charts/osac/values.schema.json
@@ -611,7 +611,8 @@
                         "",
                         "esi",
                         "netris",
-                        "nico"
+                        "nico",
+                        "agentless_net"
                       ]
                     },
                     "NETWORK_STEPS_COLLECTION": {


### PR DESCRIPTION
The agentless_net backend needs NETWORK_CLASS set to enable write_ssh_keys in the cluster provisioning playbook.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting `agentless_net` as a network class during configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->