### PR TITLE
OSAC-3277: resolve StorageTier at volume creation

### DIFF
--- a/fulfillment-service/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -1216,6 +1216,15 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 	}
 	privatev1.RegisterStorageTiersServer(grpcServer, privateStorageTiersServer)
 
+	// Create the storage tiers DAO for tier resolution in the volumes server:
+	storageTiersDAO, err := dao.NewGenericDAO[*privatev1.StorageTier]().
+		SetLogger(c.logger).
+		SetTenancyLogic(tenancyLogic).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to create storage tiers DAO: %w", err)
+	}
+
 	// Create the private volumes server:
 	c.logger.InfoContext(ctx, "Creating private volumes server")
 	privateVolumesServer, err := servers.NewPrivateVolumesServer().
@@ -1224,6 +1233,7 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 		SetAttributionLogic(privateAttributionLogic).
 		SetTenancyLogic(tenancyLogic).
 		SetMetricsRegisterer(metricsRegisterer).
+		SetStorageTiersDAO(storageTiersDAO).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create private volumes server: %w", err)

--- a/fulfillment-service/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"net/http"
 	"os"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -30,10 +31,12 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
+	grpccodes "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
 	healthv1 "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/reflection"
+	grpcstatus "google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -1216,7 +1219,8 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 	}
 	privatev1.RegisterStorageTiersServer(grpcServer, privateStorageTiersServer)
 
-	// Create the storage tiers DAO for tier resolution in the volumes server:
+	// Create the tier resolver for the volumes server. The resolver looks up a
+	// StorageTier by name and returns the first backend association.
 	storageTiersDAO, err := dao.NewGenericDAO[*privatev1.StorageTier]().
 		SetLogger(c.logger).
 		SetTenancyLogic(tenancyLogic).
@@ -1224,6 +1228,7 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 	if err != nil {
 		return fmt.Errorf("failed to create storage tiers DAO: %w", err)
 	}
+	tierResolver := newDAOTierResolver(storageTiersDAO)
 
 	// Create the private volumes server:
 	c.logger.InfoContext(ctx, "Creating private volumes server")
@@ -1233,7 +1238,7 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 		SetAttributionLogic(privateAttributionLogic).
 		SetTenancyLogic(tenancyLogic).
 		SetMetricsRegisterer(metricsRegisterer).
-		SetStorageTiersDAO(storageTiersDAO).
+		SetTierResolver(tierResolver).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create private volumes server: %w", err)
@@ -1787,6 +1792,42 @@ const tokenIssuerFlagHelp = `
 _URL_ - Issuer URL for JWT tokens. Used as the iss claim. Token
 consumers derive the JWKS endpoint as <issuer>/.well-known/jwks.json.
 `
