### PR TITLE
OSAC-4035: Fix nightly build with sub charts versions

### DIFF
--- a/.github/workflows/bump-submodules.yaml
+++ b/.github/workflows/bump-submodules.yaml
@@ -17,15 +17,13 @@ jobs:
           token: ${{ secrets.OSAC_BOT_PAT }}
 
       # osac-operator, fulfillment-service, osac-aap,
-      # bare-metal-fulfillment-operator, and osac-ui are all either part
-      # of this mono-repo's own commit history or a real released OCI
-      # chart/image dependency now -- there is no submodule left under
-      # base/ to bump a commit pin toward (only osac-csi-driver remains a
-      # submodule, and it isn't bumped by this workflow). The "check
-      # published images, checkout submodule, sync-image-tags --fix"
-      # steps that used to live here were removed for that reason, not
-      # just trimmed -- there's nothing left for them to do. Only the
-      # osac-test-infra pin bump below still applies.
+      # bare-metal-fulfillment-operator, osac-csi-driver, and osac-ui are
+      # all part of this mono-repo's own commit history or a real released
+      # OCI chart/image dependency now -- there are no submodules left to
+      # bump. The "check published images, checkout submodule,
+      # sync-image-tags --fix" steps that used to live here were removed for
+      # that reason, not just trimmed -- there's nothing left for them to
+      # do. Only the osac-test-infra pin bump below still applies.
       - name: Bump pinned osac-test-infra reusable-workflow SHA(s)
         id: pins
         env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -258,7 +258,7 @@ jobs:
 
   # osac-installer's own smoke test: deploy the umbrella chart (which
   # composes every other component's chart via file:// dependencies, plus
-  # osac-ui/osac-csi-driver's submodule/OCI dependencies) to a local Kind
+  # osac-ui's OCI chart dependency) to a local Kind
   # cluster and verify it installs and upgrades idempotently. Distinct from
   # the jobs above, which test one component in isolation -- this is the
   # only place that exercises the umbrella chart's composition of all of
@@ -273,12 +273,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6
       with:
-        submodules: recursive
         persist-credentials: false
-
-    - name: Update submodules to pinned commits
-      working-directory: osac-installer
-      run: git submodule update --init --recursive
 
     - name: Set up Helm
       uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -19,31 +19,134 @@ env:
 
 jobs:
   # -------------------------------------------------------------------
-  # Job 1: Run E2E tests against the current commit
+  # Job 1: Prepare — pin osac-ui and push temp branch
+  # osac-ui is the only external dependency needing a gated pin per run.
+  # Resolve osac-ui@main HEAD (ls-remote); accept only when GHCR already
+  # has ghcr.io/.../osac-ui:sha-<7>. Write pinned/osac-ui.commit; stamp
+  # umbrella ui.images.ui and CI values files. Push nightly/<date>-<sha>-<run>
+  # temp branch — consumed by e2e-test and publish (one pin for whole run).
   # -------------------------------------------------------------------
