### PR TITLE
OSAC-4061: replace kustomize with Helm in osac-operator and BMF

### DIFF
--- a/.github/workflows/build-bmf-image.yaml
+++ b/.github/workflows/build-bmf-image.yaml
@@ -147,32 +147,27 @@ jobs:
           echo "Full SHA tag: $FULL_SHA_TAG"
           echo "Manifest tag: $SHA_TAG-manifests"
 
-      # Set up Go for kustomize operations
-      - name: Set up Go for manifest generation
-        if: github.event_name != 'pull_request'
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: 'bare-metal-fulfillment-operator/go.mod'
-
-      # Generate manifests with kustomize pointing to the SHA-tagged image
-      - name: Generate manifests with kustomize
+      # Generate manifests with Helm pointing to the SHA-tagged image
+      - name: Generate manifests with Helm
         if: github.event_name != 'pull_request'
         working-directory: bare-metal-fulfillment-operator
         run: |
-          # Install kustomize
-          make kustomize
+          # Split full SHA tag into repository and tag
+          FULL_TAG="${{ steps.sha-tag.outputs.full-sha-tag }}"
+          REPO="${FULL_TAG%:*}"
+          TAG="${FULL_TAG##*:}"
 
-          # Create dist directory
           mkdir -p dist
 
-          # Set the manager image to the SHA-tagged version
-          cd config/manager && ../../bin/kustomize edit set image controller=${{ steps.sha-tag.outputs.full-sha-tag }}
+          # Generate CRDs + operator manifests
+          helm template bmf-operator-crds charts/operator-crds > dist/install.yaml
+          echo "---" >> dist/install.yaml
+          helm template bmf-operator charts/operator \
+            --namespace bare-metal-fulfillment-operator-system \
+            --set image.repository="$REPO" \
+            --set image.tag="$TAG" >> dist/install.yaml
 
-          # Generate the complete manifest
-          cd ../..
-          ./bin/kustomize build config/default > dist/install.yaml
-
-          echo "Generated manifest with image: ${{ steps.sha-tag.outputs.full-sha-tag }}"
+          echo "Generated manifest with image: ${FULL_TAG}"
           echo "Manifest content preview:"
           head -20 dist/install.yaml
 

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -54,9 +54,9 @@ jobs:
         working-directory: osac-operator
         run: make test
 
-      - name: Validate kustomize configurations
+      - name: Validate Helm charts
         working-directory: osac-operator
-        run: make test-kustomize
+        run: make helm-validate
 
       - name: Run smoke test
         timeout-minutes: 15
@@ -156,32 +156,27 @@ jobs:
           echo "Full SHA tag: $FULL_SHA_TAG"
           echo "Manifest tag: $SHA_TAG-manifests"
 
-      # Set up Go for kustomize operations
-      - name: Set up Go for manifest generation
-        if: github.event_name != 'pull_request'
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: 'osac-operator/go.mod'
-
-      # Generate manifests with kustomize pointing to the SHA-tagged image
-      - name: Generate manifests with kustomize
+      # Generate manifests with Helm pointing to the SHA-tagged image
+      - name: Generate manifests with Helm
         if: github.event_name != 'pull_request'
         working-directory: osac-operator
         run: |
-          # Install kustomize
-          make kustomize
+          # Split full SHA tag into repository and tag
+          FULL_TAG="${{ steps.sha-tag.outputs.full-sha-tag }}"
+          REPO="${FULL_TAG%:*}"
+          TAG="${FULL_TAG##*:}"
 
-          # Create dist directory
           mkdir -p dist
 
-          # Set the manager image to the SHA-tagged version
-          cd config/manager && ../../bin/kustomize edit set image controller=${{ steps.sha-tag.outputs.full-sha-tag }}
+          # Generate CRDs + operator manifests
+          helm template osac-operator-crds charts/operator-crds > dist/install.yaml
+          echo "---" >> dist/install.yaml
+          helm template osac-operator charts/operator \
+            --namespace osac-operator-system \
+            --set image.repository="$REPO" \
+            --set image.tag="$TAG" >> dist/install.yaml
 
