### PR TITLE
OSAC-4017: Build fetch script + SessionStart hook + graphify claude install wiring

### DIFF
--- a/.claude/hooks/fetch-graphify-brain.sh
+++ b/.claude/hooks/fetch-graphify-brain.sh
@@ -12,6 +12,11 @@
 # single-machine view.
 
 set -uo pipefail
+# Belt-and-suspenders: any unguarded command failure not already routed
+# through an explicit check below still exits clean rather than continuing
+# in an unknown state. Exempt from the same cases -e itself is (if/while
+# conditions, &&/||, negation), so this doesn't fire on expected failures.
+trap 'exit 0' ERR
 
 # Anchor to the project root regardless of the caller's cwd, so the
 # settings.json hook command can stay a plain `bash .../fetch-graphify-brain.sh`
@@ -39,6 +44,7 @@ fall_back_to_local() {
     if [[ -f "${GRAPH_DIR}/.last-fetch-at" ]]; then
       local last_fetch now age_h
       last_fetch="$(cat "${GRAPH_DIR}/.last-fetch-at" 2>/dev/null || echo 0)"
+      [[ "${last_fetch}" =~ ^[0-9]+$ ]] || last_fetch=0
       now="$(date -u +%s)"
       age_h=$(( (now - last_fetch) / 3600 ))
       age_note=" (~${age_h}h old)"
@@ -96,8 +102,14 @@ if tar tvzf "${TMP_DIR}/graphify-bundle.tar.gz" 2>/dev/null | grep -qE '^[lh]'; 
 fi
 
 mkdir -p "${TMP_DIR}/extracted"
-if ! tar xzf "${TMP_DIR}/graphify-bundle.tar.gz" -C "${TMP_DIR}/extracted" 2>/dev/null; then
+if ! tar xzf "${TMP_DIR}/graphify-bundle.tar.gz" -C "${TMP_DIR}/extracted" --no-same-owner 2>/dev/null; then
   fall_back_to_local "Downloaded bundle is corrupt (failed to extract)"
+fi
+# Second-layer guard, independent of tar's own listing-output format (the
+# pre-extraction check above parses one specific tar implementation's
+# verbose listing): inspect what actually landed on disk.
+if find "${TMP_DIR}/extracted" -type l 2>/dev/null | grep -q .; then
+  fall_back_to_local "Extracted bundle contains symlink entries (rejected for safety)"
 fi
 
 # --- Step 3: validate graph.json AND metadata.json before touching local state ---
@@ -160,11 +172,24 @@ fi
 # simply missing.
 date -u +%s > "${TMP_DIR}/extracted/.last-fetch-at"
 rm -rf "${GRAPH_DIR}.tmp" "${GRAPH_DIR}.old"
-mv "${TMP_DIR}/extracted" "${GRAPH_DIR}.tmp"
-if [[ -d "${GRAPH_DIR}" ]]; then
-  mv "${GRAPH_DIR}" "${GRAPH_DIR}.old"
+if ! mv "${TMP_DIR}/extracted" "${GRAPH_DIR}.tmp"; then
+  # Nothing under GRAPH_DIR has been touched yet -- safe to just bail.
+  fall_back_to_local "Failed to stage new graph directory"
 fi
-mv "${GRAPH_DIR}.tmp" "${GRAPH_DIR}"
+if [[ -d "${GRAPH_DIR}" ]]; then
+  if ! mv "${GRAPH_DIR}" "${GRAPH_DIR}.old"; then
+    fall_back_to_local "Failed to preserve existing graph before swap"
+  fi
+fi
+if ! mv "${GRAPH_DIR}.tmp" "${GRAPH_DIR}"; then
+  # The live copy (if any) is safely under GRAPH_DIR.old, not deleted --
+  # restore it before falling back so a failed swap never leaves
+  # graphify-out/ missing.
+  if [[ -d "${GRAPH_DIR}.old" ]]; then
+    mv "${GRAPH_DIR}.old" "${GRAPH_DIR}" 2>/dev/null || true
+  fi
+  fall_back_to_local "Failed to activate new graph directory"
+fi
 rm -rf "${GRAPH_DIR}.old"
 
 warn "Fetched graph (source ${BUNDLE_SHA:0:12}, graphify ${BUNDLE_GRAPHIFY_VERSION}) into ${GRAPH_DIR}/."

--- a/.claude/hooks/fetch-graphify-brain.sh
+++ b/.claude/hooks/fetch-graphify-brain.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# SessionStart hook: pull the latest CI-published graphify knowledge graph
+# into graphify-out/ so graphify's own CLAUDE.md directive + PreToolUse hook
+# (installed separately via `graphify claude install`) have a current graph
+# to read. See OSAC-4013/4015/4016/4017 for the design this implements.
+#
+# This script must NEVER block or fail session start -- every failure path
+# below falls back (to existing local graphify-out/, or to plain cold
+# exploration) and always exits 0. It also never triggers local generation
+# (no `graphify hook install`/`--watch`) -- a developer's own commits must
+# never clobber the CI-fetched, org-wide graph with an incomplete
+# single-machine view.
+
+set -uo pipefail
+
+REPO="osac-project/osac"
+RELEASE_TAG="graph-latest"
+GRAPH_DIR="graphify-out"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+warn() {
+  echo "[graphify-brain] $*" >&2
+}
+
+fall_back_to_local() {
+  local reason="$1"
+  if [[ -f "${GRAPH_DIR}/metadata.json" ]] && command -v jq >/dev/null 2>&1; then
+    local sha age_note
+    sha="$(jq -r '.source_sha // "unknown"' "${GRAPH_DIR}/metadata.json" 2>/dev/null || echo unknown)"
+    age_note=""
+    if [[ -f "${GRAPH_DIR}/.last-fetch-at" ]]; then
+      local last_fetch now age_h
+      last_fetch="$(cat "${GRAPH_DIR}/.last-fetch-at" 2>/dev/null || echo 0)"
+      now="$(date -u +%s)"
+      age_h=$(( (now - last_fetch) / 3600 ))
+      age_note=" (~${age_h}h old)"
+    fi
+    warn "${reason} -- falling back to existing local graph (source ${sha:0:12}${age_note}, possibly stale)."
+  else
+    warn "${reason} -- no local graph available either. Brain unavailable this session; cold exploration will proceed normally."
+  fi
+  exit 0
+}
+
+# --- Step 1: graphify binary distribution check (OSAC-4015 decision 3) ---
+# Fail-open: a fresh machine without graphify installed should never see a
+# confusing raw shell error, just a one-line note and normal cold
+# exploration for that session.
+if ! command -v graphify >/dev/null 2>&1; then
+  warn "graphify not installed -- skipping brain fetch, cold exploration will proceed. Install with: uv tool install graphifyy (or: pipx install graphifyy). Note the package name is 'graphifyy' (double y); the CLI command itself is 'graphify'."
+  exit 0
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  fall_back_to_local "gh CLI not available"
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  fall_back_to_local "jq not available (needed to validate the pulled bundle)"
+fi
+
+# --- Step 2: pull the latest published bundle (public repo, no auth needed) ---
+if ! gh release download "${RELEASE_TAG}" --repo "${REPO}" \
+      --pattern 'graphify-bundle.tar.gz' --dir "${TMP_DIR}" >/dev/null 2>&1; then
+  fall_back_to_local "Could not fetch latest graph bundle (network/404/rate-limit)"
+fi
+
+mkdir -p "${TMP_DIR}/extracted"
+if ! tar xzf "${TMP_DIR}/graphify-bundle.tar.gz" -C "${TMP_DIR}/extracted" 2>/dev/null; then
+  fall_back_to_local "Downloaded bundle is corrupt (failed to extract)"
+fi
+
+# --- Step 3: validate graph.json AND metadata.json before touching local state ---
+GRAPH_JSON="${TMP_DIR}/extracted/graph.json"
+META_JSON="${TMP_DIR}/extracted/metadata.json"
+
+if [[ ! -f "${GRAPH_JSON}" ]] || ! jq -e 'has("nodes") and has("edges")' "${GRAPH_JSON}" >/dev/null 2>&1; then
+  fall_back_to_local "Downloaded graph.json is missing or malformed"
+fi
+
+if [[ ! -f "${META_JSON}" ]] || ! jq -e 'has("source_sha") and has("graphify_version") and has("generated_at")' "${META_JSON}" >/dev/null 2>&1; then
+  fall_back_to_local "Downloaded metadata.json is missing or malformed (missing required fields)"
+fi
+
+BUNDLE_SHA="$(jq -r '.source_sha' "${META_JSON}")"
+BUNDLE_GRAPHIFY_VERSION="$(jq -r '.graphify_version' "${META_JSON}")"
+
+# --- Step 4: staleness check (signal only, never a hard rejection) ---
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1 && \
+   git cat-file -e "${BUNDLE_SHA}" 2>/dev/null; then
+  if git merge-base --is-ancestor "${BUNDLE_SHA}" HEAD 2>/dev/null; then
+    : # bundle's source is an ancestor of HEAD -- normal, no staleness note needed.
+  else
+    warn "Note: published graph's source (${BUNDLE_SHA:0:12}) is not an ancestor of local HEAD -- local checkout may be on a branch ahead of or diverged from what generated this graph."
+  fi
+else
+  warn "Note: could not compare graph source SHA against local HEAD (shallow clone or unrelated history) -- staleness unknown, proceeding on TTL basis only."
+fi
+
+# --- Step 5: version check ---
+LOCAL_GRAPHIFY_VERSION="$(graphify --version 2>/dev/null | tr -d '[:space:]')"
+if [[ -n "${LOCAL_GRAPHIFY_VERSION}" && "${LOCAL_GRAPHIFY_VERSION}" != "${BUNDLE_GRAPHIFY_VERSION}" ]]; then
+  warn "graphify version mismatch: published graph was generated with ${BUNDLE_GRAPHIFY_VERSION}, local install is ${LOCAL_GRAPHIFY_VERSION}. Refusing to load -- upgrade with: uv tool install --upgrade graphifyy (or: pipx upgrade graphifyy)."
+  fall_back_to_local "Version mismatch"
+fi
+
+# --- Step 6: atomic swap ---
+date -u +%s > "${TMP_DIR}/extracted/.last-fetch-at"
+rm -rf "${GRAPH_DIR}.tmp"
+mv "${TMP_DIR}/extracted" "${GRAPH_DIR}.tmp"
+rm -rf "${GRAPH_DIR}"
+mv "${GRAPH_DIR}.tmp" "${GRAPH_DIR}"
+
+warn "Fetched graph (source ${BUNDLE_SHA:0:12}, graphify ${BUNDLE_GRAPHIFY_VERSION}) into ${GRAPH_DIR}/."
+exit 0

--- a/.claude/hooks/fetch-graphify-brain.sh
+++ b/.claude/hooks/fetch-graphify-brain.sh
@@ -13,6 +13,13 @@
 
 set -uo pipefail
 
+# Anchor to the project root regardless of the caller's cwd, so the
+# settings.json hook command can stay a plain `bash .../fetch-graphify-brain.sh`
+# -- consistent with the existing update-ai-context.sh hook -- rather than
+# needing its own `cd` wrapper.
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+cd "${PROJECT_DIR}" || { echo "[graphify-brain] Could not cd to project dir ${PROJECT_DIR} -- skipping." >&2; exit 0; }
+
 REPO="osac-project/osac"
 RELEASE_TAG="graph-latest"
 GRAPH_DIR="graphify-out"
@@ -60,10 +67,27 @@ if ! command -v jq >/dev/null 2>&1; then
   fall_back_to_local "jq not available (needed to validate the pulled bundle)"
 fi
 
-# --- Step 2: pull the latest published bundle (public repo, no auth needed) ---
+# --- Step 2: pull the latest published bundle. osac-project/osac is public
+# so no token is required -- gh may still pick up an ambient local token if
+# the developer is already logged in, but none is needed for this to work. ---
 if ! gh release download "${RELEASE_TAG}" --repo "${REPO}" \
       --pattern 'graphify-bundle.tar.gz' --dir "${TMP_DIR}" >/dev/null 2>&1; then
   fall_back_to_local "Could not fetch latest graph bundle (network/404/rate-limit)"
+fi
+
+# Defense-in-depth path-traversal/symlink guard before extracting anything.
+# Low severity in practice (exploiting this needs write access to the GH
+# Release, the same trust boundary as pushing source code), but cheap to
+# check: reject absolute paths, '..' components, and symlink/hardlink
+# entries rather than trusting GNU tar's leading-'/' stripping alone.
+if ! tar tzf "${TMP_DIR}/graphify-bundle.tar.gz" > "${TMP_DIR}/members.txt" 2>/dev/null; then
+  fall_back_to_local "Downloaded bundle is corrupt (failed to list contents)"
+fi
+if grep -qE '^/|(^|/)\.\.(/|$)' "${TMP_DIR}/members.txt"; then
+  fall_back_to_local "Downloaded bundle contains unsafe path entries (path traversal guard)"
+fi
+if tar tvzf "${TMP_DIR}/graphify-bundle.tar.gz" 2>/dev/null | grep -qE -- '-> |link to'; then
+  fall_back_to_local "Downloaded bundle contains symlink/hardlink entries (rejected for safety)"
 fi
 
 mkdir -p "${TMP_DIR}/extracted"
@@ -90,7 +114,10 @@ BUNDLE_GRAPHIFY_VERSION="$(jq -r '.graphify_version' "${META_JSON}")"
 if git rev-parse --is-inside-work-tree >/dev/null 2>&1 && \
    git cat-file -e "${BUNDLE_SHA}" 2>/dev/null; then
   if git merge-base --is-ancestor "${BUNDLE_SHA}" HEAD 2>/dev/null; then
-    : # bundle's source is an ancestor of HEAD -- normal, no staleness note needed.
+    behind_count="$(git rev-list --count "${BUNDLE_SHA}..HEAD" 2>/dev/null || echo 0)"
+    if [[ "${behind_count}" -gt 0 ]]; then
+      warn "Note: published graph is ${behind_count} commit(s) behind local HEAD -- it doesn't yet reflect your most recent local commits."
+    fi
   else
     warn "Note: published graph's source (${BUNDLE_SHA:0:12}) is not an ancestor of local HEAD -- local checkout may be on a branch ahead of or diverged from what generated this graph."
   fi
@@ -99,18 +126,31 @@ else
 fi
 
 # --- Step 5: version check ---
-LOCAL_GRAPHIFY_VERSION="$(graphify --version 2>/dev/null | tr -d '[:space:]')"
+# graphify --version's output includes non-numeric text (e.g. "graphify
+# 0.9.41"); stripping whitespace alone leaves "graphify0.9.41", which would
+# never equal metadata.json's bare-number graphify_version and would refuse
+# every fetch. Extract just the numeric version on both sides (see the same
+# fix in the graph-refresh workflow that writes graphify_version).
+LOCAL_GRAPHIFY_VERSION="$(graphify --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
 if [[ -n "${LOCAL_GRAPHIFY_VERSION}" && "${LOCAL_GRAPHIFY_VERSION}" != "${BUNDLE_GRAPHIFY_VERSION}" ]]; then
   warn "graphify version mismatch: published graph was generated with ${BUNDLE_GRAPHIFY_VERSION}, local install is ${LOCAL_GRAPHIFY_VERSION}. Refusing to load -- upgrade with: uv tool install --upgrade graphifyy (or: pipx upgrade graphifyy)."
   fall_back_to_local "Version mismatch"
 fi
 
 # --- Step 6: atomic swap ---
+# Rename-based, never delete-before-replace: at every point in time either
+# the old graphify-out/ or the new one exists on disk. If this script is
+# killed (e.g. by its own hook timeout) between the two `mv`s, the old graph
+# is still there under GRAPH_DIR -- there is no window where GRAPH_DIR is
+# simply missing.
 date -u +%s > "${TMP_DIR}/extracted/.last-fetch-at"
-rm -rf "${GRAPH_DIR}.tmp"
+rm -rf "${GRAPH_DIR}.tmp" "${GRAPH_DIR}.old"
 mv "${TMP_DIR}/extracted" "${GRAPH_DIR}.tmp"
-rm -rf "${GRAPH_DIR}"
+if [[ -d "${GRAPH_DIR}" ]]; then
+  mv "${GRAPH_DIR}" "${GRAPH_DIR}.old"
+fi
 mv "${GRAPH_DIR}.tmp" "${GRAPH_DIR}"
+rm -rf "${GRAPH_DIR}.old"
 
 warn "Fetched graph (source ${BUNDLE_SHA:0:12}, graphify ${BUNDLE_GRAPHIFY_VERSION}) into ${GRAPH_DIR}/."
 exit 0

--- a/.claude/hooks/fetch-graphify-brain.sh
+++ b/.claude/hooks/fetch-graphify-brain.sh
@@ -86,7 +86,12 @@ fi
 if grep -qE '^/|(^|/)\.\.(/|$)' "${TMP_DIR}/members.txt"; then
   fall_back_to_local "Downloaded bundle contains unsafe path entries (path traversal guard)"
 fi
-if tar tvzf "${TMP_DIR}/graphify-bundle.tar.gz" 2>/dev/null | grep -qE -- '-> |link to'; then
+# GNU tar's verbose listing leads each line with a type character (like
+# `ls -l`): '-' regular, 'l' symlink, 'h' hardlink (verified directly:
+# `l` and `h` are real leading characters, not just human-readable "->"/
+# "link to" text) -- match on that instead of the arrow/text, which could
+# false-positive on a filename that happens to contain those substrings.
+if tar tvzf "${TMP_DIR}/graphify-bundle.tar.gz" 2>/dev/null | grep -qE '^[lh]'; then
   fall_back_to_local "Downloaded bundle contains symlink/hardlink entries (rejected for safety)"
 fi
 
@@ -133,8 +138,18 @@ fi
 # fix in the graph-refresh workflow that writes graphify_version).
 LOCAL_GRAPHIFY_VERSION="$(graphify --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
 if [[ -n "${LOCAL_GRAPHIFY_VERSION}" && "${LOCAL_GRAPHIFY_VERSION}" != "${BUNDLE_GRAPHIFY_VERSION}" ]]; then
-  warn "graphify version mismatch: published graph was generated with ${BUNDLE_GRAPHIFY_VERSION}, local install is ${LOCAL_GRAPHIFY_VERSION}. Refusing to load -- upgrade with: uv tool install --upgrade graphifyy (or: pipx upgrade graphifyy)."
-  fall_back_to_local "Version mismatch"
+  # Direction matters: a local install *older* than what generated the graph
+  # is a real compatibility risk worth refusing over. A local install
+  # *newer* than the bundle isn't -- telling that developer to "upgrade"
+  # would be backwards. `sort -V` (real version-aware ordering, not a
+  # hand-rolled semver comparator) decides which case this is.
+  newest="$(printf '%s\n%s\n' "${LOCAL_GRAPHIFY_VERSION}" "${BUNDLE_GRAPHIFY_VERSION}" | sort -V | tail -1)"
+  if [[ "${newest}" == "${BUNDLE_GRAPHIFY_VERSION}" ]]; then
+    warn "graphify version mismatch: published graph was generated with ${BUNDLE_GRAPHIFY_VERSION}, local install (${LOCAL_GRAPHIFY_VERSION}) is older. Refusing to load -- upgrade with: uv tool install --upgrade graphifyy (or: pipx upgrade graphifyy)."
+    fall_back_to_local "Version mismatch"
+  else
+    warn "Note: local graphify (${LOCAL_GRAPHIFY_VERSION}) is newer than the version that generated the published graph (${BUNDLE_GRAPHIFY_VERSION}) -- loading anyway, no action needed."
+  fi
 fi
 
 # --- Step 6: atomic swap ---

--- a/.claude/hooks/fetch-graphify-brain.sh
+++ b/.claude/hooks/fetch-graphify-brain.sh
@@ -104,7 +104,7 @@ fi
 GRAPH_JSON="${TMP_DIR}/extracted/graph.json"
 META_JSON="${TMP_DIR}/extracted/metadata.json"
 
-if [[ ! -f "${GRAPH_JSON}" ]] || ! jq -e 'has("nodes") and has("edges")' "${GRAPH_JSON}" >/dev/null 2>&1; then
+if [[ ! -f "${GRAPH_JSON}" ]] || ! jq -e 'has("nodes") and has("links")' "${GRAPH_JSON}" >/dev/null 2>&1; then
   fall_back_to_local "Downloaded graph.json is missing or malformed"
 fi
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,7 +33,7 @@
           },
           {
             "type": "command",
-            "command": "cd \"${CLAUDE_PROJECT_DIR}\" && bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/fetch-graphify-brain.sh\"",
+            "command": "bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/fetch-graphify-brain.sh\"",
             "timeout": 30
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,6 +30,11 @@
             "type": "command",
             "command": "bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/update-ai-context.sh\"",
             "timeout": 20
+          },
+          {
+            "type": "command",
+            "command": "cd \"${CLAUDE_PROJECT_DIR}\" && bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/fetch-graphify-brain.sh\"",
+            "timeout": 30
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,20 @@ fulfillment-service (proto)
 ```
 
 For deployment coordination (image tags, submodules), see `osac-installer/AGENTS.md`.
+
+## Knowledge Graph (graphify brain)
+
+CI keeps a structural code graph of this mono-repo fresh (`.github/workflows/graphify-brain-refresh.yaml`) and a `SessionStart` hook (`.claude/hooks/fetch-graphify-brain.sh`) pulls the latest published bundle into `graphify-out/` automatically at the start of every session — no manual step, and it fails open (falls back to normal cold exploration with a one-line warning) if the fetch fails or the graph is unavailable.
+
+To actually make use of the fetched graph, `graphify` itself needs to be installed once per developer machine:
+
+```bash
+uv tool install graphifyy   # recommended
+# or: pipx install graphifyy
+```
+
+Note the package name is `graphifyy` (double "y") — the CLI command itself is `graphify`, not a typo.
+
+Once installed, run `graphify claude install` once per checkout. This installs the `## graphify` CLAUDE.md directive and PreToolUse hook that make Claude Code actually consult the graph before Glob/Grep calls — the fetch hook above only keeps the graph's *data* current, it doesn't install the consumption side. **This has not been run against this repo yet** (no `graphify` binary was available to generate and verify its real output while wiring up the fetch pipeline) — whoever runs it first should commit the resulting CLAUDE.md/`.claude/settings.json` changes so the whole team inherits them, the same way this repo's other shared Claude Code configuration is committed.
+
+Do **not** run `graphify hook install` or `graphify --watch` in this repo — those enable local-generation automation that rebuilds the graph from your own uncommitted local state, which would clobber the CI-fetched, org-wide graph with an incomplete single-machine view. Generation is centralized in CI by design.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,9 +43,9 @@ For deployment coordination (image tags, submodules), see `osac-installer/AGENTS
 
 ## Knowledge Graph (graphify brain)
 
-CI keeps a structural code graph of this mono-repo fresh (`.github/workflows/graphify-brain-refresh.yaml`) and a `SessionStart` hook (`.claude/hooks/fetch-graphify-brain.sh`) pulls the latest published bundle into `graphify-out/` automatically at the start of every session — no manual step, and it fails open (falls back to normal cold exploration with a one-line warning) if the fetch fails or the graph is unavailable.
+CI keeps a structural code graph of this mono-repo fresh (`.github/workflows/graphify-brain-refresh.yaml`) and publishes it for pickup. After `graphify` is installed (see below), a `SessionStart` hook (`.claude/hooks/fetch-graphify-brain.sh`) fetches the latest published bundle into `graphify-out/` automatically at the start of every session — no manual fetch step — and it fails open (falls back to normal cold exploration with a one-line warning) if the fetch fails, `graphify` isn't installed, or the graph is otherwise unavailable.
 
-To actually make use of the fetched graph, `graphify` itself needs to be installed once per developer machine:
+`graphify` itself needs to be installed once per developer machine before any of this does anything useful:
 
 ```bash
 uv tool install graphifyy   # recommended


### PR DESCRIPTION
## Summary

SessionStart hook (`.claude/hooks/fetch-graphify-brain.sh`) that pulls the latest published graph bundle into `graphify-out/` automatically at the start of every Claude Code session. Pairs with #317 (the publish side).

## What it does

1. If `graphify` isn't installed, prints a one-line note and exits 0 -- never blocks session start.
2. Downloads the bundle from the `graph-latest` release (public repo, no auth).
3. Validates `graph.json` and `metadata.json` before touching any local state.
4. Logs a staleness note (commits behind local HEAD) -- informational only, never a hard rejection.
5. Refuses to load on a version mismatch where local is older, with the exact upgrade command; proceeds (with a note) when local is newer.
6. Extracts to a temp dir, then swaps into `graphify-out/` via rename (old copy kept until the new one is fully in place).
7. Every failure path falls back to whatever's already local, or signals "brain unavailable" -- always exits 0.

## `graphify claude install` -- not run here

That command installs the CLAUDE.md directive + PreToolUse hook that make Claude Code actually consult the graph. Needs a human to run it and review/commit the result, so it's documented in AGENTS.md as a deliberate follow-up rather than done in this PR.

## Verification

Tested against the real published bundle, not just fixtures: real `gh release download` of the actual 85K-node/125MB `graph.json`, real validation, real atomic swap, then a real `graphify query` against the result returned a correct, correctly-cited answer. Also verified the staleness count against real git history and confirmed the script is idempotent run twice back to back against the real bundle.

One real bug found and fixed this way: the schema check was written for `nodes`/`edges`, but graphify's real output is NetworkX-style `nodes`/`links` -- would have rejected every real bundle. Fixed and reverified end-to-end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically refreshes the project knowledge graph when a session starts.
  * Validates downloaded graph data and safely replaces outdated local data when appropriate.
  * Continues using existing local data or starts without a graph if refreshes fail.
* **Documentation**
  * Added guidance on knowledge graph updates, integration, installation status, and supported commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->