-  # osac-operator, fulfillment-service, osac-aap,
-  # bare-metal-fulfillment-operator, and osac-installer itself are all
-  # mono-repo-resident now, sharing this repo's own commit history -- there
-  # is no separate submodule/commit to bump toward first, so this job tests
-  # HEAD directly instead of a bumped temporary branch.
+  prepare:
+    name: Prepare nightly state
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      temp-branch: ${{ steps.push.outputs.branch }}
+      ui-sha: ${{ steps.ui.outputs.sha }}
+      ui-short-sha: ${{ steps.ui.outputs.short-sha }}
+      ui-image-ref: ${{ steps.ui.outputs.image-ref }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6
+      with:
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    # cancel-in-progress can skip cleanup on superseded runs; prune orphaned nightly/* branches.
+    - name: Prune stale nightly temp branches
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        source osac-installer/scripts/nightly-charts.sh
+        CUTOFF=$(date -u -d '7 days ago' +%Y%m%d)
+        while read -r ref; do
+          [[ -z "${ref}" ]] && continue
+          branch="${ref#refs/heads/}"
+          branch_date="${branch#nightly/}"
+          branch_date="${branch_date%%-*}"
+          [[ "${branch_date}" =~ ^[0-9]{8}$ ]] || continue
+          if (( branch_date < CUTOFF )); then
+            safe_branch=$(_gha_sanitize_for_message "${branch}")
+            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${branch}" \
+              || echo "::warning::Could not delete stale nightly branch ${safe_branch}"
+          fi
+        done < <(gh api --paginate "repos/${GITHUB_REPOSITORY}/git/matching-refs/heads/nightly/" --jq '.[].ref')
+
+    # Resolve osac-ui@main HEAD once, but only accept it when ghcr.io/.../osac-ui:sha-<7>
+    # already exists (check_osac_ui_image). The full SHA is written to pinned/osac-ui.commit
+    # and propagated to E2E + publish via the temp branch outputs — same pin for the
+    # whole workflow run, matching the archived submodule bump model.
+    - name: Resolve and gate osac-ui SHA
+      id: ui
+      run: |
+        set -euo pipefail
+        source osac-installer/scripts/nightly-charts.sh
+
+        UI_SHA=$(check_osac_ui_image osac-ui)
+        UI_SHORT_SHA="${UI_SHA:0:7}"
+        # osac-ui is external; images always publish under ghcr.io/osac-project/osac-ui.
+        UI_IMAGE_REF=$(osac_ui_nightly_image_ref "${REGISTRY}/osac-project/osac-ui" "${UI_SHORT_SHA}")
+
+        mkdir -p osac-installer/pinned
+        printf '%s\n' "${UI_SHA}" > osac-installer/pinned/osac-ui.commit
+        stamp_umbrella_ui_values "${UI_IMAGE_REF}"
+
+        echo "sha=${UI_SHA}" >> "$GITHUB_OUTPUT"
+        echo "short-sha=${UI_SHORT_SHA}" >> "$GITHUB_OUTPUT"
+        echo "image-ref=${UI_IMAGE_REF}" >> "$GITHUB_OUTPUT"
+        echo "Pinned osac-ui ${UI_SHORT_SHA} (${UI_IMAGE_REF})"
+
+    - name: Push temporary branch
+      id: push
+      run: |
+        set -euo pipefail
+        source osac-installer/scripts/nightly-charts.sh
+        DATE=$(date -u +%Y%m%d)
+        SHORT_SHA=$(git rev-parse --short=7 HEAD)
+        BRANCH="nightly/${DATE}-${SHORT_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git checkout -b "${BRANCH}"
+        git add osac-installer/pinned/osac-ui.commit
+        for values_yaml in "${NIGHTLY_UMBRELLA_UI_VALUES[@]}"; do
+          [[ -f "${values_yaml}" ]] && git add "${values_yaml}"
+        done
+        if git diff --cached --quiet; then
+          echo "::error::No osac-ui pin changes staged — refusing to push empty temp branch"
+          exit 1
+        fi
+        git commit -m "nightly: pin osac-ui SHA and umbrella ui.images.ui"
+
+        git push origin "${BRANCH}"
+
+        echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+        echo "Pushed temp branch: ${BRANCH}"
+
+  # -------------------------------------------------------------------
+  # Job 2: E2E validation — test temp branch, not github.sha
+  # Reusable vmaas full-install workflow; installer-ref = prepare temp branch.
+  # Mono-repo components (operator, fulfillment-service, etc.) share that
+  # branch commit. osac-ui pin travels on the branch via pinned/osac-ui.commit
+  # and stamped umbrella ui.images.ui — same SHA E2E will install as publish.
+  # -------------------------------------------------------------------
   e2e-test:
     name: E2E validation
+    needs: prepare
     permissions:
       contents: read
     uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main
     with:
       test-suite: vmaas
       installer-repo: ${{ github.repository }}
-      installer-ref: ${{ github.sha }}
+      installer-ref: ${{ needs.prepare.outputs.temp-branch }}
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: main
 
   # -------------------------------------------------------------------
-  # Job 2: Package and publish the umbrella chart (only if E2E passes)
+  # Job 3: Publish — version and push all charts (only if E2E passes)
+  # Checkout prepare temp branch; reuse gated osac-ui SHA (not osac-ui@main).
+  # Stamp, package, and push every mono-repo sub-chart plus osac-ui sub-chart
+  # and the umbrella osac chart to GHCR OCI. Charts only — does not build
+  # or push container images (mono-repo images stay :latest in values).
   # -------------------------------------------------------------------
   publish:
     name: Publish nightly chart
-    needs: e2e-test
+    needs: [prepare, e2e-test]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -55,11 +158,27 @@ jobs:
       base-version: ${{ steps.version.outputs.base-version }}
 
     steps:
-    - name: Checkout repository
+    - name: Checkout temporary branch
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6
       with:
-        ref: ${{ github.sha }}
-        submodules: recursive
+        ref: ${{ needs.prepare.outputs.temp-branch }}
+        fetch-depth: 0
+        persist-credentials: false
+
+    # osac-ui is an external repo (not in the osac mono-repo). The prepare job
+    # resolves one gated SHA per run (ls-remote main + GHCR sha-<7> manifest check)
+    # and records it in osac-installer/pinned/osac-ui.commit on the temp branch.
+    # Publish reuses that exact commit — do not checkout ref: main here.
+    # Reproducibility is enforced by:
+    #   - resolve_bare_release_tag_at() for chart semver baseline (git describe on pinned SHA)
+    #   - image pin ghcr.io/.../osac-ui:sha-<short-sha> (also stamped on umbrella ui.images.ui)
+    #   - rewrite_umbrella_osac_ui_dependency_and_rebuild() after publishing the nightly chart
+    - name: Checkout osac-ui at pinned SHA
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6
+      with:
+        repository: osac-project/osac-ui
+        ref: ${{ needs.prepare.outputs.ui-sha }}
+        path: osac-ui
         fetch-depth: 0
         persist-credentials: false
 
@@ -95,18 +214,112 @@ jobs:
         # Chart.yaml placeholder, which is never bumped) so the nightly
         # version reflects where this build actually sits relative to
         # real releases.
-        BASE_TAG=$(resolve_release_tag .)
+        BASE_TAG=$(resolve_release_tag . osac)
         BASE_VERSION="${BASE_TAG#osac/v}"
         VERSION="${BASE_VERSION}-${NIGHTLY_SUFFIX}"
 
         echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
         echo "base-version=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
         echo "short-sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+        echo "nightly-suffix=${NIGHTLY_SUFFIX}" >> "$GITHUB_OUTPUT"
         echo "Nightly version: ${VERSION} (base: ${BASE_VERSION})"
 
+    - name: Stamp and package sub-charts
+      env:
+        NIGHTLY_SUFFIX: ${{ steps.version.outputs.nightly-suffix }}
+        UI_SHA: ${{ needs.prepare.outputs.ui-sha }}
+        UI_SHORT_SHA: ${{ needs.prepare.outputs.ui-short-sha }}
+        UI_IMAGE_REF: ${{ needs.prepare.outputs.ui-image-ref }}
+      run: |
+        set -euo pipefail
+        # Repo root (not osac-installer/) — sub-charts live under component directories.
+        source osac-installer/scripts/nightly-charts.sh
+
+        # Ensure target packaging directory exists
+        mkdir -p ./packaged-charts
+        : > chart-sources.txt
+
+        # Define sub-component map (component_dir -> chart_paths). Version baselines
+        # come from per-component git tags (<component>/vX.Y.Z), not static files.
+        # Components without a release tag yet (currently osac-metering and
+        # osac-csi-driver) are skipped here with a ::warning:: — they are not
+        # published to GHCR until their first <component>/vX.Y.Z tag exists. The
+        # umbrella chart still embeds them via file:// at Chart.yaml placeholder
+        # versions (0.0.0); installs work, but those sub-charts are not
+        # independently pullable from the OCI registry until published.
+        # TODO: derive SUB_CHARTS from umbrella file:// dependencies instead of hardcoding.
+        declare -A SUB_CHARTS=(
+          ["osac-operator"]="osac-operator/charts/operator osac-operator/charts/operator-crds"
+          ["fulfillment-service"]="fulfillment-service/charts/service"
+          ["osac-aap"]="osac-aap/charts/aap"
+          ["bare-metal-fulfillment-operator"]="bare-metal-fulfillment-operator/charts/operator bare-metal-fulfillment-operator/charts/operator-crds"
+          ["osac-metering"]="osac-metering/charts/osac-metering"
+          ["osac-csi-driver"]="osac-csi-driver/charts/csi-driver osac-csi-driver/charts/csi-backends"
+        )
+
+        for COMPONENT in $(printf '%s\n' "${!SUB_CHARTS[@]}" | sort); do
+          if ! BASE_TAG=$(resolve_release_tag . "${COMPONENT}"); then
+            safe_component=$(_gha_sanitize_for_message "${COMPONENT}")
+            echo "::warning::Skipping ${safe_component} sub-charts — no ${safe_component}/vX.Y.Z release tag found yet"
+            continue
+          fi
+          # Per-component base semver (independent of umbrella BASE_VERSION in the version step).
+          BASE_VERSION="${BASE_TAG#"${COMPONENT}"/v}"
+          SUB_VERSION="${BASE_VERSION}-${NIGHTLY_SUFFIX}"
+
+          echo "Stamping ${COMPONENT} sub-charts to version ${SUB_VERSION} (from tag ${BASE_TAG})..."
+
+          # Intentional word splitting: each SUB_CHARTS value lists multiple chart paths.
+          for CHART_DIR in ${SUB_CHARTS[$COMPONENT]}; do
+            CHART_NAME=$(read_validated_chart_name "${CHART_DIR}")
+
+            # Update Chart.yaml version fields (strenv avoids shell interpolation in yq)
+            SUB_VERSION="${SUB_VERSION}" yq -i '.version = strenv(SUB_VERSION)' "${CHART_DIR}/Chart.yaml"
+            SUB_VERSION="${SUB_VERSION}" yq -i '.appVersion = strenv(SUB_VERSION)' "${CHART_DIR}/Chart.yaml"
+
+            # Package sub-chart
+            helm package "${CHART_DIR}" --destination ./packaged-charts
+
+            # Push individual sub-chart to OCI registry (GHCR)
+            helm push "./packaged-charts/${CHART_NAME}-${SUB_VERSION}.tgz" "oci://${REGISTRY}/${CHARTS_REPO}"
+            append_chart_source chart-sources.txt "${CHART_NAME}" "${SUB_VERSION}"
+          done
+        done
+
+        # osac-ui is required for nightly umbrella installs (ui.enabled). GHCR image
+        # existence was verified in prepare; baseline semver uses git describe on the
+        # pinned commit (not highest merged tag). Parent umbrella ui.images.ui was
+        # already stamped on the temp branch; subchart values stamp is defense-in-depth.
+        echo "Stamping osac-ui chart from pinned SHA ${UI_SHORT_SHA}..."
+        if ! UI_BASE_TAG=$(resolve_bare_release_tag_at osac-ui "${UI_SHA}"); then
+          echo "::warning title=osac-ui::No vX.Y.Z release tag found for osac-ui — skipping sub-chart stamping"
+        else
+          UI_CHART_DIR="osac-ui/charts/ui"
+          UI_CHART_NAME=$(read_validated_chart_name "${UI_CHART_DIR}")
+          UI_SUB_VERSION=$(compute_nightly_chart_version "${UI_BASE_TAG}" "${NIGHTLY_SUFFIX}")
+          stamp_osac_ui_chart "${UI_CHART_DIR}" "${UI_SUB_VERSION}" "${UI_IMAGE_REF}"
+          helm package "${UI_CHART_DIR}" --destination ./packaged-charts
+          helm push "./packaged-charts/${UI_CHART_NAME}-${UI_SUB_VERSION}.tgz" "oci://${REGISTRY}/${CHARTS_REPO}"
+          append_chart_source chart-sources.txt "${UI_CHART_NAME}" "${UI_SUB_VERSION}" "${UI_SHORT_SHA}" "${UI_SHA}"
+          echo "${UI_SUB_VERSION}" > osac-ui-nightly-version.txt
+        fi
+
     - name: Build umbrella chart dependencies
-      working-directory: osac-installer
-      run: helm dependency build charts/osac/
+      env:
+        OCI_REPO: oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
+        UI_IMAGE_REF: ${{ needs.prepare.outputs.ui-image-ref }}
+      run: |
+        set -euo pipefail
+        source osac-installer/scripts/nightly-charts.sh
+        if [[ -f osac-ui-nightly-version.txt ]]; then
+          UI_SUB_VERSION=$(<osac-ui-nightly-version.txt)
+          rewrite_umbrella_osac_ui_dependency_and_rebuild \
+            osac-installer/charts/osac/Chart.yaml "${UI_SUB_VERSION}" "${OCI_REPO}"
+        else
+          helm dependency build osac-installer/charts/osac/
+        fi
+        # Re-stamp all NIGHTLY_UMBRELLA_UI_VALUES paths (same set as prepare; idempotent defense-in-depth).
+        stamp_umbrella_ui_values "${UI_IMAGE_REF}"
 
     - name: Lint chart
       working-directory: osac-installer
@@ -138,11 +351,20 @@ jobs:
         echo "Verifying umbrella chart was published successfully..."
         helm show chart "${OCI_REPO}/osac" --version "${VERSION}"
 
+    - name: Record umbrella chart in manifest
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
+      run: |
+        set -euo pipefail
+        source osac-installer/scripts/nightly-charts.sh
+        append_chart_source chart-sources.txt osac "${VERSION}"
+
     - name: Generate images.txt
       env:
         VERSION: ${{ steps.version.outputs.version }}
         BASE_VERSION: ${{ steps.version.outputs.base-version }}
         SHORT_SHA: ${{ steps.version.outputs.short-sha }}
+        UI_SHORT_SHA: ${{ needs.prepare.outputs.ui-short-sha }}
       run: |
         set -euo pipefail
         # grep's own no-match exit code (1) must not poison the pipeline under
@@ -167,6 +389,7 @@ jobs:
         echo "" >> images.txt
         echo "# Chart source & version" >> images.txt
         echo "# osac: source=v${BASE_VERSION} (${SHORT_SHA}), chart=oci://${REGISTRY}/${CHARTS_REPO}/osac:${VERSION}" >> images.txt
+        echo "# osac-ui: source=sha-${UI_SHORT_SHA}, chart=oci://${REGISTRY}/${CHARTS_REPO}/osac-ui (see chart-sources.txt)" >> images.txt
 
         echo "--- images.txt ---"
         cat images.txt
@@ -178,14 +401,18 @@ jobs:
         path: |
           osac-installer/osac-${{ steps.version.outputs.version }}.tgz
           images.txt
+          chart-sources.txt
         retention-days: 14
 
   # -------------------------------------------------------------------
-  # Job 3: Tag and send success notification
+  # Job 4: Tag and notify — record success on temp branch + Slack
+  # Create osac/v<version> git tag at the temp branch commit (same pin E2E
+  # tested and publish packaged). Download chart-sources.txt artifact; post
+  # Slack summary with published chart OCI links.
   # -------------------------------------------------------------------
   tag-and-notify:
     name: Tag and notify
-    needs: publish
+    needs: [prepare, publish]
     runs-on: osac-ci
     timeout-minutes: 15
     if: success()
@@ -194,6 +421,8 @@ jobs:
       contents: write
       # Look up the package version URL for the Slack notification
       packages: read
+      # Download chart-sources.txt from the publish job
+      actions: read
     env:
       VERSION: ${{ needs.publish.outputs.version }}
 
@@ -201,17 +430,41 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6
       with:
-        ref: ${{ github.sha }}
+        ref: ${{ needs.prepare.outputs.temp-branch }}
         fetch-depth: 0
+        # persist-credentials left enabled (default): this job pushes the nightly git tag.
 
     - name: Create nightly tag
       run: |
+        set -euo pipefail
+        source osac-installer/scripts/nightly-charts.sh
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         TAG="osac/v${VERSION}"
+        COMMIT_SHA=$(git rev-parse HEAD)
+
+        if git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" 2>/dev/null; then
+          EXISTING_SHA=$(git rev-parse "${TAG}^{commit}")
+          if [[ "${EXISTING_SHA}" == "${COMMIT_SHA}" ]]; then
+            echo "Tag ${TAG} already exists at ${COMMIT_SHA}; skipping create/push"
+            exit 0
+          fi
+          safe_tag=$(_gha_sanitize_for_message "${TAG}")
+          safe_existing=$(_gha_sanitize_for_message "${EXISTING_SHA}")
+          safe_commit=$(_gha_sanitize_for_message "${COMMIT_SHA}")
+          echo "::error::Tag ${safe_tag} already exists at ${safe_existing}, expected ${safe_commit}; refusing to move tag"
+          exit 1
+        fi
+
         git tag "${TAG}" -m "Nightly build ${VERSION}"
         git push origin "${TAG}"
         echo "Tagged: ${TAG}"
+
+    - name: Download chart manifest
+      uses: actions/download-artifact@65a9edc588058a7f27ea910f833ef1ec12f0aefd  # v4.1.8
+      with:
+        name: nightly-${{ env.VERSION }}
+        path: nightly-artifacts
 
     - name: Retrieve Slack webhook from Vault
       id: vault
@@ -227,42 +480,14 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         set -euo pipefail
-
-        # Package version pages are keyed by numeric version id, not the
-        # tag -- look the id up via the Packages API. Versions are returned
-        # newest-first, so the one we just pushed is always near the top of
-        # the first page. Without ?tag=, GitHub's UI shows the page titled
-        # by digest instead of the human-readable tag (tag is URL-encoded
-        # since it ends up in a query string).
-        #
-        # Best-effort only: never let a failed/empty lookup take down the
-        # whole notification -- degrade to a plain, unlinked version
-        # instead. `|| true` at each call site absorbs curl/jq failures
-        # under `set -e`.
-        chart_version_url() {
-          local version=$1
-          local encoded_version url
-          encoded_version=$(jq -rn --arg v "${version}" '$v|@uri')
-          url=$(curl -sf --max-time 15 \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/orgs/${REPO_OWNER}/packages/container/charts%2Fosac/versions?per_page=100" \
-          | jq -r --arg v "${version}" '.[] | select(.metadata.container.tags | index($v)) | .html_url' \
-          | head -1) || true
-          [ -n "${url}" ] && echo "${url}?tag=${encoded_version}"
-        }
+        source osac-installer/scripts/nightly-charts.sh
 
         WORKFLOW_URL="${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}"
-        URL=$(chart_version_url "${VERSION}" || true)
-        if [ -n "${URL}" ]; then
-          VERSION_LINE="<${URL}|${VERSION}>"
-        else
-          VERSION_LINE="${VERSION}"
-        fi
+        SUMMARY_TEXT=$(build_slack_charts_published_summary nightly-artifacts/chart-sources.txt "${REPO_OWNER}" "${GH_TOKEN}")
 
         jq -n \
           --arg version "${VERSION}" \
-          --arg summary "*Chart published:* \`osac\` ${VERSION_LINE}" \
+          --arg summary "${SUMMARY_TEXT}" \
           --arg workflow_url "${WORKFLOW_URL}" \
           '{
             "blocks": [
@@ -288,11 +513,11 @@ jobs:
           -d @/tmp/slack-payload.json
 
   # -------------------------------------------------------------------
-  # Job 4: Notify on failure
+  # Job 5: Notify on failure
   # -------------------------------------------------------------------
   notify-failure:
     name: Notify failure
-    needs: [e2e-test, publish, tag-and-notify]
+    needs: [prepare, e2e-test, publish, tag-and-notify]
     runs-on: osac-ci
     timeout-minutes: 10
     if: failure()
@@ -347,3 +572,32 @@ jobs:
         curl -sf --max-time 15 -X POST "${SLACK_WEBHOOK_URL}" \
           -H "Content-Type: application/json" \
           -d @/tmp/slack-payload.json
+
+  # -------------------------------------------------------------------
+  # Job 6: Cleanup — delete temp branch (always, success or failure)
+  # -------------------------------------------------------------------
+  cleanup:
+    name: Cleanup temp branch
+    needs: [prepare, e2e-test, publish, tag-and-notify, notify-failure]
+    runs-on: ubuntu-latest
+    if: always()
+    permissions:
+      contents: write
+    env:
+      NIGHTLY_BRANCH: ${{ needs.prepare.outputs.temp-branch }}
+
+    steps:
+    - name: Delete temporary branch
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        if [[ -z "${NIGHTLY_BRANCH}" ]]; then
+          echo "::notice::No temp branch to delete (prepare may not have pushed one)"
+          exit 0
+        fi
+        if gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${NIGHTLY_BRANCH}"; then
+          echo "::notice::Deleted temp branch ${NIGHTLY_BRANCH}"
+        else
+          echo "::warning::Could not delete temp branch ${NIGHTLY_BRANCH}"
+        fi

--- a/.gitignore
+++ b/.gitignore
@@ -192,7 +192,7 @@ cython_debug/
 /osac-installer/kubeconfig.hub-access
 /osac-installer/charts/*/charts/*.tgz
 /osac-installer/charts/*/Chart.lock
-/osac-installer/chart-versions.txt
+/chart-sources.txt
 /osac-installer/images.txt
 /osac-installer/images-raw.txt
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ fulfillment-service (proto)
 └→ osac-installer (RBAC, Helm) — depends on all above
 ```
 
-For deployment coordination (image tags, submodules), see `osac-installer/AGENTS.md`.
+For deployment coordination (image tags, per-component release tags), see `osac-installer/AGENTS.md`.
 
 ## Knowledge Graph (graphify brain)
 

--- a/osac-aap/.ai-bot/instructions.md
+++ b/osac-aap/.ai-bot/instructions.md
@@ -147,13 +147,13 @@ Extends default with: line-length disabled, document-start disabled,
 indent-sequences whatever, hyphens max-spaces-after 4, truthy check-keys
 false, comments min-spaces-from-content 1.
 
-## Cross-Repo Dependencies
+## Cross-Component Dependencies
 
 Changes in osac-aap often require coordinated changes in:
 - **osac-operator** -- CRD spec changes, controller logic
 - **fulfillment-service** -- proto/API field additions
-- **osac-installer** -- submodule bump (automated via CI)
+- **osac-installer** -- chart dependency and Helm values update (mono-repo PR)
 
-You operate on this repo only. If a fix requires changes in another repo,
+You operate on this repo only. If a fix requires changes in another component,
 document the dependency in the PR description and stop. Do not attempt
-cross-repo changes.
+cross-component changes.

--- a/osac-installer/.ai-bot/feedback-workflow.md
+++ b/osac-installer/.ai-bot/feedback-workflow.md
@@ -10,10 +10,9 @@ to understand the prior session's decisions and changes.
 
 ## Feedback Handling Rules
 
-1. **Submodule boundaries**: If feedback asks you to change a file inside
-   any `base/*/` directory (discover submodules with: `git submodule status`),
-   explain that these are submodules and the change belongs in the component
-   repo. Suggest what the reviewer should do instead.
+1. **Mono-repo boundaries**: If feedback asks you to change a file in a sibling
+   component directory (e.g. `../osac-operator/`), make the change there and land
+   one PR at the `osac` repo root. **osac-ui** is external (OCI chart).
 
 2. **Values consistency**: If feedback applies to one values file, check
    whether other values files (development, vmaas-ci, caas-ci)

--- a/osac-installer/.ai-bot/instructions.md
+++ b/osac-installer/.ai-bot/instructions.md
@@ -1,10 +1,11 @@
 # OSAC Installer Instructions
 
-This is a **Helm-based infrastructure/deployment repository**. It
-assembles component submodules (osac-operator, fulfillment-service,
-osac-aap, bare-metal-fulfillment-operator, osac-ui) and deploys them
-via a Helm umbrella chart. There is no Go code, no container builds,
-and no unit tests in this repo. All validation is structural.
+This is a **Helm-based infrastructure/deployment repository** in the `osac`
+mono-repo. It assembles component charts (osac-operator, fulfillment-service,
+osac-aap, bare-metal-fulfillment-operator, osac-csi-driver, osac-metering) via
+`file://` references and deploys **osac-ui** from an external OCI chart. There is
+no Go code, no container builds, and no unit tests in this directory. All
+validation is structural.
 
 ## Validation Commands
 
@@ -50,10 +51,12 @@ values/
   vmaas-ci/values.yaml           # VMaaS CI: pinned images
   caas-ci/values.yaml            # CaaS CI: pinned images
 
-base/                            # Git submodules (version tracking) -- discover with: git submodule status
 prerequisites/                   # Cluster-wide operator manifests
 scripts/                         # Automation scripts (setup, teardown, sync)
 ```
+
+Component source lives in sibling directories at the `osac` repo root (not under
+`osac-installer/`). **osac-ui** is external (OCI chart dependency).
 
 ## Coding Conventions
 
@@ -69,6 +72,8 @@ scripts/                         # Automation scripts (setup, teardown, sync)
 
 ## What Not to Modify
 
-- Do not modify files inside any `base/*/` directories (discover with:
-  `git submodule status`) -- these are submodules. Changes to component
-  manifests belong in the component repos.
+- Do not edit component implementation under sibling mono-repo directories
+  (e.g. `../fulfillment-service/`) from an `osac-installer/`-only mindset —
+  land one PR at the `osac` repo root. **osac-ui** is external; chart version
+  bumps belong in `charts/osac/Chart.yaml` or release workflows, not ad-hoc
+  edits in a checkout of `osac-ui` from here.

--- a/osac-installer/.ai-bot/new-ticket-workflow.md
+++ b/osac-installer/.ai-bot/new-ticket-workflow.md
@@ -14,8 +14,8 @@ is structural (YAML lint, pre-commit, Helm lint, Helm template render).
 
 3. **Read and execute .ai-workflows/bugfix/skills/fix.md**
    Implement the minimal fix. Key constraints:
-   - Never modify files inside any `base/*/` submodule directories
-     (discover with: `git submodule status`).
+   - Do not edit component code under sibling mono-repo directories (e.g.
+     `../fulfillment-service/`) from an installer-only change — use one `osac` PR.
 
 4. **Validate changes**
    Run all validation commands from the installer root in sequence. If any

--- a/osac-installer/AGENTS.md
+++ b/osac-installer/AGENTS.md
@@ -2,13 +2,19 @@
 
 Helm-based deployment orchestrator for OSAC components. No Go code, no builds, no unit tests — only structural validation.
 
-Helm-based deployment system for the OSAC platform. Component repos (osac-operator, osac-fulfillment-service, osac-aap, bare-metal-fulfillment-operator, osac-ui) are aggregated as Git submodules under `base/` for version tracking. Deployment uses three Helm charts in sequence: `charts/osac-deps/` (Phase 1), `charts/osac-infra/` (Phase 2), `charts/osac/` (Phase 3).
+Helm-based deployment system for the OSAC platform in the `osac` mono-repo.
+osac-operator, fulfillment-service, osac-aap, bare-metal-fulfillment-operator,
+osac-csi-driver, and osac-metering are sibling directories at the repository
+root (referenced via `file://` in `charts/osac/Chart.yaml`). **osac-ui** is an
+external OCI chart dependency. Deployment uses three Helm charts in sequence:
+`charts/osac-deps/` (Phase 1), `charts/osac-infra/` (Phase 2),
+`charts/osac/` (Phase 3).
 
 ## Quick Start
 
 ```bash
-# Initialize submodules
-git submodule update --init --recursive
+# Build umbrella chart dependencies
+make helm-deps
 
 # Validate changes
 yamllint --strict .
@@ -20,17 +26,14 @@ make helm-validate
 ## Common Commands
 
 ```bash
-# Initialize submodules
-git submodule update --init --recursive
-
 # Helm lint (all three charts)
 make helm-lint
 
 # Helm template render (dry-run validation against all values files)
 make helm-validate
 
-# Sync submodules and rebuild chart dependencies
-make sync-charts
+# Rebuild chart dependencies
+make helm-deps
 
 # Full install (infra + osac)
 make install PLATFORM=openshift PROFILE=<profile> NS=<namespace>
@@ -48,10 +51,14 @@ make test PLATFORM=kind PROFILE=dev NS=osac SUITE=fulfillment
 
 ## Critical Rules
 
-**Submodules (READ ONLY):**
-- Never modify any `base/*/` directories (discover submodules with: `git submodule status`)
-- Changes belong in component repos
-- All git commands must run from installer root — never `cd` into submodule directories or use `git -C base/...`
+**Mono-repo components (READ ONLY from osac-installer paths):**
+- osac-operator, fulfillment-service, osac-aap, bare-metal-fulfillment-operator,
+  osac-csi-driver, and osac-metering live as sibling directories at the `osac`
+  repo root — edit them there and land one mono-repo PR; do not treat
+  `osac-installer/` as the source of truth for component code.
+- **osac-ui** is external (OCI chart); the installer references a released
+  version in `charts/osac/Chart.yaml` unless a workflow overrides it (e.g.
+  nightly `rewrite_umbrella_osac_ui_dependency()`).
 
 **Helm Schema:**
 - Every value in `charts/osac/values.yaml` **must** have matching `values.schema.json` entry
@@ -73,7 +80,7 @@ make test PLATFORM=kind PROFILE=dev NS=osac SUITE=fulfillment
 
 See `docs/helm-deployment-guide.md` for complete architecture details, including:
 - Helm chart structure and dependencies
-- Submodule organization and version tracking
+- Mono-repo component layout and version tracking (per-component git tags)
 - Prerequisites and operator deployment patterns
 - Values file organization per environment
 
@@ -82,7 +89,6 @@ charts/osac/           # Helm umbrella chart (Chart.yaml, values.yaml, values.sc
 charts/osac-deps/      # Phase 1: CRD providers (OLM subscriptions on OpenShift)
 charts/osac-infra/     # Phase 2: Shared infrastructure (CA, Keycloak, Gateway, PostgreSQL)
 values/<profile>/      # Per-profile values (dev, vmaas-ci, bmaas-ci, caas-ci, full-ci)
-base/                  # Git submodules — discover with: git submodule status
 prerequisites/         # Reference manifests for manual prerequisite installation
 scripts/               # Automation scripts (see README.md for full list)
 ```
@@ -107,8 +113,8 @@ Phase 3: charts/osac/                   # OSAC platform (per-instance workload)
       bare-metal-fulfillment-operator (conditional: bmf.enabled)
       -- mono-repo-resident sibling directories, via file:// references
     csi-driver, csi-backends (conditional: csiDriver.enabled)
-      -- osac-csi-driver, the one remaining real submodule under base/,
-      also via a file:// reference
+      -- osac-csi-driver, a mono-repo-resident sibling directory checked
+      out at the repository root, also via a file:// reference
     osac-ui (conditional: ui.enabled)
       -- a real external chart, via an oci:// reference pinned to a
       released version in Chart.yaml
@@ -131,15 +137,22 @@ values/
 Pull secrets and AAP license files are stored alongside values files (e.g.,
 `values/<profile>/pull-secret.json`, `values/<profile>/license.zip`).
 
-osac-operator, fulfillment-service, osac-aap, and bare-metal-fulfillment-operator
-are mono-repo-resident directories, not submodules -- they share this repo's own
-commit history with osac-installer itself (only osac-csi-driver, under `base/`,
-remains a real submodule). There is deliberately no image-tag pinning/syncing
-for these four in `values/*/instance.yaml`: CI values files use the live tag
-published by each component's own workflow -- `main` for fulfillment-service
-(the only one of the four that doesn't publish a current `latest`) and
-`latest` for osac-operator, osac-aap, and bare-metal-fulfillment-operator.
-There is no separate commit/tag to keep in sync and no bump-bot involved.
+osac-operator, fulfillment-service, osac-aap, bare-metal-fulfillment-operator,
+osac-csi-driver, and osac-metering are all mono-repo-resident directories
+checked out at the repository root, not submodules -- they share this repo's
+own commit history with osac-installer itself (there are no submodules under
+`base/` any longer).
+There is deliberately no image-tag pinning/syncing in `values/*/values.yaml` for
+fulfillment-service, osac-operator, osac-aap, bare-metal-fulfillment-operator,
+osac-csi-driver, and osac-metering: CI values files use the live tag published
+by each component's own workflow -- `main` for fulfillment-service (the only
+one of the six that doesn't publish a current `latest`) and `latest` for
+osac-operator, osac-aap, bare-metal-fulfillment-operator, osac-csi-driver,
+and osac-metering. osac-metering follows the standard `<component>/vX.Y.Z` tag
+rule via `resolve_release_tag()` but has no release tag yet -- nightly sub-chart
+OCI publish is skipped with a warning until the first tag is cut (same as
+osac-csi-driver today). There is no separate commit/tag to keep in sync and no
+bump-bot involved.
 
 Prerequisites are installed via `make install-infra`, which handles both
 osac-deps and osac-infra charts, gated by values toggles. `ca-bundle` Bundle is
@@ -157,16 +170,49 @@ See `README.md` for complete script documentation. Most commonly used:
 - **oc.sh** -- Wraps `oc` with `--as` impersonation when `OC_IMPERSONATE` is set
 - **refresh-after-snapshot.py** -- Refreshes Helm-deployed cluster after booting from cold snapshot
 - **setup-caas-agents.sh** -- Sets up CaaS agent infrastructure (InfraEnv + agent VM + label + approve)
-- **lib.sh** -- Shared shell functions: `retry_until`, `wait_for_resource`, `wait_for_namespace_cleanup`, `retry_command`, `http_retry`, `http_json`, `resolve_release_tag`, `check_postgres_prerequisites`
+- **lib.sh** -- Shared shell functions: `retry_until`, `wait_for_resource`, `wait_for_namespace_cleanup`, `retry_command`, `http_retry`, `http_json`, `resolve_release_tag(path, [tag_prefix])` (nearest `<prefix>/vX.Y.Z` git tag; default prefix `osac`), `resolve_bare_release_tag(path)` (nearest bare `vX.Y.Z` tag for external repos like osac-ui), `resolve_bare_release_tag_at(path, ref)` (nearest ancestor bare tag at a pinned commit), `check_postgres_prerequisites`
+- **nightly-charts.sh** -- Nightly chart manifest + Slack helpers (`check_osac_ui_image`, `append_chart_source`, `build_slack_charts_published_summary`, `stamp_osac_ui_chart`, `stamp_umbrella_ui_image_ref`, `stamp_umbrella_ui_values`, `rewrite_umbrella_osac_ui_dependency`, `rewrite_umbrella_osac_ui_dependency_and_rebuild`)
 
 ### CI Workflows
 
 GitHub Actions only discovers workflows under the repo root's `.github/workflows/`,
 so osac-installer-specific CI now lives there (not under `osac-installer/.github/`):
-`nightly-build.yaml` (nightly umbrella chart build+publish, tested via e2e against
-the current commit directly -- no submodule bump step) and
-`publish-osac-installer-chart.yaml` (manual-dispatch umbrella chart release; takes
-one mono-repo release `version` plus an independent `ui_version` for osac-ui).
+`nightly-build.yaml` (scheduled nightly + manual dispatch: `prepare` gates
+osac-ui@main on an existing `ghcr.io/.../osac-ui:sha-<7>` image, writes
+`pinned/osac-ui.commit`, stamps umbrella `ui.images.ui` on umbrella + CI
+values, and pushes a temp branch; E2E validates that branch; `publish`
+versions every mono-repo sub-chart from per-component `<component>/vX.Y.Z`
+tags, packages, and pushes each to GHCR, then checks out pinned osac-ui,
+stamps/publishes its sub-chart with the gated image ref, rebuilds umbrella
+dependencies, and publishes the umbrella chart — this workflow publishes charts
+only; mono-repo and osac-ui container images are referenced from values/chart
+stamps, not rebuilt here (`images.txt` lists the rendered refs);
+`tag-and-notify` tags `osac/v<version>` and Slack-lists `chart-sources.txt`)
+and `publish-osac-installer-chart.yaml` (manual-dispatch umbrella chart release;
+takes one mono-repo release `version` plus an independent `ui_version` for
+osac-ui).
+Nightly sub-chart OCI publishing covers osac-operator (operator +
+operator-crds), fulfillment-service, osac-aap, bare-metal-fulfillment-operator
+(+ crds), osac-metering, osac-csi-driver (csi-driver + csi-backends), external
+osac-ui, and the umbrella chart. Baseline semver uses `resolve_release_tag()`
+per mono-repo component; components without a `<component>/vX.Y.Z` tag yet
+(e.g. osac-metering, osac-csi-driver) are skipped until their first release
+tag is cut. osac-ui uses `resolve_bare_release_tag_at()` on the pinned commit.
+
+**osac-ui nightly source strategy** (external repo; see `nightly-build.yaml`
+`prepare` and `Resolve and gate osac-ui SHA` steps):
+
+| Step | Behavior |
+|------|----------|
+| `check_osac_ui_image()` | `ls-remote osac-ui@main` → verify `ghcr.io/.../osac-ui:sha-<7>` manifest exists (HTTP 200); fail if image not published yet |
+| Pin once per run | Full SHA written to `pinned/osac-ui.commit` on temp branch; publish checks out that exact commit |
+| Baseline semver | `resolve_bare_release_tag_at()` uses `git describe` on the pinned SHA (nearest ancestor `vX.Y.Z`) |
+| Umbrella image | `stamp_umbrella_ui_values()` sets `ui.images.ui` to `ghcr.io/.../osac-ui:sha-<7>` on umbrella + CI values (parent values win over subchart defaults) |
+| OCI chart dep | `rewrite_umbrella_osac_ui_dependency_and_rebuild()` rewrites Chart.yaml, deletes Chart.lock, runs `helm dependency build` |
+
+Slack success notifications list all published charts (including osac-ui) in a
+box table. `chart_version_url()` emits `::warning::` when a GHCR package page
+lookup fails so unlinked versions in Slack are visible in the Actions log.
 osac-installer's own `e2e-*-full-install.yml`, `helm-lint.yaml`, and
 `integration-tests.yml` coverage is also at root (matrixed/composed alongside the
 other components). See root `.github/workflows/` for the full list.
@@ -188,5 +234,6 @@ Detailed information moved from this file to specialized docs:
 - **Architecture & deployment:** `docs/helm-deployment-guide.md`
 - **Script reference:** `README.md`
 - **CLI usage:** `OSAC-CLI-HOWTO.md`
-- **Component repos:** `base/*/AGENTS.md` (discover with: `git submodule status`)
+- **Component conventions:** sibling dirs at repo root (e.g.
+  `../fulfillment-service/AGENTS.md`, `../osac-operator/AGENTS.md`)
 - **Design docs:** [osac-project/docs/architecture](https://github.com/osac-project/docs/tree/main/architecture)

--- a/osac-installer/CLAUDE.md
+++ b/osac-installer/CLAUDE.md
@@ -6,7 +6,7 @@ This is an infrastructure/deployment repository (Helm-based) with no Go code, co
 
 ### Read Tool
 
-Use for reading YAML manifests, Helm chart files, scripts, submodule metadata. Primary targets:
+Use for reading YAML manifests, Helm chart files, and scripts. Primary targets:
 
 - `charts/osac/values.yaml`, `charts/osac/values.schema.json` -- Helm default values and schema
 - `values/<env>/values.yaml` -- Helm environment-specific values
@@ -20,7 +20,8 @@ Use for updating Helm chart files, YAML manifests, shell scripts. Common edits:
 - New/changed keys in `charts/osac/values.yaml` -- always add a matching property in `charts/osac/values.schema.json`
 - Script logic in `scripts/*.sh` (follow `set -euo pipefail`)
 
-Never use Edit for files in submodule directories (`base/*/` -- discover with: `git submodule status`).
+Never use Edit for component code under sibling mono-repo directories (e.g.
+`../fulfillment-service/`). Edit those paths from the `osac` repo root in one PR.
 
 ### Write Tool
 
@@ -30,7 +31,8 @@ Use sparingly. Most work is editing existing files. Valid use cases:
 - New Helm values files in `values/<env>/`
 - Session artifacts (`.ai-bot/diagnosis.md`, `.ai-bot/pr.md`)
 
-Never use Write for files in submodule directories (`base/*/` -- discover with: `git submodule status`).
+Never use Write for component code under sibling mono-repo directories (e.g.
+`../fulfillment-service/`). Edit those paths from the `osac` repo root in one PR.
 
 ### Bash Tool
 
@@ -45,7 +47,7 @@ pre-commit run --all-files
 make helm-lint
 make helm-validate
 
-# Git operations (always from installer root, never inside submodules)
+# Git operations (always from installer root)
 git status
 git add file1 file2
 git commit -s -m "OSAC-XXXX: description

--- a/osac-installer/Makefile
+++ b/osac-installer/Makefile
@@ -246,9 +246,7 @@ endif
 ##@ Charts
 
 .PHONY: sync-charts
-sync-charts: ## Update submodules and rebuild chart dependencies
-	git submodule update --init --recursive
-	helm dependency build $(OSAC_CHART)
+sync-charts: helm-deps ## Rebuild chart dependencies (alias for helm-deps)
 
 .PHONY: helm-deps
 helm-deps: ## Build Helm chart dependencies

--- a/osac-installer/OSAC-CLI-HOWTO.md
+++ b/osac-installer/OSAC-CLI-HOWTO.md
@@ -68,9 +68,9 @@ oc cluster-info
 ### 1. Clone and Build the CLI
 
 ```bash
-# Clone the repository
-git clone https://github.com/osac-project/fulfillment-service.git
-cd fulfillment-service
+# Clone the mono-repo and enter fulfillment-service
+git clone https://github.com/osac-project/osac.git
+cd osac/fulfillment-service
 
 # Check the Go module configuration
 cat go.mod
@@ -129,18 +129,17 @@ For development work, set up the environment:
 mkdir -p ~/workspace/fulfillment
 cd ~/workspace/fulfillment
 
-# Clone related repositories
-git clone https://github.com/osac-project/fulfillment-service.git
-git clone https://github.com/osac-project/osac-installer.git
+# Clone the osac mono-repo (fulfillment-service and osac-installer live inside it)
+git clone https://github.com/osac-project/osac.git
 
 # Set up development environment variables
-export OSAC_CLI_ROOT=~/workspace/fulfillment/fulfillment-service
-export OSAC_INSTALLER_ROOT=~/workspace/fulfillment/osac-installer
+export OSAC_CLI_ROOT=~/workspace/fulfillment/osac/fulfillment-service
+export OSAC_INSTALLER_ROOT=~/workspace/fulfillment/osac/osac-installer
 export KUBECONFIG=~/workspace/fulfillment/kubeconfig
 
 # Add to ~/.bashrc for persistence
-echo 'export OSAC_CLI_ROOT=~/workspace/fulfillment/fulfillment-service' >> ~/.bashrc
-echo 'export OSAC_INSTALLER_ROOT=~/workspace/fulfillment/osac-installer' >> ~/.bashrc
+echo 'export OSAC_CLI_ROOT=~/workspace/fulfillment/osac/fulfillment-service' >> ~/.bashrc
+echo 'export OSAC_INSTALLER_ROOT=~/workspace/fulfillment/osac/osac-installer' >> ~/.bashrc
 ```
 
 ## Configuration

--- a/osac-installer/README.md
+++ b/osac-installer/README.md
@@ -89,7 +89,7 @@ target Hub cluster.
 | **Storage** | Dynamic storage class available (e.g., `ocs-storagecluster-cephfs`, `lvms-storage`) | Required for persistence of operator and AAP components. |
 | **Permissions** | Cluster-admin access to deploy operators and create CRDs | Limited access users can only deploy into namespaces configured by the admin. |
 | **License Files** | `license.zip` (AAP subscription) | Must be placed in your values directory (e.g., `values/<env>/license.zip`). |
-| **Internet Access** | Outbound access to GitHub (for fetching submodules, releases) | Required during installation and updates. |
+| **Internet Access** | Outbound access to GitHub and `ghcr.io` (for fetching chart dependencies, OCI charts, and releases) | Required during installation and updates. |
 
 
 ## Installation
@@ -111,12 +111,13 @@ Place the downloaded `license.zip` file in your values directory (e.g., `values/
 
 ### Pre-Installation Steps
 
-#### 1. Initialize Submodules
+#### 1. Build Chart Dependencies
 
-The OSAC installer uses Git submodules for version tracking:
+In the `osac` mono-repo, component charts are sibling directories referenced via
+`file://` in the umbrella `Chart.yaml`. Build dependencies before installing:
 
 ```bash
-$ git submodule update --init --recursive
+make helm-deps
 ```
 
 #### 2. Populate Local Secrets
@@ -229,8 +230,9 @@ make install-osac  PLATFORM=... PROFILE=... NS=...  # OSAC application only
 make uninstall     PLATFORM=... PROFILE=... NS=...  # Full uninstall
 make test          PLATFORM=... PROFILE=... NS=... SUITE=...  # Integration tests
 make helm-lint                                       # Lint all charts
+make helm-template       # Dry-run render all templates
 make helm-validate                                   # Lint + template (full validation)
-make sync-charts         # Update submodules + rebuild dependencies
+make sync-charts         # Rebuild chart dependencies (legacy alias; runs helm dependency build)
 ```
 
 ### Monitor Progress

--- a/osac-installer/charts/osac/Chart.yaml
+++ b/osac-installer/charts/osac/Chart.yaml
@@ -6,29 +6,29 @@ version: 0.0.1
 
 dependencies:
   - name: osac-operator-crds
-    version: ">=0.0.0"
+    version: ">=0.0.0-0"
     repository: "file://../../../osac-operator/charts/operator-crds"
     alias: operatorCrds
   - name: osac-operator
-    version: ">=0.0.0"
+    version: ">=0.0.0-0"
     repository: "file://../../../osac-operator/charts/operator"
     alias: operator
     condition: operator.enabled
   - name: fulfillment-service
-    version: ">=0.0.0"
+    version: ">=0.0.0-0"
     repository: "file://../../../fulfillment-service/charts/service"
     alias: service
     condition: service.enabled
   - name: osac-aap
-    version: ">=0.0.0"
+    version: ">=0.0.0-0"
     repository: "file://../../../osac-aap/charts/aap"
     alias: aap
   - name: bare-metal-fulfillment-operator-crds
-    version: ">=0.0.0"
+    version: ">=0.0.0-0"
     repository: "file://../../../bare-metal-fulfillment-operator/charts/operator-crds"
     alias: bmfCrds
   - name: bare-metal-fulfillment-operator
-    version: ">=0.0.0"
+    version: ">=0.0.0-0"
     repository: "file://../../../bare-metal-fulfillment-operator/charts/operator"
     alias: bmf
     condition: bmf.enabled
@@ -38,17 +38,17 @@ dependencies:
     alias: ui
     condition: ui.enabled
   - name: osac-metering
-    version: ">=0.0.0"
+    version: ">=0.0.0-0"
     repository: "file://../../../osac-metering/charts/osac-metering"
     alias: metering
     condition: metering.enabled
   - name: csi-driver
-    version: ">=0.0.0"
+    version: ">=0.0.0-0"
     repository: "file://../../../osac-csi-driver/charts/csi-driver"
     alias: csiDriver
     condition: csiDriver.enabled
   - name: csi-backends
-    version: ">=0.0.0"
+    version: ">=0.0.0-0"
     repository: "file://../../../osac-csi-driver/charts/csi-backends"
     alias: csiBackends
     condition: csiDriver.enabled

--- a/osac-installer/docs/helm-deployment-guide.md
+++ b/osac-installer/docs/helm-deployment-guide.md
@@ -15,9 +15,9 @@ Helm install.
 ## Quick Start
 
 ```bash
-git clone https://github.com/osac-project/osac-installer.git
-cd osac-installer
-git submodule update --init --recursive
+git clone https://github.com/osac-project/osac.git
+cd osac/osac-installer
+make helm-deps
 
 # Place your AAP license file
 cp /path/to/license.zip values/vmaas-ci/

--- a/osac-installer/pinned/.gitkeep
+++ b/osac-installer/pinned/.gitkeep
@@ -1,0 +1,2 @@
+# Populated on nightly temp branches by the prepare job (see nightly-build.yaml).
+# Committed on main as a placeholder so the directory exists in-repo.

--- a/osac-installer/pinned/README.md
+++ b/osac-installer/pinned/README.md
@@ -1,0 +1,5 @@
+# Pinned external refs
+
+`osac-ui.commit` is written by the nightly `prepare` job on a temporary branch and
+records the gated osac-ui commit used for that run's E2E and publish jobs. It is
+not committed on `main`.

--- a/osac-installer/scripts/lib.sh
+++ b/osac-installer/scripts/lib.sh
@@ -102,7 +102,7 @@ http_retry() {
     local err_msg="$1" retries="$2" interval="$3"
     shift 3
     for attempt in $(seq 1 "$retries"); do
-        curl -ksS --fail-with-body "$@" && return 0
+        curl -sS --fail-with-body "$@" && return 0
         if (( attempt < retries )); then
             echo "  http_retry: attempt ${attempt}/${retries} failed, retrying in ${interval}s..." >&2
             sleep "$interval"
@@ -120,7 +120,7 @@ http_json() {
     shift 4
     local result
     for attempt in $(seq 1 "$retries"); do
-        if result=$(curl -ksS --fail-with-body "$@" | jq -r "$filter"); then
+        if result=$(curl -sS --fail-with-body "$@" | jq -r "$filter"); then
             printf '%s\n' "$result"
             return 0
         fi
@@ -133,30 +133,84 @@ http_json() {
     return 1
 }
 
-# Resolve the nearest real (non-nightly) osac/vX.Y.Z umbrella-chart release
-# tag reachable from a repo path's HEAD. --match narrows git describe's glob
-# search to tags shaped like "osac/vX.Y.Z" -- scoped by the "osac/" prefix,
-# not just a bare "vX.Y.Z", because git tags aren't path-scoped and a bare
-# vX.Y.Z pattern can match an unrelated component's old tag (e.g.
-# fulfillment-service tagged bare vX.Y.Z releases before OSAC-3529 moved it
-# to a component-scoped prefix; that history is still reachable from HEAD).
-# --match is still a glob, not a real anchor (its trailing '*' is needed to
-# allow multi-digit version segments, but that same '*' would also accept a
-# stray "-rc1"/".4" suffix), so the result is re-validated with a real regex
-# before being trusted. Fails loudly rather than silently guessing a
-# version: publishing a chart under a made-up placeholder tag would be worse
-# than failing the build outright, since it could get pushed to the
-# registry unnoticed.
-# Usage: resolve_release_tag <repo_path>
+# Resolve the nearest real (non-nightly) component release tag reachable from a
+# repo path's HEAD. --match narrows git describe's glob search to tags shaped
+# like "<prefix>/vX.Y.Z" -- scoped by the component prefix, not just a bare
+# "vX.Y.Z", because git tags aren't path-scoped and a bare vX.Y.Z pattern can
+# match an unrelated component's old tag (e.g. fulfillment-service tagged bare
+# vX.Y.Z releases before OSAC-3529 moved it to a component-scoped prefix; that
+# history is still reachable from HEAD). --match is still a glob, not a real
+# anchor (its trailing '*' is needed to allow multi-digit version segments,
+# but that same '*' would also accept a stray "-rc1"/".4" suffix), so the
+# result is re-validated with a real regex before being trusted. Fails loudly
+# rather than silently guessing a version: publishing a chart under a made-up
+# placeholder tag would be worse than failing the build outright, since it
+# could get pushed to the registry unnoticed.
+# Usage: resolve_release_tag <repo_path> [tag_prefix]
+# tag_prefix defaults to "osac" (umbrella chart tags: osac/vX.Y.Z).
 resolve_release_tag() {
     local path="$1"
+    local prefix="${2:-osac}"
     local tag
-    if ! tag=$(git -C "${path}" describe --tags --abbrev=0 --match 'osac/v[0-9]*.[0-9]*.[0-9]*' --exclude '*-nightly*' 2>/dev/null); then
-        echo "ERROR: no real (non-nightly) osac/vX.Y.Z release tag reachable from ${path} — refusing to guess a version" >&2
+    local match_pattern
+    local validate_regex
+
+    if [[ ! "${prefix}" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+        echo "ERROR: invalid tag prefix '${prefix}' — must match [a-zA-Z0-9_-]+" >&2
         return 1
     fi
-    if [[ ! "${tag}" =~ ^osac/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        echo "ERROR: nearest release tag '${tag}' reachable from ${path} is not a plain osac/vX.Y.Z tag — refusing to guess a version" >&2
+
+    match_pattern="${prefix}/v[0-9]*.[0-9]*.[0-9]*"
+    validate_regex="^${prefix}/v[0-9]+\\.[0-9]+\\.[0-9]+$"
+
+    if ! tag=$(git -C "${path}" describe --tags --abbrev=0 --match "${match_pattern}" --exclude '*-nightly*' 2>/dev/null); then
+        echo "ERROR: no real (non-nightly) ${prefix}/vX.Y.Z release tag reachable from ${path} — refusing to guess a version" >&2
+        return 1
+    fi
+    if [[ ! "${tag}" =~ ${validate_regex} ]]; then
+        echo "ERROR: nearest release tag '${tag}' reachable from ${path} is not a plain ${prefix}/vX.Y.Z tag — refusing to guess a version" >&2
+        return 1
+    fi
+    echo "${tag}"
+}
+
+# Resolve the nearest real (non-nightly) bare vX.Y.Z release tag reachable from an
+# external repo path (e.g. osac-ui, which tags v0.0.5 rather than osac-ui/v0.0.5).
+# Pre-release-only tags (e.g. v0.0.1-rc1) are ignored; repos with no stable tag fail loud.
+# Usage: resolve_bare_release_tag <repo_path>
+resolve_bare_release_tag() {
+    local path="$1"
+    local tag
+    local validate_regex='^v[0-9]+\.[0-9]+\.[0-9]+$'
+
+    while IFS= read -r tag; do
+        [[ -z "${tag}" ]] && continue
+        [[ "${tag}" == *-nightly* ]] && continue
+        if [[ "${tag}" =~ ${validate_regex} ]]; then
+            echo "${tag}"
+            return 0
+        fi
+    done < <(git -C "${path}" tag -l 'v[0-9]*.[0-9]*.[0-9]*' --merged HEAD --sort=-v:refname 2>/dev/null)
+
+    echo "ERROR: no real (non-nightly) vX.Y.Z release tag reachable from ${path} — refusing to guess a version" >&2
+    return 1
+}
+
+# Resolve the nearest real (non-nightly) bare vX.Y.Z tag that is an ancestor of ref
+# (e.g. a pinned osac-ui commit). Matches archived submodule git describe behavior.
+# Usage: resolve_bare_release_tag_at <repo_path> <ref>
+resolve_bare_release_tag_at() {
+    local path="$1" ref="$2"
+    local tag
+    local validate_regex='^v[0-9]+\.[0-9]+\.[0-9]+$'
+
+    if ! tag=$(git -C "${path}" describe --tags --match 'v[0-9]*.[0-9]*.[0-9]*' --abbrev=0 \
+        --exclude '*-nightly*' --exclude '*-*' "${ref}" 2>/dev/null); then
+        echo "ERROR: no vX.Y.Z release tag reachable from ${ref} in ${path}" >&2
+        return 1
+    fi
+    if [[ "${tag}" == *-nightly* ]] || [[ ! "${tag}" =~ ${validate_regex} ]]; then
+        echo "ERROR: nearest tag '${tag}' at ${ref} in ${path} is not a plain vX.Y.Z tag" >&2
         return 1
     fi
     echo "${tag}"

--- a/osac-installer/scripts/nightly-charts.sh
+++ b/osac-installer/scripts/nightly-charts.sh
@@ -1,0 +1,432 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Shared helpers for nightly chart publishing and Slack notifications.
+
+if ! declare -F http_retry >/dev/null 2>&1; then
+    # shellcheck source=lib.sh
+    source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+fi
+
+readonly NIGHTLY_CHART_SLACK_ORDER=(
+    osac-operator-crds
+    bare-metal-fulfillment-operator-crds
+    osac-operator
+    fulfillment-service
+    osac-aap
+    bare-metal-fulfillment-operator
+    osac-metering
+    csi-driver
+    csi-backends
+    osac-ui
+    osac
+)
+
+# Umbrella and CI values files that override osac-ui subchart .Values.images.ui.
+readonly NIGHTLY_UMBRELLA_UI_VALUES=(
+    osac-installer/charts/osac/values.yaml
+    osac-installer/values/dev/instance.yaml
+    osac-installer/values/vmaas-ci/instance.yaml
+    osac-installer/values/bmaas-ci/instance.yaml
+    osac-installer/values/full-ci/instance.yaml
+)
+
+# Usage: append_chart_source <manifest_file> <chart_name> <version> [short_sha] [full_sha]
+# Appends one line to chart-sources.txt (chart name, version, optional source SHA).
+append_chart_source() {
+    local manifest_file="$1" chart_name="$2" version="$3"
+    local short_sha="${4:-}" full_sha="${5:-}"
+    if [[ -n "${short_sha}" && -n "${full_sha}" ]]; then
+        printf '%s %s %s %s\n' "${chart_name}" "${version}" "${short_sha}" "${full_sha}" >> "${manifest_file}"
+    else
+        printf '%s %s\n' "${chart_name}" "${version}" >> "${manifest_file}"
+    fi
+}
+
+# Usage: check_osac_ui_image [repo_name]
+# Resolve osac-ui@main HEAD and verify ghcr.io/osac-project/<repo>:sha-<7> exists.
+# Prints the full commit SHA on stdout; fails if the image is not published yet.
+check_osac_ui_image() {
+    local repo="${1:-osac-ui}"
+    local sha tag token safe_repo safe_sha attempt
+
+    if [[ ! "${repo}" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+        safe_repo=$(_gha_sanitize_for_message "${repo}")
+        echo "::error::Invalid osac-ui repo name '${safe_repo}' — must match [a-zA-Z0-9._-]+" >&2
+        return 1
+    fi
+
+    for attempt in 1 2 3; do
+        if sha=$(git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=10 \
+            ls-remote "https://github.com/osac-project/${repo}.git" refs/heads/main | cut -f1); then
+            [[ -n "${sha}" ]] && break
+        fi
+        if (( attempt < 3 )); then
+            echo "  check_osac_ui_image: git ls-remote attempt ${attempt}/3 failed, retrying in 5s..." >&2
+            sleep 5
+        fi
+    done
+
+    if [[ -z "${sha}" || ! "${sha}" =~ ^[0-9a-f]{40}$ ]]; then
+        safe_sha=$(_gha_sanitize_for_message "${sha}")
+        safe_repo=$(_gha_sanitize_for_message "${repo}")
+        echo "::error::Could not resolve ${safe_repo} main HEAD SHA (got: '${safe_sha}')" >&2
+        return 1
+    fi
+
+    tag="sha-${sha:0:7}"
+    safe_repo=$(_gha_sanitize_for_message "${repo}")
+    if ! token=$(http_json "Could not obtain GHCR token to verify ${safe_repo}:${tag}" 3 5 '.token' \
+        "https://ghcr.io/token?scope=repository:osac-project/${repo}:pull"); then
+        echo "::error::Could not obtain GHCR token to verify ${safe_repo}:${tag}" >&2
+        return 1
+    fi
+    if [[ -z "${token}" || "${token}" == "null" ]]; then
+        echo "::error::GHCR token is empty or null for ${safe_repo}:${tag}" >&2
+        return 1
+    fi
+
+    if ! http_retry "${safe_repo} main HEAD ${sha:0:7} has no published image (tag ${tag})" 3 5 \
+        -s -o /dev/null \
+        -H "Authorization: Bearer ${token}" \
+        -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json" \
+        "https://ghcr.io/v2/osac-project/${repo}/manifests/${tag}"; then
+        echo "::error::${safe_repo} main HEAD ${sha:0:7} has no published image (tag ${tag})" >&2
+        return 1
+    fi
+
+    echo "${sha}"
+}
+
+# Strip characters that break or inject GitHub Actions workflow commands.
+_gha_sanitize_for_message() {
+    local value="$1"
+    value="${value//$'\n'/}"
+    value="${value//$'\r'/}"
+    value="${value//$'\x1b'/}"
+    value="${value//::/ }"
+    value="${value//%0A/}"
+    value="${value//%0D/}"
+    value="${value//%0a/}"
+    value="${value//%0d/}"
+    printf '%s' "${value}"
+}
+
+# Usage: read_validated_chart_name <chart_dir>
+# Print chart name from Chart.yaml; return 1 with sanitized ::error if invalid.
+read_validated_chart_name() {
+    local chart_dir="$1"
+    local chart_name safe_name safe_dir
+
+    if [[ ! -f "${chart_dir}/Chart.yaml" ]]; then
+        safe_dir=$(_gha_sanitize_for_message "${chart_dir}")
+        echo "::error::Chart manifest '${safe_dir}/Chart.yaml' not found!" >&2
+        return 1
+    fi
+
+    chart_name=$(yq -r '.name' "${chart_dir}/Chart.yaml")
+    if [[ -z "${chart_name}" || "${chart_name}" == "null" ]]; then
+        safe_dir=$(_gha_sanitize_for_message "${chart_dir}")
+        echo "::error::Chart name missing in ${safe_dir}/Chart.yaml" >&2
+        return 1
+    fi
+    if [[ ! "${chart_name}" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+        safe_name=$(_gha_sanitize_for_message "${chart_name}")
+        safe_dir=$(_gha_sanitize_for_message "${chart_dir}")
+        echo "::error title=${safe_name}::Invalid chart name in ${safe_dir}/Chart.yaml (name must match [a-zA-Z0-9._-]+)" >&2
+        return 1
+    fi
+    echo "${chart_name}"
+}
+
+# Usage: compute_nightly_chart_version <base_tag> <nightly_suffix>
+compute_nightly_chart_version() {
+    local base_tag="$1" nightly_suffix="$2"
+    local base_version="${base_tag#v}"
+    printf '%s-%s' "${base_version}" "${nightly_suffix}"
+}
+
+# Usage: osac_ui_nightly_image_ref <image_repo> <short_sha>
+osac_ui_nightly_image_ref() {
+    local image_repo="$1" short_sha="$2"
+    printf '%s:sha-%s' "${image_repo}" "${short_sha}"
+}
+
+# Usage: stamp_umbrella_ui_image_ref <values_yaml> <image_ref>
+stamp_umbrella_ui_image_ref() {
+    local values_yaml="$1" image_ref="$2"
+    local safe_values_yaml
+    if [[ ! -f "${values_yaml}" ]]; then
+        safe_values_yaml=$(_gha_sanitize_for_message "${values_yaml}")
+        echo "::warning title=Missing values file::Values file not found: ${safe_values_yaml} — skipping ui.images.ui stamp" >&2
+        return 0
+    fi
+    IMAGE_REF="${image_ref}" yq -i '.ui.images.ui = strenv(IMAGE_REF)' "${values_yaml}"
+}
+
+# Usage: stamp_umbrella_ui_values <image_ref>
+stamp_umbrella_ui_values() {
+    local image_ref="$1" values_yaml
+    for values_yaml in "${NIGHTLY_UMBRELLA_UI_VALUES[@]}"; do
+        stamp_umbrella_ui_image_ref "${values_yaml}" "${image_ref}"
+    done
+}
+
+# Usage: _chart_slack_rank <chart_name>
+_chart_slack_rank() {
+    local chart_name="$1"
+    local i
+    for i in "${!NIGHTLY_CHART_SLACK_ORDER[@]}"; do
+        if [[ "${NIGHTLY_CHART_SLACK_ORDER[$i]}" == "${chart_name}" ]]; then
+            echo "${i}"
+            return 0
+        fi
+    done
+    echo 999
+}
+
+# Usage: _sort_chart_manifest <manifest_file>
+_sort_chart_manifest() {
+    local manifest_file="$1"
+    local -a rows=()
+    local chart_name version rank _short_sha _full_sha safe_path
+
+    if [[ ! -f "${manifest_file}" ]]; then
+        safe_path=$(_gha_sanitize_for_message "${manifest_file}")
+        echo "::warning title=_sort_chart_manifest::Manifest file not found: ${safe_path}" >&2
+        return 0
+    fi
+
+    while read -r chart_name version _short_sha _full_sha; do
+        [[ -z "${chart_name}" ]] && continue
+        rank=$(_chart_slack_rank "${chart_name}")
+        rows+=("${rank} ${chart_name} ${version}")
+    done < "${manifest_file}"
+
+    if ((${#rows[@]} == 0)); then
+        return 0
+    fi
+
+    printf '%s\n' "${rows[@]}" | sort -n -k1,1 | while read -r _rank chart version; do
+        printf '%s %s\n' "${chart}" "${version}"
+    done
+}
+
+# Usage: _slack_display_name <chart_name>
+_slack_display_name() {
+    local chart_name="$1"
+    if [[ "${chart_name}" == "osac" ]]; then
+        echo "osac (umbrella)"
+    else
+        echo "${chart_name}"
+    fi
+}
+
+# Usage: _slack_table_hline <width>
+_slack_table_hline() {
+    local width="$1"
+    printf '─%.0s' $(seq 1 "${width}")
+}
+
+# Usage: _slack_name_cell <width> <name>
+_slack_name_cell() {
+    local width="$1" name="$2"
+    printf '%-*s' "${width}" "${name}"
+}
+
+# Usage: _slack_version_cell_plain <version_w> <ver>
+_slack_version_cell_plain() {
+    local version_w="$1" ver="$2"
+    local pad=$(( version_w - ${#ver} ))
+    (( pad < 0 )) && pad=0
+    printf '%s%*s' "${ver}" "${pad}" ""
+}
+
+# Usage: _format_slack_linked_version <version> <url>
+_format_slack_linked_version() {
+    local version="$1" url="$2"
+    if [[ -n "${url}" ]]; then
+        printf '<%s|%s>' "${url}" "${version}"
+    else
+        printf '%s' "${version}"
+    fi
+}
+
+# Usage: _slack_version_cell_linked <version_w> <ver> <url>
+_slack_version_cell_linked() {
+    local version_w="$1" ver="$2" url="$3"
+    local linked pad
+    linked=$(_format_slack_linked_version "${ver}" "${url}")
+    pad=$(( version_w - ${#ver} ))
+    (( pad < 0 )) && pad=0
+    printf '%s%*s' "${linked}" "${pad}" ""
+}
+
+# Usage: _build_slack_charts_table <manifest_file> [linked] [repo_owner] [gh_token]
+_build_slack_charts_table() {
+    local manifest_file="$1"
+    local linked="${2:-false}"
+    local repo_owner="${3:-}"
+    local gh_token="${4:-}"
+    local -a names=() versions=() urls=()
+    local chart_name version display_name url
+    local name_w=5 version_w=7
+    local name ver i table
+
+    if [[ "${linked}" == true ]]; then
+        while read -r chart_name version _short_sha _full_sha; do
+            [[ -z "${chart_name}" ]] && continue
+            display_name=$(_slack_display_name "${chart_name}")
+            url=$(chart_version_url "${chart_name}" "${version}" "${repo_owner}" "${gh_token}")
+            names+=("${display_name}")
+            versions+=("${version}")
+            urls+=("${url}")
+        done < <(_sort_chart_manifest "${manifest_file}")
+    else
+        while read -r chart_name version _short_sha _full_sha; do
+            [[ -z "${chart_name}" ]] && continue
+            display_name=$(_slack_display_name "${chart_name}")
+            names+=("${display_name}")
+            versions+=("${version}")
+        done < <(_sort_chart_manifest "${manifest_file}")
+    fi
+
+    for name in "${names[@]}"; do
+        (( ${#name} > name_w )) && name_w=${#name}
+    done
+    for ver in "${versions[@]}"; do
+        (( ${#ver} > version_w )) && version_w=${#ver}
+    done
+
+    local name_border=$(( name_w + 2 )) version_border=$(( version_w + 2 ))
+
+    table="┌$(_slack_table_hline "${name_border}")┬$(_slack_table_hline "${version_border}")┐"
+    if [[ "${linked}" == true ]]; then
+        table="${table}"$'\n'"│ $(_slack_name_cell "${name_w}" "Chart") │ $(_slack_version_cell_linked "${version_w}" "Version" "") │"
+        table="${table}"$'\n'"├$(_slack_table_hline "${name_border}")┼$(_slack_table_hline "${version_border}")┤"
+        for i in "${!names[@]}"; do
+            table="${table}"$'\n'"│ $(_slack_name_cell "${name_w}" "${names[$i]}") │ $(_slack_version_cell_linked "${version_w}" "${versions[$i]}" "${urls[$i]}") │"
+        done
+    else
+        table="${table}"$'\n'"│ $(_slack_name_cell "${name_w}" "Chart") │ $(_slack_version_cell_plain "${version_w}" "Version") │"
+        table="${table}"$'\n'"├$(_slack_table_hline "${name_border}")┼$(_slack_table_hline "${version_border}")┤"
+        for i in "${!names[@]}"; do
+            table="${table}"$'\n'"│ $(_slack_name_cell "${name_w}" "${names[$i]}") │ $(_slack_version_cell_plain "${version_w}" "${versions[$i]}") │"
+        done
+    fi
+    table="${table}"$'\n'"└$(_slack_table_hline "${name_border}")┴$(_slack_table_hline "${version_border}")┘"
+    printf '%s' "${table}"
+}
+
+# Usage: rewrite_umbrella_osac_ui_dependency <chart_yaml> <ui_version> <oci_repo>
+rewrite_umbrella_osac_ui_dependency() {
+    local chart_yaml="$1" ui_version="$2" oci_repo="$3"
+    local safe_chart_yaml
+    if [[ ! -f "${chart_yaml}" ]]; then
+        safe_chart_yaml=$(_gha_sanitize_for_message "${chart_yaml}")
+        echo "::error::Chart manifest not found: ${safe_chart_yaml}" >&2
+        return 1
+    fi
+    UI_VERSION="${ui_version}" yq -i \
+        '(.dependencies[] | select(.name == "osac-ui")).version = strenv(UI_VERSION)' \
+        "${chart_yaml}"
+    UI_REPO="${oci_repo}" yq -i \
+        '(.dependencies[] | select(.name == "osac-ui")).repository = strenv(UI_REPO)' \
+        "${chart_yaml}"
+}
+
+# Usage: rewrite_umbrella_osac_ui_dependency_and_rebuild <chart_yaml> <ui_version> <oci_repo>
+rewrite_umbrella_osac_ui_dependency_and_rebuild() {
+    local chart_yaml="$1" ui_version="$2" oci_repo="$3"
+    local chart_dir
+    chart_dir=$(dirname "${chart_yaml}")
+
+    rewrite_umbrella_osac_ui_dependency "${chart_yaml}" "${ui_version}" "${oci_repo}"
+    rm -f "${chart_dir}/Chart.lock"
+    helm dependency build "${chart_dir}/"
+}
+
+# Usage: stamp_osac_ui_chart <chart_dir> <sub_version> <image_ref>
+stamp_osac_ui_chart() {
+    local chart_dir="$1" sub_version="$2" image_ref="$3"
+    # osac-ui/charts/ui/templates/deployment.yaml reads .Values.images.ui
+    SUB_VERSION="${sub_version}" yq -i '.version = strenv(SUB_VERSION)' "${chart_dir}/Chart.yaml"
+    SUB_VERSION="${sub_version}" yq -i '.appVersion = strenv(SUB_VERSION)' "${chart_dir}/Chart.yaml"
+    IMAGE_REF="${image_ref}" yq -i '.images.ui = strenv(IMAGE_REF)' "${chart_dir}/values.yaml"
+}
+
+# Usage: chart_version_url <chart_name> <version> <repo_owner> <gh_token>
+chart_version_url() {
+    local chart_name="$1" version="$2" repo_owner="$3" gh_token="$4"
+    local encoded_version response url
+
+    if [[ ! "${chart_name}" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+        echo "::warning::Skipping GHCR package lookup for chart with invalid name; Slack link omitted" >&2
+        return 0
+    fi
+
+    if [[ ! "${repo_owner}" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+        echo "::warning::Skipping GHCR package lookup for invalid repo owner; Slack link omitted" >&2
+        return 0
+    fi
+
+    if [[ ! "${version}" =~ ^[a-zA-Z0-9._+-]+$ ]]; then
+        echo "::warning::Skipping GHCR package lookup for invalid version; Slack link omitted" >&2
+        return 0
+    fi
+
+    encoded_version=$(jq -rn --arg v "${version}" '$v|@uri')
+
+    if ! response=$(curl -sf --max-time 15 \
+        -H "Authorization: Bearer ${gh_token}" \
+        -H "Accept: application/vnd.github+json" \
+        "https://api.github.com/orgs/${repo_owner}/packages/container/charts%2F${chart_name}/versions?per_page=100"); then
+        echo "::warning::Could not look up GHCR package page for chart ${chart_name}@${version} (Packages API request failed); Slack link omitted" >&2
+        return 0
+    fi
+
+    url=$(jq -r --arg v "${version}" '.[] | select(.metadata.container.tags | index($v)) | .html_url' <<< "${response}" | head -1) || {
+        echo "::warning::Could not parse Packages API response for chart ${chart_name}@${version}; Slack link omitted" >&2
+        return 0
+    }
+
+    if [[ -z "${url}" || "${url}" == "null" ]]; then
+        echo "::warning::No GHCR package page found for chart ${chart_name}@${version} (not in first 100 package versions); Slack link omitted" >&2
+        return 0
+    fi
+
+    echo "${url}?tag=${encoded_version}"
+}
+
+# Usage: _osac_ui_source_from_manifest <manifest_file>
+_osac_ui_source_from_manifest() {
+    local manifest_file="$1"
+    local chart_name version short_sha full_sha
+
+    while read -r chart_name version short_sha full_sha; do
+        if [[ "${chart_name}" == "osac-ui" && -n "${short_sha}" ]]; then
+            if [[ -n "${full_sha}" ]]; then
+                printf '%s (%s)' "${short_sha}" "${full_sha}"
+            else
+                printf '%s' "${short_sha}"
+            fi
+            return 0
+        fi
+    done < "${manifest_file}"
+}
+
+# Usage: build_slack_charts_published_summary <manifest_file> <repo_owner> <gh_token>
+build_slack_charts_published_summary() {
+    local manifest_file="$1" repo_owner="$2" gh_token="$3"
+    local table ui_source
+
+    table=$(_build_slack_charts_table "${manifest_file}" true "${repo_owner}" "${gh_token}")
+
+    # Plain mrkdwn (no code fence): linked version cells use <url|text> markup.
+    printf '*Charts published:*\n%s' "${table}"
+
+    ui_source=$(_osac_ui_source_from_manifest "${manifest_file}") || true
+    if [[ -n "${ui_source}" ]]; then
+        printf '\n\n*osac-ui source:* `%s` (image tag `sha-%s`)' "${ui_source}" "${ui_source%% *}"
+    fi
+}

--- a/osac-operator/.claude/rules/common-tasks.md
+++ b/osac-operator/.claude/rules/common-tasks.md
@@ -15,12 +15,12 @@
 3. Update controller logic in `internal/controller/{resource}_controller.go`
 4. Update feedback controller if field needs sync to fulfillment-service
 
-## Cross-Repo Change Order
+## Cross-Component Change Order
 
 1. **fulfillment-service**: Update proto definitions, regenerate
 2. **osac-operator**: Update CRD types, controller logic, `buf generate`
 3. **osac-aap**: Update Ansible roles/playbooks
-4. **osac-installer**: Update submodules, add RBAC if needed
+4. **osac-installer**: Update Helm values/RBAC if needed
 
 ## RBAC Changes
 


### PR DESCRIPTION
## Summary

Restores per-component sub-chart versioning and OCI registry publication in the nightly build workflow following the monorepo migration. Replaces the interim `osac-ui@main` checkout with the archived pinned-SHA model: gated resolve once in `prepare`, temp branch for E2E + publish, Chart.lock bust after dependency rewrite, and umbrella `ui.images.ui` stamping.

## osac-ui pinned SHA (restored archived guards)

1. **`prepare` job** — `check_osac_ui_image()` (`ls-remote` main + GHCR `sha-<7>` manifest gate) resolves one SHA per run, writes `osac-installer/pinned/osac-ui.commit`, stamps `ui.images.ui` on umbrella + CI values, pushes temp branch.
2. **E2E** — runs against the temp branch (pinned UI image, not frozen `0.0.5`).
3. **Publish** — checks out osac-ui at pinned SHA; baseline semver via `resolve_bare_release_tag_at()` (`git describe` on pinned commit); `rewrite_umbrella_osac_ui_dependency_and_rebuild()` deletes Chart.lock before `helm dependency build`.
4. **Slack manifest** — `chart-sources.txt` records osac-ui nightly version + source SHA.

## Other changes

- Sub-chart baselines from per-component git tags via `resolve_release_tag()`; untagged components skipped with `::warning::`.
- Helm `>=0.0.0-0` constraints for nightly pre-release dependency matching.
- Shared helpers in `osac-installer/scripts/nightly-charts.sh`.

## Test plan

- [ ] Nightly `prepare` fails when osac-ui main HEAD has no GHCR `sha-<7>` image
- [ ] Temp branch carries `pinned/osac-ui.commit` and `ui.images.ui:sha-<7>` in vmaas-ci values
- [ ] Umbrella `Chart.lock` resolves nightly osac-ui OCI version (not `0.0.5`) after rewrite
- [ ] `helm template` with development values lists `osac-ui:sha-<7>`
- [ ] E2E receives `installer-ref: nightly/...` temp branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Nightly releases now test and publish from the same prepared state.
  - Published charts include version metadata, component tags, and source details.
  - Release notifications include chart publication summaries.
  - Temporary nightly branches are automatically cleaned up, with old branches pruned.
  - Added support for pinned nightly references and improved chart publishing validation.

- **Documentation**
  - Updated setup and deployment guidance for the consolidated repository layout.
  - Clarified chart dependency workflows and legacy synchronization commands.
  - Added guidance for contribution boundaries and nightly references.

- **Bug Fixes**
  - Improved stable release-tag validation.
  - Helm chart dependencies now accept prerelease-compatible versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->