-          # Generate the complete manifest
-          cd ../..
-          ./bin/kustomize build config/default > dist/install.yaml
-
-          echo "Generated manifest with image: ${{ steps.sha-tag.outputs.full-sha-tag }}"
+          echo "Generated manifest with image: ${FULL_TAG}"
           echo "Manifest content preview:"
           head -20 dist/install.yaml
 

--- a/bare-metal-fulfillment-operator/AGENTS.md
+++ b/bare-metal-fulfillment-operator/AGENTS.md
@@ -31,7 +31,7 @@ make helm-crds                 # Sync CRDs to operator-crds chart + operator man
 make check-helm-crds           # Runs helm-crds then verifies no drift (may modify generated files)
 
 make run                       # Run controller locally
-make install                   # Install CRDs via kustomize
+make install                   # Install CRDs via Helm
 make deploy IMG=<registry>/bare-metal-fulfillment-operator:tag
 make undeploy                  # Remove operator from cluster
 make uninstall                 # Remove CRDs from cluster

--- a/bare-metal-fulfillment-operator/Makefile
+++ b/bare-metal-fulfillment-operator/Makefile
@@ -1,54 +1,3 @@
-# VERSION defines the project version for the bundle.
-# Update this value when you upgrade the version of your project.
-# To re-generate a bundle for another specific version without changing the standard setup, you can:
-# - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
-# - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.1
-
-# CHANNELS define the bundle channels used in the bundle.
-# Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
-# To re-generate a bundle for other specific channels without changing the standard setup, you can:
-# - use the CHANNELS as arg of the bundle target (e.g make bundle CHANNELS=candidate,fast,stable)
-# - use environment variables to overwrite this value (e.g export CHANNELS="candidate,fast,stable")
-ifneq ($(origin CHANNELS), undefined)
-BUNDLE_CHANNELS := --channels=$(CHANNELS)
-endif
-
-# DEFAULT_CHANNEL defines the default channel used in the bundle.
-# Add a new line here if you would like to change its default config. (E.g DEFAULT_CHANNEL = "stable")
-# To re-generate a bundle for any other default channel without changing the default setup, you can:
-# - use the DEFAULT_CHANNEL as arg of the bundle target (e.g make bundle DEFAULT_CHANNEL=stable)
-# - use environment variables to overwrite this value (e.g export DEFAULT_CHANNEL="stable")
-ifneq ($(origin DEFAULT_CHANNEL), undefined)
-BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
-endif
-BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
-
-# IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.
-# This variable is used to construct full image tags for bundle and catalog images.
-#
-# For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# openshift.io/bare-metal-fulfillment-operator-bundle:$VERSION and openshift.io/bare-metal-fulfillment-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= openshift.io/bare-metal-fulfillment-operator
-
-# BUNDLE_IMG defines the image:tag used for the bundle.
-# You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
-BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
-
-# BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
-BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
-
-# USE_IMAGE_DIGESTS defines if images are resolved via tags or digests
-# You can enable this value if you would like to use SHA Based Digests
-# To enable set flag to true
-USE_IMAGE_DIGESTS ?= false
-ifeq ($(USE_IMAGE_DIGESTS), true)
-	BUNDLE_GEN_FLAGS += --use-image-digests
-endif
-
-# Set the Operator SDK version to use. By default, what is installed on the system is used.
-# This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.42.1
 # Image URL to use all building/pushing image targets
 IMG ?= ghcr.io/osac-project/bare-metal-fulfillment-operator:latest
 # Name of Containerfile
@@ -71,6 +20,12 @@ CONTAINER_TOOL ?= podman
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
+
+# Split IMG into repository and tag for Helm values.
+IMG_REPO = $(firstword $(subst :, ,$(IMG)))
+IMG_TAG = $(or $(word 2,$(subst :, ,$(IMG))),latest)
+
+DEPLOY_NAMESPACE ?= bare-metal-fulfillment-operator-system
 
 .PHONY: all
 all: build
@@ -186,6 +141,15 @@ check-helm-crds: helm-crds ## Verify Helm CRD templates match config/crd/bases.
 		exit 1; \
 	fi
 
