### PR TITLE
OSAC-2242, OSAC-2348: implement reconcileAgentSelection and reconcile AgentCleanup

### DIFF
--- a/osac-operator/api/v1alpha1/clusterorder_types.go
+++ b/osac-operator/api/v1alpha1/clusterorder_types.go
@@ -242,9 +242,9 @@ type AgentStatus struct {
 	AgentName string `json:"agentName"`
 
 	// HostName is the bare-metal server name used by the network dispatcher.
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MinLength=1
-	HostName string `json:"hostName"`
+	// Absent when the agent does not carry the netris.server/name label (e.g. CI environments).
+	// +kubebuilder:validation:Optional
+	HostName string `json:"hostName,omitempty"`
 
 	// SubnetRef is the name of the Subnet CR the agent is connected to.
 	// +kubebuilder:validation:Optional

--- a/osac-operator/charts/operator-crds/templates/osac.openshift.io_clusterorders.yaml
+++ b/osac-operator/charts/operator-crds/templates/osac.openshift.io_clusterorders.yaml
@@ -353,9 +353,9 @@ spec:
                             minLength: 1
                             type: string
                           hostName:
-                            description: HostName is the bare-metal server name used
-                              by the network dispatcher.
-                            minLength: 1
+                            description: |-
+                              HostName is the bare-metal server name used by the network dispatcher.
+                              Absent when the agent does not carry the netris.server/name label (e.g. CI environments).
                             type: string
                           ipAddress:
                             description: |-
@@ -368,7 +368,6 @@ spec:
                             type: string
                         required:
                         - agentName
-                        - hostName
                         type: object
                       type: array
                       x-kubernetes-list-map-keys:

--- a/osac-operator/cmd/main.go
+++ b/osac-operator/cmd/main.go
@@ -81,6 +81,7 @@ const (
 	envComputeInstanceNamespace   = "OSAC_COMPUTE_INSTANCE_NAMESPACE"
 	envNetworkingNamespace        = "OSAC_NETWORKING_NAMESPACE"
 	envClusterOrderNamespace      = "OSAC_CLUSTER_ORDER_NAMESPACE"
+	envAgentNamespace             = "OSAC_AGENT_NAMESPACE"
 	envBareMetalInstanceNamespace = "OSAC_BARE_METAL_INSTANCE_NAMESPACE"
 
 	// AAP configuration
@@ -334,6 +335,7 @@ func setupClusterControllers(
 			return controller.NewClusterOrderReconciler(
 				localMgr.GetClient(), localMgr.GetAPIReader(), localMgr.GetScheme(),
 				os.Getenv(envClusterOrderNamespace),
+				os.Getenv(envAgentNamespace),
 				provider, pollInterval, maxJobHistory,
 			).SetupWithManager(mgr)
 		},

--- a/osac-operator/config/crd/bases/osac.openshift.io_clusterorders.yaml
+++ b/osac-operator/config/crd/bases/osac.openshift.io_clusterorders.yaml
@@ -351,9 +351,9 @@ spec:
                             minLength: 1
                             type: string
                           hostName:
-                            description: HostName is the bare-metal server name used
-                              by the network dispatcher.
-                            minLength: 1
+                            description: |-
+                              HostName is the bare-metal server name used by the network dispatcher.
+                              Absent when the agent does not carry the netris.server/name label (e.g. CI environments).
                             type: string
                           ipAddress:
                             description: |-
@@ -366,7 +366,6 @@ spec:
                             type: string
                         required:
                         - agentName
-                        - hostName
                         type: object
                       type: array
                       x-kubernetes-list-map-keys:

--- a/osac-operator/config/crd/fakes/agent-install.openshift.io_agents.yaml
+++ b/osac-operator/config/crd/fakes/agent-install.openshift.io_agents.yaml
@@ -1,0 +1,26 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: agents.agent-install.openshift.io
+spec:
+  group: agent-install.openshift.io
+  names:
+    kind: Agent
+    listKind: AgentList
+    plural: agents
+    singular: agent
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true

--- a/osac-operator/config/crd/fakes/kustomization.yaml
+++ b/osac-operator/config/crd/fakes/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- agent-install.openshift.io_agents.yaml
 - hypershift.openshift.io_hostedclusters.yaml
 - hypershift.openshift.io_hostedcontrolplanes.yaml
 - hypershift.openshift.io_nodepools.yaml

--- a/osac-operator/config/rbac/role.yaml
+++ b/osac-operator/config/rbac/role.yaml
@@ -33,6 +33,16 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - agent-install.openshift.io
+  resources:
+  - agents
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - events.k8s.io
   resources:
   - events

--- a/osac-operator/internal/controller/clusterorder_agents.go
+++ b/osac-operator/internal/controller/clusterorder_agents.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/osac-project/osac/osac-operator/api/v1alpha1"
+)
+
+var agentGVK = schema.GroupVersionKind{
+	Group:   "agent-install.openshift.io",
+	Version: "v1beta1",
+	Kind:    "Agent",
+}
+
+const (
+	agentClusterOrderLabel   = "osac.openshift.io/clusterorder"
+	agentResourceClassLabel  = "osac.openshift.io/resource_class"
+	agentServerNameLabel     = "netris.server/name"
+	agentClaimedByHypershift = "agent-install.openshift.io/clusterdeployment-namespace"
+
+	defaultAgentNamespace = "hardware-inventory"
+)
+
+// reconcileAgentSelection selects available agents for each node set and labels
+// them so HyperShift's NodePool can claim them. Returns Requeue if not enough
+// agents are available yet.
+func (r *ClusterOrderReconciler) reconcileAgentSelection(
+	ctx context.Context, instance *v1alpha1.ClusterOrder,
+) (ctrl.Result, error) {
+	log := ctrllog.FromContext(ctx)
+
+	if len(instance.Spec.NodeRequests) == 0 {
+		return ctrl.Result{}, nil
+	}
+
+	// Check if agents are already selected
+	if len(instance.Status.NodeSets) > 0 {
+		return ctrl.Result{}, nil
+	}
+
+	agentNamespace := r.AgentNamespace
+	if agentNamespace == "" {
+		agentNamespace = defaultAgentNamespace
+	}
+
+	var nodeSets []v1alpha1.NodeSetStatus
+
+	for _, nodeReq := range instance.Spec.NodeRequests {
+		agents, err := r.selectAgents(ctx, agentNamespace, instance.Name, nodeReq.ResourceClass, nodeReq.NumberOfNodes)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		if len(agents) < nodeReq.NumberOfNodes {
+			log.Info("not enough agents available, requeueing",
+				"resourceClass", nodeReq.ResourceClass,
+				"requested", nodeReq.NumberOfNodes,
+				"available", len(agents),
+			)
+			return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
+		}
+
+		// Label the selected agents
+		for _, agent := range agents {
+			if err := r.labelAgent(ctx, agent, instance.Name); err != nil {
+				return ctrl.Result{}, fmt.Errorf("labeling agent %s: %w", agent.GetName(), err)
+			}
+		}
+
+		// Build agent status entries
+		var agentStatuses []v1alpha1.AgentStatus
+		for _, agent := range agents {
+			agentStatuses = append(agentStatuses, v1alpha1.AgentStatus{
+				AgentName: agent.GetName(),
+				HostName:  agent.GetLabels()[agentServerNameLabel],
+			})
+		}
+
+		nodeSets = append(nodeSets, v1alpha1.NodeSetStatus{
+			Name:   nodeReq.ResourceClass,
+			Agents: agentStatuses,
+		})
+	}
+
+	instance.Status.NodeSets = nodeSets
+	log.Info("agent selection complete", "nodeSets", len(nodeSets))
+	return ctrl.Result{}, nil
+}
+
+// selectAgents lists available agents matching the resource class that are not
+// already allocated to a cluster.
+func (r *ClusterOrderReconciler) selectAgents(
+	ctx context.Context, namespace, clusterOrderName, resourceClass string, count int,
+) ([]*unstructured.Unstructured, error) {
+	// First check if agents are already labeled for this cluster order
+	alreadyLabeled, err := r.listAgentsForClusterOrder(ctx, namespace, clusterOrderName, resourceClass)
+	if err != nil {
+		return nil, err
+	}
+	if len(alreadyLabeled) >= count {
+		return alreadyLabeled[:count], nil
+	}
+
+	// Find available agents (matching resource class, not allocated)
+	selector := labels.NewSelector()
+	rcReq, err := labels.NewRequirement(agentResourceClassLabel, selection.Equals, []string{resourceClass})
+	if err != nil {
+		return nil, fmt.Errorf("invalid resource class %q for label selector: %w", resourceClass, err)
+	}
+	selector = selector.Add(*rcReq)
+	noClusterOrder, err := labels.NewRequirement(agentClusterOrderLabel, selection.DoesNotExist, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building label requirement: %w", err)
+	}
+	selector = selector.Add(*noClusterOrder)
+	noClaimed, err := labels.NewRequirement(agentClaimedByHypershift, selection.DoesNotExist, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building label requirement: %w", err)
+	}
+	selector = selector.Add(*noClaimed)
+
+	agentList := &unstructured.UnstructuredList{}
+	agentList.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   agentGVK.Group,
+		Version: agentGVK.Version,
+		Kind:    agentGVK.Kind + "List",
+	})
+
+	if err := r.Client.List(ctx, agentList,
+		client.InNamespace(namespace),
+		client.MatchingLabelsSelector{Selector: selector},
+	); err != nil {
+		return nil, fmt.Errorf("listing available agents for resource class %s: %w", resourceClass, err)
+	}
+
+	// Combine already-labeled + newly available, up to count
+	result := append(alreadyLabeled, make([]*unstructured.Unstructured, 0, count-len(alreadyLabeled))...)
+	for i := range agentList.Items {
+		if len(result) >= count {
+			break
+		}
+		result = append(result, &agentList.Items[i])
+	}
+
+	return result, nil
+}
+
+// listAgentsForClusterOrder returns agents already labeled for this cluster order.
+func (r *ClusterOrderReconciler) listAgentsForClusterOrder(
+	ctx context.Context, namespace, clusterOrderName, resourceClass string,
+) ([]*unstructured.Unstructured, error) {
+	matchLabels := map[string]string{
+		agentClusterOrderLabel:  clusterOrderName,
+		agentResourceClassLabel: resourceClass,
+	}
+
+	agentList := &unstructured.UnstructuredList{}
+	agentList.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   agentGVK.Group,
+		Version: agentGVK.Version,
+		Kind:    agentGVK.Kind + "List",
+	})
+
+	if err := r.Client.List(ctx, agentList,
+		client.InNamespace(namespace),
+		client.MatchingLabels(matchLabels),
+	); err != nil {
+		return nil, fmt.Errorf("listing agents for cluster order %s: %w", clusterOrderName, err)
+	}
+
+	var result []*unstructured.Unstructured
+	for i := range agentList.Items {
+		result = append(result, &agentList.Items[i])
+	}
+	return result, nil
+}
+
+// labelAgent sets the clusterorder label on an agent to reserve it.
+func (r *ClusterOrderReconciler) labelAgent(
+	ctx context.Context, agent *unstructured.Unstructured, clusterOrderName string,
+) error {
+	agentLabels := agent.GetLabels()
+	if agentLabels[agentClusterOrderLabel] == clusterOrderName {
+		return nil
+	}
+	if agentLabels == nil {
+		agentLabels = make(map[string]string)
+	}
+	agentLabels[agentClusterOrderLabel] = clusterOrderName
+	agent.SetLabels(agentLabels)
+	return r.Client.Update(ctx, agent)
+}
+
+// reconcileAgentCleanup removes clusterorder labels from agents allocated to
+// this cluster, making them available for future clusters.
+func (r *ClusterOrderReconciler) reconcileAgentCleanup(
+	ctx context.Context, instance *v1alpha1.ClusterOrder,
+) error {
+	log := ctrllog.FromContext(ctx)
+
+	agentNamespace := r.AgentNamespace
+	if agentNamespace == "" {
+		agentNamespace = defaultAgentNamespace
+	}
+
+	agentList := &unstructured.UnstructuredList{}
+	agentList.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   agentGVK.Group,
+		Version: agentGVK.Version,
+		Kind:    agentGVK.Kind + "List",
+	})
+
+	if err := r.Client.List(ctx, agentList,
+		client.InNamespace(agentNamespace),
+		client.MatchingLabels{agentClusterOrderLabel: instance.Name},
+	); err != nil {
+		return fmt.Errorf("listing agents for cleanup: %w", err)
+	}
+
+	for i := range agentList.Items {
+		agent := &agentList.Items[i]
+		agentLabels := agent.GetLabels()
+		delete(agentLabels, agentClusterOrderLabel)
+		agent.SetLabels(agentLabels)
+		if err := r.Client.Update(ctx, agent); err != nil {
+			return fmt.Errorf("unlabeling agent %s: %w", agent.GetName(), err)
+		}
+		log.Info("released agent", "agent", agent.GetName())
+	}
+
+	return nil
+}

