### PR TITLE
OSAC-3765: Wire BMH manager, RBAC, and Helm bcmCerts

### DIFF
--- a/bare-metal-fulfillment-operator/charts/operator/templates/clusterrole.yaml
+++ b/bare-metal-fulfillment-operator/charts/operator/templates/clusterrole.yaml
@@ -11,6 +11,8 @@ rules:
   resources:
   - baremetalhosts
   verbs:
+  - create
+  - delete
   - get
   - list
   - patch

--- a/bare-metal-fulfillment-operator/charts/operator/templates/deployment.yaml
+++ b/bare-metal-fulfillment-operator/charts/operator/templates/deployment.yaml
@@ -108,6 +108,9 @@ spec:
             mountPath: /etc/openstack/
           - name: profiles
             mountPath: /etc/osac/profile/
+          - name: bcm-certs
+            mountPath: /etc/osac/certs/bcm-certs/
+            readOnly: true
       volumes:
         - name: inventory-config
           secret:
@@ -122,6 +125,10 @@ spec:
         - name: profiles
           configMap:
             name: {{ .Values.configMaps.profiles }}
+            optional: true
+        - name: bcm-certs
+          secret:
+            secretName: {{ .Values.secrets.bcmCerts }}
             optional: true
       serviceAccountName: {{ include "bare-metal-fulfillment-operator.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10

--- a/bare-metal-fulfillment-operator/charts/operator/values.yaml
+++ b/bare-metal-fulfillment-operator/charts/operator/values.yaml
@@ -23,6 +23,7 @@ secrets:
   inventoryConfig: "osac-inventory-config"
   managementConfig: "osac-management-config"
   osClouds: "osac-os-clouds"
+  bcmCerts: "osac-bcm-certs"
 
 configMaps:
   profiles: "osac-profiles"

--- a/bare-metal-fulfillment-operator/cmd/main.go
+++ b/bare-metal-fulfillment-operator/cmd/main.go
@@ -42,7 +42,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/yaml"
 
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	osacv1alpha1 "github.com/osac-project/osac/bare-metal-fulfillment-operator/api/v1alpha1"
+	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/baremetalhost"
 	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/controller"
 	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/helpers"
 	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/inventory"
@@ -85,8 +87,8 @@ const (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-
 	utilruntime.Must(osacv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(metal3api.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 
@@ -408,15 +410,8 @@ func setupBareMetalInstanceController(
 		return fmt.Errorf("failed to parse inventory config: %w", err)
 	}
 
-	inventoryClient, err := inventory.NewClient(ctx, &inventoryConfig)
-	if err != nil {
-		return fmt.Errorf("failed to create inventory client: %w", err)
-	}
-	if inventoryClient == nil {
-		return fmt.Errorf("unsupported inventory type %q", inventoryConfig.Type)
-	}
-
-	// Read and parse management configuration
+	// Parse management config before inventory client — Metal3 management
+	// triggers BMH manager wiring on the inventory config.
 	managementConfigPath := helpers.GetEnvWithDefault(envManagementConfigPath, "/etc/osac/management/management.yaml")
 	managementConfigData, err := os.ReadFile(managementConfigPath)
 	if err != nil {
@@ -426,6 +421,27 @@ func setupBareMetalInstanceController(
 	var managementConfig management.Config
 	if err := yaml.Unmarshal(managementConfigData, &managementConfig); err != nil {
 		return fmt.Errorf("failed to parse management config: %w", err)
+	}
+
+	if err := wireBMHManager(&managementConfig, &inventoryConfig, mgr.GetClient()); err != nil {
+		return err
+	}
+
+	inventoryClient, err := inventory.NewClient(ctx, &inventoryConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create inventory client: %w", err)
+	}
+	if inventoryClient == nil {
+		return fmt.Errorf("unsupported inventory type %q", inventoryConfig.Type)
+	}
+
+	if bcmClient, ok := inventoryClient.(*inventory.BCMClient); ok {
+		if cw := bcmClient.CertWatcher(); cw != nil {
+			if err := mgr.Add(cw); err != nil {
+				return fmt.Errorf("failed to add BCM cert watcher: %w", err)
+			}
+			setupLog.Info("BCM cert watcher registered")
+		}
 	}
 
 	managementClient, err := management.NewClient(ctx, &managementConfig)
@@ -471,5 +487,22 @@ func setupBareMetalInstanceController(
 	).SetupWithManager(mgr, maxConcurrentReconciles); err != nil {
 		return fmt.Errorf("baremetalinstance controller: %w", err)
 	}
+	return nil
+}
+
+func wireBMHManager(
+	managementCfg *management.Config,
+	inventoryCfg *inventory.Config,
+	k8sClient client.Client,
+) error {
+	if managementCfg.Type != "metal3" {
+		return nil
+	}
+	ns, err := management.ParseMetal3ManagementNamespace(managementCfg)
+	if err != nil {
+		return fmt.Errorf("failed to parse metal3 namespace for BMH manager: %w", err)
+	}
+	inventoryCfg.BMHManager = baremetalhost.NewManager(k8sClient, ns)
+	setupLog.Info("BMH manager configured", "namespace", ns)
 	return nil
 }

--- a/bare-metal-fulfillment-operator/cmd/main.go
+++ b/bare-metal-fulfillment-operator/cmd/main.go
@@ -45,6 +45,7 @@ import (
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	osacv1alpha1 "github.com/osac-project/osac/bare-metal-fulfillment-operator/api/v1alpha1"
 	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/baremetalhost"
+	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/bcmclient"
 	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/controller"
 	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/helpers"
 	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/inventory"
@@ -423,25 +424,9 @@ func setupBareMetalInstanceController(
 		return fmt.Errorf("failed to parse management config: %w", err)
 	}
 
-	if err := wireBMHManager(&managementConfig, &inventoryConfig, mgr.GetClient()); err != nil {
-		return err
-	}
-
-	inventoryClient, err := inventory.NewClient(ctx, &inventoryConfig)
+	inventoryClient, err := createInventoryClient(ctx, &inventoryConfig, &managementConfig, mgr)
 	if err != nil {
-		return fmt.Errorf("failed to create inventory client: %w", err)
-	}
-	if inventoryClient == nil {
-		return fmt.Errorf("unsupported inventory type %q", inventoryConfig.Type)
-	}
-
-	if bcmClient, ok := inventoryClient.(*inventory.BCMClient); ok {
-		if cw := bcmClient.CertWatcher(); cw != nil {
-			if err := mgr.Add(cw); err != nil {
-				return fmt.Errorf("failed to add BCM cert watcher: %w", err)
-			}
-			setupLog.Info("BCM cert watcher registered")
-		}
+		return err
 	}
 
 	managementClient, err := management.NewClient(ctx, &managementConfig)
@@ -490,19 +475,67 @@ func setupBareMetalInstanceController(
 	return nil
 }
 
-func wireBMHManager(
-	managementCfg *management.Config,
+func createInventoryClient(
+	ctx context.Context,
 	inventoryCfg *inventory.Config,
-	k8sClient client.Client,
-) error {
-	if managementCfg.Type != "metal3" {
-		return nil
+	managementCfg *management.Config,
+	mgr ctrl.Manager,
+) (inventory.Client, error) {
+	if inventoryCfg.Type == "bcm" {
+		return createBCMInventoryClient(ctx, inventoryCfg, managementCfg, mgr)
 	}
-	ns, err := management.ParseMetal3ManagementNamespace(managementCfg)
+
+	inventoryClient, err := inventory.NewClient(ctx, inventoryCfg)
 	if err != nil {
-		return fmt.Errorf("failed to parse metal3 namespace for BMH manager: %w", err)
+		return nil, fmt.Errorf("failed to create inventory client: %w", err)
 	}
-	inventoryCfg.BMHManager = baremetalhost.NewManager(k8sClient, ns)
-	setupLog.Info("BMH manager configured", "namespace", ns)
-	return nil
+	if inventoryClient == nil {
+		return nil, fmt.Errorf("unsupported inventory type %q", inventoryCfg.Type)
+	}
+	return inventoryClient, nil
+}
+
+func createBCMInventoryClient(
+	ctx context.Context,
+	inventoryCfg *inventory.Config,
+	managementCfg *management.Config,
+	mgr ctrl.Manager,
+) (inventory.Client, error) {
+	bcmCfg, err := inventory.ParseBCMOptions(inventoryCfg.Options)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse bcm options: %w", err)
+	}
+
+	certDir := filepath.Join("/etc/osac/certs", bcmCfg.CredentialsSecret)
+	bcmClient, err := bcmclient.NewClient(ctx, &bcmclient.Config{
+		URL:                bcmCfg.URL,
+		CertFile:           filepath.Join(certDir, "tls.crt"),
+		KeyFile:            filepath.Join(certDir, "tls.key"),
+		CAFile:             filepath.Join(certDir, "ca.crt"),
+		InsecureSkipVerify: bcmCfg.InsecureSkipVerify,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create bcm client: %w", err)
+	}
+
+	var bmhMgr *baremetalhost.Manager
+	if managementCfg.Type == "metal3" {
+		ns, err := management.ParseMetal3ManagementNamespace(managementCfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse metal3 namespace for BMH manager: %w", err)
+		}
+		bmhMgr = baremetalhost.NewManager(mgr.GetClient(), ns)
+		setupLog.Info("BMH manager configured", "namespace", ns)
+	}
+
+	client := inventory.NewBCMClient(bcmClient, bmhMgr, inventoryCfg.HostClass)
+
+	if cw := client.CertWatcher(); cw != nil {
+		if err := mgr.Add(cw); err != nil {
+			return nil, fmt.Errorf("failed to add BCM cert watcher: %w", err)
+		}
+		setupLog.Info("BCM cert watcher registered")
+	}
+
+	return client, nil
 }

--- a/bare-metal-fulfillment-operator/cmd/main_test.go
+++ b/bare-metal-fulfillment-operator/cmd/main_test.go
@@ -22,10 +22,14 @@ import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
 	. "github.com/onsi/gomega"    //nolint:revive,staticcheck
 
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	osacv1alpha1 "github.com/osac-project/osac/bare-metal-fulfillment-operator/api/v1alpha1"
+	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/inventory"
+	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/management"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestMain(t *testing.T) {
@@ -76,11 +80,75 @@ var _ = Describe("Scheme Initialization", func() {
 	})
 
 	It("should handle core Kubernetes types", func() {
-		// Test that standard Kubernetes types are available
 		pod := &corev1.Pod{}
 		gvks, _, err := scheme.ObjectKinds(pod)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(gvks).NotTo(BeEmpty())
 		Expect(gvks[0].Kind).To(Equal("Pod"))
+	})
+
+	It("should register metal3 BareMetalHost types", func() {
+		Expect(scheme.IsGroupRegistered("metal3.io")).To(BeTrue())
+
+		bmh := &metal3api.BareMetalHost{}
+		gvks, _, err := scheme.ObjectKinds(bmh)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gvks).NotTo(BeEmpty())
+		Expect(gvks[0].Kind).To(Equal("BareMetalHost"))
+	})
+})
+
+var _ = Describe("wireBMHManager", func() {
+	It("should set BMHManager when management is metal3", func() {
+		managementCfg := &management.Config{
+			Type: "metal3",
+			Options: map[string]any{
+				"metal3": map[string]any{
+					"namespace": "osac-baremetal",
+				},
+			},
+		}
+
+		var inventoryCfg inventory.Config
+		testScheme := runtime.NewScheme()
+		Expect(metal3api.AddToScheme(testScheme)).To(Succeed())
+		k8sClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
+
+		err := wireBMHManager(managementCfg, &inventoryCfg, k8sClient)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(inventoryCfg.BMHManager).NotTo(BeNil())
+		Expect(inventoryCfg.BMHManager.Namespace()).To(Equal("osac-baremetal"))
+	})
+
+	It("should not set BMHManager when management is not metal3", func() {
+		managementCfg := &management.Config{
+			Type: "openstack",
+			Options: map[string]any{
+				"openstack": map[string]any{},
+			},
+		}
+
+		var inventoryCfg inventory.Config
+		k8sClient := fake.NewClientBuilder().Build()
+
+		err := wireBMHManager(managementCfg, &inventoryCfg, k8sClient)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(inventoryCfg.BMHManager).To(BeNil())
+	})
+
+	It("should return error when metal3 namespace is missing", func() {
+		managementCfg := &management.Config{
+			Type: "metal3",
+			Options: map[string]any{
+				"metal3": map[string]any{},
+			},
+		}
+
+		var inventoryCfg inventory.Config
+		k8sClient := fake.NewClientBuilder().Build()
+
+		err := wireBMHManager(managementCfg, &inventoryCfg, k8sClient)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("namespace is required"))
 	})
 })

--- a/bare-metal-fulfillment-operator/cmd/main_test.go
+++ b/bare-metal-fulfillment-operator/cmd/main_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
@@ -29,7 +30,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestMain(t *testing.T) {
@@ -98,57 +98,18 @@ var _ = Describe("Scheme Initialization", func() {
 	})
 })
 
-var _ = Describe("wireBMHManager", func() {
-	It("should set BMHManager when management is metal3", func() {
+var _ = Describe("createInventoryClient", func() {
+	It("should return error for unsupported inventory type", func() {
+		inventoryCfg := &inventory.Config{
+			Type: "unknown",
+		}
 		managementCfg := &management.Config{
 			Type: "metal3",
-			Options: map[string]any{
-				"metal3": map[string]any{
-					"namespace": "osac-baremetal",
-				},
-			},
 		}
 
-		var inventoryCfg inventory.Config
-		testScheme := runtime.NewScheme()
-		Expect(metal3api.AddToScheme(testScheme)).To(Succeed())
-		k8sClient := fake.NewClientBuilder().WithScheme(testScheme).Build()
-
-		err := wireBMHManager(managementCfg, &inventoryCfg, k8sClient)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(inventoryCfg.BMHManager).NotTo(BeNil())
-		Expect(inventoryCfg.BMHManager.Namespace()).To(Equal("osac-baremetal"))
-	})
-
-	It("should not set BMHManager when management is not metal3", func() {
-		managementCfg := &management.Config{
-			Type: "openstack",
-			Options: map[string]any{
-				"openstack": map[string]any{},
-			},
-		}
-
-		var inventoryCfg inventory.Config
-		k8sClient := fake.NewClientBuilder().Build()
-
-		err := wireBMHManager(managementCfg, &inventoryCfg, k8sClient)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(inventoryCfg.BMHManager).To(BeNil())
-	})
-
-	It("should return error when metal3 namespace is missing", func() {
-		managementCfg := &management.Config{
-			Type: "metal3",
-			Options: map[string]any{
-				"metal3": map[string]any{},
-			},
-		}
-
-		var inventoryCfg inventory.Config
-		k8sClient := fake.NewClientBuilder().Build()
-
-		err := wireBMHManager(managementCfg, &inventoryCfg, k8sClient)
+		client, err := createInventoryClient(context.Background(), inventoryCfg, managementCfg, nil)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("namespace is required"))
+		Expect(err.Error()).To(ContainSubstring("unsupported inventory type"))
+		Expect(client).To(BeNil())
 	})
 })

--- a/bare-metal-fulfillment-operator/config/manager/manager.yaml
+++ b/bare-metal-fulfillment-operator/config/manager/manager.yaml
@@ -108,6 +108,9 @@ spec:
             mountPath: /etc/openstack/
           - name: profiles
             mountPath: /etc/osac/profile/
+          - name: bcm-certs
+            mountPath: /etc/osac/certs/bcm-certs/
+            readOnly: true
       volumes:
         - name: inventory-config
           secret:
@@ -122,6 +125,10 @@ spec:
         - name: profiles
           configMap:
             name: osac-profiles
+            optional: true
+        - name: bcm-certs
+          secret:
+            secretName: osac-bcm-certs
             optional: true
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/bare-metal-fulfillment-operator/config/rbac/role.yaml
+++ b/bare-metal-fulfillment-operator/config/rbac/role.yaml
@@ -9,6 +9,8 @@ rules:
   resources:
   - baremetalhosts
   verbs:
+  - create
+  - delete
   - get
   - list
   - patch

--- a/bare-metal-fulfillment-operator/hack/sync-helm-operator.py
+++ b/bare-metal-fulfillment-operator/hack/sync-helm-operator.py
@@ -53,6 +53,7 @@ SECRET_TO_VALUES: dict[str, str] = {
     "osac-inventory-config": "{{ .Values.secrets.inventoryConfig }}",
     "osac-management-config": "{{ .Values.secrets.managementConfig }}",
     "osac-os-clouds": "{{ .Values.secrets.osClouds }}",
+    "osac-bcm-certs": "{{ .Values.secrets.bcmCerts }}",
 }
 CONFIGMAP_TO_VALUES: dict[str, str] = {
     "osac-profiles": "{{ .Values.configMaps.profiles }}",

--- a/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_controller.go
+++ b/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_controller.go
@@ -97,7 +97,7 @@ func NewBareMetalInstanceReconciler(
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=baremetalinstances,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=baremetalinstances/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=baremetalinstances/finalizers,verbs=update
-// +kubebuilder:rbac:groups=metal3.io,resources=baremetalhosts,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=metal3.io,resources=baremetalhosts,verbs=create;delete;get;list;watch;update;patch
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=subnets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=networkclasses,verbs=get;list;watch
 

--- a/bare-metal-fulfillment-operator/internal/inventory/bcm.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/bcm.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inventory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+
+	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/baremetalhost"
+	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/bcmclient"
+)
+
+const certBaseDir = "/etc/osac/certs"
+
+var (
+	_ Client        = (*BCMClient)(nil)
+	_ NewClientFunc = NewClientFunc(NewBCMClient)
+)
+
+func init() {
+	newClientFuncs["bcm"] = NewBCMClient
+}
+
+// bcmClientConfig holds the BCM-specific options from the inventory config.
+type bcmClientConfig struct {
+	URL                string `json:"url"`
+	CredentialsSecret  string `json:"credentialsSecret"`
+	InsecureSkipVerify bool   `json:"insecureSkipVerify"`
+}
+
+// BCMClient implements inventory.Client by wrapping a bcmclient.Client
+// for BCM API communication and a baremetalhost.Manager for BMH lifecycle.
+type BCMClient struct {
+	client     *bcmclient.Client
+	bmhManager *baremetalhost.Manager
+	hostClass  string
+}
+
+// NewBCMClient creates a BCM inventory client from the generic inventory config.
+func NewBCMClient(ctx context.Context, cfg *Config) (Client, error) {
+	bcmOpts, ok := cfg.Options["bcm"]
+	if !ok {
+		return nil, fmt.Errorf("bcm options not found in config")
+	}
+
+	raw, err := json.Marshal(bcmOpts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal bcm options: %w", err)
+	}
+
+	var bcmClientCfg bcmClientConfig
+	if err := json.Unmarshal(raw, &bcmClientCfg); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal bcm options: %w", err)
+	}
+
+	if bcmClientCfg.URL == "" {
+		return nil, fmt.Errorf("bcm url is required in config")
+	}
+	if bcmClientCfg.CredentialsSecret == "" {
+		return nil, fmt.Errorf("bcm credentialsSecret is required in config")
+	}
+
+	certDir := filepath.Join(certBaseDir, bcmClientCfg.CredentialsSecret)
+	if !strings.HasPrefix(certDir, certBaseDir+"/") {
+		return nil, fmt.Errorf("bcm credentialsSecret resolves outside cert directory")
+	}
+	bcmCfg := &bcmclient.Config{
+		URL:                bcmClientCfg.URL,
+		CertFile:           filepath.Join(certDir, "tls.crt"),
+		KeyFile:            filepath.Join(certDir, "tls.key"),
+		CAFile:             filepath.Join(certDir, "ca.crt"),
+		InsecureSkipVerify: bcmClientCfg.InsecureSkipVerify,
+	}
+
+	client, err := bcmclient.NewClient(ctx, bcmCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create bcm client: %w", err)
+	}
+
+	return &BCMClient{
+		client:     client,
+		bmhManager: cfg.BMHManager,
+		hostClass:  cfg.HostClass,
+	}, nil
+}
+
+// CertWatcher returns the certificate watcher for registration with the
+// controller manager. The manager calls Start on it to enable automatic
+// certificate rotation.
+func (c *BCMClient) CertWatcher() *certwatcher.CertWatcher {
+	return c.client.CertWatcher()
+}
+
+// NewBCMClientForTest creates a BCMClient with injected dependencies for testing.
+func NewBCMClientForTest(client *bcmclient.Client, bmhManager *baremetalhost.Manager, hostClass string) *BCMClient {
+	return &BCMClient{
+		client:     client,
+		bmhManager: bmhManager,
+		hostClass:  hostClass,
+	}
+}
+
+// FindFreeHost is implemented in OSAC-3766.
+func (c *BCMClient) FindFreeHost(_ context.Context, _ map[string]string) (*Host, error) {
+	return nil, fmt.Errorf("bcm FindFreeHost not implemented")
+}
+
+// AssignHost is implemented in OSAC-3767 through OSAC-3769.
+func (c *BCMClient) AssignHost(_ context.Context, _ string, _ string, _ map[string]string) (*Host, error) {
+	return nil, fmt.Errorf("bcm AssignHost not implemented")
+}
+
+// UnassignHost is implemented in OSAC-3771.
+func (c *BCMClient) UnassignHost(_ context.Context, _ string, _ []string) error {
+	return fmt.Errorf("bcm UnassignHost not implemented")
+}

--- a/bare-metal-fulfillment-operator/internal/inventory/bcm.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/bcm.go
@@ -26,38 +26,29 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 
 	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/baremetalhost"
-	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/bcmclient"
 )
 
 const certBaseDir = "/etc/osac/certs"
 
-var (
-	_ Client        = (*BCMClient)(nil)
-	_ NewClientFunc = NewClientFunc(NewBCMClient)
-)
-
-func init() {
-	newClientFuncs["bcm"] = NewBCMClient
+// BCMAPI defines the BCM client operations needed by the inventory adapter.
+// Satisfied by *bcmclient.Client; defined here so tests can substitute a mock
+// without depending on the bcmclient package.
+type BCMAPI interface {
+	CertWatcher() *certwatcher.CertWatcher
 }
 
-// bcmClientConfig holds the BCM-specific options from the inventory config.
-type bcmClientConfig struct {
+var _ Client = (*BCMClient)(nil)
+
+// BCMClientConfig holds the BCM-specific options parsed from the inventory config.
+type BCMClientConfig struct {
 	URL                string `json:"url"`
 	CredentialsSecret  string `json:"credentialsSecret"`
 	InsecureSkipVerify bool   `json:"insecureSkipVerify"`
 }
 
-// BCMClient implements inventory.Client by wrapping a bcmclient.Client
-// for BCM API communication and a baremetalhost.Manager for BMH lifecycle.
-type BCMClient struct {
-	client     *bcmclient.Client
-	bmhManager *baremetalhost.Manager
-	hostClass  string
-}
-
-// NewBCMClient creates a BCM inventory client from the generic inventory config.
-func NewBCMClient(ctx context.Context, cfg *Config) (Client, error) {
-	bcmOpts, ok := cfg.Options["bcm"]
+// ParseBCMOptions extracts and validates BCM options from the inventory config.
+func ParseBCMOptions(options map[string]any) (*BCMClientConfig, error) {
+	bcmOpts, ok := options["bcm"]
 	if !ok {
 		return nil, fmt.Errorf("bcm options not found in config")
 	}
@@ -67,40 +58,41 @@ func NewBCMClient(ctx context.Context, cfg *Config) (Client, error) {
 		return nil, fmt.Errorf("failed to marshal bcm options: %w", err)
 	}
 
-	var bcmClientCfg bcmClientConfig
-	if err := json.Unmarshal(raw, &bcmClientCfg); err != nil {
+	var cfg BCMClientConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal bcm options: %w", err)
 	}
 
-	if bcmClientCfg.URL == "" {
+	if cfg.URL == "" {
 		return nil, fmt.Errorf("bcm url is required in config")
 	}
-	if bcmClientCfg.CredentialsSecret == "" {
+	if cfg.CredentialsSecret == "" {
 		return nil, fmt.Errorf("bcm credentialsSecret is required in config")
 	}
 
-	certDir := filepath.Join(certBaseDir, bcmClientCfg.CredentialsSecret)
+	certDir := filepath.Join(certBaseDir, cfg.CredentialsSecret)
 	if !strings.HasPrefix(certDir, certBaseDir+"/") {
 		return nil, fmt.Errorf("bcm credentialsSecret resolves outside cert directory")
 	}
-	bcmCfg := &bcmclient.Config{
-		URL:                bcmClientCfg.URL,
-		CertFile:           filepath.Join(certDir, "tls.crt"),
-		KeyFile:            filepath.Join(certDir, "tls.key"),
-		CAFile:             filepath.Join(certDir, "ca.crt"),
-		InsecureSkipVerify: bcmClientCfg.InsecureSkipVerify,
-	}
 
-	client, err := bcmclient.NewClient(ctx, bcmCfg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create bcm client: %w", err)
-	}
+	return &cfg, nil
+}
 
+// BCMClient implements inventory.Client by wrapping a BCMAPI
+// for BCM API communication and a baremetalhost.Manager for BMH lifecycle.
+type BCMClient struct {
+	client     BCMAPI
+	bmhManager *baremetalhost.Manager
+	hostClass  string
+}
+
+// NewBCMClient creates a BCM inventory client with injected dependencies.
+func NewBCMClient(client BCMAPI, bmhManager *baremetalhost.Manager, hostClass string) *BCMClient {
 	return &BCMClient{
 		client:     client,
-		bmhManager: cfg.BMHManager,
-		hostClass:  cfg.HostClass,
-	}, nil
+		bmhManager: bmhManager,
+		hostClass:  hostClass,
+	}
 }
 
 // CertWatcher returns the certificate watcher for registration with the
@@ -108,15 +100,6 @@ func NewBCMClient(ctx context.Context, cfg *Config) (Client, error) {
 // certificate rotation.
 func (c *BCMClient) CertWatcher() *certwatcher.CertWatcher {
 	return c.client.CertWatcher()
-}
-
-// NewBCMClientForTest creates a BCMClient with injected dependencies for testing.
-func NewBCMClientForTest(client *bcmclient.Client, bmhManager *baremetalhost.Manager, hostClass string) *BCMClient {
-	return &BCMClient{
-		client:     client,
-		bmhManager: bmhManager,
-		hostClass:  hostClass,
-	}
 }
 
 // FindFreeHost is implemented in OSAC-3766.

--- a/bare-metal-fulfillment-operator/internal/inventory/bcm_test.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/bcm_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inventory
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
+	. "github.com/onsi/gomega"    //nolint:revive,staticcheck
+
+	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/bcmclient"
+)
+
+func TestBCMInventoryAdapter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "BCM Inventory Adapter Suite")
+}
+
+var _ = Describe("BCM Inventory Adapter", func() {
+	Describe("NewBCMClient", func() {
+		It("should return error when bcm key is missing from options", func() {
+			cfg := &Config{
+				Type:      "bcm",
+				HostClass: "bcm",
+				Options:   map[string]any{},
+			}
+			_, err := NewBCMClient(context.Background(), cfg)
+			Expect(err).To(MatchError(ContainSubstring("bcm options not found in config")))
+		})
+
+		It("should return error when url is missing", func() {
+			cfg := &Config{
+				Type:      "bcm",
+				HostClass: "bcm",
+				Options: map[string]any{
+					"bcm": map[string]any{
+						"credentialsSecret": "osac-bcm-certs",
+					},
+				},
+			}
+			_, err := NewBCMClient(context.Background(), cfg)
+			Expect(err).To(MatchError(ContainSubstring("bcm url is required in config")))
+		})
+
+		It("should return error when credentialsSecret is missing", func() {
+			cfg := &Config{
+				Type:      "bcm",
+				HostClass: "bcm",
+				Options: map[string]any{
+					"bcm": map[string]any{
+						"url": "https://bcm-head:8081",
+					},
+				},
+			}
+			_, err := NewBCMClient(context.Background(), cfg)
+			Expect(err).To(MatchError(ContainSubstring("bcm credentialsSecret is required in config")))
+		})
+
+		It("should return error when bcm options are invalid", func() {
+			cfg := &Config{
+				Type:      "bcm",
+				HostClass: "bcm",
+				Options: map[string]any{
+					"bcm": "not-a-map",
+				},
+			}
+			_, err := NewBCMClient(context.Background(), cfg)
+			Expect(err).To(MatchError(ContainSubstring("failed to unmarshal bcm options")))
+		})
+	})
+
+	Describe("Registration", func() {
+		It("should register the bcm type in the client factory", func() {
+			_, ok := newClientFuncs["bcm"]
+			Expect(ok).To(BeTrue())
+		})
+	})
+
+	Describe("NewBCMClientForTest", func() {
+		var (
+			server *httptest.Server
+			client *BCMClient
+		)
+
+		BeforeEach(func() {
+			server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, err := fmt.Fprint(w, `{"cm_version":"11.0"}`)
+				Expect(err).NotTo(HaveOccurred())
+			}))
+			DeferCleanup(server.Close)
+
+			bcm := bcmclient.NewClientForTest(server.Client(), server.URL)
+			client = NewBCMClientForTest(bcm, nil, "bcm")
+		})
+
+		It("should create a BCMClient with the provided dependencies", func() {
+			Expect(client).NotTo(BeNil())
+			Expect(client.hostClass).To(Equal("bcm"))
+			Expect(client.bmhManager).To(BeNil())
+		})
+	})
+
+	Describe("Stub methods", func() {
+		var client *BCMClient
+
+		BeforeEach(func() {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, err := fmt.Fprint(w, `{}`)
+				Expect(err).NotTo(HaveOccurred())
+			}))
+			DeferCleanup(server.Close)
+
+			bcm := bcmclient.NewClientForTest(server.Client(), server.URL)
+			client = NewBCMClientForTest(bcm, nil, "bcm")
+		})
+
+		It("should return not-implemented error from FindFreeHost", func() {
+			host, err := client.FindFreeHost(context.Background(), nil)
+			Expect(err).To(MatchError(ContainSubstring("not implemented")))
+			Expect(host).To(BeNil())
+		})
+
+		It("should return not-implemented error from AssignHost", func() {
+			host, err := client.AssignHost(context.Background(), "ns/host1", "bmi-123", nil)
+			Expect(err).To(MatchError(ContainSubstring("not implemented")))
+			Expect(host).To(BeNil())
+		})
+
+		It("should return not-implemented error from UnassignHost", func() {
+			err := client.UnassignHost(context.Background(), "ns/host1", nil)
+			Expect(err).To(MatchError(ContainSubstring("not implemented")))
+		})
+	})
+})

--- a/bare-metal-fulfillment-operator/internal/inventory/bcm_test.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/bcm_test.go
@@ -18,16 +18,17 @@ package inventory
 
 import (
 	"context"
-	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
 	. "github.com/onsi/gomega"    //nolint:revive,staticcheck
 
-	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/bcmclient"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 )
+
+type mockBCMAPI struct{}
+
+func (m *mockBCMAPI) CertWatcher() *certwatcher.CertWatcher { return nil }
 
 func TestBCMInventoryAdapter(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -35,84 +36,65 @@ func TestBCMInventoryAdapter(t *testing.T) {
 }
 
 var _ = Describe("BCM Inventory Adapter", func() {
-	Describe("NewBCMClient", func() {
+	Describe("ParseBCMOptions", func() {
 		It("should return error when bcm key is missing from options", func() {
-			cfg := &Config{
-				Type:      "bcm",
-				HostClass: "bcm",
-				Options:   map[string]any{},
-			}
-			_, err := NewBCMClient(context.Background(), cfg)
+			_, err := ParseBCMOptions(map[string]any{})
 			Expect(err).To(MatchError(ContainSubstring("bcm options not found in config")))
 		})
 
 		It("should return error when url is missing", func() {
-			cfg := &Config{
-				Type:      "bcm",
-				HostClass: "bcm",
-				Options: map[string]any{
-					"bcm": map[string]any{
-						"credentialsSecret": "osac-bcm-certs",
-					},
+			_, err := ParseBCMOptions(map[string]any{
+				"bcm": map[string]any{
+					"credentialsSecret": "osac-bcm-certs",
 				},
-			}
-			_, err := NewBCMClient(context.Background(), cfg)
+			})
 			Expect(err).To(MatchError(ContainSubstring("bcm url is required in config")))
 		})
 
 		It("should return error when credentialsSecret is missing", func() {
-			cfg := &Config{
-				Type:      "bcm",
-				HostClass: "bcm",
-				Options: map[string]any{
-					"bcm": map[string]any{
-						"url": "https://bcm-head:8081",
-					},
+			_, err := ParseBCMOptions(map[string]any{
+				"bcm": map[string]any{
+					"url": "https://bcm-head:8081",
 				},
-			}
-			_, err := NewBCMClient(context.Background(), cfg)
+			})
 			Expect(err).To(MatchError(ContainSubstring("bcm credentialsSecret is required in config")))
 		})
 
 		It("should return error when bcm options are invalid", func() {
-			cfg := &Config{
-				Type:      "bcm",
-				HostClass: "bcm",
-				Options: map[string]any{
-					"bcm": "not-a-map",
-				},
-			}
-			_, err := NewBCMClient(context.Background(), cfg)
+			_, err := ParseBCMOptions(map[string]any{
+				"bcm": "not-a-map",
+			})
 			Expect(err).To(MatchError(ContainSubstring("failed to unmarshal bcm options")))
 		})
-	})
 
-	Describe("Registration", func() {
-		It("should register the bcm type in the client factory", func() {
-			_, ok := newClientFuncs["bcm"]
-			Expect(ok).To(BeTrue())
+		It("should parse valid options", func() {
+			cfg, err := ParseBCMOptions(map[string]any{
+				"bcm": map[string]any{
+					"url":                "https://bcm-head:8081",
+					"credentialsSecret":  "osac-bcm-certs",
+					"insecureSkipVerify": true,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.URL).To(Equal("https://bcm-head:8081"))
+			Expect(cfg.CredentialsSecret).To(Equal("osac-bcm-certs"))
+			Expect(cfg.InsecureSkipVerify).To(BeTrue())
+		})
+
+		It("should reject credentialsSecret that escapes cert directory", func() {
+			_, err := ParseBCMOptions(map[string]any{
+				"bcm": map[string]any{
+					"url":               "https://bcm-head:8081",
+					"credentialsSecret": "../../etc/shadow",
+				},
+			})
+			Expect(err).To(MatchError(ContainSubstring("resolves outside cert directory")))
 		})
 	})
 
-	Describe("NewBCMClientForTest", func() {
-		var (
-			server *httptest.Server
-			client *BCMClient
-		)
-
-		BeforeEach(func() {
-			server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				_, err := fmt.Fprint(w, `{"cm_version":"11.0"}`)
-				Expect(err).NotTo(HaveOccurred())
-			}))
-			DeferCleanup(server.Close)
-
-			bcm := bcmclient.NewClientForTest(server.Client(), server.URL)
-			client = NewBCMClientForTest(bcm, nil, "bcm")
-		})
-
+	Describe("NewBCMClient", func() {
 		It("should create a BCMClient with the provided dependencies", func() {
+			client := NewBCMClient(&mockBCMAPI{}, nil, "bcm")
 			Expect(client).NotTo(BeNil())
 			Expect(client.hostClass).To(Equal("bcm"))
 			Expect(client.bmhManager).To(BeNil())
@@ -123,15 +105,7 @@ var _ = Describe("BCM Inventory Adapter", func() {
 		var client *BCMClient
 
 		BeforeEach(func() {
-			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				_, err := fmt.Fprint(w, `{}`)
-				Expect(err).NotTo(HaveOccurred())
-			}))
-			DeferCleanup(server.Close)
-
-			bcm := bcmclient.NewClientForTest(server.Client(), server.URL)
-			client = NewBCMClientForTest(bcm, nil, "bcm")
+			client = NewBCMClient(&mockBCMAPI{}, nil, "bcm")
 		})
 
 		It("should return not-implemented error from FindFreeHost", func() {

--- a/bare-metal-fulfillment-operator/internal/inventory/client.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/client.go
@@ -19,14 +19,17 @@ package inventory
 
 import (
 	"context"
+
+	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/baremetalhost"
 )
 
 // Config is a struct that holds info needed to create a new client implementation
 type Config struct {
-	Name      string         `json:"name"`
-	Type      string         `json:"type"`
-	Options   map[string]any `json:"options"`
-	HostClass string         `json:"hostClass"`
+	Name       string                 `json:"name"`
+	Type       string                 `json:"type"`
+	Options    map[string]any         `json:"options"`
+	HostClass  string                 `json:"hostClass"`
+	BMHManager *baremetalhost.Manager `json:"-"`
 }
 
 // Host is the common return type all clients must use

--- a/bare-metal-fulfillment-operator/internal/inventory/client.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/client.go
@@ -19,17 +19,14 @@ package inventory
 
 import (
 	"context"
-
-	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/baremetalhost"
 )
 
 // Config is a struct that holds info needed to create a new client implementation
 type Config struct {
-	Name       string                 `json:"name"`
-	Type       string                 `json:"type"`
-	Options    map[string]any         `json:"options"`
-	HostClass  string                 `json:"hostClass"`
-	BMHManager *baremetalhost.Manager `json:"-"`
+	Name      string         `json:"name"`
+	Type      string         `json:"type"`
+	Options   map[string]any `json:"options"`
+	HostClass string         `json:"hostClass"`
 }
 
 // Host is the common return type all clients must use

--- a/bare-metal-fulfillment-operator/internal/management/metal3.go
+++ b/bare-metal-fulfillment-operator/internal/management/metal3.go
@@ -59,7 +59,7 @@ func (m *Metal3Client) TestClient() client.Client {
 }
 
 func NewMetal3ManagementClient(ctx context.Context, cfg *Config) (Client, error) {
-	namespace, err := parseMetal3ManagementNamespace(cfg)
+	namespace, err := ParseMetal3ManagementNamespace(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func NewMetal3ManagementClient(ctx context.Context, cfg *Config) (Client, error)
 	}, nil
 }
 
-func parseMetal3ManagementNamespace(cfg *Config) (string, error) {
+func ParseMetal3ManagementNamespace(cfg *Config) (string, error) {
 	metal3Opts, ok := cfg.Options["metal3"]
 	if !ok {
 		return "", fmt.Errorf("metal3 options not found in management config")


### PR DESCRIPTION
## Summary

Fresh rewrite of #231 — pure wiring only, no duplicate code.

- Wire `baremetalhost.Manager` into inventory config when management backend is Metal3
- Register BCM `CertWatcher` with the controller manager for automatic certificate rotation
- Add `metal3api` to scheme for BareMetalHost CR operations
- Add `create`/`delete` RBAC for BareMetalHosts (kubebuilder marker + generated)
- Add `bcmCerts` secret volume mount at `/etc/osac/certs/bcm-certs/`
- Export `ParseMetal3ManagementNamespace` for main.go wiring
- Reorder management config parsing before inventory client creation

**53 insertions, 13 deletions** (vs ~1,500 lines in #231)

Supersedes: #231
Depends on: #228 (bcmclient), #237 (baremetalhost.Manager, merged), #353 (BCM adapter)

## Test plan

- [x] `go build ./...` compiles clean
- [x] `make test` — all tests pass
- [x] `make lint` — 0 issues
- [ ] Reviewer: verify cert path `/etc/osac/certs/bcm-certs/` aligns across adapter, Helm mount, and config/manager
- [ ] Reviewer: verify RBAC create/delete generated correctly from kubebuilder marker

Assisted-by: Claude Code <noreply@anthropic.com>