+.PHONY: helm-validate
+helm-validate: ## Validate Helm chart templates render without errors.
+	@echo "Validating Helm charts..."
+	helm lint charts/operator
+	helm lint charts/operator-crds
+	helm template bmf-operator charts/operator > /dev/null
+	helm template bmf-operator-crds charts/operator-crds > /dev/null
+	@echo "All Helm charts are valid"
+
 ##@ Build
 
 .PHONY: build
@@ -225,10 +189,14 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	rm ${CONTAINERFILE}.cross
 
 .PHONY: build-installer
-build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
+build-installer: helm-crds ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default > dist/install.yaml
+	helm template bmf-operator-crds charts/operator-crds > dist/install.yaml
+	echo "---" >> dist/install.yaml
+	helm template bmf-operator charts/operator \
+		--namespace $(DEPLOY_NAMESPACE) \
+		--set image.repository=$(IMG_REPO) \
+		--set image.tag=$(IMG_TAG) >> dist/install.yaml
 
 ##@ Deployment
 
@@ -237,21 +205,23 @@ ifndef ignore-not-found
 endif
 
 .PHONY: install
-install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
+install: helm-crds ## Install CRDs into the K8s cluster specified in ~/.kube/config.
+	helm upgrade --install bmf-operator-crds charts/operator-crds
 
 .PHONY: uninstall
-uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+uninstall: ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
+	helm uninstall bmf-operator-crds || $(ignore-not-found)
 
 .PHONY: deploy
-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
+deploy: helm-crds ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	helm upgrade --install bmf-operator charts/operator \
+		--namespace $(DEPLOY_NAMESPACE) --create-namespace \
+		--set image.repository=$(IMG_REPO) \
+		--set image.tag=$(IMG_TAG)
 
 .PHONY: undeploy
-undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
+	helm uninstall bmf-operator --namespace $(DEPLOY_NAMESPACE) || $(ignore-not-found)
 
 ##@ Dependencies
 
@@ -263,24 +233,17 @@ $(LOCALBIN):
 ## Tool Binaries
 KUBECTL ?= kubectl
 KIND ?= kind
-KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v5.6.0
 CONTROLLER_TOOLS_VERSION ?= v0.18.0
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
 GOLANGCI_LINT_VERSION ?= v2.1.0
-
-.PHONY: kustomize
-kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
-$(KUSTOMIZE): $(LOCALBIN)
-	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5,$(KUSTOMIZE_VERSION))
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
@@ -320,76 +283,3 @@ mv $(1) $(1)-$(3) ;\
 } ;\
 ln -sf $(1)-$(3) $(1)
 endef
