### PR TITLE
OSAC-3273, OSAC-4036: enforce Volume spec field immutability in Update

### DIFF
--- a/fulfillment-service/internal/servers/private_volumes_server.go
+++ b/fulfillment-service/internal/servers/private_volumes_server.go
@@ -161,12 +161,14 @@ func (s *PrivateVolumesServer) validateVolumeCreate(vol *privatev1.Volume) error
 
 func (s *PrivateVolumesServer) Update(ctx context.Context,
 	request *privatev1.VolumesUpdateRequest) (response *privatev1.VolumesUpdateResponse, err error) {
+	// Get the object identifier:
 	id := request.GetObject().GetId()
 	if id == "" {
 		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
 		return
 	}
 
+	// Fetch the existing object:
 	getRequest := &privatev1.VolumesGetRequest{}
 	getRequest.SetId(id)
 	var getResponse *privatev1.VolumesGetResponse
@@ -176,18 +178,32 @@ func (s *PrivateVolumesServer) Update(ctx context.Context,
 	}
 
 	existing := getResponse.GetObject()
-	merged := proto.Clone(existing).(*privatev1.Volume)
+
+	// Merge the update into a clone of the existing object:
+	merged := cloneVolume(existing)
 	applyVolumeUpdate(merged, request.GetObject(), request.GetUpdateMask())
 
-	err = validateVolumeSpecImmutability(merged, existing)
+	// Validate immutable fields:
+	err = validateVolumeImmutability(merged, existing)
 	if err != nil {
 		return
 	}
+
+	// Set the merged spec back into the request for the generic update:
+	request.GetObject().SetSpec(merged.GetSpec())
 
 	err = s.generic.Update(ctx, request, &response)
 	return
 }
 
+// cloneVolume creates a deep copy of a Volume.
+func cloneVolume(v *privatev1.Volume) *privatev1.Volume {
+	return proto.Clone(v).(*privatev1.Volume)
+}
+
+// applyVolumeUpdate applies the update fields onto the base object, respecting the field mask.
+// If no mask is provided, all fields from the update are applied.
+// Field mask paths use the spec/status prefix (e.g., "spec.storage_tier", "status.state") per API conventions.
 func applyVolumeUpdate(base, update *privatev1.Volume, mask *fieldmaskpb.FieldMask) {
 	if mask == nil || len(mask.GetPaths()) == 0 {
 		proto.Merge(base, update)
@@ -202,12 +218,18 @@ func applyVolumeUpdate(base, update *privatev1.Volume, mask *fieldmaskpb.FieldMa
 		case "spec.access_mode":
 			base.GetSpec().SetAccessMode(update.GetSpec().GetAccessMode())
 		case "spec.pvc_ref":
+			// pvc_ref is intentionally mutable: set by the CSI driver post-creation.
 			base.GetSpec().SetPvcRef(update.GetSpec().GetPvcRef())
+		default:
+			// Unknown paths are handled by the generic update layer.
 		}
 	}
 }
 
