### PR TITLE
OSAC-1541: Improve SetLimit semantics in generic DAO

### DIFF
--- a/fulfillment-service/docs/API.md
+++ b/fulfillment-service/docs/API.md
@@ -383,8 +383,9 @@ message ThingsListResponse {
 ```
 
 - `offset` is the zero-based index of the first result to return. Defaults to zero.
-- `limit` is the maximum number of results. When omitted, the server returns all matching objects
-  (though it may cap the result set for performance reasons).
+- `limit` is the maximum number of results. When omitted, the server applies a default limit. When
+  set to zero, the server returns only the total count with an empty items list (useful for clients
+  that only need to know how many items match a filter). Negative values are rejected with an error.
 - `filter` is a [CEL](https://cel.dev) expression evaluated against each candidate object. See
   [docs/FILTER.md](FILTER.md) for the full details of the supported CEL subset.
 - `order` specifies the sort order using a syntax similar to SQL `ORDER BY`, for example

--- a/fulfillment-service/internal/database/dao/dao_errors.go
+++ b/fulfillment-service/internal/database/dao/dao_errors.go
@@ -183,6 +183,16 @@ func (e *ErrNotUnique) Error() string {
 	return e.Reason
 }
 
+// ErrValidation indicates that a request parameter failed validation.
+type ErrValidation struct {
+	Reason string
+}
+
+// Error returns the error message.
+func (e *ErrValidation) Error() string {
+	return e.Reason
+}
+
 // ErrDeadlock indicates that a PostgreSQL deadlock was detected. The caller should retry the operation.
 type ErrDeadlock struct{}
 

--- a/fulfillment-service/internal/database/dao/generic_dao_list.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_list.go
@@ -27,8 +27,8 @@ type ListRequest[O Object] struct {
 	request[O]
 	filter   string
 	limit    int32
-	limitSet bool
 	offset   int32
+	limitSet bool
 }
 
 // SetFilter sets the CEL expression that defines which objects should be returned.
@@ -69,7 +69,9 @@ func (r *ListRequest[O]) Do(ctx context.Context) (response *ListResponse[O], err
 func (r *ListRequest[O]) do(ctx context.Context) (response *ListResponse[O], err error) {
 	// Reject negative limits early:
 	if r.limit < 0 {
-		err = fmt.Errorf("limit must be a non-negative integer, but it is %d", r.limit)
+		err = &ErrValidation{
+			Reason: fmt.Sprintf("limit must be a non-negative integer, but it is %d", r.limit),
+		}
 		return
 	}
 
@@ -116,10 +118,10 @@ func (r *ListRequest[O]) do(ctx context.Context) (response *ListResponse[O], err
 		return
 	}
 
-	// When the limit was explicitly set to zero, return only the count:
+	// Return only the count for explicit zero limit:
 	if r.limitSet && r.limit == 0 {
 		response = &ListResponse[O]{
-			total: int32(total), // #nosec G115 -- bounded by MaxLimit
+			total: int32(total), // #nosec G115 -- overflow requires >2B rows
 		}
 		return
 	}
@@ -256,7 +258,7 @@ func (r *ListRequest[O]) do(ctx context.Context) (response *ListResponse[O], err
 	// Create and return the response:
 	response = &ListResponse[O]{
 		size:  int32(len(items)), // #nosec G115 -- bounded by MaxLimit
-		total: int32(total),      // #nosec G115 -- bounded by MaxLimit
+		total: int32(total),      // #nosec G115 -- overflow requires >2B rows
 		items: items,
 	}
 	return

--- a/fulfillment-service/internal/database/dao/generic_dao_list.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_list.go
@@ -25,9 +25,10 @@ import (
 // ListRequest represents a request to list objects with pagination and filtering.
 type ListRequest[O Object] struct {
 	request[O]
-	filter string
-	limit  int32
-	offset int32
+	filter   string
+	limit    int32
+	limitSet bool
+	offset   int32
 }
 
 // SetFilter sets the CEL expression that defines which objects should be returned.
@@ -36,9 +37,11 @@ func (r *ListRequest[O]) SetFilter(value string) *ListRequest[O] {
 	return r
 }
 
-// SetLimit sets the maximum number of items to return.
+// SetLimit sets the maximum number of items to return. A negative value will cause Do to
+// return an error. Zero means return only the count, skipping the item query.
 func (r *ListRequest[O]) SetLimit(value int32) *ListRequest[O] {
 	r.limit = value
+	r.limitSet = true
 	return r
 }
 
@@ -64,6 +67,12 @@ func (r *ListRequest[O]) Do(ctx context.Context) (response *ListResponse[O], err
 }
 
 func (r *ListRequest[O]) do(ctx context.Context) (response *ListResponse[O], err error) {
+	// Reject negative limits early:
+	if r.limit < 0 {
+		err = fmt.Errorf("limit must be a non-negative integer, but it is %d", r.limit)
+		return
+	}
+
 	// Add tenant visibility filter:
 	err = r.addTenancyFilter(ctx)
 	if err != nil {
@@ -107,6 +116,14 @@ func (r *ListRequest[O]) do(ctx context.Context) (response *ListResponse[O], err
 		return
 	}
 
+	// When the limit was explicitly set to zero, return only the count:
+	if r.limitSet && r.limit == 0 {
+		response = &ListResponse[O]{
+			total: int32(total), // #nosec G115 -- bounded by MaxLimit
+		}
+		return
+	}
+
 	// Fetch the results:
 	buffer.Reset()
 	fmt.Fprintf(
@@ -144,11 +161,9 @@ func (r *ListRequest[O]) do(ctx context.Context) (response *ListResponse[O], err
 	r.sql.params = append(r.sql.params, offset)
 	fmt.Fprintf(&buffer, ` offset $%d`, len(r.sql.params))
 
-	// Add the limit:
+	// Add the limit (negative already rejected, explicit zero already handled):
 	limit := r.limit
-	if limit < 0 {
-		limit = 0
-	} else if limit == 0 {
+	if limit == 0 {
 		limit = r.dao.defaultLimit
 	} else if limit > r.dao.maxLimit {
 		limit = r.dao.maxLimit

--- a/fulfillment-service/internal/database/dao/generic_dao_test.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_test.go
@@ -1251,18 +1251,26 @@ var _ = Describe("Generic DAO", func() {
 				Expect(response.GetItems()[0].Id).To(Equal(objects[0].Id))
 			})
 
-			It("Interprets negative limit as requesting zero items", func() {
-				response, err := generic.List().
+			It("Rejects negative limit with an error", func() {
+				_, err := generic.List().
 					SetLimit(-123).
+					Do(ctx)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("limit must be a non-negative integer"))
+			})
+
+			It("Returns only count when limit is explicitly set to zero", func() {
+				response, err := generic.List().
+					SetLimit(0).
 					Do(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.GetSize()).To(BeZero())
+				Expect(response.GetTotal()).To(BeNumerically("==", objectCount))
 				Expect(response.GetItems()).To(BeEmpty())
 			})
 
-			It("Interprets zero limit as requesting the default number of items", func() {
+			It("Uses default limit when limit is not set", func() {
 				response, err := generic.List().
-					SetLimit(0).
 					Do(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.GetSize()).To(BeNumerically("==", defaultLimit))

--- a/fulfillment-service/internal/servers/bare_metal_instance_types_server.go
+++ b/fulfillment-service/internal/servers/bare_metal_instance_types_server.go
@@ -144,7 +144,9 @@ func (s *BareMetalInstanceTypesServer) List(ctx context.Context,
 	// Create private request with same parameters:
 	privateRequest := &privatev1.BareMetalInstanceTypesListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 	privateRequest.SetOrder(request.GetOrder())
 

--- a/fulfillment-service/internal/servers/baremetal_instance_catalog_items_server.go
+++ b/fulfillment-service/internal/servers/baremetal_instance_catalog_items_server.go
@@ -145,7 +145,9 @@ func (s *BareMetalInstanceCatalogItemsServer) List(ctx context.Context,
 	request *publicv1.BareMetalInstanceCatalogItemsListRequest) (response *publicv1.BareMetalInstanceCatalogItemsListResponse, err error) {
 	privateRequest := &privatev1.BareMetalInstanceCatalogItemsListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	composedFilter, err := s.addPublishedFilter(request.GetFilter())
 	if err != nil {
 		return nil, err

--- a/fulfillment-service/internal/servers/baremetal_instance_templates_server.go
+++ b/fulfillment-service/internal/servers/baremetal_instance_templates_server.go
@@ -122,7 +122,9 @@ func (s *BareMetalInstanceTemplatesServer) List(ctx context.Context,
 	request *publicv1.BareMetalInstanceTemplatesListRequest) (response *publicv1.BareMetalInstanceTemplatesListResponse, err error) {
 	privateRequest := &privatev1.BareMetalInstanceTemplatesListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 
 	privateResponse, err := s.delegate.List(ctx, privateRequest)

--- a/fulfillment-service/internal/servers/baremetal_instances_server.go
+++ b/fulfillment-service/internal/servers/baremetal_instances_server.go
@@ -131,7 +131,9 @@ func (s *BareMetalInstancesServer) List(ctx context.Context,
 	request *publicv1.BareMetalInstancesListRequest) (response *publicv1.BareMetalInstancesListResponse, err error) {
 	privateRequest := &privatev1.BareMetalInstancesListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 
 	privateResponse, err := s.delegate.List(ctx, privateRequest)

--- a/fulfillment-service/internal/servers/cluster_catalog_items_server.go
+++ b/fulfillment-service/internal/servers/cluster_catalog_items_server.go
@@ -138,7 +138,9 @@ func (s *ClusterCatalogItemsServer) List(ctx context.Context,
 	request *publicv1.ClusterCatalogItemsListRequest) (response *publicv1.ClusterCatalogItemsListResponse, err error) {
 	privateRequest := &privatev1.ClusterCatalogItemsListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	composedFilter, err := s.addPublishedFilter(request.GetFilter())
 	if err != nil {
 		return nil, err

--- a/fulfillment-service/internal/servers/cluster_templates_server.go
+++ b/fulfillment-service/internal/servers/cluster_templates_server.go
@@ -136,7 +136,9 @@ func (s *ClusterTemplatesServer) List(ctx context.Context,
 	// Create private request with same parameters:
 	privateRequest := &privatev1.ClusterTemplatesListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 
 	// Delegate to private server:

--- a/fulfillment-service/internal/servers/cluster_versions_server.go
+++ b/fulfillment-service/internal/servers/cluster_versions_server.go
@@ -149,7 +149,9 @@ func (s *ClusterVersionsServer) List(ctx context.Context,
 	request *publicv1.ClusterVersionsListRequest) (*publicv1.ClusterVersionsListResponse, error) {
 	privateRequest := &privatev1.ClusterVersionsListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	composedFilter, err := composeFilterDefaults(request.GetFilter(), clusterVersionFilterDefaults)
 	if err != nil {
 		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "%v", err)

--- a/fulfillment-service/internal/servers/clusters_server.go
+++ b/fulfillment-service/internal/servers/clusters_server.go
@@ -203,7 +203,9 @@ func (s *ClustersServer) List(ctx context.Context,
 	// Create private request with same parameters:
 	privateRequest := &privatev1.ClustersListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 
 	// Delegate to private server:

--- a/fulfillment-service/internal/servers/compute_instance_catalog_items_server.go
+++ b/fulfillment-service/internal/servers/compute_instance_catalog_items_server.go
@@ -138,7 +138,9 @@ func (s *ComputeInstanceCatalogItemsServer) List(ctx context.Context,
 	request *publicv1.ComputeInstanceCatalogItemsListRequest) (response *publicv1.ComputeInstanceCatalogItemsListResponse, err error) {
 	privateRequest := &privatev1.ComputeInstanceCatalogItemsListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	composedFilter, err := s.addPublishedFilter(request.GetFilter())
 	if err != nil {
 		return nil, err

--- a/fulfillment-service/internal/servers/compute_instance_templates_server.go
+++ b/fulfillment-service/internal/servers/compute_instance_templates_server.go
@@ -136,7 +136,9 @@ func (s *ComputeInstanceTemplatesServer) List(ctx context.Context,
 	// Create private request with same parameters:
 	privateRequest := &privatev1.ComputeInstanceTemplatesListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 
 	// Delegate to private server:

--- a/fulfillment-service/internal/servers/compute_instances_server.go
+++ b/fulfillment-service/internal/servers/compute_instances_server.go
@@ -136,7 +136,9 @@ func (s *ComputeInstancesServer) List(ctx context.Context,
 	// Create private request with same parameters:
 	privateRequest := &privatev1.ComputeInstancesListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 
 	// Delegate to private server:

--- a/fulfillment-service/internal/servers/disk_images_server.go
+++ b/fulfillment-service/internal/servers/disk_images_server.go
@@ -137,7 +137,9 @@ func (s *DiskImagesServer) List(ctx context.Context,
 	request *publicv1.DiskImagesListRequest) (response *publicv1.DiskImagesListResponse, err error) {
 	privateRequest := &privatev1.DiskImagesListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	composedFilter, err := composeFilterDefaults(request.GetFilter(), diskImageFilterDefaults)
 	if err != nil {
 		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "%v", err)

--- a/fulfillment-service/internal/servers/external_ip_attachments_server.go
+++ b/fulfillment-service/internal/servers/external_ip_attachments_server.go
@@ -129,7 +129,9 @@ func (s *ExternalIPAttachmentsServer) List(ctx context.Context,
 	request *publicv1.ExternalIPAttachmentsListRequest) (*publicv1.ExternalIPAttachmentsListResponse, error) {
 	privateRequest := &privatev1.ExternalIPAttachmentsListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 	privateRequest.SetOrder(request.GetOrder())
 

--- a/fulfillment-service/internal/servers/external_ips_server.go
+++ b/fulfillment-service/internal/servers/external_ips_server.go
@@ -129,7 +129,9 @@ func (s *ExternalIPsServer) List(ctx context.Context,
 	request *publicv1.ExternalIPsListRequest) (response *publicv1.ExternalIPsListResponse, err error) {
 	privateRequest := &privatev1.ExternalIPsListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 	privateRequest.SetOrder(request.GetOrder())
 

--- a/fulfillment-service/internal/servers/generic_server.go
+++ b/fulfillment-service/internal/servers/generic_server.go
@@ -379,16 +379,19 @@ func (s *GenericServer[O]) List(ctx context.Context, request any, response any) 
 	type requestIface interface {
 		GetOffset() int32
 		GetLimit() int32
+		HasLimit() bool
 		GetFilter() string
 	}
 	requestMsg := request.(requestIface)
 
 	// List the objects:
-	daoResponse, err := s.dao.List().
+	listRequest := s.dao.List().
 		SetFilter(requestMsg.GetFilter()).
-		SetOffset(requestMsg.GetOffset()).
-		SetLimit(requestMsg.GetLimit()).
-		Do(ctx)
+		SetOffset(requestMsg.GetOffset())
+	if requestMsg.HasLimit() {
+		listRequest.SetLimit(requestMsg.GetLimit())
+	}
+	daoResponse, err := listRequest.Do(ctx)
 	if err != nil {
 		var deniedErr *dao.ErrDenied
 		if errors.As(err, &deniedErr) {

--- a/fulfillment-service/internal/servers/generic_server.go
+++ b/fulfillment-service/internal/servers/generic_server.go
@@ -393,6 +393,10 @@ func (s *GenericServer[O]) List(ctx context.Context, request any, response any) 
 	}
 	daoResponse, err := listRequest.Do(ctx)
 	if err != nil {
+		var validationErr *dao.ErrValidation
+		if errors.As(err, &validationErr) {
+			return grpcstatus.Errorf(grpccodes.InvalidArgument, "%s", validationErr.Reason)
+		}
 		var deniedErr *dao.ErrDenied
 		if errors.As(err, &deniedErr) {
 			return grpcstatus.Errorf(grpccodes.PermissionDenied, "%s", deniedErr.Reason)

--- a/fulfillment-service/internal/servers/host_types_server.go
+++ b/fulfillment-service/internal/servers/host_types_server.go
@@ -136,7 +136,9 @@ func (s *HostTypesServer) List(ctx context.Context,
 	// Create private request with same parameters:
 	privateRequest := &privatev1.HostTypesListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 	privateRequest.SetOrder(request.GetOrder())
 

--- a/fulfillment-service/internal/servers/identity_providers_server.go
+++ b/fulfillment-service/internal/servers/identity_providers_server.go
@@ -170,7 +170,9 @@ func (s *IdentityProvidersServer) List(ctx context.Context,
 	// Create private request with same parameters:
 	privateRequest := &privatev1.IdentityProvidersListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 
 	// Delegate to private server:

--- a/fulfillment-service/internal/servers/instance_types_server.go
+++ b/fulfillment-service/internal/servers/instance_types_server.go
@@ -153,7 +153,9 @@ func (s *InstanceTypesServer) List(ctx context.Context,
 	// Create private request with same parameters:
 	privateRequest := &privatev1.InstanceTypesListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	composedFilter, err := composeFilterDefaults(request.GetFilter(), instanceTypeFilterDefaults)
 	if err != nil {
 		return nil, grpcstatus.Errorf(grpccodes.InvalidArgument, "%v", err)

--- a/fulfillment-service/internal/servers/nat_gateways_server.go
+++ b/fulfillment-service/internal/servers/nat_gateways_server.go
@@ -129,7 +129,9 @@ func (s *NATGatewaysServer) List(ctx context.Context,
 	request *publicv1.NATGatewaysListRequest) (response *publicv1.NATGatewaysListResponse, err error) {
 	privateRequest := &privatev1.NATGatewaysListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 	privateRequest.SetOrder(request.GetOrder())
 

--- a/fulfillment-service/internal/servers/network_classes_server.go
+++ b/fulfillment-service/internal/servers/network_classes_server.go
@@ -152,7 +152,9 @@ func (s *NetworkClassesServer) List(ctx context.Context,
 	// Create private request with same parameters:
 	privateRequest := &privatev1.NetworkClassesListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 	privateRequest.SetOrder(request.GetOrder())
 

--- a/fulfillment-service/internal/servers/project_memberships_server.go
+++ b/fulfillment-service/internal/servers/project_memberships_server.go
@@ -135,7 +135,9 @@ func (s *ProjectMembershipsServer) List(ctx context.Context,
 	request *publicv1.ProjectMembershipsListRequest) (response *publicv1.ProjectMembershipsListResponse, err error) {
 	privateRequest := &privatev1.ProjectMembershipsListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 	privateRequest.SetOrder(request.GetOrder())
 

--- a/fulfillment-service/internal/servers/projects_server.go
+++ b/fulfillment-service/internal/servers/projects_server.go
@@ -138,7 +138,9 @@ func (s *ProjectsServer) List(ctx context.Context,
 	request *publicv1.ProjectsListRequest) (response *publicv1.ProjectsListResponse, err error) {
 	privateRequest := &privatev1.ProjectsListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetOrder(request.GetOrder())
 	privateRequest.SetFilter(request.GetFilter())
 	privateResponse, err := s.private.List(ctx, privateRequest)

--- a/fulfillment-service/internal/servers/role_bindings_server.go
+++ b/fulfillment-service/internal/servers/role_bindings_server.go
@@ -135,7 +135,9 @@ func (s *RoleBindingsServer) List(ctx context.Context,
 	request *publicv1.RoleBindingsListRequest) (response *publicv1.RoleBindingsListResponse, err error) {
 	privateRequest := &privatev1.RoleBindingsListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 	privateRequest.SetOrder(request.GetOrder())
 

--- a/fulfillment-service/internal/servers/roles_server.go
+++ b/fulfillment-service/internal/servers/roles_server.go
@@ -135,7 +135,9 @@ func (s *RolesServer) List(ctx context.Context,
 	request *publicv1.RolesListRequest) (response *publicv1.RolesListResponse, err error) {
 	privateRequest := &privatev1.RolesListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 	privateRequest.SetOrder(request.GetOrder())
 

--- a/fulfillment-service/internal/servers/secrets_server.go
+++ b/fulfillment-service/internal/servers/secrets_server.go
@@ -170,7 +170,9 @@ func (s *SecretsServer) List(ctx context.Context,
 	request *publicv1.SecretsListRequest) (response *publicv1.SecretsListResponse, err error) {
 	privateRequest := &privatev1.SecretsListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 	privateRequest.SetOrder(request.GetOrder())
 

--- a/fulfillment-service/internal/servers/security_groups_server.go
+++ b/fulfillment-service/internal/servers/security_groups_server.go
@@ -136,7 +136,9 @@ func (s *SecurityGroupsServer) List(ctx context.Context,
 	// Create private request with same parameters:
 	privateRequest := &privatev1.SecurityGroupsListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 	privateRequest.SetOrder(request.GetOrder())
 

--- a/fulfillment-service/internal/servers/subnets_server.go
+++ b/fulfillment-service/internal/servers/subnets_server.go
@@ -136,7 +136,9 @@ func (s *SubnetsServer) List(ctx context.Context,
 	// Create private request with same parameters:
 	privateRequest := &privatev1.SubnetsListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 	privateRequest.SetOrder(request.GetOrder())
 

--- a/fulfillment-service/internal/servers/tenants_server.go
+++ b/fulfillment-service/internal/servers/tenants_server.go
@@ -130,7 +130,9 @@ func (s *TenantsServer) List(ctx context.Context,
 	// Create private request with same parameters:
 	privateRequest := &privatev1.TenantsListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 	privateRequest.SetOrder(request.GetOrder())
 

--- a/fulfillment-service/internal/servers/users_server.go
+++ b/fulfillment-service/internal/servers/users_server.go
@@ -134,7 +134,9 @@ func (s *UsersServer) List(ctx context.Context,
 	// Create private request with same parameters:
 	privateRequest := &privatev1.UsersListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 
 	// Delegate to private server:

--- a/fulfillment-service/internal/servers/virtual_networks_server.go
+++ b/fulfillment-service/internal/servers/virtual_networks_server.go
@@ -147,7 +147,9 @@ func (s *VirtualNetworksServer) List(ctx context.Context,
 	// Create private request with same parameters:
 	privateRequest := &privatev1.VirtualNetworksListRequest{}
 	privateRequest.SetOffset(request.GetOffset())
-	privateRequest.SetLimit(request.GetLimit())
+	if request.HasLimit() {
+		privateRequest.SetLimit(request.GetLimit())
+	}
 	privateRequest.SetFilter(request.GetFilter())
 	privateRequest.SetOrder(request.GetOrder())
 


### PR DESCRIPTION
Summary

  - Reject negative limit values with an error instead of silently treating them as zero items
  - When limit is explicitly set to zero, return only the count (skip item-fetching query) - useful
  for clients that only need to know how many items match a filter
  - Distinguish "limit not set" (use default) from "limit set to zero" (count-only) via a limitSet
  field in ListRequest

  Details

  The SetLimit method on ListRequest previously had legacy semantics from before ListRequest existed
  as a type:

  - Negative value: was returning zero items silently → now returns an error
  - Zero (explicit via SetLimit(0)): was using default limit (100) → now runs only the SELECT COUNT(*)
  query and returns the total with an empty items slice
  - Zero (not set, SetLimit never called): was using default limit → unchanged
  - Positive value: unchanged

  A limitSet bool field was added to ListRequest to distinguish between the two zero cases.

  Changes are in generic_dao_list.go (DAO logic) and generic_dao_test.go (updated + new test cases).

  Test plan

  - [x] "Rejects negative limit with an error" — verifies error is returned
  - [x] "Returns only count when limit is explicitly set to zero" — verifies count-only response with
  empty items
  - [x] "Uses default limit when limit is not set" — verifies default behavior is preserved
  - [x] All 10 limit-related DAO tests pass against PostgreSQL