-
-.PHONY: operator-sdk
-OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
-operator-sdk: ## Download operator-sdk locally if necessary.
-ifeq (,$(wildcard $(OPERATOR_SDK)))
-ifeq (, $(shell which operator-sdk 2>/dev/null))
-	@{ \
-	set -e ;\
-	mkdir -p $(dir $(OPERATOR_SDK)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
-	chmod +x $(OPERATOR_SDK) ;\
-	}
-else
-OPERATOR_SDK = $(shell which operator-sdk)
-endif
-endif
-
-.PHONY: bundle
-bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
-	$(OPERATOR_SDK) generate kustomize manifests -q
-	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
-	$(OPERATOR_SDK) bundle validate ./bundle
-
-.PHONY: bundle-build
-bundle-build: ## Build the bundle image.
-	$(CONTAINER_TOOL) build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
-
-.PHONY: bundle-push
-bundle-push: ## Push the bundle image.
-	$(MAKE) image-push IMG=$(BUNDLE_IMG)
-
-.PHONY: opm
-OPM = $(LOCALBIN)/opm
-opm: ## Download opm locally if necessary.
-ifeq (,$(wildcard $(OPM)))
-ifeq (,$(shell which opm 2>/dev/null))
-	@{ \
-	set -e ;\
-	mkdir -p $(dir $(OPM)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.55.0/$${OS}-$${ARCH}-opm ;\
-	chmod +x $(OPM) ;\
-	}
-else
-OPM = $(shell which opm)
-endif
-endif
-
-# A comma-separated list of bundle images (e.g. make catalog-build BUNDLE_IMGS=example.com/operator-bundle:v0.1.0,example.com/operator-bundle:v0.2.0).
-# These images MUST exist in a registry and be pull-able.
-BUNDLE_IMGS ?= $(BUNDLE_IMG)
-
-# The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:v0.2.0).
-CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:v$(VERSION)
-
-# Set CATALOG_BASE_IMG to an existing catalog image tag to add $BUNDLE_IMGS to that image.
-ifneq ($(origin CATALOG_BASE_IMG), undefined)
-FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG)
-endif
-
-# Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
-# This recipe invokes 'opm' in 'semver' bundle add mode. For more information on add modes, see:
-# https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
-.PHONY: catalog-build
-catalog-build: opm ## Build a catalog image.
-	$(OPM) index add --container-tool $(CONTAINER_TOOL) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
-
-# Push the catalog image.
-.PHONY: catalog-push
-catalog-push: ## Push a catalog image.
-	$(MAKE) image-push IMG=$(CATALOG_IMG)

--- a/bare-metal-fulfillment-operator/README.md
+++ b/bare-metal-fulfillment-operator/README.md
@@ -198,7 +198,7 @@ make deploy IMG=<some-registry>/bare-metal-fulfillment-operator:tag
 You can apply the samples (examples) from the config/sample:
 
 ``` sh
-kubectl apply -k config/samples/
+kubectl apply -f config/samples/
 ```
 
 > **NOTE**: Ensure that the samples has default values to test it out.
@@ -235,7 +235,7 @@ make build-installer IMG=<some-registry>/bare-metal-fulfillment-operator:tag
 ```
 
 NOTE: The makefile target mentioned above generates an 'install.yaml' file in
-the dist directory. This file contains all the resources built with Kustomize,
+the dist directory. This file contains all the resources built with Helm,
 which are necessary to install this project without its dependencies.
 
 2.  Using the installer

--- a/osac-operator/.claude/rules/common-pitfalls.md
+++ b/osac-operator/.claude/rules/common-pitfalls.md
@@ -30,7 +30,7 @@ Operator uses Go modules, not vendoring. Delete `vendor/` if it exists. Use `go 
 ## 8. Integration test failures
 - Update `kustomization.yaml` after renaming/deleting manifests
 - Clean up test clusters: `kind delete cluster --name osac`
-- Run `make test-kustomize` before committing manifest changes
+- Run `make helm-validate` before committing chart changes
 
 ## 9. gRPC client version mismatches
 Update module version in `buf.gen.yaml`, never edit proto files directly.

--- a/osac-operator/AGENTS.md
+++ b/osac-operator/AGENTS.md
@@ -35,8 +35,8 @@ OSAC operator is a Kubernetes operator that reconciles infrastructure resources 
 # Build and test (requires Go 1.26.3)
 make build                    # Build manager + console-proxy (runs 'make test' first, then builds)
 make test                     # Unit tests only (excludes e2e)
-make test-integration         # Runs test + test-kustomize + test-smoke
-make test-kustomize           # Validate all kustomization.yaml configs (catches missing files)
+make test-integration         # Runs test + helm-validate + test-smoke
+make helm-validate            # Validate Helm chart templates render without errors
 make test-smoke               # Create kind cluster 'osac-test', apply CRDs + samples, verify ComputeInstance
 make test-integration-kind    # Go integration tests against a running kind cluster
 make lint                     # golangci-lint v2.12.1 (strict — always run before commit)
@@ -125,12 +125,12 @@ hack/sync-helm-crds.py     # Script invoked by `make helm-crds` to sync CRDs to 
 ## Testing
 
 - **Unit tests**: Ginkgo + Gomega with `envtest` (real etcd + kube-apiserver)
-- **Integration**: `make test-kustomize` (manifest validation) + `make test-smoke` (kind cluster)
+- **Integration**: `make helm-validate` (Helm chart validation) + `make test-smoke` (kind cluster)
 - **Go integration tests**: `test/integration/` (console_proxy_test.go, integration_suite_test.go, networking_test.go) — run against an already-running kind cluster via `make test-integration-kind` (`go test ./test/integration/ -v -ginkgo.v`)
 - **E2E tests**: pytest-based, live in the separate `osac-test-infra` repo; triggered by the root-level `.github/workflows/e2e-vmaas-full-install.yml`, which builds and deploys both `osac-operator` and `fulfillment-service` together
 - Kind cluster defaults to `osac` (`KIND_CLUSTER_NAME` in Makefile line 81), but smoke tests create `osac-test`
 - Clean up: `kind delete cluster --name osac-test`
-- `test-kustomize` catches missing files in kustomization.yaml — always run before committing manifest changes
+- `helm-validate` catches broken Helm chart templates — always run before committing chart changes
 
 ## Code Quality
 
@@ -161,7 +161,7 @@ Hooks are configured in `.claude/settings.json` and run automatically during age
 - [ ] `make helm-crds` run after CRD regeneration
 - [ ] `make lint` passes (enforced by CI)
 - [ ] `make test` passes
-- [ ] `make test-kustomize` passes (catches missing files)
+- [ ] `make helm-validate` passes (catches broken chart templates)
 - [ ] CRD changes tested against a cluster
 - [ ] Cross-repo dependencies documented in PR description
 - [ ] PR title includes Jira key (e.g., "OSAC-12345: fix subnet race")
@@ -169,7 +169,7 @@ Hooks are configured in `.claude/settings.json` and run automatically during age
 
 ## CI Workflows
 
-- **build-image.yaml**: Runs `make test`, `make test-kustomize`, `make test-smoke`, then builds and pushes container + manifest container
+- **build-image.yaml**: Runs `make test`, `make helm-validate`, `make test-smoke`, then builds and pushes container + manifest container
 - **check-generated-code.yaml** (repo root, matrixed across components): Validates `buf generate` output unchanged (ensures gRPC client is up-to-date)
 - **helm-lint.yaml**: Checks CRD sync (`hack/sync-helm-crds.py`) and lints Helm charts
 - **e2e-vmaas-full-install.yml** (repo root, shared with fulfillment-service): builds both components and runs E2E tests in a VMaaS environment

--- a/osac-operator/Makefile
+++ b/osac-operator/Makefile
@@ -1,56 +1,5 @@
-# VERSION defines the project version for the bundle.
-# Update this value when you upgrade the version of your project.
-# To re-generate a bundle for another specific version without changing the standard setup, you can:
-# - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
-# - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.1
-
-# CHANNELS define the bundle channels used in the bundle.
-# Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
-# To re-generate a bundle for other specific channels without changing the standard setup, you can:
-# - use the CHANNELS as arg of the bundle target (e.g make bundle CHANNELS=candidate,fast,stable)
-# - use environment variables to overwrite this value (e.g export CHANNELS="candidate,fast,stable")
-ifneq ($(origin CHANNELS), undefined)
-BUNDLE_CHANNELS := --channels=$(CHANNELS)
-endif
-
-# DEFAULT_CHANNEL defines the default channel used in the bundle.
-# Add a new line here if you would like to change its default config. (E.g DEFAULT_CHANNEL = "stable")
-# To re-generate a bundle for any other default channel without changing the default setup, you can:
-# - use the DEFAULT_CHANNEL as arg of the bundle target (e.g make bundle DEFAULT_CHANNEL=stable)
-# - use environment variables to overwrite this value (e.g export DEFAULT_CHANNEL="stable")
-ifneq ($(origin DEFAULT_CHANNEL), undefined)
-BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
-endif
-BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
-
-# IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.
-# This variable is used to construct full image tags for bundle and catalog images.
-#
-# For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# openshift.io/osac-operator-bundle:$VERSION and openshift.io/osac-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= openshift.io/osac-operator
-
-# BUNDLE_IMG defines the image:tag used for the bundle.
-# You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
-BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
-
-# BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
-BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
-
-# USE_IMAGE_DIGESTS defines if images are resolved via tags or digests
-# You can enable this value if you would like to use SHA Based Digests
-# To enable set flag to true
-USE_IMAGE_DIGESTS ?= false
-ifeq ($(USE_IMAGE_DIGESTS), true)
-	BUNDLE_GEN_FLAGS += --use-image-digests
-endif
-
 OSAC_DEV_NAMESPACE ?= osac-operator-dev
 
-# Set the Operator SDK version to use. By default, what is installed on the system is used.
-# This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
-OPERATOR_SDK_VERSION ?= v1.39.1
 # Image URL to use all building/pushing image targets
 IMG ?= ghcr.io/osac-project/osac-operator:latest
 # Name of Containerfile
@@ -84,6 +33,12 @@ KIND_CLUSTER_NAME = osac
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
+
+# Split IMG into repository and tag for Helm values.
+IMG_REPO = $(firstword $(subst :, ,$(IMG)))
+IMG_TAG = $(or $(word 2,$(subst :, ,$(IMG))),latest)
+
+DEPLOY_NAMESPACE ?= osac-operator-system
 
 .PHONY: all
 all: build
@@ -128,26 +83,23 @@ test: manifests generate fmt vet envtest ## Run tests.
 	GOTOOLCHAIN=$(GOTOOLCHAIN_AUTO) KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v '/test/integration$$') -coverprofile cover.out
 
 .PHONY: test-integration
