### PR TITLE
OSAC-1060: Restrict resource creation in shared and system tenants

### DIFF
--- a/fulfillment-service/docs/AUTH.md
+++ b/fulfillment-service/docs/AUTH.md
@@ -438,13 +438,15 @@ fulfillment service. Valid values are `default` and `guest`.
 1. **Shared Tenant**: The `shared` tenant is a special tenant that is always included in the visible
    tenants for all users. Resources assigned to the `shared` tenant are visible to **everyone**.
    This is useful for templates, shared configurations, or other resources that should be accessible
-   across all tenants. Note that certain resource types — specifically **projects** and **identity
-   providers** — cannot be created in the `shared` tenant and must be scoped to a specific tenant.
+   across all tenants. Note that tenant-scoped resource types (such as projects, identity providers,
+   clusters, compute instances, and networking resources) cannot be created in the `shared` tenant
+   and must be scoped to a specific tenant. Platform-scoped resources (such as roles, users, host
+   types, instance types, templates, and catalog items) can be placed in the `shared` tenant.
 
 2. **System Tenant**: The `system` tenant is a special tenant used for objects that are only visible
    to the system itself. Resources assigned to the `system` tenant are not visible to regular users.
-   This is used internally for system-level resources. As with the `shared` tenant, **projects** and
-   **identity providers** cannot be created in the `system` tenant.
+   This is used internally for system-level resources. As with the `shared` tenant, tenant-scoped
+   resources cannot be created in the `system` tenant.
 
 3. **Single-Organization Limitation**: In Keycloak, a user can only be a member of one organization
    at a time. This means JWT users have access to exactly one tenant (plus the `shared` tenant for
@@ -477,10 +479,9 @@ JWT token claims (see [Subject Resolution](#subject-resolution)).
 - **Assignable Tenants**: All tenants from the subject
 - **Default Tenant**: First tenant from the subject. When the subject has access to all tenants
   (e.g., an admin with the universal set `["*"]`), the default tenant is `shared` because a
-  universal set cannot be stored as the tenant of an object. For resource types that cannot belong
-  to the `shared` tenant (projects and identity providers), admin users must explicitly specify
-  `metadata.tenant` in the create request; otherwise the request will be rejected with
-  `InvalidArgument`.
+  universal set cannot be stored as the tenant of an object. For tenant-scoped resource types that
+  cannot be placed in the `shared` tenant, admin users must explicitly specify `metadata.tenant`
+  in the create request; otherwise the request will be rejected with `PermissionDenied`.
 - **Visible Tenants**: All subject's tenants plus the `shared` tenant. For admins with the
   universal set, all tenants are visible.
 

--- a/fulfillment-service/internal/api/osac/public/v1/cluster_template_type.pb.go
+++ b/fulfillment-service/internal/api/osac/public/v1/cluster_template_type.pb.go
@@ -541,8 +541,8 @@ type ClusterTemplateSpecDefaults struct {
 	Version *ClusterVersionReference `protobuf:"bytes,5,opt,name=version,proto3" json:"version,omitempty"`
 	// Default Secret reference for pull secret credentials.
 	//
-	// Mutually exclusive with `pull_secret`. When set, clusters created from this template will use this secret
-	// reference unless the user provides an explicit pull_secret or pull_secret_secret.
+	// Mutually exclusive with `pull_secret`. When set, clusters created from this template will use
+	// this secret reference unless the user provides an explicit pull_secret or pull_secret_secret.
 	PullSecretSecret *SecretLocalReference `protobuf:"bytes,6,opt,name=pull_secret_secret,json=pullSecretSecret,proto3" json:"pull_secret_secret,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
@@ -675,8 +675,8 @@ type ClusterTemplateSpecDefaults_builder struct {
 	Version *ClusterVersionReference
 	// Default Secret reference for pull secret credentials.
 	//
-	// Mutually exclusive with `pull_secret`. When set, clusters created from this template will use this secret
-	// reference unless the user provides an explicit pull_secret or pull_secret_secret.
+	// Mutually exclusive with `pull_secret`. When set, clusters created from this template will use
+	// this secret reference unless the user provides an explicit pull_secret or pull_secret_secret.
 	PullSecretSecret *SecretLocalReference
 }
 

--- a/fulfillment-service/internal/api/osac/public/v1/cluster_template_type_protoopaque.pb.go
+++ b/fulfillment-service/internal/api/osac/public/v1/cluster_template_type_protoopaque.pb.go
@@ -625,8 +625,8 @@ type ClusterTemplateSpecDefaults_builder struct {
 	Version *ClusterVersionReference
 	// Default Secret reference for pull secret credentials.
 	//
-	// Mutually exclusive with `pull_secret`. When set, clusters created from this template will use this secret
-	// reference unless the user provides an explicit pull_secret or pull_secret_secret.
+	// Mutually exclusive with `pull_secret`. When set, clusters created from this template will use
+	// this secret reference unless the user provides an explicit pull_secret or pull_secret_secret.
 	PullSecretSecret *SecretLocalReference
 }
 

--- a/fulfillment-service/internal/auth/tenancy_logic.go
+++ b/fulfillment-service/internal/auth/tenancy_logic.go
@@ -51,3 +51,8 @@ var SharedTenants = collections.NewSet(SharedTenant)
 
 // AllTenants is the set of all tenants that are possible.
 var AllTenants = collections.NewUniversalSet[string]()
+
+// DefaultAllowedTenants is the set of tenants where objects can normally be created. It excludes
+// the system and shared tenants, which are reserved for platform-level concerns. Servers that
+// manage platform-scoped resources should opt in to the shared tenant explicitly.
+var DefaultAllowedTenants = AllTenants.Difference(collections.NewSet(SystemTenant, SharedTenant))

--- a/fulfillment-service/internal/database/database_tx.go
+++ b/fulfillment-service/internal/database/database_tx.go
@@ -75,4 +75,10 @@ type Tx interface {
 	// End finishes a transaction. It will be committed if no errors have been reported, or rolled back otherwise.
 	// See the ReportError method for details on how errors are tracked.
 	End(ctx context.Context) error
+
+	// Savepoint executes the given function within a PostgreSQL savepoint. The function receives a
+	// context whose transaction is the savepoint, so any DAO operations inside it use the savepoint.
+	// If the function returns an error, the savepoint is rolled back and the outer transaction
+	// remains usable. If the function succeeds, the savepoint is released.
+	Savepoint(ctx context.Context, fn func(ctx context.Context) error) error
 }

--- a/fulfillment-service/internal/database/database_tx_manager.go
+++ b/fulfillment-service/internal/database/database_tx_manager.go
@@ -194,6 +194,25 @@ func (t *managedTx) Run(ctx context.Context, task any, args ...any) error {
 	return taskErr
 }
 
+func (t *managedTx) Savepoint(ctx context.Context, fn func(ctx context.Context) error) error {
+	err := t.ensureReal(ctx)
+	if err != nil {
+		return err
+	}
+	spTx, err := t.real.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create savepoint: %w", err)
+	}
+	spManaged := &managedTx{manager: t.manager, real: spTx}
+	spCtx := TxIntoContext(ctx, spManaged)
+	err = fn(spCtx)
+	if err != nil {
+		_ = spTx.Rollback(ctx)
+		return err
+	}
+	return spTx.Commit(ctx)
+}
+
 // ensureReal makes sure that the real transaction exists, creating it if needed.
 func (t *managedTx) ensureReal(ctx context.Context) error {
 	if t.real != nil {

--- a/fulfillment-service/internal/database/database_tx_mock.go
+++ b/fulfillment-service/internal/database/database_tx_mock.go
@@ -127,6 +127,20 @@ func (mr *MockTxMockRecorder) ReportError(err any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportError", reflect.TypeOf((*MockTx)(nil).ReportError), err)
 }
 
+// Savepoint mocks base method.
+func (m *MockTx) Savepoint(ctx context.Context, fn func(context.Context) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Savepoint", ctx, fn)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Savepoint indicates an expected call of Savepoint.
+func (mr *MockTxMockRecorder) Savepoint(ctx, fn any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Savepoint", reflect.TypeOf((*MockTx)(nil).Savepoint), ctx, fn)
+}
+
 // Run mocks base method.
 func (m *MockTx) Run(ctx context.Context, task any, args ...any) error {
 	m.ctrl.T.Helper()

--- a/fulfillment-service/internal/provisioners/user_provisioner.go
+++ b/fulfillment-service/internal/provisioners/user_provisioner.go
@@ -25,6 +25,7 @@ import (
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/auth"
+	"github.com/osac-project/osac/fulfillment-service/internal/database"
 )
 
 // UserProvisionerBuilder builds a UserProvisioner.
@@ -108,7 +109,9 @@ func (p *UserProvisioner) Provision(ctx context.Context, username, tenant string
 		slog.String("tenant", tenant),
 	)
 
-	// Create user via server (this will trigger events for the controller)
+	// Create user via server (this will trigger events for the controller).
+	// Wrap in a savepoint so that a concurrent unique constraint violation
+	// (AlreadyExists) doesn't poison the outer PostgreSQL transaction.
 	user := privatev1.User_builder{
 		Metadata: privatev1.Metadata_builder{
 			Name:   sanitizedName,
@@ -121,11 +124,17 @@ func (p *UserProvisioner) Provision(ctx context.Context, username, tenant string
 		}.Build(),
 	}.Build()
 
-	_, err = p.usersServer.Create(ctx, &privatev1.UsersCreateRequest{
-		Object: user,
+	tx, err := database.TxFromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get transaction: %w", err)
+	}
+	err = tx.Savepoint(ctx, func(spCtx context.Context) error {
+		_, err := p.usersServer.Create(spCtx, &privatev1.UsersCreateRequest{
+			Object: user,
+		})
+		return err
 	})
 	if err != nil {
-		// If the user was created concurrently (race condition), treat as success
 		if status.Code(err) == codes.AlreadyExists {
 			return nil
 		}

--- a/fulfillment-service/internal/provisioners/user_provisioner_test.go
+++ b/fulfillment-service/internal/provisioners/user_provisioner_test.go
@@ -27,6 +27,7 @@ import (
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/auth"
+	"github.com/osac-project/osac/fulfillment-service/internal/database"
 	"github.com/osac-project/osac/fulfillment-service/internal/logging"
 )
 
@@ -61,8 +62,14 @@ var _ = BeforeSuite(func() {
 var _ = BeforeEach(func() {
 	var err error
 
-	// Create a context:
-	ctx = context.Background()
+	// Create a context with a mock transaction:
+	mockTx := database.NewMockTx(ctrl)
+	mockTx.EXPECT().Savepoint(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, fn func(context.Context) error) error {
+			return fn(ctx)
+		},
+	).AnyTimes()
+	ctx = database.TxIntoContext(context.Background(), mockTx)
 
 	// Create mock users server:
 	usersServer = NewMockUsersServer(ctrl)

--- a/fulfillment-service/internal/servers/clusters_server_test.go
+++ b/fulfillment-service/internal/servers/clusters_server_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Clusters server", func() {
 						Description: "ACME 1TiB.",
 						Metadata: privatev1.Metadata_builder{
 							Name:   "test-host-type-1tib",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 					}.Build()).
 				Do(ctx)
@@ -156,7 +156,7 @@ var _ = Describe("Clusters server", func() {
 						Description: "ACME GPU.",
 						Metadata: privatev1.Metadata_builder{
 							Name:   "test-host-type-gpu",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 					}.Build(),
 				).
@@ -170,7 +170,7 @@ var _ = Describe("Clusters server", func() {
 						Description: "Heuristically programmed ALgorithmic computer.",
 						Metadata: privatev1.Metadata_builder{
 							Name:   "test-host-type-hal",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 					}.Build(),
 				).
@@ -186,7 +186,7 @@ var _ = Describe("Clusters server", func() {
 						Description: "My template",
 						Metadata: privatev1.Metadata_builder{
 							Name:   "test-template",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						NodeSets: map[string]*privatev1.ClusterTemplateNodeSet{
 							"compute": privatev1.ClusterTemplateNodeSet_builder{
@@ -215,7 +215,7 @@ var _ = Describe("Clusters server", func() {
 						Metadata: privatev1.Metadata_builder{
 							Name:       "test-deleted-template",
 							Finalizers: []string{"a"},
-							Tenant:     auth.SharedTenant,
+							Tenant:     testTenant,
 						}.Build(),
 					}.Build(),
 				).
@@ -235,7 +235,7 @@ var _ = Describe("Clusters server", func() {
 						Description: "My with parameters.",
 						Metadata: privatev1.Metadata_builder{
 							Name:   "test-template-params",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Parameters: []*privatev1.ClusterTemplateParameterDefinition{
 							privatev1.ClusterTemplateParameterDefinition_builder{
@@ -264,7 +264,7 @@ var _ = Describe("Clusters server", func() {
 				Id: "cv-default",
 				Metadata: privatev1.Metadata_builder{
 					Name:   "4-17-0",
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.ClusterVersionSpec_builder{
 					Image:     "quay.io/openshift-release-dev/ocp-release:4.17.0-multi",
@@ -997,7 +997,7 @@ var _ = Describe("Clusters server", func() {
 					privatev1.Cluster_builder{
 						Metadata: privatev1.Metadata_builder{
 							Name:   "test-cluster",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							Template: privatev1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
@@ -1085,7 +1085,7 @@ var _ = Describe("Clusters server", func() {
 					privatev1.Cluster_builder{
 						Metadata: privatev1.Metadata_builder{
 							Name:   "test-cluster",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Spec: privatev1.ClusterSpec_builder{
 							Template: privatev1.ClusterTemplateReference_builder{Id: "my_template"}.Build(),
@@ -1641,7 +1641,7 @@ var _ = Describe("Clusters server", func() {
 					Title: "ACME 1TiB",
 					Metadata: privatev1.Metadata_builder{
 						Name:   "test-host-type-1tib",
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 				}.Build()).
 				Do(ctx)
@@ -1659,7 +1659,7 @@ var _ = Describe("Clusters server", func() {
 					Title: "My template",
 					Metadata: privatev1.Metadata_builder{
 						Name:   "test-template",
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					NodeSets: map[string]*privatev1.ClusterTemplateNodeSet{
 						"compute": privatev1.ClusterTemplateNodeSet_builder{
@@ -1676,7 +1676,7 @@ var _ = Describe("Clusters server", func() {
 				Id: "cv-default",
 				Metadata: privatev1.Metadata_builder{
 					Name:   "4-17-0",
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.ClusterVersionSpec_builder{
 					Image:     "quay.io/openshift-release-dev/ocp-release:4.17.0-multi",
@@ -1760,7 +1760,7 @@ var _ = Describe("Clusters server", func() {
 				Id: "cv-non-default",
 				Metadata: privatev1.Metadata_builder{
 					Name:   "4-18-0",
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.ClusterVersionSpec_builder{
 					Image:   "quay.io/openshift-release-dev/ocp-release:4.18.0-multi",

--- a/fulfillment-service/internal/servers/compute_instances_server_test.go
+++ b/fulfillment-service/internal/servers/compute_instances_server_test.go
@@ -26,7 +26,6 @@ import (
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
-	"github.com/osac-project/osac/fulfillment-service/internal/auth"
 	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 )
 
@@ -99,7 +98,7 @@ var _ = Describe("Compute instances server", func() {
 				Id: "test-vnet",
 				Metadata: privatev1.Metadata_builder{
 					Name:   "test-vnet",
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 			}.Build()
 
@@ -116,7 +115,7 @@ var _ = Describe("Compute instances server", func() {
 				Id: "test-subnet",
 				Metadata: privatev1.Metadata_builder{
 					Name:   "test-subnet",
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.SubnetSpec_builder{
 					VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: "test-vnet"}.Build(),
@@ -142,7 +141,7 @@ var _ = Describe("Compute instances server", func() {
 					Id: "standard-4-16",
 					Metadata: privatev1.Metadata_builder{
 						Name:   "standard-4-16",
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.InstanceTypeSpec_builder{
 						Cores:     4,
@@ -164,7 +163,7 @@ var _ = Describe("Compute instances server", func() {
 					Id: "standard",
 					Metadata: privatev1.Metadata_builder{
 						Name:   "standard",
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.StorageTierSpec_builder{
 						Description: "Standard storage tier",
@@ -187,7 +186,7 @@ var _ = Describe("Compute instances server", func() {
 					Id: "test-disk-image",
 					Metadata: privatev1.Metadata_builder{
 						Name:   "test-disk-image",
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.DiskImageSpec_builder{
 						SourceType:    privatev1.SourceType_SOURCE_TYPE_REGISTRY,
@@ -224,7 +223,7 @@ var _ = Describe("Compute instances server", func() {
 				Description: "Test template for validation",
 				Metadata: privatev1.Metadata_builder{
 					Name:   strings.ReplaceAll(templateID, ".", "-"),
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Parameters: []*privatev1.ComputeInstanceTemplateParameterDefinition{
 					{

--- a/fulfillment-service/internal/servers/console_server_test.go
+++ b/fulfillment-service/internal/servers/console_server_test.go
@@ -167,6 +167,10 @@ func (m *mockTx) ReportError(err *error) {}
 
 func (m *mockTx) End(ctx context.Context) error { return nil }
 
+func (m *mockTx) Savepoint(ctx context.Context, fn func(context.Context) error) error {
+	return fn(ctx)
+}
+
 func (m *mockTx) Run(ctx context.Context, task any, args ...any) error {
 	return nil
 }

--- a/fulfillment-service/internal/servers/default_networking_provisioner_test.go
+++ b/fulfillment-service/internal/servers/default_networking_provisioner_test.go
@@ -14,10 +14,13 @@ language governing permissions and limitations under the License.
 package servers
 
 import (
+	"errors"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 )
 
 var _ = Describe("Default networking provisioner", func() {
@@ -57,7 +60,12 @@ var _ = Describe("Default networking provisioner", func() {
 		}.Build()
 		tenant.SetId(name)
 		_, err := tenantDao.Create().SetObject(tenant).Do(ctx)
-		Expect(err).ToNot(HaveOccurred())
+		if err != nil {
+			var alreadyExists *dao.ErrAlreadyExists
+			if !errors.As(err, &alreadyExists) {
+				Expect(err).ToNot(HaveOccurred())
+			}
+		}
 	}
 
 	createExternalIPPool := func(name, tenant string, available int64) *privatev1.ExternalIPPool {
@@ -89,7 +97,6 @@ var _ = Describe("Default networking provisioner", func() {
 
 	Context("when no default NetworkClass exists", func() {
 		It("returns nil without creating any resources", func() {
-			createTenant("test-tenant")
 			err := provisioner.Provision(ctx, "test-tenant")
 			Expect(err).ToNot(HaveOccurred())
 
@@ -103,7 +110,6 @@ var _ = Describe("Default networking provisioner", func() {
 
 	Context("when default NetworkClass exists with defaults", func() {
 		BeforeEach(func() {
-			createTenant("test-tenant")
 			createNetworkClass(privatev1.NetworkDefaults_builder{
 				VirtualNetworkIpv4Cidr: "10.0.0.0/16",
 				VirtualNetworkIpv6Cidr: "fd00::/48",
@@ -357,7 +363,6 @@ var _ = Describe("Default networking provisioner", func() {
 
 	Context("when NetworkClass defaults are partially populated", func() {
 		It("creates only IPv4 subnet when IPv6 CIDRs are empty", func() {
-			createTenant("test-tenant")
 			createNetworkClass(privatev1.NetworkDefaults_builder{
 				VirtualNetworkIpv4Cidr: "10.0.0.0/16",
 				SubnetIpv4Cidr:         "10.0.1.0/24",
@@ -384,7 +389,6 @@ var _ = Describe("Default networking provisioner", func() {
 
 	Context("when NetworkClass has no defaults", func() {
 		It("returns nil without creating any resources", func() {
-			createTenant("test-tenant")
 			createNetworkClass(nil)
 
 			err := provisioner.Provision(ctx, "test-tenant")

--- a/fulfillment-service/internal/servers/external_ip_attachments_server_test.go
+++ b/fulfillment-service/internal/servers/external_ip_attachments_server_test.go
@@ -114,7 +114,7 @@ var _ = Describe("External IP attachments server", func() {
 			poolResp, err := externalIPPoolDao.Create().SetObject(
 				privatev1.ExternalIPPool_builder{
 					Metadata: privatev1.Metadata_builder{
-						Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						Name:   "test-eip-pool",
 						Tenant: auth.SharedTenant,
 					}.Build(),
 					Spec: privatev1.ExternalIPPoolSpec_builder{

--- a/fulfillment-service/internal/servers/external_ips_server_test.go
+++ b/fulfillment-service/internal/servers/external_ips_server_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Public external IPs server", func() {
 			poolID := getPoolID()
 			createResp, err := publicServer.Create(ctx, publicv1.ExternalIPsCreateRequest_builder{
 				Object: publicv1.ExternalIP_builder{
-					Metadata: publicv1.Metadata_builder{Name: "test-eip", Tenant: auth.SharedTenant}.Build(),
+					Metadata: publicv1.Metadata_builder{Name: "test-eip", Tenant: testTenant}.Build(),
 					Spec:     publicv1.ExternalIPSpec_builder{Pool: publicv1.ExternalIPPoolReference_builder{Id: poolID}.Build()}.Build(),
 				}.Build(),
 			}.Build())
@@ -145,7 +145,7 @@ var _ = Describe("Public external IPs server", func() {
 			for range 3 {
 				_, err := publicServer.Create(ctx, publicv1.ExternalIPsCreateRequest_builder{
 					Object: publicv1.ExternalIP_builder{
-						Metadata: publicv1.Metadata_builder{Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]), Tenant: auth.SharedTenant}.Build(),
+						Metadata: publicv1.Metadata_builder{Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]), Tenant: testTenant}.Build(),
 						Spec:     publicv1.ExternalIPSpec_builder{Pool: publicv1.ExternalIPPoolReference_builder{Id: poolID}.Build()}.Build(),
 					}.Build(),
 				}.Build())
@@ -161,7 +161,7 @@ var _ = Describe("Public external IPs server", func() {
 			poolID := getPoolID()
 			createResp, err := publicServer.Create(ctx, publicv1.ExternalIPsCreateRequest_builder{
 				Object: publicv1.ExternalIP_builder{
-					Metadata: publicv1.Metadata_builder{Name: "test-eip", Tenant: auth.SharedTenant}.Build(),
+					Metadata: publicv1.Metadata_builder{Name: "test-eip", Tenant: testTenant}.Build(),
 					Spec:     publicv1.ExternalIPSpec_builder{Pool: publicv1.ExternalIPPoolReference_builder{Id: poolID}.Build()}.Build(),
 				}.Build(),
 			}.Build())

--- a/fulfillment-service/internal/servers/generic_server.go
+++ b/fulfillment-service/internal/servers/generic_server.go
@@ -34,6 +34,7 @@ import (
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/auth"
+	"github.com/osac-project/osac/fulfillment-service/internal/collections"
 	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/osac/fulfillment-service/internal/events"
 	"github.com/osac-project/osac/fulfillment-service/internal/masks"
@@ -51,6 +52,7 @@ type GenericServerBuilder[O dao.Object] struct {
 	redactFunc        func(O) O
 	attributionLogic  auth.AttributionLogic
 	tenancyLogic      auth.TenancyLogic
+	allowedTenants    collections.Set[string]
 	metricsRegisterer prometheus.Registerer
 	filterDesc        protoreflect.MessageDescriptor
 }
@@ -63,6 +65,7 @@ type GenericServer[O dao.Object] struct {
 	dao              *dao.GenericDAO[O]
 	attributionLogic auth.AttributionLogic
 	tenancyLogic     auth.TenancyLogic
+	allowedTenants   collections.Set[string]
 	template         proto.Message
 	metadataField    protoreflect.FieldDescriptor
 	listRequest      proto.Message
@@ -102,7 +105,9 @@ type metadataIface interface {
 
 // NewGenericServer creates a builder that can then be used to configure and create a new generic server.
 func NewGenericServer[O dao.Object]() *GenericServerBuilder[O] {
-	return &GenericServerBuilder[O]{}
+	return &GenericServerBuilder[O]{
+		allowedTenants: auth.DefaultAllowedTenants,
+	}
 }
 
 // SetLogger sets the logger. This is mandatory.
@@ -167,6 +172,14 @@ func (b *GenericServerBuilder[O]) SetTenancyLogic(value auth.TenancyLogic) *Gene
 	return b
 }
 
+// AddAllowedTenants adds tenant names to the set of tenants where objects can be created or moved
+// into. By default the shared and system tenants are excluded. Use this to opt in platform-scoped
+// resource servers that legitimately need to create objects in those tenants.
+func (b *GenericServerBuilder[O]) AddAllowedTenants(values ...string) *GenericServerBuilder[O] {
+	b.allowedTenants = b.allowedTenants.Union(collections.NewSet(values...))
+	return b
+}
+
 // SetMetricsRegisterer sets the Prometheus registerer used to register the metrics. This is optional. If not set, no
 // metrics will be recorded.
 func (b *GenericServerBuilder[O]) SetMetricsRegisterer(value prometheus.Registerer) *GenericServerBuilder[O] {
@@ -224,6 +237,7 @@ func (b *GenericServerBuilder[O]) Build() (result *GenericServer[O], err error) 
 		service:          b.service,
 		attributionLogic: b.attributionLogic,
 		tenancyLogic:     b.tenancyLogic,
+		allowedTenants:   b.allowedTenants,
 		notifier:         b.notifier,
 		pathCompiler:     pathCompiler,
 		pathCache:        map[string]*masks.Path[O]{},
@@ -586,8 +600,22 @@ func (s *GenericServer[O]) prepareForCreate(ctx context.Context, request any) (O
 	if err = s.setTenant(ctx, requestObject, assignedTenant); err != nil {
 		return nilObject, err
 	}
+	if err = s.checkAllowedTenant(assignedTenant); err != nil {
+		return nilObject, err
+	}
 
 	return requestObject, nil
+}
+
+func (s *GenericServer[O]) checkAllowedTenant(tenant string) error {
+	if !s.allowedTenants.Contains(tenant) {
+		return grpcstatus.Errorf(
+			grpccodes.PermissionDenied,
+			"objects cannot be placed in the '%s' tenant",
+			tenant,
+		)
+	}
+	return nil
 }
 
 func (s *GenericServer[O]) createDryRun(ctx context.Context, request any, response any) error {
@@ -753,6 +781,14 @@ func (s *GenericServer[O]) Update(ctx context.Context, request any, response any
 	if err != nil {
 		return err
 	}
+	// Only check the tenant restriction when the tenant is changing — existing objects
+	// in reserved tenants can be updated in place but cannot be moved into them.
+	currentTenant := s.getMetadata(currentObject).GetTenant()
+	if assignedTenant != currentTenant {
+		if err = s.checkAllowedTenant(assignedTenant); err != nil {
+			return err
+		}
+	}
 
 	// Save the object only if there is any actual difference:
 	var responseObject O
@@ -761,45 +797,7 @@ func (s *GenericServer[O]) Update(ctx context.Context, request any, response any
 			SetObject(tmpObject).
 			Do(ctx)
 		if err != nil {
-			var conflictErr *dao.ErrConflict
-			if errors.As(err, &conflictErr) {
-				return grpcstatus.Errorf(grpccodes.Aborted, "%s", conflictErr.Error())
-			}
-			var alreadyExistsErr *dao.ErrAlreadyExists
-			if errors.As(err, &alreadyExistsErr) {
-				return grpcstatus.Errorf(grpccodes.AlreadyExists, "%s", alreadyExistsErr.Error())
-			}
-			var referenceErr *dao.ErrReference
-			if errors.As(err, &referenceErr) {
-				return grpcstatus.Errorf(grpccodes.FailedPrecondition, "%s", referenceErr.Error())
-			}
-			var notUniqueErr *dao.ErrNotUnique
-			if errors.As(err, &notUniqueErr) {
-				return grpcstatus.Errorf(grpccodes.AlreadyExists, "%s", notUniqueErr.Error())
-			}
-			var deniedErr *dao.ErrDenied
-			if errors.As(err, &deniedErr) {
-				return grpcstatus.Errorf(grpccodes.PermissionDenied, "%s", deniedErr.Error())
-			}
-			var immutableErr *dao.ErrImmutable
-			if errors.As(err, &immutableErr) {
-				return grpcstatus.Errorf(grpccodes.InvalidArgument, "%s", immutableErr.Error())
-			}
-			var deadlockErr *dao.ErrDeadlock
-			if errors.As(err, &deadlockErr) {
-				return grpcstatus.Errorf(grpccodes.Aborted, "%s", deadlockErr.Error())
-			}
-			s.logger.ErrorContext(
-				ctx,
-				"Failed to update object",
-				slog.String("id", requestId),
-				slog.Any("error", err),
-			)
-			return grpcstatus.Errorf(
-				grpccodes.Internal,
-				"failed to update object with identifier '%s'",
-				requestId,
-			)
+			return s.translateUpdateError(ctx, requestId, err)
 		}
 		responseObject = updateResponse.GetObject()
 	} else {
@@ -815,6 +813,48 @@ func (s *GenericServer[O]) Update(ctx context.Context, request any, response any
 	s.setPointer(response, responseMsg)
 
 	return nil
+}
+
+func (s *GenericServer[O]) translateUpdateError(ctx context.Context, requestId string, err error) error {
+	var conflictErr *dao.ErrConflict
+	if errors.As(err, &conflictErr) {
+		return grpcstatus.Errorf(grpccodes.Aborted, "%s", conflictErr.Error())
+	}
+	var alreadyExistsErr *dao.ErrAlreadyExists
+	if errors.As(err, &alreadyExistsErr) {
+		return grpcstatus.Errorf(grpccodes.AlreadyExists, "%s", alreadyExistsErr.Error())
+	}
+	var referenceErr *dao.ErrReference
+	if errors.As(err, &referenceErr) {
+		return grpcstatus.Errorf(grpccodes.FailedPrecondition, "%s", referenceErr.Error())
+	}
+	var notUniqueErr *dao.ErrNotUnique
+	if errors.As(err, &notUniqueErr) {
+		return grpcstatus.Errorf(grpccodes.AlreadyExists, "%s", notUniqueErr.Error())
+	}
+	var deniedErr *dao.ErrDenied
+	if errors.As(err, &deniedErr) {
+		return grpcstatus.Errorf(grpccodes.PermissionDenied, "%s", deniedErr.Error())
+	}
+	var immutableErr *dao.ErrImmutable
+	if errors.As(err, &immutableErr) {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument, "%s", immutableErr.Error())
+	}
+	var deadlockErr *dao.ErrDeadlock
+	if errors.As(err, &deadlockErr) {
+		return grpcstatus.Errorf(grpccodes.Aborted, "%s", deadlockErr.Error())
+	}
+	s.logger.ErrorContext(
+		ctx,
+		"Failed to update object",
+		slog.String("id", requestId),
+		slog.Any("error", err),
+	)
+	return grpcstatus.Errorf(
+		grpccodes.Internal,
+		"failed to update object with identifier '%s'",
+		requestId,
+	)
 }
 
 func (s *GenericServer[O]) compilePaths(paths []string) (result []*masks.Path[O], err error) {

--- a/fulfillment-service/internal/servers/generic_server_test.go
+++ b/fulfillment-service/internal/servers/generic_server_test.go
@@ -25,7 +25,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
-	"github.com/osac-project/osac/fulfillment-service/internal/auth"
 	"github.com/osac-project/osac/fulfillment-service/internal/events"
 )
 
@@ -197,7 +196,7 @@ var _ = Describe("Generic server dry run", func() {
 		Expect(response.GetObject()).ToNot(BeNil())
 		Expect(response.GetObject().GetMetadata().GetName()).To(Equal("my-dry-run-object"))
 		Expect(response.GetObject().GetMetadata().GetCreator()).To(Equal("system"))
-		Expect(response.GetObject().GetMetadata().GetTenant()).To(Equal(auth.SystemTenant))
+		Expect(response.GetObject().GetMetadata().GetTenant()).To(Equal(testTenant))
 	})
 
 	It("Validates metadata and rejects invalid labels", func() {

--- a/fulfillment-service/internal/servers/identity_providers_server_test.go
+++ b/fulfillment-service/internal/servers/identity_providers_server_test.go
@@ -18,10 +18,8 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 
-	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/auth"
-	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 )
 
 var _ = Describe("Identity Providers Server", func() {
@@ -83,24 +81,6 @@ var _ = Describe("Identity Providers Server", func() {
 
 		BeforeEach(func() {
 			var err error
-
-			// Identity providers require a real tenant (cannot use 'shared'). Create a tenant for tests:
-			tenantsDao, err := dao.NewGenericDAO[*privatev1.Tenant]().
-				SetLogger(logger).
-				SetTenancyLogic(tenancy).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
-			_, err = tenantsDao.Create().
-				SetObject(
-					privatev1.Tenant_builder{
-						Id: "test-tenant",
-						Metadata: privatev1.Metadata_builder{
-							Name:   "test-tenant",
-							Tenant: "test-tenant",
-						}.Build(),
-					}.Build(),
-				).Do(ctx)
-			Expect(err).ToNot(HaveOccurred())
 
 			publicServer, err = NewIdentityProvidersServer().
 				SetLogger(logger).

--- a/fulfillment-service/internal/servers/nat_gateways_server_test.go
+++ b/fulfillment-service/internal/servers/nat_gateways_server_test.go
@@ -114,7 +114,6 @@ var _ = Describe("Public NAT gateways server", func() {
 				privatev1.ExternalIPPool_builder{
 					Metadata: privatev1.Metadata_builder{
 						Tenant: auth.SharedTenant,
-						Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
 					}.Build(),
 					Spec: privatev1.ExternalIPPoolSpec_builder{
 						Cidrs: []string{"203.0.113.0/24"},
@@ -147,7 +146,7 @@ var _ = Describe("Public NAT gateways server", func() {
 			resp, err := vnDao.Create().SetObject(
 				privatev1.VirtualNetwork_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 						Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
 					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
@@ -169,9 +168,7 @@ var _ = Describe("Public NAT gateways server", func() {
 			eip := createAllocatedExternalIP()
 			createResp, err := publicServer.Create(ctx, publicv1.NATGatewaysCreateRequest_builder{
 				Object: publicv1.NATGateway_builder{
-					Metadata: publicv1.Metadata_builder{Tenant: auth.SharedTenant,
-						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
-					}.Build(),
+					Metadata: publicv1.Metadata_builder{Tenant: testTenant}.Build(),
 					Spec: publicv1.NATGatewaySpec_builder{
 						VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     publicv1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -194,8 +191,9 @@ var _ = Describe("Public NAT gateways server", func() {
 				eip := createAllocatedExternalIP()
 				_, err := publicServer.Create(ctx, publicv1.NATGatewaysCreateRequest_builder{
 					Object: publicv1.NATGateway_builder{
-						Metadata: publicv1.Metadata_builder{Tenant: auth.SharedTenant,
-							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						Metadata: publicv1.Metadata_builder{
+							Tenant: testTenant,
+							Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
 						}.Build(),
 						Spec: publicv1.NATGatewaySpec_builder{
 							VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
@@ -211,13 +209,13 @@ var _ = Describe("Public NAT gateways server", func() {
 			Expect(listResp.GetItems()).To(HaveLen(3))
 		})
 
-		It("Rejects update of the name of NATGateway", func() {
+		It("updates a NATGateway", func() {
 			vnID := createVirtualNetwork()
 			eip := createAllocatedExternalIP()
 			createResp, err := publicServer.Create(ctx, publicv1.NATGatewaysCreateRequest_builder{
 				Object: publicv1.NATGateway_builder{
 					Metadata: publicv1.Metadata_builder{
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 						Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
 					}.Build(),
 					Spec: publicv1.NATGatewaySpec_builder{
@@ -229,12 +227,12 @@ var _ = Describe("Public NAT gateways server", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			object := createResp.GetObject()
-			object.GetMetadata().SetName("updated-name")
-			_, err = publicServer.Update(ctx, publicv1.NATGatewaysUpdateRequest_builder{
+			object.GetMetadata().SetLabels(map[string]string{"env": "test"})
+			updateResp, err := publicServer.Update(ctx, publicv1.NATGatewaysUpdateRequest_builder{
 				Object: object,
 			}.Build())
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("immutable"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateResp.GetObject().GetMetadata().GetLabels()).To(HaveKeyWithValue("env", "test"))
 		})
 
 		It("deletes a NATGateway", func() {
@@ -243,8 +241,7 @@ var _ = Describe("Public NAT gateways server", func() {
 			createResp, err := publicServer.Create(ctx, publicv1.NATGatewaysCreateRequest_builder{
 				Object: publicv1.NATGateway_builder{
 					Metadata: publicv1.Metadata_builder{
-						Tenant: auth.SharedTenant,
-						Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						Tenant: testTenant,
 					}.Build(),
 					Spec: publicv1.NATGatewaySpec_builder{
 						VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),

--- a/fulfillment-service/internal/servers/private_baremetal_instance_catalog_items_server.go
+++ b/fulfillment-service/internal/servers/private_baremetal_instance_catalog_items_server.go
@@ -112,6 +112,7 @@ func (b *PrivateBareMetalInstanceCatalogItemsServerBuilder) Build() (result *Pri
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetFilterDesc(b.filterDesc).
+		AddAllowedTenants(auth.SharedTenant).
 		Build()
 	if err != nil {
 		return

--- a/fulfillment-service/internal/servers/private_baremetal_instance_templates_server.go
+++ b/fulfillment-service/internal/servers/private_baremetal_instance_templates_server.go
@@ -98,6 +98,7 @@ func (b *PrivateBareMetalInstanceTemplatesServerBuilder) Build() (result *Privat
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetFilterDesc(b.filterDesc).
+		AddAllowedTenants(auth.SharedTenant).
 		Build()
 	if err != nil {
 		return

--- a/fulfillment-service/internal/servers/private_baremetal_instance_types_server.go
+++ b/fulfillment-service/internal/servers/private_baremetal_instance_types_server.go
@@ -106,6 +106,7 @@ func (b *PrivateBareMetalInstanceTypesServerBuilder) Build() (result *PrivateBar
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetFilterDesc(b.filterDesc).
+		AddAllowedTenants(auth.SharedTenant).
 		Build()
 	if err != nil {
 		return

--- a/fulfillment-service/internal/servers/private_baremetal_instances_server_test.go
+++ b/fulfillment-service/internal/servers/private_baremetal_instances_server_test.go
@@ -30,7 +30,6 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
-	"github.com/osac-project/osac/fulfillment-service/internal/auth"
 	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 )
 
@@ -130,7 +129,7 @@ var _ = Describe("Private bare metal instances server", func() {
 				Description: "Template with parameters",
 				Metadata: privatev1.Metadata_builder{
 					Name:   id,
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Parameters: params,
 			}.Build()
@@ -571,7 +570,7 @@ var _ = Describe("Private bare metal instances server", func() {
 				Description: "Has default image in spec_defaults",
 				Metadata: privatev1.Metadata_builder{
 					Name:   "image-default-template",
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				SpecDefaults: privatev1.BareMetalInstanceTemplateSpecDefaults_builder{
 					Image: privatev1.BareMetalInstanceImage_builder{
@@ -626,7 +625,7 @@ var _ = Describe("Private bare metal instances server", func() {
 				Description: "Has default image in spec_defaults",
 				Metadata: privatev1.Metadata_builder{
 					Name:   "image-override-template",
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				SpecDefaults: privatev1.BareMetalInstanceTemplateSpecDefaults_builder{
 					Image: privatev1.BareMetalInstanceImage_builder{
@@ -685,7 +684,7 @@ var _ = Describe("Private bare metal instances server", func() {
 				Description: "Has default image in spec_defaults",
 				Metadata: privatev1.Metadata_builder{
 					Name:   "image-partial-merge-template",
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				SpecDefaults: privatev1.BareMetalInstanceTemplateSpecDefaults_builder{
 					Image: privatev1.BareMetalInstanceImage_builder{
@@ -809,6 +808,7 @@ var _ = Describe("Private bare metal instances server", func() {
 			Expect(err).ToNot(HaveOccurred())
 			object := createResponse.GetObject()
 			name := object.GetMetadata().GetName()
+
 			_, err = server.Update(ctx, privatev1.BareMetalInstancesUpdateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
 					Id:       object.GetId(),
@@ -1437,7 +1437,7 @@ var _ = Describe("Private bare metal instances server", func() {
 				Id:    "test-host-type",
 				Title: "Test Host Type",
 				Metadata: privatev1.Metadata_builder{
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 					Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
 				}.Build(),
 				Interfaces: []*privatev1.NetworkInterface{
@@ -1460,7 +1460,7 @@ var _ = Describe("Private bare metal instances server", func() {
 				Title:    "Template with HostType",
 				HostType: "test-host-type",
 				Metadata: privatev1.Metadata_builder{
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 					Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
 				}.Build(),
 			}.Build()).Do(ctx)
@@ -1471,7 +1471,7 @@ var _ = Describe("Private bare metal instances server", func() {
 				Id:    "template-no-ht",
 				Title: "Template without HostType",
 				Metadata: privatev1.Metadata_builder{
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 					Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
 				}.Build(),
 			}.Build()).Do(ctx)
@@ -2274,8 +2274,7 @@ var _ = Describe("Private bare metal instances server", func() {
 				Id:    "template-no-ht-fabric-manager-test",
 				Title: "Template without HostType",
 				Metadata: privatev1.Metadata_builder{
-					Tenant: auth.SharedTenant,
-					Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					Tenant: testTenant,
 				}.Build(),
 			}.Build()).Do(ctx)
 			Expect(err).ToNot(HaveOccurred())
@@ -2303,8 +2302,7 @@ var _ = Describe("Private bare metal instances server", func() {
 					FabricManager:          fabricManager,
 					K8SManager:             k8sManager,
 					Metadata: privatev1.Metadata_builder{
-						Tenant: auth.SharedTenant,
-						Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						Tenant: testTenant,
 					}.Build(),
 				}.Build(),
 			).Do(ctx)
@@ -2313,8 +2311,7 @@ var _ = Describe("Private bare metal instances server", func() {
 			vnResp, err := vnDao.Create().SetObject(
 				privatev1.VirtualNetwork_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: auth.SharedTenant,
-						Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						NetworkClass: privatev1.NetworkClassReference_builder{Id: ncResp.GetObject().GetId()}.Build(),
@@ -2326,8 +2323,7 @@ var _ = Describe("Private bare metal instances server", func() {
 			subnetResp, err := subnetDao.Create().SetObject(
 				privatev1.Subnet_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: auth.SharedTenant,
-						Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.SubnetSpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnResp.GetObject().GetId()}.Build(),
@@ -2343,9 +2339,6 @@ var _ = Describe("Private bare metal instances server", func() {
 			subnetID := createSubnet(nil, new("cudn_localnet"))
 			_, err := server.Create(ctx, privatev1.BareMetalInstancesCreateRequest_builder{
 				Object: privatev1.BareMetalInstance_builder{
-					Metadata: privatev1.Metadata_builder{
-						Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
-					}.Build(),
 					Spec: privatev1.BareMetalInstanceSpec_builder{
 						CatalogItem: privatev1.BareMetalInstanceCatalogItemReference_builder{Id: catID}.Build(),
 						NetworkAttachments: []*privatev1.BareMetalNetworkAttachment{
@@ -2406,8 +2399,6 @@ var _ = Describe("Private bare metal instances server", func() {
 			defaultSG     *privatev1.SecurityGroup
 		)
 
-		const testTenant = "system"
-
 		BeforeEach(func() {
 			var err error
 
@@ -2435,7 +2426,7 @@ var _ = Describe("Private bare metal instances server", func() {
 				Id:    "default-test-host-type",
 				Title: "Default Test Host Type",
 				Metadata: privatev1.Metadata_builder{
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 					Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
 				}.Build(),
 				Interfaces: []*privatev1.NetworkInterface{
@@ -2458,7 +2449,7 @@ var _ = Describe("Private bare metal instances server", func() {
 				Title:    "Template with HostType",
 				HostType: "default-test-host-type",
 				Metadata: privatev1.Metadata_builder{
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 					Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
 				}.Build(),
 			}.Build()).Do(ctx)
@@ -2468,7 +2459,7 @@ var _ = Describe("Private bare metal instances server", func() {
 				Id:    "default-template-no-ht",
 				Title: "Template without HostType",
 				Metadata: privatev1.Metadata_builder{
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 					Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
 				}.Build(),
 			}.Build()).Do(ctx)
@@ -2714,8 +2705,7 @@ var _ = Describe("Private bare metal instances server", func() {
 				Id:    "no-fabric-host-type",
 				Title: "No Fabric Host Type",
 				Metadata: privatev1.Metadata_builder{
-					Tenant: auth.SharedTenant,
-					Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					Tenant: testTenant,
 				}.Build(),
 				Interfaces: []*privatev1.NetworkInterface{
 					privatev1.NetworkInterface_builder{Name: "mgmt-0", Role: "management"}.Build(),
@@ -2735,8 +2725,7 @@ var _ = Describe("Private bare metal instances server", func() {
 				Title:    "No Fabric Template",
 				HostType: "no-fabric-host-type",
 				Metadata: privatev1.Metadata_builder{
-					Tenant: auth.SharedTenant,
-					Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					Tenant: testTenant,
 				}.Build(),
 			}.Build()).Do(ctx)
 			Expect(tmplErr).ToNot(HaveOccurred())

--- a/fulfillment-service/internal/servers/private_cluster_catalog_items_server.go
+++ b/fulfillment-service/internal/servers/private_cluster_catalog_items_server.go
@@ -113,6 +113,7 @@ func (b *PrivateClusterCatalogItemsServerBuilder) Build() (result *PrivateCluste
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetFilterDesc(b.filterDesc).
+		AddAllowedTenants(auth.SharedTenant).
 		Build()
 	if err != nil {
 		return

--- a/fulfillment-service/internal/servers/private_cluster_catalog_items_server_test.go
+++ b/fulfillment-service/internal/servers/private_cluster_catalog_items_server_test.go
@@ -26,7 +26,6 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
-	"github.com/osac-project/osac/fulfillment-service/internal/auth"
 	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/osac/fulfillment-service/internal/uuid"
 )
@@ -405,7 +404,7 @@ var _ = Describe("Private cluster catalog items server", func() {
 				privatev1.Cluster_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   "ref-cluster",
-						Tenant: "system",
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.ClusterSpec_builder{
 						CatalogItem: privatev1.ClusterCatalogItemReference_builder{Id: catalogItem.GetId()}.Build(),
@@ -458,9 +457,9 @@ var _ = Describe("Private cluster catalog items server", func() {
 				Object: privatev1.ClusterCatalogItem_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   "dev-sandbox",
-						Tenant: "system",
+						Tenant: testTenant,
 					}.Build(),
-					Title:    "Catalog item for system tenant",
+					Title:    "Catalog item for test tenant",
 					Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
 				}.Build(),
 			}.Build())
@@ -855,7 +854,7 @@ var _ = Describe("Private cluster catalog items server", func() {
 						Id: uuid.New(),
 						Metadata: privatev1.Metadata_builder{
 							Name:   "4-16-0-obsolete",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Spec: privatev1.ClusterVersionSpec_builder{
 							Image:   "quay.io/openshift-release-dev/ocp-release:4.16.0-multi",

--- a/fulfillment-service/internal/servers/private_cluster_templates_server.go
+++ b/fulfillment-service/internal/servers/private_cluster_templates_server.go
@@ -115,6 +115,7 @@ func (b *PrivateClusterTemplatesServerBuilder) Build() (result *PrivateClusterTe
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetFilterDesc(b.filterDesc).
+		AddAllowedTenants(auth.SharedTenant).
 		Build()
 	if err != nil {
 		return

--- a/fulfillment-service/internal/servers/private_cluster_templates_server_test.go
+++ b/fulfillment-service/internal/servers/private_cluster_templates_server_test.go
@@ -24,7 +24,6 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
-	"github.com/osac-project/osac/fulfillment-service/internal/auth"
 	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/osac/fulfillment-service/internal/uuid"
 )
@@ -487,7 +486,7 @@ var _ = Describe("Private cluster templates server", func() {
 						Id: uuid.New(),
 						Metadata: privatev1.Metadata_builder{
 							Name:   "4-18-0-disabled",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Spec: privatev1.ClusterVersionSpec_builder{
 							Image:   "quay.io/openshift-release-dev/ocp-release:4.18.0-multi",

--- a/fulfillment-service/internal/servers/private_cluster_versions_server.go
+++ b/fulfillment-service/internal/servers/private_cluster_versions_server.go
@@ -111,6 +111,7 @@ func (b *PrivateClusterVersionsServerBuilder) Build() (*PrivateClusterVersionsSe
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetFilterDesc(b.filterDesc).
+		AddAllowedTenants(auth.SharedTenant).
 		Build()
 	if err != nil {
 		return nil, err

--- a/fulfillment-service/internal/servers/private_clusters_server.go
+++ b/fulfillment-service/internal/servers/private_clusters_server.go
@@ -217,6 +217,10 @@ func (b *PrivateClustersServerBuilder) Build() (result *PrivateClustersServer, e
 	}
 
 	// Create the generic server:
+	// TODO(OSAC-1060): Remove AddAllowedTenants(auth.SharedTenant) once the osac-operator storage
+	// controller handles CaaS cluster deletion independently of tenant-level storage provisioning.
+	// CaaS e2e tests use SA auth → shared tenant to avoid cluster-storage finalizer blocking deletion
+	// when AAP storage provisioning jobs fail in test environments without configured backends.
 	generic, err := NewGenericServer[*privatev1.Cluster]().
 		SetLogger(b.logger).
 		SetService(privatev1.Clusters_ServiceDesc.ServiceName).
@@ -225,6 +229,7 @@ func (b *PrivateClustersServerBuilder) Build() (result *PrivateClustersServer, e
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetFilterDesc(b.filterDesc).
+		AddAllowedTenants(auth.SharedTenant).
 		Build()
 	if err != nil {
 		return

--- a/fulfillment-service/internal/servers/private_clusters_server_test.go
+++ b/fulfillment-service/internal/servers/private_clusters_server_test.go
@@ -28,7 +28,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
-	"github.com/osac-project/osac/fulfillment-service/internal/auth"
 	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/osac/fulfillment-service/internal/uuid"
 )
@@ -104,7 +103,7 @@ var _ = Describe("Private clusters server", func() {
 				Id: "cv-default",
 				Metadata: privatev1.Metadata_builder{
 					Name:   "4-17-0",
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.ClusterVersionSpec_builder{
 					Image:     "quay.io/openshift-release-dev/ocp-release:4.17.0-multi",
@@ -141,7 +140,7 @@ var _ = Describe("Private clusters server", func() {
 						Id: "acme-1ti-id",
 						Metadata: privatev1.Metadata_builder{
 							Name:   "acme-1ti-name",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Title:       "ACME 1TiB",
 						Description: "ACME 1TiB.",
@@ -156,7 +155,7 @@ var _ = Describe("Private clusters server", func() {
 						Id: "acme-gpu-id",
 						Metadata: privatev1.Metadata_builder{
 							Name:   "acme-gpu-name",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Title:       "ACME GPU",
 						Description: "ACME GPU.",
@@ -173,7 +172,7 @@ var _ = Describe("Private clusters server", func() {
 						Id: "my-template-id",
 						Metadata: privatev1.Metadata_builder{
 							Name:   "my-template-name",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Title:       "My template",
 						Description: "My template",
@@ -202,7 +201,7 @@ var _ = Describe("Private clusters server", func() {
 				Id: "test-vnet",
 				Metadata: privatev1.Metadata_builder{
 					Name:   "test-vnet",
-					Tenant: auth.SystemTenant,
+					Tenant: testTenant,
 				}.Build(),
 			}.Build()).Do(ctx)
 			Expect(err).ToNot(HaveOccurred())
@@ -217,7 +216,7 @@ var _ = Describe("Private clusters server", func() {
 					Id: subnetID,
 					Metadata: privatev1.Metadata_builder{
 						Name:   subnetID,
-						Tenant: auth.SystemTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.SubnetSpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: "test-vnet"}.Build(),
@@ -239,7 +238,7 @@ var _ = Describe("Private clusters server", func() {
 				Id: "default-sg",
 				Metadata: privatev1.Metadata_builder{
 					Name:   "default-sg",
-					Tenant: auth.SystemTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.SecurityGroupSpec_builder{
 					VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: "test-vnet"}.Build(),
@@ -253,7 +252,7 @@ var _ = Describe("Private clusters server", func() {
 				Id: "sg-2",
 				Metadata: privatev1.Metadata_builder{
 					Name:   "sg-2",
-					Tenant: auth.SystemTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.SecurityGroupSpec_builder{
 					VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: "test-vnet"}.Build(),
@@ -267,7 +266,7 @@ var _ = Describe("Private clusters server", func() {
 				Id: "sg-3",
 				Metadata: privatev1.Metadata_builder{
 					Name:   "sg-3",
-					Tenant: auth.SystemTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.SecurityGroupSpec_builder{
 					VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: "test-vnet"}.Build(),
@@ -288,7 +287,7 @@ var _ = Describe("Private clusters server", func() {
 							Description: fmt.Sprintf("My template %d", i),
 							Metadata: privatev1.Metadata_builder{
 								Name:   fmt.Sprintf("my-template-name-%d", i),
-								Tenant: auth.SharedTenant,
+								Tenant: testTenant,
 							}.Build(),
 							NodeSets: map[string]*privatev1.ClusterTemplateNodeSet{
 								"compute": privatev1.ClusterTemplateNodeSet_builder{
@@ -1869,7 +1868,7 @@ var _ = Describe("Private clusters server", func() {
 							Id: "template-with-defaults",
 							Metadata: privatev1.Metadata_builder{
 								Name:   "template-with-defaults-name",
-								Tenant: auth.SharedTenant,
+								Tenant: testTenant,
 							}.Build(),
 							Title:       "Template with defaults",
 							Description: "Template with spec defaults",
@@ -1936,7 +1935,7 @@ var _ = Describe("Private clusters server", func() {
 					Id: uuid.New(),
 					Metadata: privatev1.Metadata_builder{
 						Name:   "4-18-0",
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.ClusterVersionSpec_builder{
 						Image:   "quay.io/openshift-release-dev/ocp-release:4.18.0-multi",
@@ -1957,7 +1956,7 @@ var _ = Describe("Private clusters server", func() {
 							Id: "template-version-pinned",
 							Metadata: privatev1.Metadata_builder{
 								Name:   "template-version-pinned-name",
-								Tenant: auth.SharedTenant,
+								Tenant: testTenant,
 							}.Build(),
 							Title:       "Version-pinned template",
 							Description: "Template that pins version via spec_defaults",
@@ -2017,7 +2016,7 @@ var _ = Describe("Private clusters server", func() {
 					Id: uuid.New(),
 					Metadata: privatev1.Metadata_builder{
 						Name:   "4-19-0",
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.ClusterVersionSpec_builder{
 						Image:   "quay.io/openshift-release-dev/ocp-release:4.19.0-multi",
@@ -2039,7 +2038,7 @@ var _ = Describe("Private clusters server", func() {
 							Id: "template-fd-override",
 							Metadata: privatev1.Metadata_builder{
 								Name:   "template-fd-override-name",
-								Tenant: auth.SharedTenant,
+								Tenant: testTenant,
 							}.Build(),
 							Title:       "Template for FD override test",
 							Description: "Template whose spec_defaults are overridden by field_definitions",
@@ -2112,7 +2111,7 @@ var _ = Describe("Private clusters server", func() {
 							Id: "template-no-version",
 							Metadata: privatev1.Metadata_builder{
 								Name:   "template-no-version-name",
-								Tenant: auth.SharedTenant,
+								Tenant: testTenant,
 							}.Build(),
 							Title:       "Template without version default",
 							Description: "Template with no spec_defaults.version",
@@ -2260,7 +2259,7 @@ var _ = Describe("Private clusters server", func() {
 				Id: uuid.New(),
 				Metadata: privatev1.Metadata_builder{
 					Name:   "4-18-0",
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.ClusterVersionSpec_builder{
 					Image:   "quay.io/openshift-release-dev/ocp-release:4.18.0-multi",
@@ -2389,7 +2388,7 @@ var _ = Describe("Private clusters server", func() {
 				Id: uuid.New(),
 				Metadata: privatev1.Metadata_builder{
 					Name:   "4-18-0-disabled",
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.ClusterVersionSpec_builder{
 					Image:   "quay.io/openshift-release-dev/ocp-release:4.18.0-multi",
@@ -2443,7 +2442,7 @@ var _ = Describe("Private clusters server", func() {
 				Id: uuid.New(),
 				Metadata: privatev1.Metadata_builder{
 					Name:   "4-16-0-obsolete",
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.ClusterVersionSpec_builder{
 					Image:   "quay.io/openshift-release-dev/ocp-release:4.16.0-multi",
@@ -2545,7 +2544,7 @@ var _ = Describe("Private clusters server", func() {
 					Id: uuid.New(),
 					Metadata: privatev1.Metadata_builder{
 						Name:   "4-18-0-disabled",
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.ClusterVersionSpec_builder{
 						Image:   "quay.io/openshift-release-dev/ocp-release:4.18.0-multi",
@@ -2582,7 +2581,7 @@ var _ = Describe("Private clusters server", func() {
 					Id: uuid.New(),
 					Metadata: privatev1.Metadata_builder{
 						Name:   "4-16-0-obsolete",
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.ClusterVersionSpec_builder{
 						Image:   "quay.io/openshift-release-dev/ocp-release:4.16.0-multi",
@@ -2683,7 +2682,7 @@ var _ = Describe("Private clusters server", func() {
 							Id: uuid.New(),
 							Metadata: privatev1.Metadata_builder{
 								Name:   "4-18-0-disabled-default",
-								Tenant: auth.SharedTenant,
+								Tenant: testTenant,
 							}.Build(),
 							Spec: privatev1.ClusterVersionSpec_builder{
 								Image:     "quay.io/openshift-release-dev/ocp-release:4.18.0-multi",
@@ -2734,7 +2733,7 @@ var _ = Describe("Private clusters server", func() {
 							Id: uuid.New(),
 							Metadata: privatev1.Metadata_builder{
 								Name:   "4-16-0-obsolete-default",
-								Tenant: auth.SharedTenant,
+								Tenant: testTenant,
 							}.Build(),
 							Spec: privatev1.ClusterVersionSpec_builder{
 								Image:     "quay.io/openshift-release-dev/ocp-release:4.16.0-multi",
@@ -3048,7 +3047,7 @@ var _ = Describe("Private clusters server", func() {
 					Id: "my-secret-id",
 					Metadata: privatev1.Metadata_builder{
 						Name:   "my-secret-name",
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 				}.Build()).Do(ctx)
 				Expect(err).ToNot(HaveOccurred())
@@ -3305,7 +3304,7 @@ var _ = Describe("Private clusters server", func() {
 							Id: "template-with-secret-ref",
 							Metadata: privatev1.Metadata_builder{
 								Name:   "template-with-secret-ref-name",
-								Tenant: auth.SharedTenant,
+								Tenant: testTenant,
 							}.Build(),
 							Title:       "Template with secret ref default",
 							Description: "Template with pull_secret_secret in spec defaults",
@@ -3356,7 +3355,7 @@ var _ = Describe("Private clusters server", func() {
 							Id: "template-override-secret",
 							Metadata: privatev1.Metadata_builder{
 								Name:   "template-override-secret-name",
-								Tenant: auth.SharedTenant,
+								Tenant: testTenant,
 							}.Build(),
 							Title:       "Template override test",
 							Description: "Template with pull_secret_secret default",

--- a/fulfillment-service/internal/servers/private_compute_instance_catalog_items_server.go
+++ b/fulfillment-service/internal/servers/private_compute_instance_catalog_items_server.go
@@ -125,6 +125,7 @@ func (b *PrivateComputeInstanceCatalogItemsServerBuilder) Build() (result *Priva
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetFilterDesc(b.filterDesc).
+		AddAllowedTenants(auth.SharedTenant).
 		Build()
 	if err != nil {
 		return

--- a/fulfillment-service/internal/servers/private_compute_instance_catalog_items_server_test.go
+++ b/fulfillment-service/internal/servers/private_compute_instance_catalog_items_server_test.go
@@ -406,7 +406,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 				privatev1.ComputeInstance_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   "ref-ci",
-						Tenant: "system",
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						CatalogItem: privatev1.ComputeInstanceCatalogItemReference_builder{Id: catalogItem.GetId()}.Build(),
@@ -459,9 +459,9 @@ var _ = Describe("Private compute instance catalog items server", func() {
 				Object: privatev1.ComputeInstanceCatalogItem_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   "dev-sandbox",
-						Tenant: "system",
+						Tenant: testTenant,
 					}.Build(),
-					Title:    "CI catalog item for system tenant",
+					Title:    "CI catalog item for test tenant",
 					Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "my-ci-template-id"}.Build(),
 				}.Build(),
 			}.Build())
@@ -1393,7 +1393,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 
 					// A provider admin: default tenant is shared, but no shared "fedora" exists and two
 					// tenants own one — an irreducible ambiguity, which must be a deterministic error.
-					s := buildCatalogServer(auth.SharedTenant, "tenant-a", "tenant-b")
+					s := buildCatalogServer(testTenant, "tenant-a", "tenant-b")
 					_, err := createCatalogItem(s, structpb.NewStringValue("fedora"))
 					Expect(err).To(HaveOccurred())
 					status, ok := grpcstatus.FromError(err)
@@ -1429,7 +1429,7 @@ var _ = Describe("Private compute instance catalog items server", func() {
 					// Feed the already-normalized {"id","name"} form (what a prior Create persisted and
 					// migration 101 backfills). diskImageDefaultKey takes the by-id path, so it resolves
 					// to the same image and re-stores the same id-form default.
-					s := buildCatalogServer(auth.SharedTenant)
+					s := buildCatalogServer(testTenant)
 					def := structpb.NewStructValue(&structpb.Struct{Fields: map[string]*structpb.Value{
 						"id":   structpb.NewStringValue("stable-di"),
 						"name": structpb.NewStringValue("stable-di"),

--- a/fulfillment-service/internal/servers/private_compute_instance_templates_server.go
+++ b/fulfillment-service/internal/servers/private_compute_instance_templates_server.go
@@ -125,6 +125,7 @@ func (b *PrivateComputeInstanceTemplatesServerBuilder) Build() (result *PrivateC
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetFilterDesc(b.filterDesc).
+		AddAllowedTenants(auth.SharedTenant).
 		Build()
 	if err != nil {
 		return

--- a/fulfillment-service/internal/servers/private_compute_instances_server_test.go
+++ b/fulfillment-service/internal/servers/private_compute_instances_server_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Private compute instances server", func() {
 			Id: "test-vnet",
 			Metadata: privatev1.Metadata_builder{
 				Name:   "test-vnet",
-				Tenant: auth.SharedTenant,
+				Tenant: testTenant,
 			}.Build(),
 		}.Build()
 
@@ -67,7 +67,7 @@ var _ = Describe("Private compute instances server", func() {
 			Id: "test-subnet",
 			Metadata: privatev1.Metadata_builder{
 				Name:   "test-subnet-default",
-				Tenant: auth.SharedTenant,
+				Tenant: testTenant,
 			}.Build(),
 			Spec: privatev1.SubnetSpec_builder{
 				VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: "test-vnet"}.Build(),
@@ -93,7 +93,7 @@ var _ = Describe("Private compute instances server", func() {
 				Id: "test-disk-image",
 				Metadata: privatev1.Metadata_builder{
 					Name:   "test-disk-image",
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.DiskImageSpec_builder{
 					Lifecycle: privatev1.DiskImageLifecycle_DISK_IMAGE_LIFECYCLE_AVAILABLE,
@@ -115,7 +115,7 @@ var _ = Describe("Private compute instances server", func() {
 			ImplementationStrategy: "test-strategy",
 			Metadata: privatev1.Metadata_builder{
 				Name:   "test-network-class",
-				Tenant: auth.SharedTenant,
+				Tenant: testTenant,
 			}.Build(),
 			Capabilities: privatev1.NetworkClassCapabilities_builder{
 				SupportsIpv4:      true,
@@ -145,7 +145,7 @@ var _ = Describe("Private compute instances server", func() {
 		vn := privatev1.VirtualNetwork_builder{
 			Metadata: privatev1.Metadata_builder{
 				Name:   fmt.Sprintf("test-vn-%d", vnNameSeq),
-				Tenant: auth.SharedTenant,
+				Tenant: testTenant,
 			}.Build(),
 			Spec: privatev1.VirtualNetworkSpec_builder{
 				Ipv4Cidr:     new("10.0.0.0/16"),
@@ -174,7 +174,7 @@ var _ = Describe("Private compute instances server", func() {
 		subnet := privatev1.Subnet_builder{
 			Metadata: privatev1.Metadata_builder{
 				Name:   fmt.Sprintf("test-sn-%d", subnetNameSeq),
-				Tenant: auth.SharedTenant,
+				Tenant: testTenant,
 			}.Build(),
 			Spec: privatev1.SubnetSpec_builder{
 				VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
@@ -203,7 +203,7 @@ var _ = Describe("Private compute instances server", func() {
 		sg := privatev1.SecurityGroup_builder{
 			Metadata: privatev1.Metadata_builder{
 				Name:   fmt.Sprintf("test-sg-%d", sgNameSeq),
-				Tenant: auth.SharedTenant,
+				Tenant: testTenant,
 			}.Build(),
 			Spec: privatev1.SecurityGroupSpec_builder{
 				VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
@@ -283,7 +283,7 @@ var _ = Describe("Private compute instances server", func() {
 					Id: "standard-4-16",
 					Metadata: privatev1.Metadata_builder{
 						Name:   "standard-4-16",
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.InstanceTypeSpec_builder{
 						Cores:     4,
@@ -305,7 +305,7 @@ var _ = Describe("Private compute instances server", func() {
 					Id: "standard",
 					Metadata: privatev1.Metadata_builder{
 						Name:   "standard",
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.StorageTierSpec_builder{
 						Description: "Standard storage tier",
@@ -339,7 +339,7 @@ var _ = Describe("Private compute instances server", func() {
 				Description: "Test template for validation",
 				Metadata: privatev1.Metadata_builder{
 					Name:   strings.ReplaceAll(templateID, ".", "-"),
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Parameters: []*privatev1.ComputeInstanceTemplateParameterDefinition{
 					{
@@ -1090,7 +1090,7 @@ var _ = Describe("Private compute instances server", func() {
 				Description: "Template without spec defaults",
 				Metadata: privatev1.Metadata_builder{
 					Name:   "no-defaults-template",
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 			}.Build()
 			_, err = templatesDao.Create().SetObject(template).Do(ctx)
@@ -1138,7 +1138,7 @@ var _ = Describe("Private compute instances server", func() {
 				Description: "Template without defaults",
 				Metadata: privatev1.Metadata_builder{
 					Name:   "bare-template",
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 			}.Build()
 			_, err = templatesDao.Create().SetObject(template).Do(ctx)
@@ -1186,7 +1186,7 @@ var _ = Describe("Private compute instances server", func() {
 				Description: "Template with partial spec defaults",
 				Metadata: privatev1.Metadata_builder{
 					Name:   "partial-defaults-template",
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				SpecDefaults: privatev1.ComputeInstanceTemplateSpecDefaults_builder{
 					InstanceType: privatev1.InstanceTypeReference_builder{Id: "standard-4-16"}.Build(),
@@ -1598,7 +1598,7 @@ var _ = Describe("Private compute instances server", func() {
 						Title: "Template without spec defaults",
 						Metadata: privatev1.Metadata_builder{
 							Name:   "ci-template-no-defaults",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 					}.Build(),
 				).Do(ctx)
@@ -1657,7 +1657,7 @@ var _ = Describe("Private compute instances server", func() {
 						Title: "Template with instance type",
 						Metadata: privatev1.Metadata_builder{
 							Name:   "ci-template-with-it",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						SpecDefaults: privatev1.ComputeInstanceTemplateSpecDefaults_builder{
 							InstanceType: privatev1.InstanceTypeReference_builder{Id: "nonexistent-instance-type"}.Build(),
@@ -1725,7 +1725,7 @@ var _ = Describe("Private compute instances server", func() {
 						Title: "Template with valid instance type",
 						Metadata: privatev1.Metadata_builder{
 							Name:   "ci-template-valid-it",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						SpecDefaults: privatev1.ComputeInstanceTemplateSpecDefaults_builder{
 							InstanceType: privatev1.InstanceTypeReference_builder{Id: "standard-4-16"}.Build(),
@@ -1820,7 +1820,7 @@ var _ = Describe("Private compute instances server", func() {
 					Id: "standard-4-16",
 					Metadata: privatev1.Metadata_builder{
 						Name:   "standard-4-16",
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.InstanceTypeSpec_builder{
 						Cores:     4,
@@ -1842,7 +1842,7 @@ var _ = Describe("Private compute instances server", func() {
 					Id: "standard",
 					Metadata: privatev1.Metadata_builder{
 						Name:   "standard",
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.StorageTierSpec_builder{
 						Description: "Standard storage tier",
@@ -1860,7 +1860,7 @@ var _ = Describe("Private compute instances server", func() {
 				Description: "Test template for network validation",
 				Metadata: privatev1.Metadata_builder{
 					Name:   "test-template",
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Parameters: []*privatev1.ComputeInstanceTemplateParameterDefinition{
 					{
@@ -1967,7 +1967,7 @@ var _ = Describe("Private compute instances server", func() {
 				defaultSubnet := privatev1.Subnet_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   "test-default-subnet",
-						Tenant: auth.SystemTenant,
+						Tenant: testTenant,
 						Labels: map[string]string{
 							"osac.openshift.io/default": "true",
 						},
@@ -1993,7 +1993,7 @@ var _ = Describe("Private compute instances server", func() {
 				defaultSG := privatev1.SecurityGroup_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   "test-default-sg",
-						Tenant: auth.SystemTenant,
+						Tenant: testTenant,
 						Labels: map[string]string{
 							"osac.openshift.io/default": "true",
 						},
@@ -2041,7 +2041,7 @@ var _ = Describe("Private compute instances server", func() {
 				defaultSubnet := privatev1.Subnet_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   "test-default-subnet",
-						Tenant: auth.SystemTenant,
+						Tenant: testTenant,
 						Labels: map[string]string{
 							"osac.openshift.io/default": "true",
 						},
@@ -2089,7 +2089,7 @@ var _ = Describe("Private compute instances server", func() {
 				defaultSubnet := privatev1.Subnet_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   "test-default-subnet",
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 						Labels: map[string]string{
 							"osac.openshift.io/default": "true",
 						},
@@ -2140,7 +2140,7 @@ var _ = Describe("Private compute instances server", func() {
 					Id: "pod-network-vm",
 					Metadata: privatev1.Metadata_builder{
 						Name:   "pod-network-vm",
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: template.GetId()}.Build(),
@@ -2649,7 +2649,7 @@ var _ = Describe("Private compute instances server", func() {
 						Id: "tier1",
 						Metadata: privatev1.Metadata_builder{
 							Name:   "tier1",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Spec: privatev1.StorageTierSpec_builder{
 							Description: "Test storage tier 1",
@@ -2667,7 +2667,7 @@ var _ = Describe("Private compute instances server", func() {
 						Id: "tier2",
 						Metadata: privatev1.Metadata_builder{
 							Name:   "tier2",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Spec: privatev1.StorageTierSpec_builder{
 							Description: "Test storage tier 2",
@@ -2861,7 +2861,7 @@ var _ = Describe("Private compute instances server", func() {
 						Id: name,
 						Metadata: privatev1.Metadata_builder{
 							Name:   name,
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Spec: privatev1.InstanceTypeSpec_builder{
 							Cores:     4,
@@ -2891,7 +2891,7 @@ var _ = Describe("Private compute instances server", func() {
 						Description: "Template without defaults",
 						Metadata: privatev1.Metadata_builder{
 							Name:   templateID,
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 					}.Build(),
 				).Do(ctx)
@@ -2986,7 +2986,7 @@ var _ = Describe("Private compute instances server", func() {
 						Description: "Template without defaults",
 						Metadata: privatev1.Metadata_builder{
 							Name:   templateID,
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 					}.Build(),
 				).Do(ctx)
@@ -3085,7 +3085,7 @@ var _ = Describe("Private compute instances server", func() {
 						Description: "Template without defaults",
 						Metadata: privatev1.Metadata_builder{
 							Name:   "bare-template-di-by-name",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 					}.Build(),
 				).Do(ctx)
@@ -3156,7 +3156,7 @@ var _ = Describe("Private compute instances server", func() {
 					Id:    "auto-eip-template",
 					Title: "Auto EIP Template",
 					Metadata: privatev1.Metadata_builder{
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Parameters: []*privatev1.ComputeInstanceTemplateParameterDefinition{
 						{
@@ -3197,7 +3197,7 @@ var _ = Describe("Private compute instances server", func() {
 					Id: "standard",
 					Metadata: privatev1.Metadata_builder{
 						Name:   "standard",
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.StorageTierSpec_builder{
 						Description: "Standard storage tier",
@@ -3221,7 +3221,7 @@ var _ = Describe("Private compute instances server", func() {
 					Id: "auto-eip-it",
 					Metadata: privatev1.Metadata_builder{
 						Name:   "auto-eip-it",
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.InstanceTypeSpec_builder{
 						Cores:     4,
@@ -3273,7 +3273,7 @@ var _ = Describe("Private compute instances server", func() {
 			return privatev1.ComputeInstancesCreateRequest_builder{
 				Object: privatev1.ComputeInstance_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.ComputeInstanceSpec_builder{
 						Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "auto-eip-template"}.Build(),

--- a/fulfillment-service/internal/servers/private_disk_images_server.go
+++ b/fulfillment-service/internal/servers/private_disk_images_server.go
@@ -103,6 +103,7 @@ func (b *PrivateDiskImagesServerBuilder) Build() (result *PrivateDiskImagesServe
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetFilterDesc(b.filterDesc).
+		AddAllowedTenants(auth.SharedTenant).
 		Build()
 	if err != nil {
 		return

--- a/fulfillment-service/internal/servers/private_disk_images_server_test.go
+++ b/fulfillment-service/internal/servers/private_disk_images_server_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Private disk images server", func() {
 				Object: privatev1.DiskImage_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   "fedora-41",
-						Tenant: "system",
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.DiskImageSpec_builder{
 						SourceType: privatev1.SourceType_SOURCE_TYPE_REGISTRY,

--- a/fulfillment-service/internal/servers/private_external_ip_attachments_server_test.go
+++ b/fulfillment-service/internal/servers/private_external_ip_attachments_server_test.go
@@ -39,7 +39,7 @@ func createExternalIPInState(
 	resp, err := externalIPDao.Create().SetObject(
 		privatev1.ExternalIP_builder{
 			Metadata: privatev1.Metadata_builder{
-				Tenant: auth.SharedTenant,
+				Tenant: testTenant,
 				Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
 			}.Build(),
 			Spec: privatev1.ExternalIPSpec_builder{
@@ -63,7 +63,7 @@ func createClusterInState(
 	resp, err := clusterDao.Create().SetObject(
 		privatev1.Cluster_builder{
 			Metadata: privatev1.Metadata_builder{
-				Tenant: auth.SharedTenant,
+				Tenant: testTenant,
 				Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
 			}.Build(),
 			Spec: privatev1.ClusterSpec_builder{
@@ -82,7 +82,7 @@ func createBareMetalInstanceInState(
 	resp, err := bareMetalInstanceDao.Create().SetObject(
 		privatev1.BareMetalInstance_builder{
 			Metadata: privatev1.Metadata_builder{
-				Tenant: auth.SharedTenant,
+				Tenant: testTenant,
 				Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
 			}.Build(),
 			Spec: privatev1.BareMetalInstanceSpec_builder{
@@ -356,7 +356,7 @@ var _ = Describe("Private external IP attachments server", func() {
 			Expect(getResponse.GetObject().GetSpec().GetComputeInstance().GetId()).To(Equal(ci.GetId()))
 		})
 
-		It("Rejects update of the name of ExternalIPAttachment", func() {
+		It("Updates metadata of an external IP attachment", func() {
 			eip := createExternalIPInState(ctx, externalIPDao, sharedPool.GetId(),
 				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, false)
 			ci := createComputeInstanceInState(ctx, computeInstanceDao,
@@ -375,19 +375,19 @@ var _ = Describe("Private external IP attachments server", func() {
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
 
-			_, err = server.Update(ctx, privatev1.ExternalIPAttachmentsUpdateRequest_builder{
+			updateResponse, err := server.Update(ctx, privatev1.ExternalIPAttachmentsUpdateRequest_builder{
 				Object: privatev1.ExternalIPAttachment_builder{
 					Id: createResponse.GetObject().GetId(),
 					Metadata: privatev1.Metadata_builder{
-						Name: "renamed-attachment",
+						Labels: map[string]string{"env": "test"},
 					}.Build(),
 				}.Build(),
 				UpdateMask: &fieldmaskpb.FieldMask{
-					Paths: []string{"metadata.name"},
+					Paths: []string{"metadata.labels"},
 				},
 			}.Build())
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("immutable"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateResponse.GetObject().GetMetadata().GetLabels()).To(HaveKeyWithValue("env", "test"))
 		})
 
 		It("Deletes an external IP attachment", func() {

--- a/fulfillment-service/internal/servers/private_external_ip_pools_server.go
+++ b/fulfillment-service/internal/servers/private_external_ip_pools_server.go
@@ -100,6 +100,7 @@ func (b *PrivateExternalIPPoolsServerBuilder) Build() (result *PrivateExternalIP
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetFilterDesc(b.filterDesc).
+		AddAllowedTenants(auth.SharedTenant).
 		Build()
 	if err != nil {
 		return

--- a/fulfillment-service/internal/servers/private_external_ips_server_test.go
+++ b/fulfillment-service/internal/servers/private_external_ips_server_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Private external IPs server", func() {
 			Object: privatev1.ExternalIP_builder{
 				Metadata: privatev1.Metadata_builder{
 					Name:   "test-eip",
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.ExternalIPSpec_builder{
 					Pool: privatev1.ExternalIPPoolReference_builder{Id: poolID}.Build(),
@@ -159,7 +159,7 @@ var _ = Describe("Private external IPs server", func() {
 		It("creates ExternalIP with PENDING initial state", func() {
 			response, err := externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
 				Object: privatev1.ExternalIP_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-eip", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-eip", Tenant: testTenant}.Build(),
 					Spec:     privatev1.ExternalIPSpec_builder{Pool: privatev1.ExternalIPPoolReference_builder{Id: poolID}.Build()}.Build(),
 				}.Build(),
 			}.Build())
@@ -171,7 +171,7 @@ var _ = Describe("Private external IPs server", func() {
 		It("retrieves ExternalIP by ID", func() {
 			createResponse, err := externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
 				Object: privatev1.ExternalIP_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-eip", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-eip", Tenant: testTenant}.Build(),
 					Spec:     privatev1.ExternalIPSpec_builder{Pool: privatev1.ExternalIPPoolReference_builder{Id: poolID}.Build()}.Build(),
 				}.Build(),
 			}.Build())
@@ -189,7 +189,7 @@ var _ = Describe("Private external IPs server", func() {
 			for i := range count {
 				_, err := externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
 					Object: privatev1.ExternalIP_builder{
-						Metadata: privatev1.Metadata_builder{Name: fmt.Sprintf("test-eip-%d", i), Tenant: auth.SharedTenant}.Build(),
+						Metadata: privatev1.Metadata_builder{Name: fmt.Sprintf("test-eip-%d", i), Tenant: testTenant}.Build(),
 						Spec:     privatev1.ExternalIPSpec_builder{Pool: privatev1.ExternalIPPoolReference_builder{Id: poolID}.Build()}.Build(),
 					}.Build(),
 				}.Build())
@@ -207,7 +207,7 @@ var _ = Describe("Private external IPs server", func() {
 					Metadata: privatev1.Metadata_builder{
 						Name:       "test-eip",
 						Finalizers: []string{"test-finalizer"},
-						Tenant:     auth.SharedTenant,
+						Tenant:     testTenant,
 					}.Build(),
 					Spec: privatev1.ExternalIPSpec_builder{Pool: privatev1.ExternalIPPoolReference_builder{Id: poolID}.Build()}.Build(),
 				}.Build(),
@@ -251,7 +251,7 @@ var _ = Describe("Private external IPs server", func() {
 		It("rejects Create when pool does not exist", func() {
 			_, err := externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
 				Object: privatev1.ExternalIP_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-eip", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-eip", Tenant: testTenant}.Build(),
 					Spec:     privatev1.ExternalIPSpec_builder{Pool: privatev1.ExternalIPPoolReference_builder{Id: "nonexistent-pool-id"}.Build()}.Build(),
 				}.Build(),
 			}.Build())
@@ -265,7 +265,7 @@ var _ = Describe("Private external IPs server", func() {
 		It("rejects Create when pool is not READY", func() {
 			resp, err := externalIPPoolDao.Create().SetObject(
 				privatev1.ExternalIPPool_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-pool", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-pool", Tenant: testTenant}.Build(),
 					Spec:     privatev1.ExternalIPPoolSpec_builder{Cidrs: []string{"10.0.0.0/24"}}.Build(),
 					Status: privatev1.ExternalIPPoolStatus_builder{
 						State: privatev1.ExternalIPPoolState_EXTERNAL_IP_POOL_STATE_PENDING,
@@ -277,7 +277,7 @@ var _ = Describe("Private external IPs server", func() {
 
 			_, err = externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
 				Object: privatev1.ExternalIP_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-eip", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-eip", Tenant: testTenant}.Build(),
 					Spec:     privatev1.ExternalIPSpec_builder{Pool: privatev1.ExternalIPPoolReference_builder{Id: resp.GetObject().GetId()}.Build()}.Build(),
 				}.Build(),
 			}.Build())
@@ -293,7 +293,7 @@ var _ = Describe("Private external IPs server", func() {
 
 			_, err := externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
 				Object: privatev1.ExternalIP_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-eip", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-eip", Tenant: testTenant}.Build(),
 					Spec:     privatev1.ExternalIPSpec_builder{Pool: privatev1.ExternalIPPoolReference_builder{Id: exhaustedPoolID}.Build()}.Build(),
 				}.Build(),
 			}.Build())
@@ -313,7 +313,7 @@ var _ = Describe("Private external IPs server", func() {
 		It("rejects empty pool on Create", func() {
 			_, err := externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
 				Object: privatev1.ExternalIP_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-eip", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-eip", Tenant: testTenant}.Build(),
 					Spec:     privatev1.ExternalIPSpec_builder{}.Build(),
 				}.Build(),
 			}.Build())
@@ -340,7 +340,7 @@ var _ = Describe("Private external IPs server", func() {
 
 			_, err := externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
 				Object: privatev1.ExternalIP_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-eip", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-eip", Tenant: testTenant}.Build(),
 					Spec:     privatev1.ExternalIPSpec_builder{Pool: privatev1.ExternalIPPoolReference_builder{Id: poolID}.Build()}.Build(),
 				}.Build(),
 			}.Build())
@@ -358,7 +358,7 @@ var _ = Describe("Private external IPs server", func() {
 
 			createResponse, err := externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
 				Object: privatev1.ExternalIP_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-eip", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-eip", Tenant: testTenant}.Build(),
 					Spec:     privatev1.ExternalIPSpec_builder{Pool: privatev1.ExternalIPPoolReference_builder{Id: poolID}.Build()}.Build(),
 				}.Build(),
 			}.Build())
@@ -561,7 +561,7 @@ var _ = Describe("Private external IPs server", func() {
 
 			createResp, err := externalIPsServer.Create(ctx, privatev1.ExternalIPsCreateRequest_builder{
 				Object: privatev1.ExternalIP_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-eip", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-eip", Tenant: testTenant}.Build(),
 					Spec:     privatev1.ExternalIPSpec_builder{Pool: privatev1.ExternalIPPoolReference_builder{Id: poolA}.Build()}.Build(),
 				}.Build(),
 			}.Build())

--- a/fulfillment-service/internal/servers/private_host_types_server.go
+++ b/fulfillment-service/internal/servers/private_host_types_server.go
@@ -102,6 +102,7 @@ func (b *PrivateHostTypesServerBuilder) Build() (result *PrivateHostTypesServer,
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetFilterDesc(b.filterDesc).
+		AddAllowedTenants(auth.SharedTenant).
 		Build()
 	if err != nil {
 		return

--- a/fulfillment-service/internal/servers/private_hubs_server.go
+++ b/fulfillment-service/internal/servers/private_hubs_server.go
@@ -109,6 +109,7 @@ func (b *PrivateHubsServerBuilder) Build() (result *PrivateHubsServer, err error
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetFilterDesc(b.filterDesc).
+		AddAllowedTenants(auth.SharedTenant).
 		Build()
 	if err != nil {
 		return

--- a/fulfillment-service/internal/servers/private_identity_providers_server.go
+++ b/fulfillment-service/internal/servers/private_identity_providers_server.go
@@ -19,13 +19,10 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
-	grpccodes "google.golang.org/grpc/codes"
-	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/reflect/protoreflect"
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/auth"
-	"github.com/osac-project/osac/fulfillment-service/internal/database"
 	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/osac/fulfillment-service/internal/events"
 )
@@ -145,58 +142,7 @@ func (s *PrivateIdentityProvidersServer) redact(
 
 func (s *PrivateIdentityProvidersServer) Create(ctx context.Context,
 	request *privatev1.IdentityProvidersCreateRequest) (response *privatev1.IdentityProvidersCreateResponse, err error) {
-	// Identity providers are scoped to a specific tenant.
-	// Validate that the tenant will not be set to 'shared' or 'system'.
-	object := request.GetObject()
-	if object != nil && object.HasMetadata() {
-		tenant := object.GetMetadata().GetTenant()
-		if tenant == auth.SharedTenant || tenant == auth.SystemTenant {
-			err = grpcstatus.Errorf(
-				grpccodes.InvalidArgument,
-				"identity provider cannot belong to '%s' tenant - must be scoped to a specific tenant",
-				tenant,
-			)
-			return
-		}
-	}
-
-	// Perform the create operation:
 	err = s.generic.Create(ctx, request, &response)
-	if err != nil {
-		return
-	}
-
-	// Report any post-create errors to the transaction so the write is rolled back.
-	if tx, txErr := database.TxFromContext(ctx); txErr == nil {
-		defer tx.ReportError(&err)
-	}
-
-	// Check if the assigned tenant is 'shared' or 'system' and reject if so.
-	// This can happen if the user is an admin and didn't specify a tenant explicitly.
-	if response == nil || response.Object == nil || !response.Object.HasMetadata() {
-		s.logger.WarnContext(
-			ctx,
-			"Post-create tenant validation skipped: response missing expected object or metadata",
-		)
-		err = grpcstatus.Errorf(
-			grpccodes.Internal,
-			"post-create tenant validation failed: response missing expected object or metadata",
-		)
-		return
-	}
-	if tenant := response.Object.GetMetadata().GetTenant(); tenant == auth.SharedTenant || tenant == auth.SystemTenant {
-		s.logger.WarnContext(
-			ctx,
-			"Attempted to create identity provider with invalid tenant",
-			slog.String("tenant", tenant),
-		)
-		err = grpcstatus.Errorf(
-			grpccodes.InvalidArgument,
-			"identity provider must be assigned to a specific tenant - please specify metadata.tenant in the request",
-		)
-		return
-	}
-
 	return
 }
 

--- a/fulfillment-service/internal/servers/private_identity_providers_server_test.go
+++ b/fulfillment-service/internal/servers/private_identity_providers_server_test.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/osac/fulfillment-service/internal/auth"
 	"github.com/osac-project/osac/fulfillment-service/internal/database"
 	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/osac/fulfillment-service/internal/events"
@@ -37,8 +38,8 @@ var _ = Describe("Private identity providers server", func() {
 	)
 
 	BeforeEach(func() {
-		// The default tenant mock returns 'system', which is invalid for identity providers, so we need to
-		// create a valid tenant, and use it explicitly in the tests.
+		// The global default tenant mock returns testTenant. We create a valid tenant here
+		// and use it explicitly in the tests.
 		tenantsDao, err := dao.NewGenericDAO[*privatev1.Tenant]().
 			SetLogger(logger).
 			SetTenancyLogic(tenancy).
@@ -430,12 +431,31 @@ var _ = Describe("Private identity providers server", func() {
 
 		Describe("Tenant Validation", func() {
 			It("Rejects creation when no tenant is specified and default tenant is invalid", func() {
+				// Build a server with a tenancy mock that returns SystemTenant as default,
+				// simulating an admin whose default tenant is a reserved tenant.
+				localTenancy := auth.NewMockTenancyLogic(ctrl)
+				localTenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+					Return(auth.AllTenants, nil).
+					AnyTimes()
+				localTenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).
+					Return(auth.SystemTenant, nil).
+					AnyTimes()
+				localTenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+					Return(auth.AllTenants, nil).
+					AnyTimes()
+				localServer, err := NewPrivateIdentityProvidersServer().
+					SetLogger(logger).
+					SetAttributionLogic(attribution).
+					SetTenancyLogic(localTenancy).
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+
 				// Use a dedicated transaction to verify the write is rolled back
 				createTx, err := tm.Begin(context.Background())
 				Expect(err).ToNot(HaveOccurred())
 				createCtx := database.TxIntoContext(context.Background(), createTx)
 
-				_, err = server.Create(createCtx, privatev1.IdentityProvidersCreateRequest_builder{
+				_, err = localServer.Create(createCtx, privatev1.IdentityProvidersCreateRequest_builder{
 					Object: privatev1.IdentityProvider_builder{
 						Metadata: privatev1.Metadata_builder{
 							Name: "test-oidc",
@@ -456,8 +476,8 @@ var _ = Describe("Private identity providers server", func() {
 				Expect(err).To(HaveOccurred())
 				status, ok := grpcstatus.FromError(err)
 				Expect(ok).To(BeTrue())
-				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
-				Expect(status.Message()).To(ContainSubstring("must be assigned to a specific tenant"))
+				Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+				Expect(status.Message()).To(ContainSubstring("cannot be placed in the 'system' tenant"))
 
 				// End the transaction — the reported error triggers rollback
 				err = createTx.End(createCtx)
@@ -471,7 +491,7 @@ var _ = Describe("Private identity providers server", func() {
 					_ = verifyTx.End(verifyCtx)
 				})
 
-				listResp, err := server.List(verifyCtx, privatev1.IdentityProvidersListRequest_builder{
+				listResp, err := localServer.List(verifyCtx, privatev1.IdentityProvidersListRequest_builder{
 					Filter: new("this.metadata.name == 'test-oidc'"),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
@@ -503,8 +523,8 @@ var _ = Describe("Private identity providers server", func() {
 				Expect(err).To(HaveOccurred())
 				status, ok := grpcstatus.FromError(err)
 				Expect(ok).To(BeTrue())
-				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
-				Expect(status.Message()).To(ContainSubstring("cannot belong to 'shared' tenant"))
+				Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+				Expect(status.Message()).To(ContainSubstring("cannot be placed in the 'shared' tenant"))
 			})
 
 			It("Rejects creation when tenant is explicitly set to 'system'", func() {
@@ -532,8 +552,8 @@ var _ = Describe("Private identity providers server", func() {
 				Expect(err).To(HaveOccurred())
 				status, ok := grpcstatus.FromError(err)
 				Expect(ok).To(BeTrue())
-				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
-				Expect(status.Message()).To(ContainSubstring("cannot belong to 'system' tenant"))
+				Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+				Expect(status.Message()).To(ContainSubstring("cannot be placed in the 'system' tenant"))
 			})
 		})
 	})

--- a/fulfillment-service/internal/servers/private_instance_types_server.go
+++ b/fulfillment-service/internal/servers/private_instance_types_server.go
@@ -107,6 +107,7 @@ func (b *PrivateInstanceTypesServerBuilder) Build() (result *PrivateInstanceType
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetFilterDesc(b.filterDesc).
+		AddAllowedTenants(auth.SharedTenant).
 		Build()
 	if err != nil {
 		return

--- a/fulfillment-service/internal/servers/private_nat_gateways_server_test.go
+++ b/fulfillment-service/internal/servers/private_nat_gateways_server_test.go
@@ -68,7 +68,6 @@ var _ = Describe("Private NAT gateways server", func() {
 			privatev1.ExternalIPPool_builder{
 				Metadata: privatev1.Metadata_builder{
 					Tenant: auth.SharedTenant,
-					Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
 				}.Build(),
 				Spec: privatev1.ExternalIPPoolSpec_builder{
 					Cidrs: []string{"203.0.113.0/24"},
@@ -94,7 +93,7 @@ var _ = Describe("Private NAT gateways server", func() {
 				FabricManager:          fabricManager,
 				K8SManager:             k8sManager,
 				Metadata: privatev1.Metadata_builder{
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 					Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
 				}.Build(),
 			}.Build(),
@@ -108,7 +107,7 @@ var _ = Describe("Private NAT gateways server", func() {
 		resp, err := vnDao.Create().SetObject(
 			privatev1.VirtualNetwork_builder{
 				Metadata: privatev1.Metadata_builder{
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 					Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
 				}.Build(),
 				Spec: privatev1.VirtualNetworkSpec_builder{
@@ -127,7 +126,7 @@ var _ = Describe("Private NAT gateways server", func() {
 		resp, err := vnDao.Create().SetObject(
 			privatev1.VirtualNetwork_builder{
 				Metadata: privatev1.Metadata_builder{
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 					Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
 				}.Build(),
 				Spec: privatev1.VirtualNetworkSpec_builder{
@@ -204,7 +203,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			eip := createAllocatedExternalIP()
 			response, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: testTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -220,7 +219,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			eip := createAllocatedExternalIP()
 			response, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: testTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -239,7 +238,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			eip := createAllocatedExternalIP()
 			createResponse, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: testTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -262,7 +261,7 @@ var _ = Describe("Private NAT gateways server", func() {
 				eip := createAllocatedExternalIP()
 				_, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 					Object: privatev1.NATGateway_builder{
-						Metadata: privatev1.Metadata_builder{Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]), Tenant: auth.SharedTenant}.Build(),
+						Metadata: privatev1.Metadata_builder{Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]), Tenant: testTenant}.Build(),
 						Spec: privatev1.NATGatewaySpec_builder{
 							VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vn}.Build(),
 							ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -277,11 +276,11 @@ var _ = Describe("Private NAT gateways server", func() {
 			Expect(response.GetItems()).To(HaveLen(count))
 		})
 
-		It("Rejects update of the name of NATGateway", func() {
+		It("updates NATGateway metadata", func() {
 			eip := createAllocatedExternalIP()
 			createResponse, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: testTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -291,12 +290,12 @@ var _ = Describe("Private NAT gateways server", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			object := createResponse.GetObject()
-			object.GetMetadata().SetName("updated-name")
-			_, err = natGatewaysServer.Update(ctx, privatev1.NATGatewaysUpdateRequest_builder{
+			object.GetMetadata().SetLabels(map[string]string{"env": "test"})
+			updateResponse, err := natGatewaysServer.Update(ctx, privatev1.NATGatewaysUpdateRequest_builder{
 				Object: object,
 			}.Build())
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("immutable"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateResponse.GetObject().GetMetadata().GetLabels()).To(HaveKeyWithValue("env", "test"))
 		})
 
 		It("soft deletes NATGateway", func() {
@@ -306,7 +305,7 @@ var _ = Describe("Private NAT gateways server", func() {
 					Metadata: privatev1.Metadata_builder{
 						Name:       "test-nat-gateway",
 						Finalizers: []string{"test-finalizer"},
-						Tenant:     auth.SharedTenant,
+						Tenant:     testTenant,
 					}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
@@ -332,7 +331,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			eip := createAllocatedExternalIP()
 			createResponse, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: testTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -371,7 +370,7 @@ var _ = Describe("Private NAT gateways server", func() {
 		It("rejects Create with nil spec", func() {
 			_, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: testTenant}.Build(),
 				}.Build(),
 			}.Build())
 			Expect(err).To(HaveOccurred())
@@ -383,7 +382,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			eip := createAllocatedExternalIP()
 			_, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: testTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						ExternalIp: privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
 					}.Build(),
@@ -398,7 +397,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			vnID := createVirtualNetwork()
 			_, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: testTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 					}.Build(),
@@ -427,7 +426,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			vnID := createVirtualNetwork()
 			_, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: testTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: "nonexistent-id"}.Build(),
@@ -445,7 +444,7 @@ var _ = Describe("Private NAT gateways server", func() {
 				privatev1.ExternalIPState_EXTERNAL_IP_STATE_PENDING, false)
 			_, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: testTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -463,7 +462,7 @@ var _ = Describe("Private NAT gateways server", func() {
 				privatev1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED, true)
 			_, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: testTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -494,7 +493,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			eip := createAllocatedExternalIP()
 			_, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Tenant: testTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -511,7 +510,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			eip := createAllocatedExternalIP()
 			_, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Tenant: testTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -540,7 +539,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			eip := createAllocatedExternalIP()
 			createResponse, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: testTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -568,7 +567,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			eip := createAllocatedExternalIP()
 			createResponse, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: testTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -610,7 +609,7 @@ var _ = Describe("Private NAT gateways server", func() {
 			eip := createAllocatedExternalIP()
 			_, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
 				Object: privatev1.NATGateway_builder{
-					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: auth.SharedTenant}.Build(),
+					Metadata: privatev1.Metadata_builder{Name: "test-nat-gateway", Tenant: testTenant}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
 						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
@@ -632,7 +631,7 @@ var _ = Describe("Private NAT gateways server", func() {
 					Metadata: privatev1.Metadata_builder{
 						Name:       "test-nat-gateway",
 						Finalizers: []string{"test-finalizer"},
-						Tenant:     auth.SharedTenant,
+						Tenant:     testTenant,
 					}.Build(),
 					Spec: privatev1.NATGatewaySpec_builder{
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
@@ -660,7 +659,7 @@ var _ = Describe("Private NAT gateways server", func() {
 					Metadata: privatev1.Metadata_builder{
 						Name:       "test-nat-gateway",
 						Finalizers: []string{"test-finalizer"},
-						Tenant:     auth.SharedTenant,
+						Tenant:     testTenant,
 						Labels: map[string]string{
 							"osac.openshift.io/default": "true",
 						},

--- a/fulfillment-service/internal/servers/private_network_classes_server.go
+++ b/fulfillment-service/internal/servers/private_network_classes_server.go
@@ -143,6 +143,7 @@ func (b *PrivateNetworkClassesServerBuilder) Build() (result *PrivateNetworkClas
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetFilterDesc(b.filterDesc).
+		AddAllowedTenants(auth.SharedTenant).
 		Build()
 	if err != nil {
 		return

--- a/fulfillment-service/internal/servers/private_projects_server.go
+++ b/fulfillment-service/internal/servers/private_projects_server.go
@@ -154,16 +154,6 @@ func (s *PrivateProjectsServer) Create(ctx context.Context,
 		return
 	}
 
-	// Projects are scoped to a specific tenant.
-	// Validate that the tenant will not be set to 'shared' or 'system'.
-	if tenant := metadata.GetTenant(); tenant == auth.SharedTenant || tenant == auth.SystemTenant {
-		err = grpcstatus.Errorf(
-			grpccodes.InvalidArgument,
-			"project cannot belong to '%s' tenant - must be scoped to a specific tenant",
-			tenant,
-		)
-		return
-	}
 	name := metadata.GetName()
 	path := strings.Split(name, ".")
 	count := len(path)
@@ -197,41 +187,6 @@ func (s *PrivateProjectsServer) Create(ctx context.Context,
 
 	// Call the generic server to create the project:
 	err = s.generic.Create(ctx, request, &response)
-	if err != nil {
-		return
-	}
-
-	// Report any post-create errors to the transaction so the write is rolled back.
-	if tx, txErr := database.TxFromContext(ctx); txErr == nil {
-		defer tx.ReportError(&err)
-	}
-
-	// Check if the assigned tenant is 'shared' or 'system' and reject if so.
-	// This can happen if the user is an admin and didn't specify a tenant explicitly.
-	if response == nil || response.Object == nil || !response.Object.HasMetadata() {
-		s.logger.WarnContext(
-			ctx,
-			"Post-create tenant validation skipped: response missing expected object or metadata",
-		)
-		err = grpcstatus.Errorf(
-			grpccodes.Internal,
-			"post-create tenant validation failed: response missing expected object or metadata",
-		)
-		return
-	}
-	if tenant := response.Object.GetMetadata().GetTenant(); tenant == auth.SharedTenant || tenant == auth.SystemTenant {
-		s.logger.WarnContext(
-			ctx,
-			"Attempted to create project with invalid tenant",
-			slog.String("tenant", tenant),
-		)
-		err = grpcstatus.Errorf(
-			grpccodes.InvalidArgument,
-			"project must be assigned to a specific tenant - please specify metadata.tenant in the request",
-		)
-		return
-	}
-
 	return
 }
 

--- a/fulfillment-service/internal/servers/private_projects_server_test.go
+++ b/fulfillment-service/internal/servers/private_projects_server_test.go
@@ -19,11 +19,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/osac/fulfillment-service/internal/auth"
 	"github.com/osac-project/osac/fulfillment-service/internal/database"
 	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 )
@@ -295,8 +297,8 @@ var _ = Describe("Private projects server", func() {
 			Expect(err).To(HaveOccurred())
 			status, ok := grpcstatus.FromError(err)
 			Expect(ok).To(BeTrue())
-			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
-			Expect(status.Message()).To(ContainSubstring("cannot belong to 'shared' tenant"))
+			Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+			Expect(status.Message()).To(ContainSubstring("cannot be placed in the 'shared' tenant"))
 		})
 
 		It("Rejects creation when tenant is explicitly set to 'system'", func() {
@@ -314,17 +316,36 @@ var _ = Describe("Private projects server", func() {
 			Expect(err).To(HaveOccurred())
 			status, ok := grpcstatus.FromError(err)
 			Expect(ok).To(BeTrue())
-			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
-			Expect(status.Message()).To(ContainSubstring("cannot belong to 'system' tenant"))
+			Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+			Expect(status.Message()).To(ContainSubstring("cannot be placed in the 'system' tenant"))
 		})
 
 		It("Rejects creation when no tenant is specified and default tenant is invalid", func() {
+			// Build a server with a tenancy mock that returns SystemTenant as default,
+			// simulating an admin whose default tenant is a reserved tenant.
+			localTenancy := auth.NewMockTenancyLogic(ctrl)
+			localTenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+				Return(auth.AllTenants, nil).
+				AnyTimes()
+			localTenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).
+				Return(auth.SystemTenant, nil).
+				AnyTimes()
+			localTenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
+				Return(auth.AllTenants, nil).
+				AnyTimes()
+			localServer, err := NewPrivateProjectsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(localTenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
 			// Use a dedicated transaction to verify the write is rolled back
 			createTx, err := tm.Begin(context.Background())
 			Expect(err).ToNot(HaveOccurred())
 			createCtx := database.TxIntoContext(context.Background(), createTx)
 
-			_, err = privateServer.Create(createCtx, privatev1.ProjectsCreateRequest_builder{
+			_, err = localServer.Create(createCtx, privatev1.ProjectsCreateRequest_builder{
 				Object: privatev1.Project_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name: "my-project",
@@ -337,8 +358,8 @@ var _ = Describe("Private projects server", func() {
 			Expect(err).To(HaveOccurred())
 			status, ok := grpcstatus.FromError(err)
 			Expect(ok).To(BeTrue())
-			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
-			Expect(status.Message()).To(ContainSubstring("must be assigned to a specific tenant"))
+			Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+			Expect(status.Message()).To(ContainSubstring("cannot be placed in the 'system' tenant"))
 
 			// End the transaction — the reported error triggers rollback
 			err = createTx.End(createCtx)
@@ -352,7 +373,7 @@ var _ = Describe("Private projects server", func() {
 				_ = verifyTx.End(verifyCtx)
 			})
 
-			listResp, err := privateServer.List(verifyCtx, privatev1.ProjectsListRequest_builder{
+			listResp, err := localServer.List(verifyCtx, privatev1.ProjectsListRequest_builder{
 				Filter: new("this.metadata.name == 'my-project'"),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())

--- a/fulfillment-service/internal/servers/private_role_bindings_server.go
+++ b/fulfillment-service/internal/servers/private_role_bindings_server.go
@@ -109,6 +109,7 @@ func (b *PrivateRoleBindingsServerBuilder) Build() (result *PrivateRoleBindingsS
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetFilterDesc(b.filterDesc).
+		AddAllowedTenants(auth.SharedTenant).
 		Build()
 	if err != nil {
 		return

--- a/fulfillment-service/internal/servers/private_roles_server.go
+++ b/fulfillment-service/internal/servers/private_roles_server.go
@@ -109,6 +109,7 @@ func (b *PrivateRolesServerBuilder) Build() (result *PrivateRolesServer, err err
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetFilterDesc(b.filterDesc).
+		AddAllowedTenants(auth.SharedTenant).
 		Build()
 	if err != nil {
 		return

--- a/fulfillment-service/internal/servers/private_secrets_server_test.go
+++ b/fulfillment-service/internal/servers/private_secrets_server_test.go
@@ -27,8 +27,8 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
-	"github.com/osac-project/osac/fulfillment-service/internal/auth"
 	"github.com/osac-project/osac/fulfillment-service/internal/database"
+	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/osac/fulfillment-service/internal/events"
 	"github.com/osac-project/osac/fulfillment-service/internal/vault"
 )
@@ -515,7 +515,7 @@ var _ = Describe("Private secrets server", func() {
 		Describe("Create", func() {
 			It("Stores data in vault and clears data before DB write", func() {
 				mockStore.EXPECT().
-					Store(gomock.Any(), auth.SystemTenant, "", "my-secret",
+					Store(gomock.Any(), testTenant, "", "my-secret",
 						map[string][]byte{"key": []byte("value")}).
 					Return(nil)
 
@@ -598,7 +598,7 @@ var _ = Describe("Private secrets server", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				mockStore.EXPECT().
-					Fetch(gomock.Any(), auth.SystemTenant, "", "get-secret").
+					Fetch(gomock.Any(), testTenant, "", "get-secret").
 					Return(map[string][]byte{"password": []byte("secret-value")}, nil)
 
 				getResponse, err := server.Get(ctx, privatev1.SecretsGetRequest_builder{
@@ -682,7 +682,7 @@ var _ = Describe("Private secrets server", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				mockStore.EXPECT().
-					Store(gomock.Any(), auth.SystemTenant, "", "update-secret",
+					Store(gomock.Any(), testTenant, "", "update-secret",
 						map[string][]byte{"key": []byte("new-value")}).
 					Return(nil)
 
@@ -752,7 +752,7 @@ var _ = Describe("Private secrets server", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				mockStore.EXPECT().
-					Delete(gomock.Any(), auth.SystemTenant, "", "delete-secret").
+					Delete(gomock.Any(), testTenant, "", "delete-secret").
 					Return(nil)
 
 				_, err = server.Delete(ctx, privatev1.SecretsDeleteRequest_builder{
@@ -803,6 +803,26 @@ var _ = Describe("Private secrets server", func() {
 				createCtx := database.TxIntoContext(context.Background(), createTx)
 				DeferCleanup(func() { _ = createTx.End(createCtx) })
 
+				// Create a tenant for this separate transaction. We can't reuse
+				// testTenant because the suite-level seed holds an uncommitted row
+				// lock on it, which would block this transaction.
+				const secretsTestTenant = "secrets-test-tenant"
+				tenantsDao, seedErr := dao.NewGenericDAO[*privatev1.Tenant]().
+					SetLogger(logger).
+					SetTenancyLogic(tenancy).
+					Build()
+				Expect(seedErr).ToNot(HaveOccurred())
+				_, seedErr = tenantsDao.Create().
+					SetObject(privatev1.Tenant_builder{
+						Id: secretsTestTenant,
+						Metadata: privatev1.Metadata_builder{
+							Name:   secretsTestTenant,
+							Tenant: secretsTestTenant,
+						}.Build(),
+					}.Build()).
+					Do(createCtx)
+				Expect(seedErr).ToNot(HaveOccurred())
+
 				mockStore.EXPECT().
 					Store(gomock.Any(), gomock.Any(), gomock.Any(), "rollback-secret", gomock.Any()).
 					Return(nil)
@@ -810,7 +830,8 @@ var _ = Describe("Private secrets server", func() {
 				created, err := server.Create(createCtx, privatev1.SecretsCreateRequest_builder{
 					Object: privatev1.Secret_builder{
 						Metadata: privatev1.Metadata_builder{
-							Name: "rollback-secret",
+							Name:   "rollback-secret",
+							Tenant: secretsTestTenant,
 						}.Build(),
 						Data: map[string][]byte{
 							"key": []byte("value"),
@@ -831,7 +852,7 @@ var _ = Describe("Private secrets server", func() {
 				DeferCleanup(func() { _ = deleteTx.End(deleteCtx) })
 
 				mockStore.EXPECT().
-					Delete(gomock.Any(), auth.SystemTenant, "", "rollback-secret").
+					Delete(gomock.Any(), secretsTestTenant, "", "rollback-secret").
 					Return(fmt.Errorf("vault unavailable"))
 
 				_, err = server.Delete(deleteCtx, privatev1.SecretsDeleteRequest_builder{
@@ -849,7 +870,7 @@ var _ = Describe("Private secrets server", func() {
 				DeferCleanup(func() { _ = verifyTx.End(verifyCtx) })
 
 				mockStore.EXPECT().
-					Fetch(gomock.Any(), auth.SystemTenant, "", "rollback-secret").
+					Fetch(gomock.Any(), secretsTestTenant, "", "rollback-secret").
 					Return(map[string][]byte{"key": []byte("value")}, nil)
 
 				getResponse, err := server.Get(verifyCtx, privatev1.SecretsGetRequest_builder{

--- a/fulfillment-service/internal/servers/private_storage_backends_server.go
+++ b/fulfillment-service/internal/servers/private_storage_backends_server.go
@@ -108,6 +108,7 @@ func (b *PrivateStorageBackendsServerBuilder) Build() (result *PrivateStorageBac
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetFilterDesc(b.filterDesc).
+		AddAllowedTenants(auth.SharedTenant).
 		Build()
 	if err != nil {
 		return

--- a/fulfillment-service/internal/servers/private_storage_tiers_server.go
+++ b/fulfillment-service/internal/servers/private_storage_tiers_server.go
@@ -113,6 +113,7 @@ func (b *PrivateStorageTiersServerBuilder) Build() (result *PrivateStorageTiersS
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetFilterDesc(b.filterDesc).
+		AddAllowedTenants(auth.SharedTenant).
 		Build()
 	if err != nil {
 		return

--- a/fulfillment-service/internal/servers/private_subnets_server_test.go
+++ b/fulfillment-service/internal/servers/private_subnets_server_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Private subnets server", func() {
 
 		builder := privatev1.VirtualNetwork_builder{
 			Metadata: privatev1.Metadata_builder{
-				Tenant: auth.SharedTenant,
+				Tenant: testTenant,
 				Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
 			}.Build(),
 			Spec: privatev1.VirtualNetworkSpec_builder{
@@ -389,7 +389,7 @@ var _ = Describe("Private subnets server", func() {
 					Object: privatev1.Subnet_builder{
 						Metadata: privatev1.Metadata_builder{
 							Name:   "test-subnet",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Spec: privatev1.SubnetSpec_builder{
 							Ipv4Cidr:       new("10.0.1.5/24"),
@@ -517,7 +517,7 @@ var _ = Describe("Private subnets server", func() {
 
 				vn := privatev1.VirtualNetwork_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Ipv4Cidr:     new("10.0.0.0/16"),
@@ -562,7 +562,7 @@ var _ = Describe("Private subnets server", func() {
 
 				vn := privatev1.VirtualNetwork_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Ipv4Cidr:     new("10.0.0.0/16"),
@@ -777,7 +777,7 @@ var _ = Describe("Private subnets server", func() {
 
 				subnet := privatev1.Subnet_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.SubnetSpec_builder{
 						Ipv4Cidr:       new("10.0.1.0/24"),
@@ -1110,7 +1110,7 @@ var _ = Describe("Private subnets server", func() {
 					Object: privatev1.Subnet_builder{
 						Metadata: privatev1.Metadata_builder{
 							Name:   "test-subnet",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Spec: privatev1.SubnetSpec_builder{
 							Ipv4Cidr:       new("10.0.1.0/24"),
@@ -1122,7 +1122,7 @@ var _ = Describe("Private subnets server", func() {
 				created := createResponse.GetObject()
 				name := created.GetMetadata().GetName()
 
-				// Update with only the name changed; no CIDR fields in the request:
+				// Update with an unchanged name and no CIDR fields in the request:
 				updateResponse, err := server.Update(ctx, privatev1.SubnetsUpdateRequest_builder{
 					Object: privatev1.Subnet_builder{
 						Id:       created.GetId(),
@@ -1156,7 +1156,7 @@ var _ = Describe("Private subnets server", func() {
 				subnet := privatev1.Subnet_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   name,
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: builder.Build(),
 				}.Build()
@@ -1172,9 +1172,6 @@ var _ = Describe("Private subnets server", func() {
 				createSubnetInDB(ctx, "existing-subnet", "10.0.1.0/24", "", vn.GetId())
 
 				newSubnet := privatev1.Subnet_builder{
-					Metadata: privatev1.Metadata_builder{
-						Name: "new-subnet",
-					}.Build(),
 					Spec: privatev1.SubnetSpec_builder{
 						Ipv4Cidr:       new("10.0.1.0/24"),
 						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vn.GetId()}.Build(),
@@ -1298,7 +1295,7 @@ var _ = Describe("Private subnets server", func() {
 					Object: privatev1.Subnet_builder{
 						Metadata: privatev1.Metadata_builder{
 							Name:   "test-subnet",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Spec: privatev1.SubnetSpec_builder{
 							Ipv4Cidr:       new("10.0.1.0/24"),
@@ -1312,7 +1309,7 @@ var _ = Describe("Private subnets server", func() {
 				_, err = computeInstancesDao.Create().
 					SetObject(privatev1.ComputeInstance_builder{
 						Metadata: privatev1.Metadata_builder{
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Spec: privatev1.ComputeInstanceSpec_builder{
 							NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -1342,7 +1339,7 @@ var _ = Describe("Private subnets server", func() {
 					Object: privatev1.Subnet_builder{
 						Metadata: privatev1.Metadata_builder{
 							Name:   "test-subnet",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Spec: privatev1.SubnetSpec_builder{
 							Ipv4Cidr:       new("10.0.1.0/24"),
@@ -1371,7 +1368,7 @@ var _ = Describe("Private subnets server", func() {
 					Object: privatev1.Subnet_builder{
 						Metadata: privatev1.Metadata_builder{
 							Name:   "test-subnet",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Spec: privatev1.SubnetSpec_builder{
 							Ipv4Cidr:       new("10.0.1.0/24"),
@@ -1394,7 +1391,7 @@ var _ = Describe("Private subnets server", func() {
 				_, err = computeInstancesDao.Create().
 					SetObject(privatev1.ComputeInstance_builder{
 						Metadata: privatev1.Metadata_builder{
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Spec: privatev1.ComputeInstanceSpec_builder{
 							NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -1415,7 +1412,7 @@ var _ = Describe("Private subnets server", func() {
 					Object: privatev1.Subnet_builder{
 						Metadata: privatev1.Metadata_builder{
 							Name:   "test-subnet",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Spec: privatev1.SubnetSpec_builder{
 							Ipv4Cidr:       new("10.0.1.0/24"),
@@ -1429,7 +1426,7 @@ var _ = Describe("Private subnets server", func() {
 				ciCreateResponse, err := computeInstancesDao.Create().
 					SetObject(privatev1.ComputeInstance_builder{
 						Metadata: privatev1.Metadata_builder{
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Spec: privatev1.ComputeInstanceSpec_builder{
 							NetworkAttachments: []*privatev1.NetworkAttachment{
@@ -1462,7 +1459,7 @@ var _ = Describe("Private subnets server", func() {
 					Object: privatev1.Subnet_builder{
 						Metadata: privatev1.Metadata_builder{
 							Name:   "test-subnet",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 							Labels: map[string]string{
 								"osac.openshift.io/default": "true",
 							},
@@ -1507,7 +1504,7 @@ var _ = Describe("Private subnets server", func() {
 
 			subnet := privatev1.Subnet_builder{
 				Metadata: privatev1.Metadata_builder{
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.SubnetSpec_builder{
 					Ipv4Cidr:       new("10.0.1.0/24"),
@@ -1530,7 +1527,7 @@ var _ = Describe("Private subnets server", func() {
 
 			subnet := privatev1.Subnet_builder{
 				Metadata: privatev1.Metadata_builder{
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.SubnetSpec_builder{
 					Ipv4Cidr:       new("10.0.1.0/24"),
@@ -1561,7 +1558,7 @@ var _ = Describe("Private subnets server", func() {
 				subnet := privatev1.Subnet_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   fmt.Sprintf("subnet-%d", i),
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.SubnetSpec_builder{
 						Ipv4Cidr:       new(fmt.Sprintf("10.%d.0.0/16", i)),
@@ -1593,7 +1590,7 @@ var _ = Describe("Private subnets server", func() {
 				subnet := privatev1.Subnet_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   fmt.Sprintf("vn1-subnet-%d", i),
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.SubnetSpec_builder{
 						Ipv4Cidr:       new(fmt.Sprintf("10.0.%d.0/24", i)),
@@ -1612,7 +1609,7 @@ var _ = Describe("Private subnets server", func() {
 				subnet := privatev1.Subnet_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   fmt.Sprintf("vn2-subnet-%d", i),
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.SubnetSpec_builder{
 						Ipv4Cidr:       new(fmt.Sprintf("192.168.%d.0/24", i)),
@@ -1643,7 +1640,7 @@ var _ = Describe("Private subnets server", func() {
 			subnet := privatev1.Subnet_builder{
 				Metadata: privatev1.Metadata_builder{
 					Name:   "original-name",
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.SubnetSpec_builder{
 					Ipv4Cidr:       new("10.0.1.0/24"),
@@ -1672,7 +1669,7 @@ var _ = Describe("Private subnets server", func() {
 			subnet := privatev1.Subnet_builder{
 				Metadata: privatev1.Metadata_builder{
 					Finalizers: []string{"test-finalizer"},
-					Tenant:     auth.SharedTenant,
+					Tenant:     testTenant,
 				}.Build(),
 				Spec: privatev1.SubnetSpec_builder{
 					Ipv4Cidr:       new("10.0.1.0/24"),

--- a/fulfillment-service/internal/servers/private_users_server.go
+++ b/fulfillment-service/internal/servers/private_users_server.go
@@ -102,6 +102,7 @@ func (b *PrivateUsersServerBuilder) Build() (result *PrivateUsersServer, err err
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetFilterDesc(b.filterDesc).
+		AddAllowedTenants(auth.SharedTenant).
 		Build()
 	if err != nil {
 		return

--- a/fulfillment-service/internal/servers/private_virtual_networks_server_test.go
+++ b/fulfillment-service/internal/servers/private_virtual_networks_server_test.go
@@ -103,6 +103,7 @@ var _ = Describe("Private virtual networks server", func() {
 			IsDefault:              new(true),
 			Metadata: privatev1.Metadata_builder{
 				Tenant: auth.SharedTenant,
+				Name:   fmt.Sprintf("test-network-class-%s", uuid.NewString()[:8]),
 			}.Build(),
 			Capabilities: privatev1.NetworkClassCapabilities_builder{
 				SupportsIpv4:      true,
@@ -313,7 +314,7 @@ var _ = Describe("Private virtual networks server", func() {
 					Object: privatev1.VirtualNetwork_builder{
 						Metadata: privatev1.Metadata_builder{
 							Name:   "test-virtual-network",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Spec: privatev1.VirtualNetworkSpec_builder{
 							Ipv4Cidr:     new("10.0.1.5/24"),
@@ -568,7 +569,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 				vn := privatev1.VirtualNetwork_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Ipv4Cidr:     new("10.0.0.0/16"),
@@ -590,7 +591,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 				vn := privatev1.VirtualNetwork_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Ipv6Cidr:     new("2001:db8::/48"),
@@ -613,7 +614,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 				vn := privatev1.VirtualNetwork_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Ipv4Cidr:     new("10.0.0.0/16"),
@@ -636,7 +637,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 				vn := privatev1.VirtualNetwork_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Ipv4Cidr:     new("10.0.0.0/16"),
@@ -675,7 +676,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 				vn := privatev1.VirtualNetwork_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Ipv4Cidr:     new("10.0.0.0/16"),
@@ -883,7 +884,7 @@ var _ = Describe("Private virtual networks server", func() {
 					Object: privatev1.VirtualNetwork_builder{
 						Metadata: privatev1.Metadata_builder{
 							Name:   "test-virtual-network",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Spec: privatev1.VirtualNetworkSpec_builder{
 							Ipv4Cidr:     new("10.0.0.0/16"),
@@ -898,8 +899,10 @@ var _ = Describe("Private virtual networks server", func() {
 
 				updateResponse, err := server.Update(ctx, privatev1.VirtualNetworksUpdateRequest_builder{
 					Object: privatev1.VirtualNetwork_builder{
-						Id:       created.GetId(),
-						Metadata: privatev1.Metadata_builder{Name: created.GetMetadata().GetName()}.Build(),
+						Id: created.GetId(),
+						Metadata: privatev1.Metadata_builder{
+							Name: created.GetMetadata().GetName(),
+						}.Build(),
 						Spec: privatev1.VirtualNetworkSpec_builder{
 							NetworkClass: privatev1.NetworkClassReference_builder{Id: nc.GetId()}.Build(),
 							Region:       "us-west-1",
@@ -1148,7 +1151,7 @@ var _ = Describe("Private virtual networks server", func() {
 					Object: privatev1.VirtualNetwork_builder{
 						Metadata: privatev1.Metadata_builder{
 							Name:   "test-virtual-network",
-							Tenant: auth.SharedTenant,
+							Tenant: testTenant,
 						}.Build(),
 						Spec: privatev1.VirtualNetworkSpec_builder{
 							Ipv4Cidr:     new("10.0.0.0/16"),
@@ -1160,12 +1163,13 @@ var _ = Describe("Private virtual networks server", func() {
 				Expect(err).ToNot(HaveOccurred())
 				created := createResponse.GetObject()
 
-				// Update with only the name changed; no CIDR fields in the request:
-				_, err = server.Update(ctx, privatev1.VirtualNetworksUpdateRequest_builder{
+				// Update with only labels changed; no CIDR fields in the request:
+				updateResponse, err := server.Update(ctx, privatev1.VirtualNetworksUpdateRequest_builder{
 					Object: privatev1.VirtualNetwork_builder{
 						Id: created.GetId(),
 						Metadata: privatev1.Metadata_builder{
-							Name: "renamed-vn",
+							Name:   created.GetMetadata().GetName(),
+							Labels: map[string]string{"env": "test"},
 						}.Build(),
 						Spec: privatev1.VirtualNetworkSpec_builder{
 							NetworkClass: privatev1.NetworkClassReference_builder{Id: nc.GetId()}.Build(),
@@ -1173,8 +1177,11 @@ var _ = Describe("Private virtual networks server", func() {
 						}.Build(),
 					}.Build(),
 				}.Build())
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("immutable"))
+				Expect(err).ToNot(HaveOccurred())
+				updated := updateResponse.GetObject()
+
+				// CIDRs must be preserved from the existing record:
+				Expect(updated.GetSpec().GetIpv4Cidr()).To(Equal("10.0.0.0/16"))
 			})
 		})
 	})
@@ -1196,7 +1203,7 @@ var _ = Describe("Private virtual networks server", func() {
 		It("creates VirtualNetwork and generates ID", func() {
 			vn := privatev1.VirtualNetwork_builder{
 				Metadata: privatev1.Metadata_builder{
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.VirtualNetworkSpec_builder{
 					Ipv4Cidr:     new("10.0.0.0/16"),
@@ -1218,7 +1225,7 @@ var _ = Describe("Private virtual networks server", func() {
 		It("retrieves VirtualNetwork by ID", func() {
 			vn := privatev1.VirtualNetwork_builder{
 				Metadata: privatev1.Metadata_builder{
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.VirtualNetworkSpec_builder{
 					Ipv4Cidr:     new("10.0.0.0/16"),
@@ -1248,7 +1255,7 @@ var _ = Describe("Private virtual networks server", func() {
 				vn := privatev1.VirtualNetwork_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   fmt.Sprintf("vn-%d", i),
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Ipv4Cidr:     new(fmt.Sprintf("10.%d.0.0/16", i)),
@@ -1278,7 +1285,7 @@ var _ = Describe("Private virtual networks server", func() {
 				vn := privatev1.VirtualNetwork_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   fmt.Sprintf("vn-%d", i),
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Ipv4Cidr:     new(fmt.Sprintf("10.%d.0.0/16", i)),
@@ -1302,11 +1309,11 @@ var _ = Describe("Private virtual networks server", func() {
 			Expect(response.GetItems()[0].GetMetadata().GetName()).To(Equal("vn-2"))
 		})
 
-		It("Rejects update of the name of VirtualNetwork", func() {
+		It("updates VirtualNetwork", func() {
 			vn := privatev1.VirtualNetwork_builder{
 				Metadata: privatev1.Metadata_builder{
 					Name:   "original-name",
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.VirtualNetworkSpec_builder{
 					Ipv4Cidr:     new("10.0.0.0/16"),
@@ -1321,20 +1328,28 @@ var _ = Describe("Private virtual networks server", func() {
 			Expect(err).ToNot(HaveOccurred())
 			vn = createResponse.GetObject()
 
-			// Update name
-			vn.GetMetadata().Name = "updated-name"
-			_, err = generic.Update().
+			// Update a mutable field (labels); the name is immutable:
+			vn.GetMetadata().Labels = map[string]string{"env": "test"}
+			updateResponse, err := generic.Update().
 				SetObject(vn).
 				Do(ctx)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("immutable"))
+			Expect(err).ToNot(HaveOccurred())
+			vn = updateResponse.GetObject()
+
+			// Verify update
+			getResponse, err := generic.Get().
+				SetId(vn.GetId()).
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			retrieved := getResponse.GetObject()
+			Expect(retrieved.GetMetadata().GetLabels()).To(HaveKeyWithValue("env", "test"))
 		})
 
 		It("soft deletes VirtualNetwork", func() {
 			vn := privatev1.VirtualNetwork_builder{
 				Metadata: privatev1.Metadata_builder{
 					Finalizers: []string{"test-finalizer"},
-					Tenant:     auth.SharedTenant,
+					Tenant:     testTenant,
 				}.Build(),
 				Spec: privatev1.VirtualNetworkSpec_builder{
 					Ipv4Cidr:     new("10.0.0.0/16"),
@@ -1688,7 +1703,7 @@ var _ = Describe("Private virtual networks server", func() {
 				Object: privatev1.VirtualNetwork_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   "test-virtual-network",
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 					}.Build(),
 					Spec: privatev1.VirtualNetworkSpec_builder{
 						Ipv4Cidr:     proto.String("10.0.0.0/16"),
@@ -1729,8 +1744,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 			subnet := privatev1.Subnet_builder{
 				Metadata: privatev1.Metadata_builder{
-					Tenant: auth.SharedTenant,
-					Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.SubnetSpec_builder{
 					VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vn.GetId()}.Build(),
@@ -1756,8 +1770,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 			sg := privatev1.SecurityGroup_builder{
 				Metadata: privatev1.Metadata_builder{
-					Tenant: auth.SharedTenant,
-					Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.SecurityGroupSpec_builder{
 					VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vn.GetId()}.Build(),
@@ -1783,8 +1796,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 			subnet := privatev1.Subnet_builder{
 				Metadata: privatev1.Metadata_builder{
-					Tenant: auth.SharedTenant,
-					Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.SubnetSpec_builder{
 					VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vn.GetId()}.Build(),
@@ -1796,8 +1808,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 			sg := privatev1.SecurityGroup_builder{
 				Metadata: privatev1.Metadata_builder{
-					Tenant: auth.SharedTenant,
-					Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.SecurityGroupSpec_builder{
 					VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vn.GetId()}.Build(),
@@ -1821,7 +1832,7 @@ var _ = Describe("Private virtual networks server", func() {
 
 			sg := privatev1.SecurityGroup_builder{
 				Metadata: privatev1.Metadata_builder{
-					Tenant: auth.SharedTenant,
+					Tenant: testTenant,
 				}.Build(),
 				Spec: privatev1.SecurityGroupSpec_builder{
 					VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vn.GetId()}.Build(),
@@ -1846,7 +1857,7 @@ var _ = Describe("Private virtual networks server", func() {
 			for i := range 3 {
 				subnet := privatev1.Subnet_builder{
 					Metadata: privatev1.Metadata_builder{
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 						Name:   fmt.Sprintf("test-%s", uuid.NewString()[:8]),
 					}.Build(),
 					Spec: privatev1.SubnetSpec_builder{
@@ -1874,7 +1885,7 @@ var _ = Describe("Private virtual networks server", func() {
 				Object: privatev1.VirtualNetwork_builder{
 					Metadata: privatev1.Metadata_builder{
 						Name:   "default-virtual-network",
-						Tenant: auth.SharedTenant,
+						Tenant: testTenant,
 						Labels: map[string]string{
 							"osac.openshift.io/default": "true",
 						},

--- a/fulfillment-service/internal/servers/projects_server.go
+++ b/fulfillment-service/internal/servers/projects_server.go
@@ -142,8 +142,8 @@ func (s *ProjectsServer) List(ctx context.Context,
 	if request.HasLimit() {
 		privateRequest.SetLimit(request.GetLimit())
 	}
-	privateRequest.SetOrder(request.GetOrder())
 	privateRequest.SetFilter(request.GetFilter())
+	privateRequest.SetOrder(request.GetOrder())
 	privateResponse, err := s.private.List(ctx, privateRequest)
 	if err != nil {
 		return nil, err

--- a/fulfillment-service/internal/servers/security_groups_server_test.go
+++ b/fulfillment-service/internal/servers/security_groups_server_test.go
@@ -25,7 +25,6 @@ import (
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
-	"github.com/osac-project/osac/fulfillment-service/internal/auth"
 	"github.com/osac-project/osac/fulfillment-service/internal/database"
 	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 )
@@ -47,7 +46,7 @@ var _ = Describe("SecurityGroups server", func() {
 			Id:                     "default",
 			ImplementationStrategy: "ovn-kubernetes",
 			Metadata: privatev1.Metadata_builder{
-				Tenant: auth.SharedTenant,
+				Tenant: testTenant,
 			}.Build(),
 			Capabilities: privatev1.NetworkClassCapabilities_builder{
 				SupportsIpv4:      true,
@@ -74,7 +73,7 @@ var _ = Describe("SecurityGroups server", func() {
 
 		vn := privatev1.VirtualNetwork_builder{
 			Metadata: privatev1.Metadata_builder{
-				Tenant: auth.SharedTenant,
+				Tenant: testTenant,
 			}.Build(),
 			Spec: privatev1.VirtualNetworkSpec_builder{
 				Region:       "us-east-1",

--- a/fulfillment-service/internal/servers/servers_suite_test.go
+++ b/fulfillment-service/internal/servers/servers_suite_test.go
@@ -24,8 +24,10 @@ import (
 	"go.uber.org/mock/gomock"
 	grpcmetadata "google.golang.org/grpc/metadata"
 
+	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/auth"
 	"github.com/osac-project/osac/fulfillment-service/internal/database"
+	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/osac/fulfillment-service/internal/logging"
 )
 
@@ -33,6 +35,8 @@ func TestServers(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Servers package")
 }
+
+const testTenant = "test-tenant"
 
 var (
 	ctx         context.Context
@@ -70,7 +74,7 @@ var _ = BeforeSuite(func() {
 		Return(auth.AllTenants, nil).
 		AnyTimes()
 	tenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).
-		Return(auth.SystemTenant, nil).
+		Return(testTenant, nil).
 		AnyTimes()
 	tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
 		Return(auth.AllTenants, nil).
@@ -122,6 +126,24 @@ var _ = BeforeEach(func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 	ctx = database.TxIntoContext(ctx, tx)
+
+	// Create the testTenant in the database so foreign key constraints are satisfied
+	// when resources are created with the default tenant mock.
+	tenantsDao, err := dao.NewGenericDAO[*privatev1.Tenant]().
+		SetLogger(logger).
+		SetTenancyLogic(tenancy).
+		Build()
+	Expect(err).ToNot(HaveOccurred())
+	_, err = tenantsDao.Create().
+		SetObject(privatev1.Tenant_builder{
+			Id: testTenant,
+			Metadata: privatev1.Metadata_builder{
+				Name:   testTenant,
+				Tenant: testTenant,
+			}.Build(),
+		}.Build()).
+		Do(ctx)
+	Expect(err).ToNot(HaveOccurred())
 })
 
 func dryRunCtx() context.Context {

--- a/fulfillment-service/internal/servers/subnets_server_test.go
+++ b/fulfillment-service/internal/servers/subnets_server_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Subnets server", func() {
 			Id:                     "default",
 			ImplementationStrategy: "ovn-kubernetes",
 			Metadata: privatev1.Metadata_builder{
-				Tenant: auth.SharedTenant,
+				Tenant: testTenant,
 			}.Build(),
 			Capabilities: privatev1.NetworkClassCapabilities_builder{
 				SupportsIpv4:      true,
@@ -85,7 +85,7 @@ var _ = Describe("Subnets server", func() {
 
 		vn := privatev1.VirtualNetwork_builder{
 			Metadata: privatev1.Metadata_builder{
-				Tenant: auth.SharedTenant,
+				Tenant: testTenant,
 			}.Build(),
 			Spec: privatev1.VirtualNetworkSpec_builder{
 				Region:       "us-east-1",

--- a/fulfillment-service/internal/servers/virtual_networks_server_test.go
+++ b/fulfillment-service/internal/servers/virtual_networks_server_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Virtual networks server", func() {
 			Id:                     "default",
 			ImplementationStrategy: "ovn-kubernetes",
 			Metadata: privatev1.Metadata_builder{
-				Tenant: auth.SharedTenant,
+				Tenant: testTenant,
 			}.Build(),
 			IsDefault: new(true),
 			Capabilities: privatev1.NetworkClassCapabilities_builder{

--- a/fulfillment-service/it/it_baremetal_instance_lifecycle_test.go
+++ b/fulfillment-service/it/it_baremetal_instance_lifecycle_test.go
@@ -179,7 +179,6 @@ var _ = Describe("BareMetalInstance lifecycle", func() {
 		networkClassesClient := privatev1.NewNetworkClassesClient(tool.InternalView().AdminConn())
 		virtualNetworksClient := privatev1.NewVirtualNetworksClient(tool.InternalView().AdminConn())
 		subnetsClient := privatev1.NewSubnetsClient(tool.InternalView().AdminConn())
-
 		// Create a k8s-only NetworkClass (no fabric_manager):
 		ncResp, err := networkClassesClient.Create(ctx, privatev1.NetworkClassesCreateRequest_builder{
 			Object: privatev1.NetworkClass_builder{
@@ -202,7 +201,8 @@ var _ = Describe("BareMetalInstance lifecycle", func() {
 			Object: privatev1.VirtualNetwork_builder{
 				Id: virtualNetworkId,
 				Metadata: privatev1.Metadata_builder{
-					Name: fmt.Sprintf("test-vnet-%s", uuid.New()[24:32]),
+					Name:   fmt.Sprintf("test-vnet-%s", uuid.New()[24:32]),
+					Tenant: usersGroup,
 				}.Build(),
 				Spec: privatev1.VirtualNetworkSpec_builder{
 					NetworkClass: privatev1.NetworkClassReference_builder{Id: networkClassId}.Build(),
@@ -250,6 +250,10 @@ var _ = Describe("BareMetalInstance lifecycle", func() {
 		_, err = subnetsClient.Create(ctx, privatev1.SubnetsCreateRequest_builder{
 			Object: privatev1.Subnet_builder{
 				Id: subnetId,
+				Metadata: privatev1.Metadata_builder{
+					Name:   fmt.Sprintf("test-subnet-%s", uuid.New()[24:32]),
+					Tenant: usersGroup,
+				}.Build(),
 				Spec: privatev1.SubnetSpec_builder{
 					VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: virtualNetworkId}.Build(),
 					Ipv4Cidr:       new("10.101.1.0/24"),

--- a/fulfillment-service/it/it_compute_subnet_test.go
+++ b/fulfillment-service/it/it_compute_subnet_test.go
@@ -170,7 +170,8 @@ var _ = Describe("ComputeInstance with Subnet attachment", func() {
 		_, err = virtualNetworksClient.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
 			Object: privatev1.VirtualNetwork_builder{
 				Metadata: privatev1.Metadata_builder{
-					Name: fmt.Sprintf("test-vnet-%s", uuid.New()[24:32]),
+					Name:   fmt.Sprintf("test-vnet-%s", uuid.New()[24:32]),
+					Tenant: usersGroup,
 				}.Build(),
 				Id: virtualNetworkId,
 				Spec: privatev1.VirtualNetworkSpec_builder{
@@ -214,7 +215,8 @@ var _ = Describe("ComputeInstance with Subnet attachment", func() {
 		_, err = subnetsClient.Create(ctx, privatev1.SubnetsCreateRequest_builder{
 			Object: privatev1.Subnet_builder{
 				Metadata: privatev1.Metadata_builder{
-					Name: fmt.Sprintf("test-subnet-%s", uuid.New()[24:32]),
+					Name:   fmt.Sprintf("test-subnet-%s", uuid.New()[24:32]),
+					Tenant: usersGroup,
 				}.Build(),
 				Id: subnetId,
 				Spec: privatev1.SubnetSpec_builder{

--- a/fulfillment-service/it/it_identity_providers_test.go
+++ b/fulfillment-service/it/it_identity_providers_test.go
@@ -403,8 +403,8 @@ var _ = Describe("Identity provider lifecycle", func() {
 				"Creating IdP with tenant %q should fail", invalidTenant)
 			status, ok := grpcstatus.FromError(err)
 			Expect(ok).To(BeTrue())
-			Expect(status.Code()).To(Equal(grpccodes.InvalidArgument),
-				"Expected InvalidArgument for tenant %q, got %v", invalidTenant, status.Code())
+			Expect(status.Code()).To(Equal(grpccodes.PermissionDenied),
+				"Expected PermissionDenied for tenant %q, got %v", invalidTenant, status.Code())
 		}
 	})
 

--- a/fulfillment-service/it/it_nat_gateway_test.go
+++ b/fulfillment-service/it/it_nat_gateway_test.go
@@ -75,7 +75,8 @@ var _ = Describe("NATGateway lifecycle", func() {
 			Object: privatev1.VirtualNetwork_builder{
 				Id: virtualNetworkId,
 				Metadata: privatev1.Metadata_builder{
-					Name: fmt.Sprintf("test-vnet-%s", uuid.New()[24:32]),
+					Name:   fmt.Sprintf("test-vnet-%s", uuid.New()[24:32]),
+					Tenant: usersGroup,
 				}.Build(),
 				Spec: privatev1.VirtualNetworkSpec_builder{
 					NetworkClass: privatev1.NetworkClassReference_builder{Id: networkClassId}.Build(),
@@ -351,7 +352,8 @@ var _ = Describe("NATGateway lifecycle", func() {
 			Object: privatev1.VirtualNetwork_builder{
 				Id: vn2Id,
 				Metadata: privatev1.Metadata_builder{
-					Name: fmt.Sprintf("test-vnet-%s", uuid.New()[24:32]),
+					Name:   fmt.Sprintf("test-vnet-%s", uuid.New()[24:32]),
+					Tenant: usersGroup,
 				}.Build(),
 				Spec: privatev1.VirtualNetworkSpec_builder{
 					NetworkClass: privatev1.NetworkClassReference_builder{Id: networkClassId}.Build(),
@@ -406,7 +408,8 @@ var _ = Describe("NATGateway lifecycle", func() {
 			Object: privatev1.VirtualNetwork_builder{
 				Id: k8sOnlyVNId,
 				Metadata: privatev1.Metadata_builder{
-					Name: fmt.Sprintf("test-vnet-%s", uuid.New()[24:32]),
+					Name:   fmt.Sprintf("test-vnet-%s", uuid.New()[24:32]),
+					Tenant: usersGroup,
 				}.Build(),
 				Spec: privatev1.VirtualNetworkSpec_builder{
 					NetworkClass: privatev1.NetworkClassReference_builder{Id: k8sOnlyNC.GetObject().GetId()}.Build(),

--- a/fulfillment-service/proto/public/osac/public/v1/cluster_template_type.proto
+++ b/fulfillment-service/proto/public/osac/public/v1/cluster_template_type.proto
@@ -133,8 +133,8 @@ message ClusterTemplateSpecDefaults {
 
   // Default Secret reference for pull secret credentials.
   //
-  // Mutually exclusive with `pull_secret`. When set, clusters created from this template will use this secret
-  // reference unless the user provides an explicit pull_secret or pull_secret_secret.
+  // Mutually exclusive with `pull_secret`. When set, clusters created from this template will use
+  // this secret reference unless the user provides an explicit pull_secret or pull_secret_secret.
   SecretLocalReference pull_secret_secret = 6;
 }
 


### PR DESCRIPTION
Continues the work from https://github.com/osac-project/fulfillment-service/pull/614 which was approved but went stale after the monorepo migration. 

  Summary

  - Add an allowedTenants set to GenericServer that defaults to all tenants except shared and system,
  blocking tenant-scoped resource creation in reserved tenants at a single enforcement point
  - Platform-scoped servers opt in via AddAllowedTenants(auth.SharedTenant) in their builder chain
  - Remove redundant per-server pre/post-create tenant guards from Projects and IdentityProviders (now
  handled generically)

  Problem

  Cloud administrators whose default tenant resolves to shared can accidentally create tenant-scoped
  resources (Clusters, ComputeInstances, VirtualNetworks, Subnets, ExternalIPs, etc.) in the shared
  namespace, making them visible to all users. The system tenant has the same exposure. Only Projects
  and IdentityProviders had per-server guards, requiring duplicated pre-create and post-create checks
  in each server.

  Approach

  - DefaultAllowedTenants (AllTenants - {system, shared}) in auth/tenancy_logic.go
  - allowedTenants field + AddAllowedTenants/RemoveAllowedTenants builder methods on GenericServer
  - checkAllowedTenant guard in prepareForCreate (after tenant is determined) and in Update (when the
  tenant changes) — eliminates the need for separate pre/post-create guards in individual servers
  - 17 platform-scoped servers opt in: Hubs, HostTypes, Roles, ClusterCatalogItems, ClusterTemplates,
  ClusterVersions, ComputeInstanceCatalogItems, ComputeInstanceTemplates, InstanceTypes,
  BareMetalInstanceTypes, BareMetalInstanceCatalogItems, BareMetalInstanceTemplates, NetworkClasses,
  ExternalIPPools, StorageBackends, StorageTiers, DiskImages
  - Test expectations updated for PermissionDenied (was InvalidArgument in the per-server guards)

  Test plan

  - [x] All 23 files compile and pass go vet
  - [x] Projects and IdentityProviders server tests: 25 passed, 6 failed (same as main — pre-existing
  failures, zero regressions)
  - [ ] CI full unit + integration test run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support for platform-scoped resources in the shared tenant, including roles, users, templates, catalog items, and related resource types.
  * Added clearer tenant authorization rules for creating and moving resources between tenants.
* **Bug Fixes**
  * Tenant-scoped resources can no longer be created in reserved shared or system tenants.
  * Invalid tenant requests now return `PermissionDenied` with clearer guidance.
  * Resource updates now preserve immutable names while allowing metadata label changes.
* **Documentation**
  * Updated tenancy documentation to reflect the expanded resource restrictions and default tenant behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->