### PR TITLE
OSAC-2077: CaaS template writes VIPs to ClusterOrder status

### DIFF
--- a/osac-aap/collections/ansible_collections/osac/service/roles/external_access/tasks/create.yaml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/external_access/tasks/create.yaml
@@ -3,3 +3,22 @@
   ansible.builtin.include_role:
     name: "{{ network_steps_collection }}.external_access"
     tasks_from: create.yaml
+
+- name: Write VIP annotations to ClusterOrder
+  kubernetes.core.k8s:
+    state: patched
+    definition:
+      apiVersion: osac.openshift.io/v1alpha1
+      kind: ClusterOrder
+      metadata:
+        name: "{{ cluster_order.metadata.name }}"
+        namespace: "{{ cluster_order.metadata.namespace }}"
+        annotations:
+          osac.openshift.io/api-endpoint: "{{ external_access_api_internal_ip }}"
+          osac.openshift.io/ingress-endpoint: >-
+            {{ external_access_metallb_ingress_ip | default(external_access_ingress_ip, true) }}
+  when:
+    - external_access_api_internal_ip is defined
+    - external_access_api_internal_ip | length > 0
+    - (external_access_metallb_ingress_ip is defined and external_access_metallb_ingress_ip | length > 0) or
+      (external_access_ingress_ip is defined and external_access_ingress_ip | length > 0)

--- a/osac-operator/internal/controller/clusterorder_controller.go
+++ b/osac-operator/internal/controller/clusterorder_controller.go
@@ -172,6 +172,8 @@ func (r *ClusterOrderReconciler) patchStatusWithRetry(ctx context.Context, key c
 		latest.Status.NodeRequests = computed.NodeRequests
 		latest.Status.ProvisioningJobs = computed.ProvisioningJobs
 		latest.Status.DesiredConfigVersion = computed.DesiredConfigVersion
+		latest.Status.ApiEndpoint = computed.ApiEndpoint
+		latest.Status.IngressEndpoint = computed.IngressEndpoint
 		for _, c := range computed.Conditions {
 			meta.SetStatusCondition(&latest.Status.Conditions, c)
 		}
@@ -367,6 +369,10 @@ func (r *ClusterOrderReconciler) handleHostedCluster(ctx context.Context, instan
 		}
 	}
 
+	// Copy VIP endpoints from annotations (written by the CaaS template's
+	// external_access step) into status fields for the feedback controller.
+	reconcileVIPEndpoints(instance)
+
 	// Fetch the node pools and handle them:
 	nodePools := &hypershiftv1beta1.NodePoolList{}
 	if err := r.List(ctx, nodePools, client.InNamespace(hc.Namespace), labelSelectorFromInstance(instance)); err != nil {
@@ -376,6 +382,21 @@ func (r *ClusterOrderReconciler) handleHostedCluster(ctx context.Context, instan
 		return err
 	}
 	return nil
+}
+
+// reconcileVIPEndpoints copies VIP annotations written by the CaaS template
+// into the ClusterOrder status fields consumed by the feedback controller.
+func reconcileVIPEndpoints(instance *v1alpha1.ClusterOrder) {
+	annotations := instance.GetAnnotations()
+	if annotations == nil {
+		return
+	}
+	if v := annotations[osacAPIEndpointAnnotation]; v != "" {
+		instance.Status.ApiEndpoint = v
+	}
+	if v := annotations[osacIngressEndpointAnnotation]; v != "" {
+		instance.Status.IngressEndpoint = v
+	}
 }
 
 func (r *ClusterOrderReconciler) handleNodePools(ctx context.Context, instance *v1alpha1.ClusterOrder,

--- a/osac-operator/internal/controller/clusterorder_controller_test.go
+++ b/osac-operator/internal/controller/clusterorder_controller_test.go
@@ -861,4 +861,36 @@ var _ = Describe("ClusterOrder Controller", func() {
 		})
 	})
 
+	Context("VIP endpoint reconciliation", func() {
+		It("copies VIP annotations to status", func() {
+			instance := &v1alpha1.ClusterOrder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vip",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"osac.openshift.io/api-endpoint":     "10.0.1.240",
+						"osac.openshift.io/ingress-endpoint": "10.0.1.241",
+					},
+				},
+			}
+
+			reconcileVIPEndpoints(instance)
+			Expect(instance.Status.ApiEndpoint).To(Equal("10.0.1.240"))
+			Expect(instance.Status.IngressEndpoint).To(Equal("10.0.1.241"))
+		})
+
+		It("does nothing when annotations are absent", func() {
+			instance := &v1alpha1.ClusterOrder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-no-vip",
+					Namespace: "default",
+				},
+			}
+
+			reconcileVIPEndpoints(instance)
+			Expect(instance.Status.ApiEndpoint).To(BeEmpty())
+			Expect(instance.Status.IngressEndpoint).To(BeEmpty())
+		})
+	})
+
 })

--- a/osac-operator/internal/controller/clusterorder_names.go
+++ b/osac-operator/internal/controller/clusterorder_names.go
@@ -17,6 +17,11 @@ const (
 	hubAccessClusterRoleBaseName string = "hub-access-hosted-clusters"
 )
 
+const (
+	osacAPIEndpointAnnotation     = osacPrefix + "/api-endpoint"
+	osacIngressEndpointAnnotation = osacPrefix + "/ingress-endpoint"
+)
+
 var (
 	osacClusterOrderNameLabel         string = fmt.Sprintf("%s/clusterorder", osacPrefix)
 	osacClusterOrderIDLabel           string = fmt.Sprintf("%s/clusterorder-uuid", osacPrefix)


### PR DESCRIPTION
The external_access service role now writes the discovered API and ingress VIPs as annotations on the ClusterOrder CR after the network-class-specific provisioning completes.

The ClusterOrder controller copies these annotations into the status fields (apiEndpoint, ingressEndpoint) during reconciliation. The feedback controller then syncs them to the fulfillment-service Cluster object, enabling the ExternalIPAttachment flow.

Uses the established annotation-to-status pattern since the kubernetes.core Ansible modules don't support the status subresource.

Assisted-by: Claude Code <noreply@anthropic.com>