### PR TITLE
OSAC-4043: include test files in graphify brain corpus

### DIFF
--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,14 +1,6 @@
-# graphify structural extraction scope (OSAC-1732 knowledge-graph brain).
+# graphify structural extraction scope (mono-repo knowledge-graph brain).
 #
-# Test directories are excluded: they bloat node/relationship count 3-4x on
-# information already covered by the production code they test, without
-# adding new cross-component edges. Infra/config files (.github/, charts/,
-# values/) are deliberately NOT excluded -- that's exactly where this
-# mono-repo's cross-component dependency information lives (e.g. which
-# component's chart another component's umbrella chart depends on).
-**/tests/**
-**/test/**
-**/*_test.go
-**/test_*.py
-**/*_test.py
-**/it/**
+# Test files are intentionally included in the corpus -- real usage found
+# genuine value in "which tests cover this function" questions and
+# source-to-test edges, worth the extra node/link count. See the design
+# doc's Premise 5 for the measured numbers behind this decision.


### PR DESCRIPTION
## Summary

Removes the test-directory excludes from `.graphifyignore` so test files (Go `_test.go`, Python `test_*.py`/`*_test.py`, `tests/`, `test/`, `it/`) are included in the graphify brain's corpus.

## Why

The excludes were based on general third-party guidance ("tests bloat node count 3-4x with no new edges"), never actually measured against this repo. Real usage since found genuine value in "which tests cover this function" questions and source-to-test edges -- worth reversing based on real evidence rather than continuing to trust the original guidance either way.

## Measured impact (real, not assumed)

Ran the actual extraction locally (not a guess, not the original guidance) against this repo with the new corpus scope:

- **96,879 nodes / 176,698 links**, vs. a same-day baseline of 90,180 / 162,538 (the ticket's cited baseline of 85,946 / 157,586 was already superseded by the hourly schedule by the time this ran) -- **+7.4% nodes / +8.7% links** against the same-day baseline, **+12.7% / +12.1%** against the ticket's original baseline. Not remotely 3-4x.
- Real `graphify query` wall-clock, same question, before/after: **5.36s -> 5.97s (+11%)**, comfortably under the design doc's 10s load+BFS ceiling.
- 96,879 nodes is ~57% of the design doc's 2x-baseline (~170K) ceiling.
- Local full extraction: 5m27s (extract) + 1m27s (cluster-only) with 22 local workers -- not directly comparable to the GH Actions runner's wall-clock (fewer workers there), called out as a gap rather than extrapolated.

**Neither performance ceiling in the design doc is crossed.** This was checked as a real decision point, not silently assumed clear -- see the design doc's Premise 5 and performance-ceiling Open Question, both updated with these numbers.

Also re-verified the real fetch script (`.claude/hooks/fetch-graphify-brain.sh`, from #318) against a bundle built from this larger graph -- fetches, validates, and swaps in correctly at the new size (locally; did not publish this test run to the shared `graph-latest` release to avoid overwriting it with unmerged content -- see test plan).

## Test plan

- [x] Real local extraction measured against the current baseline
- [x] Checked against the design doc's performance ceiling -- not crossed
- [x] Real fetch script (PR #318) verified against a bundle built from the new, larger graph
- [x] Design doc (Premise 5 + performance-ceiling Open Question) updated with real numbers and reversal rationale
- [ ] A real `workflow_dispatch` run on the actual GH Actions runner, once this merges (local measurement used far more parallelism than CI has -- worth confirming CI wall-clock stays reasonable, though nothing here suggests it won't)