-func validateVolumeSpecImmutability(merged, existing *privatev1.Volume) error {
+// validateVolumeImmutability checks that immutable spec fields have not been changed.
+// storage_tier, size_gib, and access_mode are immutable after creation because they are
+// provisioned directly into the vendor CSI call and cannot be modified post-creation.
+func validateVolumeImmutability(merged, existing *privatev1.Volume) error {
 	if merged.GetSpec().GetStorageTier() != existing.GetSpec().GetStorageTier() {
 		return grpcstatus.Errorf(grpccodes.InvalidArgument,
 			"field 'spec.storage_tier' is immutable and cannot be changed after creation")

--- a/fulfillment-service/internal/servers/private_volumes_server.go
+++ b/fulfillment-service/internal/servers/private_volumes_server.go
@@ -21,6 +21,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/auth"
@@ -159,8 +161,66 @@ func (s *PrivateVolumesServer) validateVolumeCreate(vol *privatev1.Volume) error
 
 func (s *PrivateVolumesServer) Update(ctx context.Context,
 	request *privatev1.VolumesUpdateRequest) (response *privatev1.VolumesUpdateResponse, err error) {
+	id := request.GetObject().GetId()
+	if id == "" {
+		err = grpcstatus.Errorf(grpccodes.InvalidArgument, "object identifier is mandatory")
+		return
+	}
+
+	getRequest := &privatev1.VolumesGetRequest{}
+	getRequest.SetId(id)
+	var getResponse *privatev1.VolumesGetResponse
+	err = s.generic.Get(ctx, getRequest, &getResponse)
+	if err != nil {
+		return
+	}
+
+	existing := getResponse.GetObject()
+	merged := proto.Clone(existing).(*privatev1.Volume)
+	applyVolumeUpdate(merged, request.GetObject(), request.GetUpdateMask())
+
+	err = validateVolumeSpecImmutability(merged, existing)
+	if err != nil {
+		return
+	}
+
 	err = s.generic.Update(ctx, request, &response)
 	return
+}
+
+func applyVolumeUpdate(base, update *privatev1.Volume, mask *fieldmaskpb.FieldMask) {
+	if mask == nil || len(mask.GetPaths()) == 0 {
+		proto.Merge(base, update)
+		return
+	}
+	for _, path := range mask.GetPaths() {
+		switch path {
+		case "spec.storage_tier":
+			base.GetSpec().SetStorageTier(update.GetSpec().GetStorageTier())
+		case "spec.size_gib":
+			base.GetSpec().SetSizeGib(update.GetSpec().GetSizeGib())
+		case "spec.access_mode":
+			base.GetSpec().SetAccessMode(update.GetSpec().GetAccessMode())
+		case "spec.pvc_ref":
+			base.GetSpec().SetPvcRef(update.GetSpec().GetPvcRef())
+		}
+	}
+}
+
+func validateVolumeSpecImmutability(merged, existing *privatev1.Volume) error {
+	if merged.GetSpec().GetStorageTier() != existing.GetSpec().GetStorageTier() {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.storage_tier' is immutable and cannot be changed after creation")
+	}
+	if merged.GetSpec().GetSizeGib() != existing.GetSpec().GetSizeGib() {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.size_gib' is immutable and cannot be changed after creation")
+	}
+	if merged.GetSpec().GetAccessMode() != existing.GetSpec().GetAccessMode() {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"field 'spec.access_mode' is immutable and cannot be changed after creation")
+	}
+	return nil
 }
 
 func (s *PrivateVolumesServer) Delete(ctx context.Context,

--- a/fulfillment-service/internal/servers/private_volumes_server_test.go
+++ b/fulfillment-service/internal/servers/private_volumes_server_test.go
@@ -517,6 +517,27 @@ var _ = Describe("Private volumes server", func() {
 				Expect(st.Code()).To(Equal(codes.InvalidArgument))
 				Expect(st.Message()).To(ContainSubstring("access_mode"))
 			})
+
+			It("Allows update that sends unchanged spec values", func() {
+				created := createVolume()
+
+				_, err := server.Update(ctx, privatev1.VolumesUpdateRequest_builder{
+					Object: privatev1.Volume_builder{
+						Id: created.GetId(),
+						Spec: privatev1.VolumeSpec_builder{
+							StorageTier: "gold",
+							SizeGib:     100,
+							AccessMode:  privatev1.VolumeAccessMode_VOLUME_ACCESS_MODE_READ_WRITE_ONCE,
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{
+						"spec.storage_tier",
+						"spec.size_gib",
+						"spec.access_mode",
+					}},
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 
 		Describe("Signal", func() {

--- a/fulfillment-service/internal/servers/private_volumes_server_test.go
+++ b/fulfillment-service/internal/servers/private_volumes_server_test.go
@@ -448,6 +448,77 @@ var _ = Describe("Private volumes server", func() {
 			})
 		})
 
+		Describe("Spec immutability", func() {
+			It("Rejects update that changes storage_tier", func() {
+				created := createVolume()
+
+				_, err := server.Update(ctx, privatev1.VolumesUpdateRequest_builder{
+					Object: privatev1.Volume_builder{
+						Id: created.GetId(),
+						Spec: privatev1.VolumeSpec_builder{
+							StorageTier: "silver",
+							SizeGib:     100,
+							AccessMode:  privatev1.VolumeAccessMode_VOLUME_ACCESS_MODE_READ_WRITE_ONCE,
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.storage_tier"}},
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				st, ok := status.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(st.Code()).To(Equal(codes.InvalidArgument))
+				Expect(st.Message()).To(ContainSubstring("storage_tier"))
+			})
+
+			It("Rejects update that changes size_gib and preserves the original value", func() {
+				created := createVolume()
+
+				_, err := server.Update(ctx, privatev1.VolumesUpdateRequest_builder{
+					Object: privatev1.Volume_builder{
+						Id: created.GetId(),
+						Spec: privatev1.VolumeSpec_builder{
+							StorageTier: "gold",
+							SizeGib:     999,
+							AccessMode:  privatev1.VolumeAccessMode_VOLUME_ACCESS_MODE_READ_WRITE_ONCE,
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.size_gib"}},
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				st, ok := status.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(st.Code()).To(Equal(codes.InvalidArgument))
+				Expect(st.Message()).To(ContainSubstring("size_gib"))
+
+				getResponse, err := server.Get(ctx, privatev1.VolumesGetRequest_builder{
+					Id: created.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getResponse.GetObject().GetSpec().GetSizeGib()).To(Equal(int64(100)))
+			})
+
+			It("Rejects update that changes access_mode", func() {
+				created := createVolume()
+
+				_, err := server.Update(ctx, privatev1.VolumesUpdateRequest_builder{
+					Object: privatev1.Volume_builder{
+						Id: created.GetId(),
+						Spec: privatev1.VolumeSpec_builder{
+							StorageTier: "gold",
+							SizeGib:     100,
+							AccessMode:  privatev1.VolumeAccessMode_VOLUME_ACCESS_MODE_READ_WRITE_MANY,
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.access_mode"}},
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				st, ok := status.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(st.Code()).To(Equal(codes.InvalidArgument))
+				Expect(st.Message()).To(ContainSubstring("access_mode"))
+			})
+		})
+
 		Describe("Signal", func() {
 			It("Signal succeeds for existing volume", func() {
 				created := createVolume()


### PR DESCRIPTION
## Summary

Fixes a bug (found during E2E testing, TC-A5) where Volume spec fields (`storage_tier`, `size_gib`, `access_mode`) could be silently modified after creation via PATCH. Adds server-side immutability validation to `PrivateVolumesServer.Update()` following the same pattern used by `PrivateBareMetalInstanceTypesServer`. No operator or Helm changes.

## Why

The `volumes` table has a `check_immutable_columns` DB trigger that protects top-level columns (`id`, `name`, `tenant`, `project`), but spec fields live inside the `data` JSONB column which the trigger cannot inspect. `Update()` previously delegated directly to `generic.Update()` with no validation, so any spec value could be overwritten.

Spec fields are provisioned directly into the vendor CSI call: the storage tier selects the backend, the size and access mode are set on the PVC. Changing them after creation would produce a split-brain between what the fulfillment-service records and what the vendor actually provisioned.

## Testing

```bash
cd fulfillment-service

# Spec immutability tests (4 specs: 3 rejection + 1 positive)
go run github.com/onsi/ginkgo/v2/ginkgo run --focus="Spec immutability" internal/servers

# Full servers suite — 1587 specs, 0 failures
go run github.com/onsi/ginkgo/v2/ginkgo run -r internal
```

## Ticket

**Feature**: [OSAC-2872](https://redhat.atlassian.net/browse/OSAC-2872) (Storage Control Plane)

**Epic**: [OSAC-3273](https://redhat.atlassian.net/browse/OSAC-3273) (Volume API, Inventory & Storage Logic)

**Task**: [OSAC-4036](https://redhat.atlassian.net/browse/OSAC-4036) (Enforce spec field immutability in Volume Update endpoint)

<br>

<small>Signed-off-by: akshaynadkarni <25892229+akshaynadkarni@users.noreply.github.com></small>
<small>Assisted-by: Claude Code <noreply@anthropic.com></small>