### PR TITLE
OSAC-4013: fix graphify-brain-refresh first-run failures

### DIFF
--- a/.github/workflows/graphify-brain-refresh.yaml
+++ b/.github/workflows/graphify-brain-refresh.yaml
@@ -102,10 +102,8 @@ jobs:
       - name: Extract or update graph
         run: |
           set -euo pipefail
-          # `update` has no --code-only flag (it's already a no-LLM,
-          # code-only re-extraction by design -- confirmed directly against
-          # the real installed CLI, `graphify update --code-only` errors
-          # with "unknown update option"). Only `extract` accepts it.
+          # update has no --code-only flag (already no-LLM by default; only
+          # extract accepts it) -- confirmed against the real CLI.
           if [[ -f graphify-out/graph.json && -f graphify-out/manifest.json ]]; then
             echo "Prior graph found -- running incremental update."
             graphify update .
@@ -113,14 +111,8 @@ jobs:
             echo "No usable prior graph -- running full extraction."
             graphify extract . --code-only
           fi
-          # Neither extract nor update reliably writes GRAPH_REPORT.md on
-          # its own -- confirmed directly: a fresh `extract` explicitly
-          # prints "next: run `graphify cluster-only <path>` to generate
-          # GRAPH_REPORT.md and name communities" and does not write it,
-          # while `update` sometimes does and sometimes doesn't depending
-          # on what changed. Run cluster-only unconditionally so the report
-          # this workflow bundles always actually exists -- confirmed
-          # idempotent/safe to run even when update already produced one.
+          # extract doesn't write GRAPH_REPORT.md itself; update sometimes
+          # does. Always (re)generate it explicitly.
           graphify cluster-only .
 
       - name: Write metadata.json
@@ -213,13 +205,8 @@ jobs:
         with:
           persist-credentials: false
 
-      # osac-ci is a self-hosted runner pool, not GH-hosted ubuntu-latest --
-      # confirmed directly (first real production run) that gh isn't
-      # preinstalled on at least one instance in the pool ("gh: command not
-      # found"), unlike ubuntu-latest where it's always present. Installing
-      # a portable copy here makes this job self-sufficient regardless of
-      # which pool instance it lands on, rather than depending on
-      # runner-fleet provisioning this workflow doesn't control.
+      # osac-ci doesn't reliably have gh preinstalled (confirmed: first
+      # prod run hit "gh: command not found"). Install a portable copy.
       - name: Ensure gh CLI is available
         run: |
           set -euo pipefail

--- a/.github/workflows/graphify-brain-refresh.yaml
+++ b/.github/workflows/graphify-brain-refresh.yaml
@@ -217,13 +217,22 @@ jobs:
           echo "gh not found on this runner -- installing a portable copy."
           GH_VERSION="2.97.0"
           case "$(uname -m)" in
-            x86_64) GH_ARCH="amd64" ;;
-            aarch64) GH_ARCH="arm64" ;;
+            x86_64)
+              GH_ARCH="amd64"
+              GH_SHA256="a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112"
+              ;;
+            aarch64)
+              GH_ARCH="arm64"
+              GH_SHA256="73ea440ecad9c9e284429997ee6f93577bc6f7bc6fba357ef62c53ad8fb641a5"
+              ;;
             *) echo "::error::Unsupported architecture $(uname -m) for gh CLI install"; exit 1 ;;
           esac
           mkdir -p /tmp/gh-install
           curl -sSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${GH_ARCH}.tar.gz" \
             -o /tmp/gh-install/gh.tar.gz
+          # Pinned checksum (from gh's own published gh_${GH_VERSION}_checksums.txt)
+          # -- verify before extracting, not after.
+          echo "${GH_SHA256}  /tmp/gh-install/gh.tar.gz" | sha256sum -c -
           tar xzf /tmp/gh-install/gh.tar.gz -C /tmp/gh-install --strip-components=1
           echo "/tmp/gh-install/bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/graphify-brain-refresh.yaml
+++ b/.github/workflows/graphify-brain-refresh.yaml
@@ -194,7 +194,7 @@ jobs:
     name: Alert on repeated publish failure
     needs: refresh
     if: failure()
-    runs-on: osac-ci
+    runs-on: graphify-builder
     timeout-minutes: 10
     permissions:
       contents: read  # only needed to resolve the local ./.github/actions/vault-slack-webhook path

--- a/.github/workflows/graphify-brain-refresh.yaml
+++ b/.github/workflows/graphify-brain-refresh.yaml
@@ -102,13 +102,26 @@ jobs:
       - name: Extract or update graph
         run: |
           set -euo pipefail
+          # `update` has no --code-only flag (it's already a no-LLM,
+          # code-only re-extraction by design -- confirmed directly against
+          # the real installed CLI, `graphify update --code-only` errors
+          # with "unknown update option"). Only `extract` accepts it.
           if [[ -f graphify-out/graph.json && -f graphify-out/manifest.json ]]; then
             echo "Prior graph found -- running incremental update."
