### PR TITLE
OSAC-3210: reject Cluster creation when NetworkClass has no k8s_manager

### DIFF
--- a/fulfillment-service/internal/servers/private_clusters_server.go
+++ b/fulfillment-service/internal/servers/private_clusters_server.go
@@ -56,6 +56,9 @@ type PrivateClustersServer struct {
 	catalogItemsDao    *dao.GenericDAO[*privatev1.ClusterCatalogItem]
 	hostTypesDao       *dao.GenericDAO[*privatev1.HostType]
 	clusterVersionsDao *dao.GenericDAO[*privatev1.ClusterVersion]
+	subnetsDao         *dao.GenericDAO[*privatev1.Subnet]
+	virtualNetworksDao *dao.GenericDAO[*privatev1.VirtualNetwork]
+	networkClassesDao  *dao.GenericDAO[*privatev1.NetworkClass]
 	generic            *GenericServer[*privatev1.Cluster]
 }
 
@@ -140,6 +143,33 @@ func (b *PrivateClustersServerBuilder) Build() (result *PrivateClustersServer, e
 		return
 	}
 
+	subnetsDao, err := dao.NewGenericDAO[*privatev1.Subnet]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	virtualNetworksDao, err := dao.NewGenericDAO[*privatev1.VirtualNetwork]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
+	networkClassesDao, err := dao.NewGenericDAO[*privatev1.NetworkClass]().
+		SetLogger(b.logger).
+		SetTenancyLogic(b.tenancyLogic).
+		SetMetricsRegisterer(b.metricsRegisterer).
+		Build()
+	if err != nil {
+		return
+	}
+
 	// Create the generic server:
 	generic, err := NewGenericServer[*privatev1.Cluster]().
 		SetLogger(b.logger).
@@ -160,6 +190,9 @@ func (b *PrivateClustersServerBuilder) Build() (result *PrivateClustersServer, e
 		catalogItemsDao:    catalogItemsDao,
 		hostTypesDao:       hostTypesDao,
 		clusterVersionsDao: clusterVersionsDao,
+		subnetsDao:         subnetsDao,
+		virtualNetworksDao: virtualNetworksDao,
+		networkClassesDao:  networkClassesDao,
 		generic:            generic,
 	}
 	return
@@ -225,6 +258,12 @@ func (s *PrivateClustersServer) Create(ctx context.Context,
 		if err != nil {
 			return
 		}
+	}
+
+	// Reject creation if the network attachment resolves to a NetworkClass
+	// without a k8s_manager — CaaS clusters need MetalLB for VIP allocation.
+	if err = s.validateNetworkAttachmentRequiresK8SManager(ctx, request.GetObject()); err != nil {
+		return
 	}
 
 	err = s.generic.Create(ctx, request, &response)
@@ -688,6 +727,75 @@ func (s *PrivateClustersServer) validateNetworkAttachmentImmutability(ctx contex
 			"cannot change spec.network_attachment.subnet from '%s' to '%s': subnet is immutable",
 			refKey(existingSubnet), refKey(newSubnet),
 		)