+
+func newDAOTierResolver(
+	tiersDAO *dao.GenericDAO[*privatev1.StorageTier],
+) servers.TierResolverFunc {
+	return func(ctx context.Context, tierName string) (*servers.TierResolution, error) {
+		filter := fmt.Sprintf("this.metadata.name == %s", strconv.Quote(tierName))
+		listResp, err := tiersDAO.List().
+			SetFilter(filter).
+			SetLimit(1).
+			Do(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to look up storage tier %q: %w", tierName, err)
+		}
+		items := listResp.GetItems()
+		if len(items) == 0 {
+			return nil, grpcstatus.Errorf(grpccodes.NotFound, "storage tier %q not found", tierName)
+		}
+		tier := items[0]
+
+		if tier.GetStatus().GetState() != privatev1.StorageTierState_STORAGE_TIER_STATE_ACTIVE {
+			return nil, grpcstatus.Errorf(grpccodes.FailedPrecondition, "storage tier %q is not active", tierName)
+		}
+
+		backends := tier.GetSpec().GetBackends()
+		if len(backends) == 0 {
+			return nil, grpcstatus.Errorf(grpccodes.FailedPrecondition,
+				"storage tier %q has no backend associations", tierName)
+		}
+
+		selected := backends[0]
+		return &servers.TierResolution{
+			BackendID: selected.GetBackendId(),
+			Protocol:  selected.GetProtocol(),
+		}, nil
+	}
+}
 
 const emergencyServiceAccountsFlagHelp = `
 _NAMES_ - Comma-separated list of Kubernetes service account names that are allowed to access the private API with

--- a/fulfillment-service/internal/servers/private_volumes_server.go
+++ b/fulfillment-service/internal/servers/private_volumes_server.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
@@ -186,7 +187,7 @@ func (s *PrivateVolumesServer) validateVolumeCreate(vol *privatev1.Volume) error
 }
 
 func (s *PrivateVolumesServer) resolveTier(ctx context.Context, tierName string) (*tierResolution, error) {
-	filter := fmt.Sprintf("metadata.name == '%s'", tierName)
+	filter := fmt.Sprintf("this.metadata.name == %s", strconv.Quote(tierName))
 	listResp, err := s.storageTiersDAO.List().
 		SetFilter(filter).
 		SetLimit(1).

--- a/fulfillment-service/internal/servers/private_volumes_server.go
+++ b/fulfillment-service/internal/servers/private_volumes_server.go
@@ -16,9 +16,7 @@ package servers
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
-	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
 	grpccodes "google.golang.org/grpc/codes"
@@ -28,9 +26,18 @@ import (
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/auth"
-	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/osac/fulfillment-service/internal/events"
 )
+
+// TierResolution holds the result of resolving a StorageTier name to a
+// concrete backend and protocol.
+type TierResolution struct {
+	BackendID string
+	Protocol  privatev1.StorageProtocol
+}
+
+// TierResolverFunc resolves a StorageTier name to a backend and protocol.
+type TierResolverFunc func(ctx context.Context, tierName string) (*TierResolution, error)
 
 type PrivateVolumesServerBuilder struct {
 	logger            *slog.Logger
@@ -38,7 +45,7 @@ type PrivateVolumesServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
-	storageTiersDAO   *dao.GenericDAO[*privatev1.StorageTier]
+	tierResolver      TierResolverFunc
 }
 
 var _ privatev1.VolumesServer = (*PrivateVolumesServer)(nil)
@@ -46,14 +53,9 @@ var _ privatev1.VolumesServer = (*PrivateVolumesServer)(nil)
 type PrivateVolumesServer struct {
 	privatev1.UnimplementedVolumesServer
 
-	logger          *slog.Logger
-	generic         *GenericServer[*privatev1.Volume]
-	storageTiersDAO *dao.GenericDAO[*privatev1.StorageTier]
-}
-
-type tierResolution struct {
-	backendID string
-	protocol  privatev1.StorageProtocol
+	logger       *slog.Logger
+	generic      *GenericServer[*privatev1.Volume]
+	tierResolver TierResolverFunc
 }
 
 func NewPrivateVolumesServer() *PrivateVolumesServerBuilder {
@@ -85,8 +87,8 @@ func (b *PrivateVolumesServerBuilder) SetMetricsRegisterer(value prometheus.Regi
 	return b
 }
 
-func (b *PrivateVolumesServerBuilder) SetStorageTiersDAO(value *dao.GenericDAO[*privatev1.StorageTier]) *PrivateVolumesServerBuilder {
-	b.storageTiersDAO = value
+func (b *PrivateVolumesServerBuilder) SetTierResolver(value TierResolverFunc) *PrivateVolumesServerBuilder {
+	b.tierResolver = value
 	return b
 }
 
@@ -99,8 +101,8 @@ func (b *PrivateVolumesServerBuilder) Build() (result *PrivateVolumesServer, err
 		err = errors.New("tenancy logic is mandatory")
 		return
 	}
-	if b.storageTiersDAO == nil {
-		err = errors.New("storage tiers DAO is mandatory")
+	if b.tierResolver == nil {
+		err = errors.New("tier resolver is mandatory")
 		return
 	}
 
@@ -117,9 +119,9 @@ func (b *PrivateVolumesServerBuilder) Build() (result *PrivateVolumesServer, err
 	}
 
 	result = &PrivateVolumesServer{
-		logger:          b.logger,
-		generic:         generic,
-		storageTiersDAO: b.storageTiersDAO,
+		logger:       b.logger,
+		generic:      generic,
+		tierResolver: b.tierResolver,
 	}
 	return
 }
@@ -145,7 +147,7 @@ func (s *PrivateVolumesServer) Create(ctx context.Context,
 		return
 	}
 
-	resolved, err := s.resolveTier(ctx, vol.GetSpec().GetStorageTier())
+	resolved, err := s.tierResolver(ctx, vol.GetSpec().GetStorageTier())
 	if err != nil {
 		return
 	}
@@ -154,8 +156,8 @@ func (s *PrivateVolumesServer) Create(ctx context.Context,
 		vol.SetStatus(&privatev1.VolumeStatus{})
 	}
 	vol.GetStatus().SetState(privatev1.VolumeState_VOLUME_STATE_CREATING)
-	vol.GetStatus().SetBackend(resolved.backendID)
-	vol.GetStatus().SetProtocol(resolved.protocol)
+	vol.GetStatus().SetBackend(resolved.BackendID)
+	vol.GetStatus().SetProtocol(resolved.Protocol)
 
 	vol.SetId("")
 
@@ -184,37 +186,6 @@ func (s *PrivateVolumesServer) validateVolumeCreate(vol *privatev1.Volume) error
 		return grpcstatus.Errorf(grpccodes.InvalidArgument, "field 'spec.access_mode' is required")
 	}
 	return nil
-}
-
-func (s *PrivateVolumesServer) resolveTier(ctx context.Context, tierName string) (*tierResolution, error) {
-	filter := fmt.Sprintf("this.metadata.name == %s", strconv.Quote(tierName))
-	listResp, err := s.storageTiersDAO.List().
-		SetFilter(filter).
-		SetLimit(1).
-		Do(ctx)
-	if err != nil {
-		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to look up storage tier %q: %v", tierName, err)
-	}
-	items := listResp.GetItems()
-	if len(items) == 0 {
-		return nil, grpcstatus.Errorf(grpccodes.NotFound, "storage tier %q not found", tierName)
-	}
-	tier := items[0]
-
-	if tier.GetStatus().GetState() != privatev1.StorageTierState_STORAGE_TIER_STATE_ACTIVE {
-		return nil, grpcstatus.Errorf(grpccodes.FailedPrecondition, "storage tier %q is not active", tierName)
-	}
-
-	backends := tier.GetSpec().GetBackends()
-	if len(backends) == 0 {
-		return nil, grpcstatus.Errorf(grpccodes.FailedPrecondition, "storage tier %q has no backend associations", tierName)
-	}
-
-	selected := backends[0]
-	return &tierResolution{
-		backendID: selected.GetBackendId(),
-		protocol:  selected.GetProtocol(),
-	}, nil
 }
 
 func (s *PrivateVolumesServer) Update(ctx context.Context,

--- a/fulfillment-service/internal/servers/private_volumes_server.go
+++ b/fulfillment-service/internal/servers/private_volumes_server.go
@@ -16,6 +16,7 @@ package servers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,6 +27,7 @@ import (
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/auth"
+	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/osac/fulfillment-service/internal/events"
 )
 
@@ -35,6 +37,7 @@ type PrivateVolumesServerBuilder struct {
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
+	storageTiersDAO   *dao.GenericDAO[*privatev1.StorageTier]
 }
 
 var _ privatev1.VolumesServer = (*PrivateVolumesServer)(nil)
@@ -42,8 +45,14 @@ var _ privatev1.VolumesServer = (*PrivateVolumesServer)(nil)
 type PrivateVolumesServer struct {
 	privatev1.UnimplementedVolumesServer
 
-	logger  *slog.Logger
-	generic *GenericServer[*privatev1.Volume]
+	logger          *slog.Logger
+	generic         *GenericServer[*privatev1.Volume]
+	storageTiersDAO *dao.GenericDAO[*privatev1.StorageTier]
+}
+
+type tierResolution struct {
+	backendID string
+	protocol  privatev1.StorageProtocol
 }
 
 func NewPrivateVolumesServer() *PrivateVolumesServerBuilder {
@@ -75,6 +84,11 @@ func (b *PrivateVolumesServerBuilder) SetMetricsRegisterer(value prometheus.Regi
 	return b
 }
 
+func (b *PrivateVolumesServerBuilder) SetStorageTiersDAO(value *dao.GenericDAO[*privatev1.StorageTier]) *PrivateVolumesServerBuilder {
+	b.storageTiersDAO = value
+	return b
+}
+
 func (b *PrivateVolumesServerBuilder) Build() (result *PrivateVolumesServer, err error) {
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
@@ -82,6 +96,10 @@ func (b *PrivateVolumesServerBuilder) Build() (result *PrivateVolumesServer, err
 	}
 	if b.tenancyLogic == nil {
 		err = errors.New("tenancy logic is mandatory")
+		return
+	}
+	if b.storageTiersDAO == nil {
+		err = errors.New("storage tiers DAO is mandatory")
 		return
 	}
 
@@ -98,8 +116,9 @@ func (b *PrivateVolumesServerBuilder) Build() (result *PrivateVolumesServer, err
 	}
 
 	result = &PrivateVolumesServer{
-		logger:  b.logger,
-		generic: generic,
+		logger:          b.logger,
+		generic:         generic,
+		storageTiersDAO: b.storageTiersDAO,
 	}
 	return
 }
@@ -125,10 +144,17 @@ func (s *PrivateVolumesServer) Create(ctx context.Context,
 		return
 	}
 
+	resolved, err := s.resolveTier(ctx, vol.GetSpec().GetStorageTier())
+	if err != nil {
+		return
+	}
+
 	if vol.GetStatus() == nil {
 		vol.SetStatus(&privatev1.VolumeStatus{})
 	}
 	vol.GetStatus().SetState(privatev1.VolumeState_VOLUME_STATE_CREATING)
+	vol.GetStatus().SetBackend(resolved.backendID)
+	vol.GetStatus().SetProtocol(resolved.protocol)
 
 	vol.SetId("")
 
@@ -157,6 +183,37 @@ func (s *PrivateVolumesServer) validateVolumeCreate(vol *privatev1.Volume) error
 		return grpcstatus.Errorf(grpccodes.InvalidArgument, "field 'spec.access_mode' is required")
 	}
 	return nil
+}
+
+func (s *PrivateVolumesServer) resolveTier(ctx context.Context, tierName string) (*tierResolution, error) {
+	filter := fmt.Sprintf("metadata.name == '%s'", tierName)
+	listResp, err := s.storageTiersDAO.List().
+		SetFilter(filter).
+		SetLimit(1).
+		Do(ctx)
+	if err != nil {
+		return nil, grpcstatus.Errorf(grpccodes.Internal, "failed to look up storage tier %q: %v", tierName, err)
+	}
+	items := listResp.GetItems()
+	if len(items) == 0 {
+		return nil, grpcstatus.Errorf(grpccodes.NotFound, "storage tier %q not found", tierName)
+	}
+	tier := items[0]
+
+	if tier.GetStatus().GetState() != privatev1.StorageTierState_STORAGE_TIER_STATE_ACTIVE {
+		return nil, grpcstatus.Errorf(grpccodes.FailedPrecondition, "storage tier %q is not active", tierName)
+	}
+
+	backends := tier.GetSpec().GetBackends()
+	if len(backends) == 0 {
+		return nil, grpcstatus.Errorf(grpccodes.FailedPrecondition, "storage tier %q has no backend associations", tierName)
+	}
+
+	selected := backends[0]
+	return &tierResolution{
+		backendID: selected.GetBackendId(),
+		protocol:  selected.GetProtocol(),
+	}, nil
 }
 
 func (s *PrivateVolumesServer) Update(ctx context.Context,

--- a/fulfillment-service/internal/servers/private_volumes_server_test.go
+++ b/fulfillment-service/internal/servers/private_volumes_server_test.go
@@ -14,6 +14,7 @@ language governing permissions and limitations under the License.
 package servers
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -28,11 +29,19 @@ import (
 
 var _ = Describe("Private volumes server", func() {
 	Describe("Creation", func() {
+		stubResolver := TierResolverFunc(func(_ context.Context, _ string) (*TierResolution, error) {
+			return &TierResolution{
+				BackendID: "test-backend",
+				Protocol:  privatev1.StorageProtocol_STORAGE_PROTOCOL_BLOCK,
+			}, nil
+		})
+
 		It("Can be built if all the required parameters are set", func() {
 			server, err := NewPrivateVolumesServer().
 				SetLogger(logger).
 				SetAttributionLogic(attribution).
 				SetTenancyLogic(tenancy).
+				SetTierResolver(stubResolver).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(server).ToNot(BeNil())
@@ -42,6 +51,7 @@ var _ = Describe("Private volumes server", func() {
 			server, err := NewPrivateVolumesServer().
 				SetAttributionLogic(attribution).
 				SetTenancyLogic(tenancy).
+				SetTierResolver(stubResolver).
 				Build()
 			Expect(err).To(MatchError("logger is mandatory"))
 			Expect(server).To(BeNil())
@@ -51,8 +61,19 @@ var _ = Describe("Private volumes server", func() {
 			server, err := NewPrivateVolumesServer().
 				SetLogger(logger).
 				SetAttributionLogic(attribution).
+				SetTierResolver(stubResolver).
 				Build()
 			Expect(err).To(MatchError("tenancy logic is mandatory"))
+			Expect(server).To(BeNil())
+		})
+
+		It("Fails if tier resolver is not set", func() {
+			server, err := NewPrivateVolumesServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).To(MatchError("tier resolver is mandatory"))
 			Expect(server).To(BeNil())
 		})
 	})
@@ -66,6 +87,12 @@ var _ = Describe("Private volumes server", func() {
 				SetLogger(logger).
 				SetAttributionLogic(attribution).
 				SetTenancyLogic(tenancy).
+				SetTierResolver(func(_ context.Context, _ string) (*TierResolution, error) {
+					return &TierResolution{
+						BackendID: "test-backend",
+						Protocol:  privatev1.StorageProtocol_STORAGE_PROTOCOL_BLOCK,
+					}, nil
+				}).
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 		})


### PR DESCRIPTION
## Summary

[OSAC-3277](https://redhat.atlassian.net/browse/OSAC-3277): Add tier resolution to the Volume Create handler in fulfillment-service.

When a Volume is created, the server now resolves spec.storage_tier to a concrete
backend and protocol before persisting. Resolution looks up the StorageTier by name,
validates it is ACTIVE with at least one BackendAssociation, and selects the first
association. The resolved backend ID and protocol are written to status.backend and
status.protocol so the reconciler and operator controller have the routing information
without a second lookup.

Fails fast with gRPC status codes: NotFound if the tier does not exist,
FailedPrecondition if the tier is not active or has no backends.

## Why

Without tier resolution, volumes were persisted with an empty backend and protocol.
The Volume controller on the operator side needs to know which vendor CSI driver to
call, and the feedback controller needs to propagate the protocol back. Resolving at
creation time is the natural place since the fulfillment-service has direct DAO access
to StorageTier records.

## Testing

```
go build ./...           # passes
uv run dev.py lint go    # 0 issues
buf lint                 # passes
```

Integration test coverage for the full Volume create flow is tracked under OSAC-4046.

## Ticket

[OSAC-3277](https://redhat.atlassian.net/browse/OSAC-3277) (under [OSAC-3273](https://redhat.atlassian.net/browse/OSAC-3273) epic, under [OSAC-2872](https://redhat.atlassian.net/browse/OSAC-2872) feature)

<br>

<small>Signed-off-by: akshaynadkarni <25892229+akshaynadkarni@users.noreply.github.com></small>
<small>Assisted-by: Cursor/Claude</small>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Volume creation now resolves and validates the requested storage tier.
  * Volumes record the selected storage backend and protocol.

* **Bug Fixes**
  * Volume creation is rejected when the storage tier cannot be found, is inactive, lacks a backend, or cannot be resolved.
  * Service startup now fails clearly if storage-tier configuration cannot be initialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->