-test-integration: test test-kustomize test-smoke ## Run all tests including integration (kustomize + smoke).
+test-integration: test helm-validate test-smoke ## Run all tests including integration (Helm validation + smoke).
 
-.PHONY: test-kustomize
-test-kustomize: kustomize ## Validate kustomize configurations (catches missing files in kustomization.yaml).
-	@echo "Validating kustomize configurations..."
-	$(KUSTOMIZE) build config/crd > /dev/null
-	$(KUSTOMIZE) build config/rbac > /dev/null
-	$(KUSTOMIZE) build config/samples > /dev/null
-	$(KUSTOMIZE) build config/default > /dev/null
-	$(KUSTOMIZE) build config/console-proxy > /dev/null
-	$(KUSTOMIZE) build config/testing/default > /dev/null
-	$(KUSTOMIZE) build config/testing/console-proxy > /dev/null
-	@echo "All kustomize configurations are valid"
+.PHONY: helm-validate
+helm-validate: ## Validate Helm chart templates render without errors.
+	@echo "Validating Helm charts..."
+	helm lint charts/operator
+	helm lint charts/operator-crds
+	helm template osac-operator charts/operator > /dev/null
+	helm template osac-operator-crds charts/operator-crds > /dev/null
+	@echo "All Helm charts are valid"
 
 .PHONY: test-smoke