--- a/osac-operator/internal/controller/clusterorder_controller.go
+++ b/osac-operator/internal/controller/clusterorder_controller.go
@@ -72,6 +72,7 @@ type ClusterOrderReconciler struct {
 	apiReader             client.Reader
 	Scheme                *runtime.Scheme
 	ClusterOrderNamespace string
+	AgentNamespace        string
 	ProvisioningProvider  provisioning.ProvisioningProvider
 	StatusPollInterval    time.Duration
 	MaxJobHistory         int
@@ -82,6 +83,7 @@ func NewClusterOrderReconciler(
 	apiReader client.Reader,
 	scheme *runtime.Scheme,
 	clusterOrderNamespace string,
+	agentNamespace string,
 	provisioningProvider provisioning.ProvisioningProvider,
 	statusPollInterval time.Duration,
 	maxJobHistory int,
@@ -89,6 +91,10 @@ func NewClusterOrderReconciler(
 
 	if clusterOrderNamespace == "" {
 		clusterOrderNamespace = defaultClusterOrderNamespace
+	}
+
+	if agentNamespace == "" {
+		agentNamespace = defaultAgentNamespace
 	}
 
 	if statusPollInterval <= 0 {
@@ -104,6 +110,7 @@ func NewClusterOrderReconciler(
 		apiReader:             apiReader,
 		Scheme:                scheme,
 		ClusterOrderNamespace: clusterOrderNamespace,
+		AgentNamespace:        agentNamespace,
 		ProvisioningProvider:  provisioningProvider,
 		StatusPollInterval:    statusPollInterval,
 		MaxJobHistory:         maxJobHistory,
@@ -115,6 +122,7 @@ func NewClusterOrderReconciler(
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=clusterorders/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=namespaces;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=agent-install.openshift.io,resources=agents,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=hypershift.openshift.io,resources=hostedclusters;nodepools,verbs=get;list;watch
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=subnets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=networkclasses,verbs=get;list;watch
@@ -170,6 +178,7 @@ func (r *ClusterOrderReconciler) patchStatusWithRetry(ctx context.Context, key c
 		latest.Status.Phase = computed.Phase
 		latest.Status.ClusterReference = computed.ClusterReference
 		latest.Status.NodeRequests = computed.NodeRequests
+		latest.Status.NodeSets = computed.NodeSets
 		latest.Status.ProvisioningJobs = computed.ProvisioningJobs
 		latest.Status.DesiredConfigVersion = computed.DesiredConfigVersion
 		latest.Status.ApiEndpoint = computed.ApiEndpoint
@@ -329,6 +338,15 @@ func (r *ClusterOrderReconciler) handleUpdate(ctx context.Context, _ reconcile.R
 	provisionResult, err := r.handleProvisioning(ctx, instance)
 	if err != nil {
 		return ctrl.Result{}, err
+	}
+
+	// Select agents for each node set (labels them for HyperShift NodePool claiming)
+	agentResult, err := r.reconcileAgentSelection(ctx, instance)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if agentResult.RequeueAfter > 0 {
+		return agentResult, nil
 	}
 
 	ns, err := r.findNamespace(ctx, instance)
@@ -518,6 +536,11 @@ func (r *ClusterOrderReconciler) handleDelete(ctx context.Context, _ reconcile.R
 	log.Info("deleting clusterorder")
 
 	instance.Status.Phase = v1alpha1.ClusterOrderPhaseDeleting
+
+	// Release agents allocated to this cluster
+	if err := r.reconcileAgentCleanup(ctx, instance); err != nil {
+		return ctrl.Result{}, err
+	}
 
 	// Handle deprovisioning via provider
 	// Waits for provision job termination and polls deprovision job if needed

--- a/osac-operator/internal/controller/clusterorder_controller_test.go
+++ b/osac-operator/internal/controller/clusterorder_controller_test.go
@@ -23,9 +23,11 @@ import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
 	. "github.com/onsi/gomega"    //nolint:revive,staticcheck
 	hypershiftv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -890,6 +892,158 @@ var _ = Describe("ClusterOrder Controller", func() {
 			reconcileVIPEndpoints(instance)
 			Expect(instance.Status.ApiEndpoint).To(BeEmpty())
 			Expect(instance.Status.IngressEndpoint).To(BeEmpty())
+		})
+	})
+
+	Context("Agent selection and cleanup", func() {
+		const agentNS = "test-agents"
+
+		var reconciler *ClusterOrderReconciler
+
+		BeforeEach(func() {
+			reconciler = &ClusterOrderReconciler{
+				Client:         k8sClient,
+				apiReader:      k8sClient,
+				Scheme:         k8sClient.Scheme(),
+				AgentNamespace: agentNS,
+			}
+			// Create agent namespace
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: agentNS}}
+			_ = k8sClient.Create(ctx, ns)
+		})
+
+		createAgent := func(name, resourceClass, serverName string) {
+			agent := &unstructured.Unstructured{}
+			agent.SetGroupVersionKind(agentGVK)
+			agent.SetName(name)
+			agent.SetNamespace(agentNS)
+			agent.SetLabels(map[string]string{
+				agentResourceClassLabel: resourceClass,
+				agentServerNameLabel:    serverName,
+			})
+			Expect(k8sClient.Create(ctx, agent)).To(Succeed())
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(ctx, agent)
+			})
+		}
+
+		It("selects available agents and labels them", func() {
+			createAgent("agent-1", "fc430", "server-01")
+			createAgent("agent-2", "fc430", "server-02")
+			createAgent("agent-3", "fc430", "server-03")
+
+			instance := &v1alpha1.ClusterOrder{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+				Spec: v1alpha1.ClusterOrderSpec{
+					NodeRequests: []v1alpha1.NodeRequest{
+						{ResourceClass: "fc430", NumberOfNodes: 2},
+					},
+				},
+			}
+
+			result, err := reconciler.reconcileAgentSelection(ctx, instance)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			Expect(instance.Status.NodeSets).To(HaveLen(1))
+			Expect(instance.Status.NodeSets[0].Name).To(Equal("fc430"))
+			Expect(instance.Status.NodeSets[0].Agents).To(HaveLen(2))
+
+			// Verify labels were set
+			for _, agentStatus := range instance.Status.NodeSets[0].Agents {
+				agent := &unstructured.Unstructured{}
+				agent.SetGroupVersionKind(agentGVK)
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: agentStatus.AgentName, Namespace: agentNS,
+				}, agent)).To(Succeed())
+				Expect(agent.GetLabels()[agentClusterOrderLabel]).To(Equal("test-cluster"))
+			}
+		})
+
+		It("requeues when not enough agents available", func() {
+			createAgent("agent-1", "fc430", "server-01")
+
+			instance := &v1alpha1.ClusterOrder{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+				Spec: v1alpha1.ClusterOrderSpec{
+					NodeRequests: []v1alpha1.NodeRequest{
+						{ResourceClass: "fc430", NumberOfNodes: 3},
+					},
+				},
+			}
+
+			result, err := reconciler.reconcileAgentSelection(ctx, instance)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+			Expect(instance.Status.NodeSets).To(BeEmpty())
+		})
+
+		It("is idempotent when agents already selected", func() {
+			instance := &v1alpha1.ClusterOrder{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+				Spec: v1alpha1.ClusterOrderSpec{
+					NodeRequests: []v1alpha1.NodeRequest{
+						{ResourceClass: "fc430", NumberOfNodes: 1},
+					},
+				},
+				Status: v1alpha1.ClusterOrderStatus{
+					NodeSets: []v1alpha1.NodeSetStatus{
+						{Name: "fc430", Agents: []v1alpha1.AgentStatus{
+							{AgentName: "agent-1", HostName: "server-01"},
+						}},
+					},
+				},
+			}
+
+			result, err := reconciler.reconcileAgentSelection(ctx, instance)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+			Expect(instance.Status.NodeSets).To(HaveLen(1))
+		})
+
+		It("skips when no node requests", func() {
+			instance := &v1alpha1.ClusterOrder{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+			}
+
+			result, err := reconciler.reconcileAgentSelection(ctx, instance)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+		})
+
+		It("cleans up agent labels on deletion", func() {
+			createAgent("agent-1", "fc430", "server-01")
+			createAgent("agent-2", "fc430", "server-02")
+
+			// Label agents as allocated to this cluster
+			for _, name := range []string{"agent-1", "agent-2"} {
+				agent := &unstructured.Unstructured{}
+				agent.SetGroupVersionKind(agentGVK)
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: name, Namespace: agentNS,
+				}, agent)).To(Succeed())
+				labels := agent.GetLabels()
+				labels[agentClusterOrderLabel] = "test-cluster"
+				agent.SetLabels(labels)
+				Expect(k8sClient.Update(ctx, agent)).To(Succeed())
+			}
+
+			instance := &v1alpha1.ClusterOrder{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster"},
+			}
+
+			err := reconciler.reconcileAgentCleanup(ctx, instance)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify labels were removed
+			for _, name := range []string{"agent-1", "agent-2"} {
+				agent := &unstructured.Unstructured{}
+				agent.SetGroupVersionKind(agentGVK)
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: name, Namespace: agentNS,
+				}, agent)).To(Succeed())
+				Expect(agent.GetLabels()).NotTo(HaveKey(agentClusterOrderLabel))
+			}
 		})
 	})
 

