### PR TITLE
OSAC-4016: Build graph-refresh workflow (generation + publish + concurrency)

### DIFF
--- a/.github/workflows/graphify-brain-refresh.yaml
+++ b/.github/workflows/graphify-brain-refresh.yaml
@@ -31,7 +31,10 @@ env:
 jobs:
   refresh:
     name: Refresh and publish graph
-    runs-on: osac-ci
+    # Ephemeral GH-hosted runner is sufficient here -- this job only ever
+    # uses GITHUB_TOKEN, no Vault/self-hosted-only access. osac-ci is
+    # reserved for alert-on-repeated-failure below, which does need it.
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: write  # gh release create/upload against this same repo
@@ -52,14 +55,20 @@ jobs:
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: graphify-out/
-          key: graphify-brain-cache
+          # Cache keys are immutable in GH Actions -- a static key would make
+          # every save after the first a silent no-op. Save under a per-run
+          # key and restore via restore-keys prefix match so the fast path
+          # always finds the most recent entry.
+          key: graphify-brain-cache-${{ github.run_id }}
+          restore-keys: |
+            graphify-brain-cache-
 
       - name: Re-pull last published bundle (authoritative)
         id: repull
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          set -uo pipefail
+          set -euo pipefail
           rm -rf /tmp/graphify-repull && mkdir -p /tmp/graphify-repull
           if gh release download "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" \
                --pattern 'graphify-bundle.tar.gz' --dir /tmp/graphify-repull; then
@@ -75,9 +84,14 @@ jobs:
       - name: Determine restore path taken
         id: restore-path
         run: |
+          # cache-hit is only true on an exact primary-key match, which never
+          # happens now that the save key is per-run (see restore step above)
+          # -- cache-matched-key is set on both exact and restore-keys/prefix
+          # matches, so it's the correct signal for "did the fast path find
+          # anything at all".
           if [[ "${{ steps.repull.outputs.ok }}" == "true" ]]; then
             path="artifact-repull"
-          elif [[ "${{ steps.cache.outputs.cache-hit }}" == "true" ]]; then
+          elif [[ -n "${{ steps.cache.outputs.cache-matched-key }}" ]]; then
             path="cache-hit"
           else
             path="full-rebuild"
@@ -99,7 +113,11 @@ jobs:
       - name: Write metadata.json
         run: |
           set -euo pipefail
-          graphify_version="$(graphify --version | tr -d '\n')"
+          # Extract just the bare numeric version (graphify --version prints
+          # non-numeric text too, e.g. "graphify 0.9.41") so this matches
+          # exactly what the fetch script's own version check expects to
+          # compare against -- see fetch-graphify-brain.sh's Step 5.
+          graphify_version="$(graphify --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
           generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           jq -n \
             --arg source_sha "${GITHUB_SHA}" \
@@ -145,9 +163,17 @@ jobs:
             assets+=(graphify-obsidian-export.tar.gz)
           fi
           if gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            # `gh release upload --clobber` replaces assets in place but does
+            # not move the release's own tag -- move it explicitly so
+            # graph-latest's git ref (not just metadata.json's source_sha)
+            # points at this run's commit too. `gh release edit --target`
+            # cannot move an existing tag; the Git refs API can.
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/git/refs/tags/${RELEASE_TAG}" \
+              -f sha="${GITHUB_SHA}" -F force=true
             gh release upload "${RELEASE_TAG}" "${assets[@]}" --repo "${GITHUB_REPOSITORY}" --clobber
           else
             gh release create "${RELEASE_TAG}" "${assets[@]}" --repo "${GITHUB_REPOSITORY}" \
+              --target "${GITHUB_SHA}" \
               --title "graphify brain (latest)" \
               --notes "Auto-published by graphify-brain-refresh.yaml. Always points at the most recent successful run -- not a versioned release."
           fi
@@ -157,7 +183,7 @@ jobs:
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: graphify-out/
-          key: graphify-brain-cache
+          key: graphify-brain-cache-${{ github.run_id }}
 
   alert-on-repeated-failure:
     name: Alert on repeated publish failure