-test-smoke: kustomize ## Run smoke test in kind cluster (creates/deletes test cluster).
+test-smoke: ## Run smoke test in kind cluster (creates/deletes test cluster).
 	@echo "Creating kind cluster..."
 	$(KIND) create cluster --name osac-test --wait 5m || true
 	@echo "Installing CRDs..."
-	$(KUBECTL) apply -k config/crd
+	helm upgrade --install osac-operator-crds charts/operator-crds
 	@echo "Creating sample ComputeInstance..."
 	$(KUBECTL) apply -f config/samples/osac_v1alpha1_computeinstance.yaml
 	@echo "Verifying ComputeInstance creation..."
@@ -263,10 +215,14 @@ docker-buildx: ## Build and push container image for cross-platform support
 	rm $(CONTAINERFILE).cross
 
 .PHONY: build-installer
-build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
+build-installer: helm-crds ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default > dist/install.yaml
+	helm template osac-operator-crds charts/operator-crds > dist/install.yaml
+	echo "---" >> dist/install.yaml
+	helm template osac-operator charts/operator \
+		--namespace $(DEPLOY_NAMESPACE) \
+		--set image.repository=$(IMG_REPO) \
+		--set image.tag=$(IMG_TAG) >> dist/install.yaml
 
 ##@ Deployment
 
@@ -275,23 +231,23 @@ ifndef ignore-not-found
 endif
 
 .PHONY: install
-install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUBECTL) apply -k config/crd
+install: helm-crds ## Install CRDs into the K8s cluster specified in ~/.kube/config.
+	helm upgrade --install osac-operator-crds charts/operator-crds
 
 .PHONY: uninstall
-uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -k config/crd
-
-DEPLOY_OVERLAY ?= config/default
+uninstall: ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
+	helm uninstall osac-operator-crds || $(ignore-not-found)
 
 .PHONY: deploy
