### PR TITLE
OSAC-4013: install tree-sitter-sql extra so .sql files are captured

### DIFF
--- a/.github/workflows/graphify-brain-refresh.yaml
+++ b/.github/workflows/graphify-brain-refresh.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install graphify
         run: |
-          pip install --user "graphifyy==${GRAPHIFY_VERSION}"
+          pip install --user "graphifyy[sql]==${GRAPHIFY_VERSION}"
           echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
 
       - name: Restore prior graphify-out/ state (fast path)


### PR DESCRIPTION
## Summary

The first real production run of graphify-brain-refresh.yaml logged: \`109 .sql file(s) contributed nothing to the graph because a dependency is missing: tree_sitter_sql not installed. Install it with: pip install "graphifyy[sql]"\`. fulfillment-service is PostgreSQL-backed, so this is a real, concrete gap -- the brain is currently blind to SQL schema/migrations.

## Fix

One-line change: \`pip install --user "graphifyy==\${GRAPHIFY_VERSION}"\` -> \`pip install --user "graphifyy[sql]==\${GRAPHIFY_VERSION}"\`.

## Verification

Confirmed locally (not guessed) that \`graphifyy[sql]==0.9.41\` resolves correctly and pulls in \`tree-sitter-sql\` as the new dependency, with everything else already satisfied:

\`\`\`
Collecting tree-sitter-sql (from graphifyy[sql]==0.9.41)
  Downloading tree_sitter_sql-0.3.11-...whl.metadata (4.0 kB)
Would install graphifyy-0.9.41 tree-sitter-sql-0.3.11
\`\`\`

Small and independent -- not bundled with the other graphify-brain-refresh fixes in #325.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated workflow environment to include SQL support for the pinned Graphify package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->