+	}
+
+	return nil
+}
+
+// validateNetworkAttachmentRequiresK8SManager rejects Cluster creation when the
+// network attachment resolves (Subnet → VirtualNetwork → NetworkClass) to a
+// NetworkClass with no k8s_manager. Without k8s_manager, the hosting cluster has
+// no MetalLB IPAddressPool and CaaS VIP allocation cannot function.
+// Dangling references are skipped — they fail independently during provisioning.
+func (s *PrivateClustersServer) validateNetworkAttachmentRequiresK8SManager(
+	ctx context.Context, cluster *privatev1.Cluster) error {
+	if cluster == nil || cluster.GetSpec() == nil || cluster.GetSpec().GetNetworkAttachment() == nil {
+		return nil
+	}
+
+	subnetKey := refKey(cluster.GetSpec().GetNetworkAttachment().GetSubnet())
+	if subnetKey == "" {
+		return nil
+	}
+
+	subnetResp, err := s.subnetsDao.Get().SetId(subnetKey).Do(ctx)
+	if err != nil {
+		var notFoundErr *dao.ErrNotFound
+		if errors.As(err, &notFoundErr) {
+			return nil
+		}
+		s.logger.ErrorContext(ctx, "failed to query subnet for k8s_manager validation",
+			slog.String("subnet_key", subnetKey), slog.Any("error", err))
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to validate network class")
+	}
+
+	virtualNetworkKey := refKey(subnetResp.GetObject().GetSpec().GetVirtualNetwork())
+	if virtualNetworkKey == "" {
+		return nil
+	}
+
+	vnResp, err := s.virtualNetworksDao.Get().SetId(virtualNetworkKey).Do(ctx)
+	if err != nil {
+		var notFoundErr *dao.ErrNotFound
+		if errors.As(err, &notFoundErr) {
+			return nil
+		}
+		s.logger.ErrorContext(ctx, "failed to query virtual network for k8s_manager validation",
+			slog.String("virtual_network_key", virtualNetworkKey), slog.Any("error", err))
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to validate network class")
+	}
+
+	networkClassKey := refKey(vnResp.GetObject().GetSpec().GetNetworkClass())
+	if networkClassKey == "" {
+		return nil
+	}
+
+	ncResp, err := s.networkClassesDao.Get().SetId(networkClassKey).Do(ctx)
+	if err != nil {
+		var notFoundErr *dao.ErrNotFound
+		if errors.As(err, &notFoundErr) {
+			return nil
+		}
+		s.logger.ErrorContext(ctx, "failed to query network class for k8s_manager validation",
+			slog.String("network_class_key", networkClassKey), slog.Any("error", err))
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to validate network class")
+	}
+
+	if !ncResp.GetObject().HasK8SManager() {
+		return grpcstatus.Errorf(grpccodes.FailedPrecondition,
+			"network_attachment: subnet '%s' uses NetworkClass '%s' which has no 'k8s_manager'; "+
+				"clusters require a k8s manager for MetalLB VIP allocation",
+			subnetKey, networkClassKey)
 	}
 
 	return nil

--- a/fulfillment-service/internal/servers/private_clusters_server_test.go
+++ b/fulfillment-service/internal/servers/private_clusters_server_test.go
@@ -1543,6 +1543,141 @@ var _ = Describe("Private clusters server", func() {
 			})
 		})
 
