### PR TITLE
OSAC-4052: exclude vendor/ trees from graphify corpus scope

### DIFF
--- a/.graphifyignore
+++ b/.graphifyignore
@@ -4,3 +4,13 @@
 # genuine value in "which tests cover this function" questions and
 # source-to-test edges, worth the extra node/link count. See the design
 # doc's Premise 5 for the measured numbers behind this decision.
+#
+# Vendored third-party trees are excluded, not just deprioritized: real
+# measurement (generic YAML/JSON coverage, not yet shipped) found a single
+# vendored Ansible collection tree responsible for the large majority of a
+# real node-count/query-time ceiling breach -- content previously invisible
+# to the graph (YAML was doc-classified) that becomes noise, not signal,
+# once extracted. Confirmed via a full-repo search that this is currently
+# the only vendor/-style tree in the mono-repo -- osac-aap/collections/ is
+# this org's own first-party Ansible content and stays in scope.
+osac-aap/vendor/**


### PR DESCRIPTION
## Summary

Excludes vendored third-party trees from `.graphifyignore`, landed ahead of a future `GRAPHIFY_VERSION` bump that will adopt generic YAML/JSON extraction ([OSAC-4050](https://redhat.atlassian.net/browse/OSAC-4050), in progress in the graphify fork, not yet released).

## Why

[OSAC-4050](https://redhat.atlassian.net/browse/OSAC-4050) measured the real corpus-wide impact of universal YAML/JSON coverage against this repo: node count grew from 96,879 to 396,492 (+309%) and query wall-clock went from ~6s to 26.2s -- a real breach of the established ceiling (10s / ~170K nodes). Root cause: 70.3% of the new nodes (278,734) come from `osac-aap/vendor/ansible_collections/...` -- a vendored third-party Ansible collection's own YAML task files and test fixtures, previously invisible under `--code-only` (YAML was doc-classified) and now fully extracted since coverage would become unconditional. This is noise for a knowledge graph of this org's own code, not signal.

## What I checked

Searched the whole mono-repo rather than assuming `osac-aap` is the only offender:
- Broad directory-name search across every component: `vendor`, `vendored`, `third_party`, `third-party`, `3rdparty`, `external`, `node_modules`, `deps`, `_vendor`.
- Checked each of the 4 Go components' own root for a `vendor/` directory (Go's own vendoring idiom) -- none vendor their dependencies.
- Checked directory sizes across all 9 top-level components for anything else vendored-looking.

**`osac-aap/vendor/` is the only vendor tree in the mono-repo today.** Excluded precisely: `osac-aap/vendor/**` matches only `ansible_collections`, nothing else lives under that path, so nothing non-vendored gets caught. Important distinction confirmed: `osac-aap/collections/` (note: no `vendor/` in the path) is this org's own first-party Ansible content and correctly stays in scope -- only `osac-aap/vendor/` is excluded.

## Explicitly NOT done, per the ticket's sequencing

Does **not** bump `GRAPHIFY_VERSION` in `graphify-brain-refresh.yaml` -- that's separate, later work once a real `graphifyy` PyPI release actually includes [OSAC-4050](https://redhat.atlassian.net/browse/OSAC-4050)'s changes. This PR only lands the exclusion ahead of time, so the ceiling breach isn't reproduced in production when that version bump eventually happens.

## Still needed before this is fully verified

**A real re-measurement against an actual `graphifyy` release including [OSAC-4050](https://redhat.atlassian.net/browse/OSAC-4050)**, using the same before/after methodology (real corpus, real query wall-clock) [OSAC-4050](https://redhat.atlassian.net/browse/OSAC-4050) used, to confirm the exclusion genuinely brings node count/query time back under the ceiling. The ~118K-node estimate in [OSAC-4050](https://redhat.atlassian.net/browse/OSAC-4050)/OSAC-4052 is not yet independently confirmed -- [OSAC-4050](https://redhat.atlassian.net/browse/OSAC-4050) hasn't shipped a release yet, so this can't be done now. Tracked as follow-up once that release exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added ignore rules for vendored third-party files.
  * Kept first-party collection content included in processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->