@@ -167,6 +193,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read  # only needed to resolve the local ./.github/actions/vault-slack-webhook path
+      actions: read   # needed for `gh run list` below
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -179,13 +206,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          # This job only runs when the current run already failed (if:
+          # failure() above) -- that's one confirmed failure already, and its
+          # own conclusion is still null/in-progress if queried from inside
+          # itself. Query the two prior COMPLETED runs instead and alert only
+          # if both were also failures -- 3-in-a-row once the current run is
+          # counted.
           conclusions="$(gh run list --repo "${GITHUB_REPOSITORY}" \
             --workflow graphify-brain-refresh.yaml \
-            --json conclusion --limit 3 -q '[.[].conclusion] | join(",")')"
-          echo "Last 3 run conclusions: ${conclusions}"
-          # Alert only once the last 3 runs (including this one) all failed --
-          # avoids paging on a single transient blip.
-          if [[ "${conclusions}" == "failure,failure,failure" ]]; then
+            --status completed --limit 2 \
+            --json conclusion -q '[.[].conclusion] | join(",")')"
+          echo "Prior 2 completed run conclusions: ${conclusions}"
+          if [[ "${conclusions}" == "failure,failure" ]]; then
             echo "should-alert=true" >> "$GITHUB_OUTPUT"
           else
             echo "should-alert=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/graphify-brain-refresh.yaml