+		Describe("k8s_manager validation", func() {
+			It("Rejects creation when NetworkClass has no k8s_manager", func() {
+				ncDao, err := dao.NewGenericDAO[*privatev1.NetworkClass]().
+					SetLogger(logger).SetTenancyLogic(tenancy).Build()
+				Expect(err).ToNot(HaveOccurred())
+				vnDao, err := dao.NewGenericDAO[*privatev1.VirtualNetwork]().
+					SetLogger(logger).SetTenancyLogic(tenancy).Build()
+				Expect(err).ToNot(HaveOccurred())
+				subDao, err := dao.NewGenericDAO[*privatev1.Subnet]().
+					SetLogger(logger).SetTenancyLogic(tenancy).Build()
+				Expect(err).ToNot(HaveOccurred())
+
+				// NetworkClass with fabric_manager only (no k8s_manager)
+				ncResp, err := ncDao.Create().SetObject(privatev1.NetworkClass_builder{
+					Metadata:               privatev1.Metadata_builder{Name: "bm-only-nc", Tenant: auth.SharedTenant}.Build(),
+					Title:                  "BM-only",
+					ImplementationStrategy: "netris",
+					FabricManager:          new("netris"),
+				}.Build()).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				ncID := ncResp.GetObject().GetId()
+
+				_, err = vnDao.Create().SetObject(privatev1.VirtualNetwork_builder{
+					Id:       "bm-only-vnet",
+					Metadata: privatev1.Metadata_builder{Name: "bm-only-vnet", Tenant: auth.SharedTenant}.Build(),
+					Spec: privatev1.VirtualNetworkSpec_builder{
+						NetworkClass: privatev1.NetworkClassReference_builder{Id: ncID}.Build(),
+					}.Build(),
+				}.Build()).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = subDao.Create().SetObject(privatev1.Subnet_builder{
+					Id:       "bm-only-subnet",
+					Metadata: privatev1.Metadata_builder{Name: "bm-only-subnet", Tenant: auth.SharedTenant}.Build(),
+					Spec: privatev1.SubnetSpec_builder{
+						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: "bm-only-vnet"}.Build(),
+						Ipv4Cidr:       new("10.99.0.0/24"),
+					}.Build(),
+					Status: privatev1.SubnetStatus_builder{
+						State: privatev1.SubnetState_SUBNET_STATE_READY,
+					}.Build(),
+				}.Build()).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = server.Create(ctx, privatev1.ClustersCreateRequest_builder{
+					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{Name: "test-bm-only-cluster"}.Build(),
+						Spec: privatev1.ClusterSpec_builder{
+							Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
+							NetworkAttachment: privatev1.ClusterNetworkAttachment_builder{
+								Subnet: privatev1.SubnetLocalReference_builder{Id: "bm-only-subnet"}.Build(),
+							}.Build(),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+				Expect(status.Message()).To(ContainSubstring("no 'k8s_manager'"))
+			})
+
+			It("Allows creation when NetworkClass has k8s_manager", func() {
+				ncDao, err := dao.NewGenericDAO[*privatev1.NetworkClass]().
+					SetLogger(logger).SetTenancyLogic(tenancy).Build()
+				Expect(err).ToNot(HaveOccurred())
+				vnDao, err := dao.NewGenericDAO[*privatev1.VirtualNetwork]().
+					SetLogger(logger).SetTenancyLogic(tenancy).Build()
+				Expect(err).ToNot(HaveOccurred())
+				subDao, err := dao.NewGenericDAO[*privatev1.Subnet]().
+					SetLogger(logger).SetTenancyLogic(tenancy).Build()
+				Expect(err).ToNot(HaveOccurred())
+
+				// NetworkClass with both managers
+				ncResp, err := ncDao.Create().SetObject(privatev1.NetworkClass_builder{
+					Metadata:               privatev1.Metadata_builder{Name: "full-nc", Tenant: auth.SharedTenant}.Build(),
+					Title:                  "Full",
+					ImplementationStrategy: "cudn",
+					FabricManager:          new("netris"),
+					K8SManager:             new("cudn_localnet"),
+				}.Build()).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				ncID := ncResp.GetObject().GetId()
+
+				_, err = vnDao.Create().SetObject(privatev1.VirtualNetwork_builder{
+					Id:       "full-vnet",
+					Metadata: privatev1.Metadata_builder{Name: "full-vnet", Tenant: auth.SharedTenant}.Build(),
+					Spec: privatev1.VirtualNetworkSpec_builder{
+						NetworkClass: privatev1.NetworkClassReference_builder{Id: ncID}.Build(),
+					}.Build(),
+				}.Build()).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = subDao.Create().SetObject(privatev1.Subnet_builder{
+					Id:       "full-subnet",
+					Metadata: privatev1.Metadata_builder{Name: "full-subnet", Tenant: auth.SharedTenant}.Build(),
+					Spec: privatev1.SubnetSpec_builder{
+						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: "full-vnet"}.Build(),
+						Ipv4Cidr:       new("10.98.0.0/24"),
+					}.Build(),
+					Status: privatev1.SubnetStatus_builder{
+						State: privatev1.SubnetState_SUBNET_STATE_READY,
+					}.Build(),
+				}.Build()).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				resp, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
+					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{Name: "test-full-cluster"}.Build(),
+						Spec: privatev1.ClusterSpec_builder{
+							Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
+							NetworkAttachment: privatev1.ClusterNetworkAttachment_builder{
+								Subnet: privatev1.SubnetLocalReference_builder{Id: "full-subnet"}.Build(),
+							}.Build(),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.GetObject()).ToNot(BeNil())
+			})
+
+			It("Skips validation when no network_attachment is set", func() {
+				resp, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
+					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{Name: "test-no-na-cluster"}.Build(),
+						Spec: privatev1.ClusterSpec_builder{
+							Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.GetObject()).ToNot(BeNil())
+			})
+		})
+
 		Describe("Catalog item", func() {
 			var catalogItemsDao *dao.GenericDAO[*privatev1.ClusterCatalogItem]
 


### PR DESCRIPTION
Validate during Cluster creation that the network attachment's NetworkClass (resolved via Subnet → VirtualNetwork → NetworkClass) has a k8s_manager configured. Without k8s_manager, the hosting cluster has no MetalLB IPAddressPool and CaaS VIP allocation cannot function.

Follows the BareMetalInstance pattern ([OSAC-1464](https://redhat.atlassian.net/browse/OSAC-1464)) which validates fabric_manager on the same chain. Dangling references are skipped — they fail independently during provisioning.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cluster creation now validates network attachments and their associated network configuration.
  * Creation is rejected when the selected network class lacks the required Kubernetes manager configuration.
  * Clusters without network attachments continue to be created without this validation.

* **Bug Fixes**
  * Missing referenced network resources are handled safely.
  * Network lookup failures now return an appropriate internal error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->