-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUBECTL) apply -k $(DEPLOY_OVERLAY)
+deploy: helm-crds ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	helm upgrade --install osac-operator charts/operator \
+		--namespace $(DEPLOY_NAMESPACE) --create-namespace \
+		--set image.repository=$(IMG_REPO) \
+		--set image.tag=$(IMG_TAG)
 
 .PHONY: undeploy
-undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -k $(DEPLOY_OVERLAY)
+undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
+	helm uninstall osac-operator --namespace $(DEPLOY_NAMESPACE) || $(ignore-not-found)
 
 ##@ Dependencies
 
@@ -302,21 +258,14 @@ $(LOCALBIN):
 
 ## Tool Binaries
 KUBECTL ?= kubectl
-KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.20.0
 ENVTEST_VERSION ?= release-0.19
 GOLANGCI_LINT_VERSION ?= v2.12.1
-
-.PHONY: kustomize
-kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
-$(KUSTOMIZE): $(LOCALBIN)
-	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5,$(KUSTOMIZE_VERSION))
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
@@ -348,76 +297,3 @@ mv $(1) $(1)-$(3) ;\
 } ;\
 ln -sf $(1)-$(3) $(1)
 endef
-
-.PHONY: operator-sdk
-OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
-operator-sdk: ## Download operator-sdk locally if necessary.
-ifeq (,$(wildcard $(OPERATOR_SDK)))
-ifeq (, $(shell which operator-sdk 2>/dev/null))
-	@{ \
-	set -e ;\
-	mkdir -p $(dir $(OPERATOR_SDK)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
-	chmod +x $(OPERATOR_SDK) ;\
-	}
-else
-OPERATOR_SDK = $(shell which operator-sdk)
-endif
-endif
-
-.PHONY: bundle
-bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
-	$(OPERATOR_SDK) generate kustomize manifests -q
-	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
-	$(OPERATOR_SDK) bundle validate ./bundle
-
-.PHONY: bundle-build
-bundle-build: ## Build the bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
-
-.PHONY: bundle-push
-bundle-push: ## Push the bundle image.
-	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
-
-.PHONY: opm
-OPM = $(LOCALBIN)/opm
-opm: ## Download opm locally if necessary.
-ifeq (,$(wildcard $(OPM)))
-ifeq (,$(shell which opm 2>/dev/null))
-	@{ \
-	set -e ;\
-	mkdir -p $(dir $(OPM)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/$${OS}-$${ARCH}-opm ;\
-	chmod +x $(OPM) ;\
-	}
-else
-OPM = $(shell which opm)
-endif
-endif
-
-# A comma-separated list of bundle images (e.g. make catalog-build BUNDLE_IMGS=example.com/operator-bundle:v0.1.0,example.com/operator-bundle:v0.2.0).
-# These images MUST exist in a registry and be pull-able.
-BUNDLE_IMGS ?= $(BUNDLE_IMG)
-
-# The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:v0.2.0).
-CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:v$(VERSION)
-
-# Set CATALOG_BASE_IMG to an existing catalog image tag to add $BUNDLE_IMGS to that image.
-ifneq ($(origin CATALOG_BASE_IMG), undefined)
-FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG)
-endif
-
-# Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
-# This recipe invokes 'opm' in 'semver' bundle add mode. For more information on add modes, see:
-# https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
-.PHONY: catalog-build
-catalog-build: opm ## Build a catalog image.
-	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
-
-# Push the catalog image.
-.PHONY: catalog-push
-catalog-push: ## Push a catalog image.
-	$(MAKE) docker-push IMG=$(CATALOG_IMG)

--- a/osac-operator/README.md
+++ b/osac-operator/README.md
@@ -244,7 +244,7 @@ make deploy IMG=<some-registry>/osac-operator:tag
 You can apply the samples (examples) from the config/sample:
 
 ``` sh
-kubectl apply -k config/samples/
+kubectl apply -f config/samples/
 ```
 
 > **NOTE**: Ensure that the samples has default values to test it out.
@@ -281,7 +281,7 @@ make build-installer IMG=<some-registry>/osac-operator:tag
 ```
 
 NOTE: The makefile target mentioned above generates an 'install.yaml' file in
-the dist directory. This file contains all the resources built with Kustomize,
+the dist directory. This file contains all the resources built with Helm,
 which are necessary to install this project without its dependencies.
 
 2.  Using the installer

--- a/osac-operator/test/integration/integration_suite_test.go
+++ b/osac-operator/test/integration/integration_suite_test.go
@@ -19,7 +19,6 @@ package integration
 import (
 	"fmt"
 	"os/exec"
-	"strings"
 	"testing"
 	"time"
 
@@ -38,8 +37,8 @@ var _ = BeforeSuite(func() {
 	By("installing cert-manager")
 	Expect(utils.InstallCertManager()).To(Succeed())
 
-	By("installing CRDs")
-	cmd := exec.Command("make", "install")
+	By("installing CRDs via Helm")
+	cmd := exec.Command("helm", "upgrade", "--install", "osac-operator-crds", "charts/operator-crds")
 	_, err := utils.Run(cmd)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -55,15 +54,13 @@ var _ = BeforeSuite(func() {
 	err = utils.LoadImageToKindClusterWithName(operatorImage)
 	Expect(err).NotTo(HaveOccurred())
 
-	By("creating manager namespace")
-	cmd = exec.Command("kubectl", "create", "ns", operatorNamespace)
-	_, err = utils.Run(cmd)
-	if err != nil && !strings.Contains(err.Error(), "AlreadyExists") {
-		Fail(fmt.Sprintf("failed to create namespace %s: %v", operatorNamespace, err))
-	}
-
-	By("deploying the controller-manager")
-	cmd = exec.Command("kubectl", "apply", "-k", "config/testing/default")
+	By("deploying the controller-manager via Helm")
+	cmd = exec.Command("helm", "upgrade", "--install", "osac-operator", "charts/operator",
+		"--namespace", operatorNamespace, "--create-namespace",
+		"--set", "image.repository=localhost/osac-operator",
+		"--set", "image.tag=latest",
+		"--set", "image.pullPolicy=Never",
+	)
 	_, err = utils.Run(cmd)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -104,7 +101,11 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	By("undeploying the controller-manager")
-	cmd := exec.Command("kubectl", "delete", "-k", "config/testing/default", "--ignore-not-found")
+	cmd := exec.Command("helm", "uninstall", "osac-operator", "--namespace", operatorNamespace)
+	_, _ = utils.Run(cmd)
+
+	By("uninstalling CRDs")
+	cmd = exec.Command("helm", "uninstall", "osac-operator-crds")
 	_, _ = utils.Run(cmd)
 
 	By("removing manager namespace")


### PR DESCRIPTION
## Summary

PR 0a of the additive-first kustomize-to-Helm migration ([OSAC-4061](https://redhat.atlassian.net/browse/OSAC-4061), epic [OSAC-3752](https://redhat.atlassian.net/browse/OSAC-3752)).

- **Makefiles** (both operators): `helm-validate` target, Helm-based `install`/`uninstall`/`deploy`/`undeploy`/`build-installer`, removed dead OLM targets and kustomize binary download
- **CI workflows**: `build-image.yaml` switches to `helm-validate` and `helm template` for manifest generation; `build-bmf-image.yaml` switches manifest generation; both drop the Go setup step that was only needed for kustomize
- **Integration tests**: `helm upgrade --install` (no `--wait` — existing `Eventually` poll handles readiness), `helm uninstall` in teardown
- **Docs**: AGENTS.md, README.md, common-pitfalls.md updated

**Kustomize overlay files are deliberately retained** — a follow-up PR (0b) will delete them after CI confirms zero remaining references.

## Test plan

- [ ] `make helm-validate` passes in both `osac-operator/` and `bare-metal-fulfillment-operator/`
- [ ] `make build-installer` generates valid `dist/install.yaml` with correct image refs
- [ ] CI `build-image.yaml` test job passes (helm-validate + smoke)
- [ ] CI `build-bmf-image.yaml` test job passes
- [ ] CI manifest container builds with correct Helm-generated manifests
- [ ] `grep -r kustomize` in Makefiles and CI workflows returns zero matches (outside kustomize overlay dirs)
- [ ] Integration tests deploy via Helm and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)