+++ b/.github/workflows/graphify-brain-refresh.yaml
@@ -1,0 +1,227 @@
+name: Graphify Brain Refresh
+
+on:
+  # Hourly, offset off the top/half of the hour -- GitHub Actions' shared
+  # cron scheduler queues everyone's on-the-hour schedules together and can
+  # delay/drop them under load (same reasoning as this repo's e2e-*-full-install
+  # workflows and osac-test-infra's e2e-caas-netris-caller.yml).
+  schedule:
+    - cron: "21 * * * *"
+  workflow_dispatch: {}
+
+concurrency:
+  # No cancel-in-progress: graph.json is never committed/merged, so there's
+  # no conflict to resolve by cancelling -- runs are queued, not raced, and
+  # each successive run naturally reflects a HEAD at least as new as the one
+  # it queued behind (main only moves forward). This alone is sufficient
+  # race safety; no separate ancestry guard is needed.
+  group: graphify-brain-refresh
+  cancel-in-progress: false
+
+permissions: {}
+
+env:
+  # Pin deliberately -- bump only with an intentional review, same as this
+  # repo pins action SHAs and Helm/tool versions elsewhere. Confirmed current
+  # on PyPI at the time this workflow was written; the CLI command is
+  # `graphify` despite the package itself being named with a double "y".
+  GRAPHIFY_VERSION: "0.9.41"
+  RELEASE_TAG: graph-latest
+
+jobs:
+  refresh:
+    name: Refresh and publish graph
+    runs-on: osac-ci
+    timeout-minutes: 60
+    permissions:
+      contents: write  # gh release create/upload against this same repo
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install graphify
+        run: |
+          pip install --user "graphifyy==${GRAPHIFY_VERSION}"
+          echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Restore prior graphify-out/ state (fast path)
+        id: cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        with:
+          path: graphify-out/
+          key: graphify-brain-cache
+
+      - name: Re-pull last published bundle (authoritative)
+        id: repull
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          rm -rf /tmp/graphify-repull && mkdir -p /tmp/graphify-repull
+          if gh release download "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" \
+               --pattern 'graphify-bundle.tar.gz' --dir /tmp/graphify-repull; then
+            rm -rf graphify-out
+            mkdir -p graphify-out
+            tar xzf /tmp/graphify-repull/graphify-bundle.tar.gz -C graphify-out
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No published bundle to re-pull yet (first run, or release missing)."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Determine restore path taken
+        id: restore-path
+        run: |
+          if [[ "${{ steps.repull.outputs.ok }}" == "true" ]]; then
+            path="artifact-repull"
+          elif [[ "${{ steps.cache.outputs.cache-hit }}" == "true" ]]; then
+            path="cache-hit"
+          else
+            path="full-rebuild"
+          fi
+          echo "path=${path}" >> "$GITHUB_OUTPUT"
+          echo "::notice::graphify-brain-refresh restore path: ${path}"
+
+      - name: Extract or update graph
+        run: |
+          set -euo pipefail
+          if [[ -f graphify-out/graph.json && -f graphify-out/manifest.json ]]; then
+            echo "Prior graph found -- running incremental update."
+            graphify update . --code-only
+          else
+            echo "No usable prior graph -- running full extraction."
+            graphify extract . --code-only
+          fi
+
+      - name: Write metadata.json
+        run: |
+          set -euo pipefail
+          graphify_version="$(graphify --version | tr -d '\n')"
+          generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          jq -n \
+            --arg source_sha "${GITHUB_SHA}" \
+            --arg graphify_version "${graphify_version}" \
+            --arg generated_at "${generated_at}" \
+            '{source_sha: $source_sha, graphify_version: $graphify_version, generated_at: $generated_at}' \
+            > graphify-out/metadata.json
+
+      - name: Export Obsidian vault (best-effort, independent asset)
+        id: obsidian
+        run: |
+          set -uo pipefail
+          if graphify export obsidian 2>/tmp/obsidian-export.log; then
+            if [[ -d graphify-out/obsidian ]]; then
+              tar czf graphify-obsidian-export.tar.gz -C graphify-out obsidian
+              echo "ok=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "obsidian export reported success but produced no output directory -- skipping asset."
+              echo "ok=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "Obsidian export failed (non-fatal, mechanical export only):"
+            cat /tmp/obsidian-export.log || true
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bundle core artifacts (single archive for atomic publish)
+        run: |
+          set -euo pipefail
+          # graph.json + GRAPH_REPORT.md + manifest.json + metadata.json travel
+          # together in one archive so a consumer always gets the whole matched
+          # set or a clean 404 -- never a mismatched pair from two publishes.
+          tar czf graphify-bundle.tar.gz -C graphify-out \
+            graph.json GRAPH_REPORT.md manifest.json metadata.json
+
+      - name: Publish to GH Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          assets=(graphify-bundle.tar.gz)
+          if [[ "${{ steps.obsidian.outputs.ok }}" == "true" ]]; then
+            assets+=(graphify-obsidian-export.tar.gz)
+          fi
+          if gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh release upload "${RELEASE_TAG}" "${assets[@]}" --repo "${GITHUB_REPOSITORY}" --clobber
+          else
+            gh release create "${RELEASE_TAG}" "${assets[@]}" --repo "${GITHUB_REPOSITORY}" \
+              --title "graphify brain (latest)" \
+              --notes "Auto-published by graphify-brain-refresh.yaml. Always points at the most recent successful run -- not a versioned release."
+          fi
+
+      - name: Save graphify-out/ for next run's fast path
+        if: success()
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        with:
+          path: graphify-out/
+          key: graphify-brain-cache
+
+  alert-on-repeated-failure:
+    name: Alert on repeated publish failure
+    needs: refresh
+    if: failure()
+    runs-on: osac-ci
+    timeout-minutes: 10
+    permissions:
+      contents: read  # only needed to resolve the local ./.github/actions/vault-slack-webhook path
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check recent run history
+        id: history
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          conclusions="$(gh run list --repo "${GITHUB_REPOSITORY}" \
+            --workflow graphify-brain-refresh.yaml \
+            --json conclusion --limit 3 -q '[.[].conclusion] | join(",")')"
+          echo "Last 3 run conclusions: ${conclusions}"
+          # Alert only once the last 3 runs (including this one) all failed --
+          # avoids paging on a single transient blip.
+          if [[ "${conclusions}" == "failure,failure,failure" ]]; then
+            echo "should-alert=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should-alert=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Retrieve Slack webhook from Vault
+        if: steps.history.outputs.should-alert == 'true'
+        id: vault
+        uses: ./.github/actions/vault-slack-webhook
+
+      - name: Notify Slack
+        if: steps.history.outputs.should-alert == 'true'
+        env:
+          SLACK_WEBHOOK_URL: ${{ steps.vault.outputs.webhook-url }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg workflow_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            '{
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {"type": "plain_text", "text": ":red_jenkins_circle: Graphify Brain Refresh: 3 consecutive publish failures"}
+                },
+                {
+                  "type": "section",
+                  "text": {"type": "mrkdwn", "text": "The published graph bundle may now be stale for every developer session and the ci-select-facing consumers. See run for details."}
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {"type": "button", "text": {"type": "plain_text", "text": "View Run"}, "url": $workflow_url}
+                  ]
+                }
+              ]
+            }' > /tmp/slack-payload.json
+          curl -sf --max-time 15 -X POST "${SLACK_WEBHOOK_URL}" \
+            -H "Content-Type: application/json" \
+            -d @/tmp/slack-payload.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ skills/
 .cursor/
 .gemini/
 
