### PR TITLE
NO-ISSUE: fix Helm hook resilience — increase backoffLimit and add curl retry

### DIFF
--- a/osac-installer/charts/osac/templates/hooks/create-hub.yaml
+++ b/osac-installer/charts/osac/templates/hooks/create-hub.yaml
@@ -48,7 +48,7 @@ metadata:
     "helm.sh/hook-weight": "25"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  backoffLimit: 5
+  backoffLimit: 10
   activeDeadlineSeconds: 900
   template:
     metadata:
@@ -111,7 +111,8 @@ spec:
             FULFILLMENT_URL="https://fulfillment-internal-api:8001"
 
             echo "Checking if hub 'hub' already exists..."
-            HTTP_CODE=$(curl -sk --connect-timeout 5 --max-time 30 \
+            HTTP_CODE=$(curl -sk --retry 5 --retry-delay 5 --retry-all-errors \
+              --connect-timeout 5 --max-time 30 \
               -o /tmp/hub-response.json -w '%{http_code}' \
               -H "Authorization: Bearer ${AUTH_TOKEN}" \
               "${FULFILLMENT_URL}/api/private/v1/hubs/hub")
@@ -119,7 +120,8 @@ spec:
 
             if [[ "${HTTP_CODE}" == "200" ]]; then
               echo "Hub exists, updating..."
-              HTTP_CODE=$(curl -sk --connect-timeout 5 --max-time 30 \
+              HTTP_CODE=$(curl -sk --retry 5 --retry-delay 5 --retry-all-errors \
+                --connect-timeout 5 --max-time 30 \
                 -o /tmp/hub-update.json -w '%{http_code}' \
                 -X PATCH \
                 -H "Authorization: Bearer ${AUTH_TOKEN}" \
@@ -131,7 +133,8 @@ spec:
               echo "Hub updated."
             else
               echo "Creating hub..."
-              HTTP_CODE=$(curl -sk --connect-timeout 5 --max-time 30 \
+              HTTP_CODE=$(curl -sk --retry 5 --retry-delay 5 --retry-all-errors \
+                --connect-timeout 5 --max-time 30 \
                 -o /tmp/hub-create.json -w '%{http_code}' \
                 -X POST \
                 -H "Authorization: Bearer ${AUTH_TOKEN}" \

--- a/osac-installer/charts/osac/templates/hooks/publish-templates.yaml
+++ b/osac-installer/charts/osac/templates/hooks/publish-templates.yaml
@@ -11,7 +11,7 @@ metadata:
     "helm.sh/hook-weight": "20"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  backoffLimit: 6
+  backoffLimit: 10
   activeDeadlineSeconds: 1300
   template:
     metadata:
@@ -36,7 +36,8 @@ spec:
             AAP_URL="http://{{ .Values.aap.aap.instance.name }}"
 
             echo "Looking up osac-publish-templates job template..."
-            JT_RESPONSE=$(curl -sf -H "Authorization: Bearer ${AAP_TOKEN}" \
+            JT_RESPONSE=$(curl -sf --retry 5 --retry-delay 5 --retry-connrefused \
+              -H "Authorization: Bearer ${AAP_TOKEN}" \
               "${AAP_URL}/api/controller/v2/job_templates/?name=osac-publish-templates")
             JT_ID=$(echo "${JT_RESPONSE}" | python3 -c "
             import sys, json
@@ -49,7 +50,8 @@ spec:
             echo "Job template ID: ${JT_ID}"
 
             echo "Launching osac-publish-templates..."
-            LAUNCH_RESPONSE=$(curl -sf -X POST \
+            LAUNCH_RESPONSE=$(curl -sf --retry 5 --retry-delay 5 --retry-connrefused \
+              -X POST \
               -H "Authorization: Bearer ${AAP_TOKEN}" \
               -H "Content-Type: application/json" \
               "${AAP_URL}/api/controller/v2/job_templates/${JT_ID}/launch/")

--- a/osac-installer/charts/osac/templates/hooks/register-local-storage.yaml
+++ b/osac-installer/charts/osac/templates/hooks/register-local-storage.yaml
@@ -11,7 +11,7 @@ metadata:
     "helm.sh/hook-weight": "31"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  backoffLimit: 5
+  backoffLimit: 10
   # waitForFulfillment polls up to 60 × (30s curl + 10s sleep) = 2400s worst case.
   # This deadline must exceed that to avoid premature termination.
   activeDeadlineSeconds: 3000
@@ -38,7 +38,7 @@ spec:
             # Step 1: Create the local StorageBackend. Capture the ID whether
             # this is the first install (2xx) or a re-install (409 = already exists).
             BACKEND_RESP=$(mktemp)
-            BACKEND_CODE=$(curl -skS \
+            BACKEND_CODE=$(curl -skS --retry 5 --retry-delay 5 --retry-all-errors \
               --connect-timeout 5 --max-time 30 \
               -o "${BACKEND_RESP}" -w '%{http_code}' \
               -X POST "${API}/storage_backends" \
@@ -53,7 +53,8 @@ spec:
                 ;;
               409)
                 echo "StorageBackend 'local' already exists, verifying spec..."
-                EXISTING=$(curl -skS --connect-timeout 5 --max-time 30 \
+                EXISTING=$(curl -skS --retry 5 --retry-delay 5 --retry-all-errors \
+                  --connect-timeout 5 --max-time 30 \
                   "${API}/storage_backends" \
                   -H "Authorization: Bearer ${AUTH_TOKEN}")
                 BACKEND_ID=$(echo "${EXISTING}" | python3 -c "import sys,json; items=json.load(sys.stdin).get('items',[]); m=next((i for i in items if i.get('metadata',{}).get('name')=='local'),None); p=m.get('spec',{}).get('provider','') if m else ''; sys.stderr.write('ERROR: backend not found or wrong provider: '+p+'\n') or sys.exit(1) if not m or p!='lvms' else print(m['id'])")
@@ -72,7 +73,7 @@ spec:
             # Protocol 2 = STORAGE_PROTOCOL_BLOCK (LVMS provides block volumes).
             TIER_BODY=$(printf '{"metadata":{"name":"local"},"spec":{"backends":[{"backend_id":"%s","protocol":2}]}}' "${BACKEND_ID}")
             TIER_RESP=$(mktemp)
-            TIER_CODE=$(curl -skS \
+            TIER_CODE=$(curl -skS --retry 5 --retry-delay 5 --retry-all-errors \
               --connect-timeout 5 --max-time 30 \
               -o "${TIER_RESP}" -w '%{http_code}' \
               -X POST "${API}/storage_tiers" \
@@ -84,7 +85,8 @@ spec:
               2??) echo "StorageTier 'local' created." ;;
               409)
                 echo "StorageTier 'local' already exists, verifying backend reference..."
-                EXISTING_TIER=$(curl -skS --connect-timeout 5 --max-time 30 \
+                EXISTING_TIER=$(curl -skS --retry 5 --retry-delay 5 --retry-all-errors \
+                  --connect-timeout 5 --max-time 30 \
                   "${API}/storage_tiers" -H "Authorization: Bearer ${AUTH_TOKEN}")
                 echo "${EXISTING_TIER}" | python3 -c "import sys,json; items=json.load(sys.stdin).get('items',[]); m=next((t for t in items if t.get('metadata',{}).get('name')=='local'),None); sys.exit(1) if not m else None; ok=next((b for b in m.get('spec',{}).get('backends',[]) if b.get('backend_id')=='${BACKEND_ID}' and b.get('protocol')==2),None); sys.stderr.write('ERROR: tier does not reference backend ${BACKEND_ID}\n') or sys.exit(1) if not ok else print('ok')"
                 ;;

--- a/osac-installer/charts/osac/templates/hooks/seed-cluster-versions.yaml
+++ b/osac-installer/charts/osac/templates/hooks/seed-cluster-versions.yaml
@@ -11,7 +11,7 @@ metadata:
     "helm.sh/hook-weight": "30"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  backoffLimit: 5
+  backoffLimit: 10
   activeDeadlineSeconds: 900
   template:
     metadata:
@@ -39,7 +39,7 @@ spec:
               local response="/tmp/cv-response.json"
               local code
 
-              code=$(curl -skS \
+              code=$(curl -skS --retry 5 --retry-delay 5 --retry-all-errors \
                 --connect-timeout 5 \
                 --max-time 30 \
                 -o "${response}" \


### PR DESCRIPTION
## Summary

- **Increase `backoffLimit`** from 5-6 to 10 on all post-install hooks (create-hub, publish-templates, seed-cluster-versions, register-local-storage), giving Kubernetes more retry attempts with exponential backoff
- **Add `--retry 5 --retry-delay 5`** to all curl API calls inside hook scripts, so each job attempt retries transient connection errors instead of failing immediately
- **Use `--retry-connrefused`** (not `--retry-all-errors`) on publish-templates AAP calls to avoid retrying permanent HTTP errors or duplicating non-idempotent POST requests

The hooks use `waitForFulfillment` (checks REST gateway `/healthz` on port 8000) but then hit the internal API at port 8001 — which may not be fully serving yet despite the gateway being up. This caused **33+ periodic `BackoffLimitExceeded` failures in 14 days** across all three E2E flavors.

## Evidence of failures

Each link below is a real periodic CI run (no PR changes) that failed at "Install OSAC" with `fulfillment-create-hub failed: BackoffLimitExceeded`:

- https://github.com/osac-project/osac/actions/runs/31211451899 (vmaas periodic)
- https://github.com/osac-project/osac/actions/runs/31204530519 (caas periodic)
- https://github.com/osac-project/osac/actions/runs/31203085121 (bmaas periodic)
- https://github.com/osac-project/osac/actions/runs/31202121960 (vmaas periodic)
- https://github.com/osac-project/osac/actions/runs/31190197116 (caas periodic)
- https://github.com/osac-project/osac/actions/runs/31188811831 (bmaas periodic)

All show the same pattern: `Error: failed post-install: 1 error occurred: * job fulfillment-create-hub failed: BackoffLimitExceeded`

## Context

CI analysis showed `fulfillment-create-hub failed: BackoffLimitExceeded` was the top cause of periodic "Install OSAC" failures. The internal API's JWKS endpoint was returning EOF when the hook ran, but with only 5 retries and no in-script retry, the hook exhausted its attempts before the API stabilized.

**Note:** The underlying root cause (init container checks port 8000 but hooks use port 8001) should be fixed separately by updating `waitForFulfillment` to probe the internal API endpoint.

## Test plan
- [x] `helm template` validates cleanly with all values files
- [x] Reviewed for silent error suppression — no `|| true` or `2>/dev/null` in hooks
- [x] `--retry-connrefused` used on non-idempotent AAP POST (prevents duplicate job launches)
- [x] `--retry-all-errors` used only on idempotent GET/POST-with-409-handling calls
- [x] Error propagation verified — all retries exhausted produces non-zero exit caught by `set -euo pipefail`
- [ ] Monitor periodic CI pass rates after merge

---

_This PR description was drafted with AI assistance ([create-pr](https://github.com/osac-project/osac-workspace/tree/main/skills/create-pr) v0.2.0). Review for accuracy_