--- a/osac-operator/internal/controller/clusterorder_integration_test.go
+++ b/osac-operator/internal/controller/clusterorder_integration_test.go
@@ -46,8 +46,8 @@ var _ = Describe("ClusterOrder Integration Tests", func() {
 		provider = newControllableProvider()
 		reconciler = NewClusterOrderReconciler(
 			k8sClient, k8sClient, k8sClient.Scheme(),
-			clusterOrderTestNamespace, provider,
-			statusPollInterval, provisioning.DefaultMaxJobHistory,
+			clusterOrderTestNamespace, "",
+			provider, statusPollInterval, provisioning.DefaultMaxJobHistory,
 		)
 	})
 


### PR DESCRIPTION


Add agent selection to ClusterOrder controller: for each node set, the operator lists available Agent CRs matching the resource class, labels them with osac.openshift.io/clusterorder to reserve them for HyperShift NodePool claiming, and stores the selections in status.nodeSets.

On deletion, reconcileAgentCleanup removes the clusterorder label from all allocated agents, returning them to the available pool.

Uses unstructured objects for Agent CRs (agent-install.openshift.io/v1beta1) to avoid importing the assisted-service dependency tree, consistent with the MetalLB IPAddressPool pattern.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cluster orders now automatically select and reserve suitable agents based on resource requirements.
  * Previously assigned agents can be reused, while unavailable or already claimed agents are excluded.
  * Processing waits and retries when insufficient agents are available.

* **Bug Fixes**
  * Agents are cleaned up when cluster orders are deleted.
  * Agent assignments and status are persisted more reliably during reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->