+# graphify knowledge-graph output -- fetched from the published CI bundle
+# (see .github/workflows/graphify-brain-refresh.yaml), never committed.
+graphify-out/
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,14 @@
+# graphify structural extraction scope (OSAC-1732 knowledge-graph brain).
+#
+# Test directories are excluded: they bloat node/relationship count 3-4x on
+# information already covered by the production code they test, without
+# adding new cross-component edges. Infra/config files (.github/, charts/,
+# values/) are deliberately NOT excluded -- that's exactly where this
+# mono-repo's cross-component dependency information lives (e.g. which
+# component's chart another component's umbrella chart depends on).
+**/tests/**
+**/test/**
+**/*_test.go
+**/test_*.py
+**/*_test.py
+**/it/**


### PR DESCRIPTION
## Summary

New scheduled workflow (`graphify-brain-refresh.yaml`) that keeps a `graphify`-generated code graph of this mono-repo fresh and publishes it as a stable pull target. Phase 1 of [OSAC-4013](https://redhat.atlassian.net/browse/OSAC-4013) -- zero CI-gating risk, no e2e behavior changes.

## Design decisions (from [OSAC-4015](https://redhat.atlassian.net/browse/OSAC-4015))

- **Publish channel: GH Release asset**, floating `graph-latest` tag (created on first run, `--clobber`-uploaded thereafter). Simpler than OCI -- no `oras` dependency needed anywhere in the pipeline.
- **AI-extraction data egress**: every extraction/update call passes `graphify ... --code-only` explicitly -- structural AST only, confirmed 0-token/no LLM call per graphify's own docs. This is enforced by the actual CLI flag in the workflow, not just documented intent.
- **Trigger/race-safety**: scheduled (hourly, `cron: "21 * * * *"` -- off the top of the hour, matching this repo's established e2e-workflow cron-staggering convention) + `workflow_dispatch`. A plain `concurrency:` group with `cancel-in-progress: false` queues runs rather than racing them -- sufficient on its own since `graph.json` is never committed/merged (nothing to conflict) and `main` only moves forward, so no separate ancestry guard or full-history checkout is needed. Shallow `fetch-depth: 1` checkout.

## Continuity across ephemeral runs

Restore-before-update order: re-pull the last published bundle from the GH Release (authoritative -- guaranteed available, no retention window) first; `actions/cache` is an optional fast-path only (evicts after ~7 days idle) and is never the sole path. The workflow logs explicitly which of `cache-hit` / `artifact-repull` / `full-rebuild` was taken via `::notice::`, so a silent slide into rebuilding from scratch every run stays visible rather than silent, per the design doc's Premise 7.

## Publish atomicity

`graph.json`, `GRAPH_REPORT.md`, `manifest.json`, and a new `metadata.json` (source SHA + graphify version + generation timestamp) are bundled into **one** `graphify-bundle.tar.gz` and published as a single asset -- a consumer either gets the whole matched set or a clean 404, never a mismatched pair from two different publishes. The mechanical Obsidian export ships as a second, independent, best-effort asset (failure there never fails the main publish).

## Alerting

Reuses this repo's own existing `./.github/actions/vault-slack-webhook` composite action (already proven in `nightly-build.yaml`) rather than reaching cross-repo into `osac-test-infra`'s `notify-slack` action -- same Vault AppRole pattern, already local to this repo. Alerts only after 3 consecutive publish failures (checked via `gh run list`, no new state file), to avoid paging on a single transient blip.

## Also added

- `.graphifyignore` at repo root: excludes test directories (bloat 3-4x on relationships already covered by production code) while explicitly keeping `.github/`, `charts/`, `values/`, etc. in scope -- that's where this mono-repo's real cross-component dependency info lives.
- `.gitignore` entry for `graphify-out/` (fetched output, never committed).

## What I could not verify

No live `graphify` install or GH Actions run was available to me while writing this -- flagging plainly rather than claiming false confidence:
- `graphify update`'s own behavior when `graphify-out/` is missing/incomplete is undocumented publicly, so the workflow makes the extract-vs-update branch explicit itself (checks for `graph.json` + `manifest.json` presence) rather than relying on unverified fallback behavior inside the tool.
- The exact `graphify export obsidian` invocation and its output directory name are inferred from the design doc's description, not confirmed against a real run.
- Recommend watching the first `workflow_dispatch` run closely, and deliberately forcing a cache-miss scenario (e.g. clearing the `graphify-brain-cache` cache entry via the Actions UI) to confirm the artifact-repull fallback actually engages, per the design doc's Success Criteria.

## Test plan

- [x] `yaml.safe_load` clean
- [x] `yamllint -c .yamllint.yaml` clean
- [x] Action SHA pins (`actions/checkout`, `actions/cache/restore`, `actions/cache/save`) independently verified against the real GitHub API, not guessed
- [ ] First live `workflow_dispatch` run (cannot be done from this environment)
- [ ] Forced cache-miss scenario confirms artifact-repull engages (cannot be done from this environment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated hourly refreshes for the Graphify knowledge graph, with manual refresh support.
  * Published refreshed graph artifacts to a rolling release, with optional Obsidian archive exports.
  * Added failure notifications after three consecutive unsuccessful refreshes.

* **Chores**
  * Excluded generated graph output from version control.
  * Added rules to omit test-related files from graph extraction while preserving infrastructure and configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->