-            graphify update . --code-only
+            graphify update .
           else
             echo "No usable prior graph -- running full extraction."
             graphify extract . --code-only
           fi
+          # Neither extract nor update reliably writes GRAPH_REPORT.md on
+          # its own -- confirmed directly: a fresh `extract` explicitly
+          # prints "next: run `graphify cluster-only <path>` to generate
+          # GRAPH_REPORT.md and name communities" and does not write it,
+          # while `update` sometimes does and sometimes doesn't depending
+          # on what changed. Run cluster-only unconditionally so the report
+          # this workflow bundles always actually exists -- confirmed
+          # idempotent/safe to run even when update already produced one.
+          graphify cluster-only .
 
       - name: Write metadata.json
         run: |
@@ -199,6 +212,33 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
+
+      # osac-ci is a self-hosted runner pool, not GH-hosted ubuntu-latest --
+      # confirmed directly (first real production run) that gh isn't
+      # preinstalled on at least one instance in the pool ("gh: command not
+      # found"), unlike ubuntu-latest where it's always present. Installing
+      # a portable copy here makes this job self-sufficient regardless of
+      # which pool instance it lands on, rather than depending on
+      # runner-fleet provisioning this workflow doesn't control.
+      - name: Ensure gh CLI is available
+        run: |
+          set -euo pipefail
+          if command -v gh >/dev/null 2>&1; then
+            echo "gh already available: $(gh --version | head -1)"
+            exit 0
+          fi
+          echo "gh not found on this runner -- installing a portable copy."
+          GH_VERSION="2.97.0"
+          case "$(uname -m)" in
+            x86_64) GH_ARCH="amd64" ;;
+            aarch64) GH_ARCH="arm64" ;;
+            *) echo "::error::Unsupported architecture $(uname -m) for gh CLI install"; exit 1 ;;
+          esac
+          mkdir -p /tmp/gh-install
+          curl -sSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${GH_ARCH}.tar.gz" \
+            -o /tmp/gh-install/gh.tar.gz
+          tar xzf /tmp/gh-install/gh.tar.gz -C /tmp/gh-install --strip-components=1
+          echo "/tmp/gh-install/bin" >> "$GITHUB_PATH"
 
       - name: Check recent run history
         id: history


### PR DESCRIPTION
## Summary

The graph-refresh workflow's first-ever real production run failed both jobs: https://github.com/osac-project/osac/actions/runs/31736315802. Root-caused both against the actual failure log and verified fixes against the real installed `graphify` binary and a real `gh` CLI download -- not guessed.

## Bug 1: `graphify update . --code-only` -- not a real flag

`--code-only` errors on `update` (`error: unknown update option: --code-only`, confirmed locally). `update` is already a no-LLM, code-only re-extraction by design -- only `extract` accepts the flag. Removed it from the `update` call.

## Bug 2: GRAPH_REPORT.md not always produced -- this is what actually broke the bundling step

The failure log shows exactly why: `extract` printed `next: run 'graphify cluster-only <path>' to generate GRAPH_REPORT.md and name communities` and did not write it, so the bundle step failed with `tar: GRAPH_REPORT.md: Cannot stat: No such file or directory`. Confirmed locally with the real binary that `extract` never writes it directly, while `update` sometimes does depending on what changed. Added an unconditional `graphify cluster-only .` call after extract/update -- confirmed idempotent/safe to run even when `update` already produced a report.

## Bug 3: `gh` CLI not available on the `osac-ci` self-hosted runner pool

The alert job (meant to catch exactly this kind of repeated failure) itself failed with `gh: command not found` -- confirmed this specific pool instance (`runner-3`) doesn't have `gh` preinstalled, unlike GH-hosted `ubuntu-latest`. No existing precedent in this repo or osac-test-infra installs `gh` explicitly on `osac-ci` (their jobs apparently rely on it already being present), so rather than assume runner-fleet provisioning I don't control, added a self-contained portable install step (current real release v2.97.0, arch-aware via `uname -m`) so this job works regardless of which pool instance it lands on.

## Verification

All three fixes tested against real tools, not just read/reasoned about:
- `graphify update . --code-only` reproduced the exact `unknown update option` error locally with the real installed `graphifyy` 0.8.46 binary.
- Ran the full corrected sequence (`extract --code-only` → `cluster-only` → bundle) end-to-end locally against a fresh test repo -- produces a valid bundle with all 4 expected files, exit 0.
- Downloaded and ran the real `gh` v2.97.0 linux/amd64 release tarball end-to-end locally to confirm the install snippet actually works, not just that the URL looks right.

## Next step

Once merged, will trigger a fresh `workflow_dispatch` run and confirm an actual successful published bundle before considering this resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automated knowledge refreshes by ensuring incremental updates and clustering complete before reports are bundled.
  - Fixed missing failure alerts on self-hosted runners by ensuring required command-line tooling is available.
  - Added support for x86_64 and aarch64 runner architectures, with clear failure handling for unsupported systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->