### PR TITLE
OSAC-4056: Set metering reconciliation interval to 5m in CI

### DIFF
--- a/osac-installer/values/caas-ci/values.yaml
+++ b/osac-installer/values/caas-ci/values.yaml
@@ -157,6 +157,8 @@ kafka:
 # --- Metering ---
 metering:
   enabled: true
+  reconciliation:
+    interval: "5m"
   echoAdapter:
     enabled: true
     image:

--- a/osac-installer/values/vmaas-ci/values.yaml
+++ b/osac-installer/values/vmaas-ci/values.yaml
@@ -183,6 +183,8 @@ kafka:
 # --- Metering ---
 metering:
   enabled: true
+  reconciliation:
+    interval: "5m"
   # Echo adapter — test/development tool only. Consumes metering events from
   # Kafka and exposes them via HTTP for E2E test assertions.
   echoAdapter:


### PR DESCRIPTION
## Summary

Set `metering.reconciliation.interval` to 5m in vmaas-ci and caas-ci helm values. Enables disruptive chaos tests (osac-test-infra#372) to verify reconciler corrections without waiting the default 60 minutes.

## Test plan

- [ ] Metering reconciler runs every 5m on CI clusters (check metering-service logs for `periodic reconciliation started`)

Related: [osac-test-infra#372](https://github.com/osac-project/osac-test-infra/pull/372)
Epic: [OSAC-3918](https://redhat.atlassian.net/browse/OSAC-3918)