### PR TITLE
NO-ISSUE: consolidate golangci-lint installation into a single shared location

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -24,9 +24,6 @@ jobs:
     - uses: bufbuild/buf-action@8c6a16e16f12ba20b6470afa9c2ba9b5ba8c97c3  # v1
       with:
         setup_only: true
-    - run: make -C osac-operator golangci-lint
-    - run: make -C bare-metal-fulfillment-operator golangci-lint
-    - run: make -C osac-csi-driver golangci-lint
     # gitleaks hook is --staged only (no-op with empty index). CI secret gate is
     # the docker PR-diff steps below (base-branch config + --ignore-gitleaks-allow).
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ skills/
 # (see .github/workflows/graphify-brain-refresh.yaml), never committed.
 graphify-out/
 
+# Shared tool binaries (tools/golangci-lint.mk), downloaded once for all components
+/tools/bin/
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,13 +60,13 @@ repos:
     name: osac-operator golangci-lint
     language: system
     files: ^osac-operator/.*\.go$
-    entry: bash -c "cd osac-operator && bin/golangci-lint run --fix"
+    entry: make -C osac-operator lint-fix
   - id: bare-metal-fulfillment-operator-golangci-lint
     pass_filenames: false
     name: bare-metal-fulfillment-operator golangci-lint
     language: system
     files: ^bare-metal-fulfillment-operator/.*\.go$
-    entry: bash -c "cd bare-metal-fulfillment-operator && bin/golangci-lint run --fix"
+    entry: make -C bare-metal-fulfillment-operator lint-fix
   - id: osac-csi-driver-golangci-lint
     pass_filenames: false
     name: osac-csi-driver golangci-lint

--- a/bare-metal-fulfillment-operator/AGENTS.md
+++ b/bare-metal-fulfillment-operator/AGENTS.md
@@ -12,7 +12,7 @@ Kubernetes operator for managing bare-metal host pools in the OSAC project. Defi
 
 ## Dev Environment
 
-**Language**: Go (see `go.mod`) | **Framework**: controller-runtime (Kubebuilder v4) | **Build tool**: Make | **Container tool**: Podman (default) | **Test framework**: Ginkgo v2 + Gomega | **Linter**: golangci-lint (see `Makefile`)
+**Language**: Go (see `go.mod`) | **Framework**: controller-runtime (Kubebuilder v4) | **Build tool**: Make | **Container tool**: Podman (default) | **Test framework**: Ginkgo v2 + Gomega | **Linter**: golangci-lint (see `../tools/golangci-lint.mk`)
 
 ```bash
 make build                     # Build manager binary
@@ -133,7 +133,7 @@ CRDs must stay in sync: after `make manifests`, run `make helm-crds` (uses `hack
 
 ## Code Quality
 
-- **golangci-lint** (see `Makefile`) with dupl, errcheck, ginkgolinter, goconst, gocyclo, govet, ineffassign, lll, misspell, prealloc, revive, staticcheck, unconvert, unused (see `.golangci.yml`)
+- **golangci-lint** (see `../tools/golangci-lint.mk`) with dupl, errcheck, ginkgolinter, goconst, gocyclo, govet, ineffassign, lll, misspell, prealloc, revive, staticcheck, unconvert, unused (see `.golangci.yml`)
 - **Pre-commit hooks**: trailing-whitespace, check-merge-conflict, end-of-file-fixer, check-added-large-files, check-case-conflict, check-json, check-symlinks, detect-private-key, yamllint --strict (excludes `config/`), golangci-lint run --fix
 - **Tests**: Ginkgo v2 + Gomega with envtest for unit tests; Kind cluster integration tests for e2e (`test/e2e/`)
 - **Test coverage**: Unit tests generate `cover.out`

--- a/bare-metal-fulfillment-operator/Makefile
+++ b/bare-metal-fulfillment-operator/Makefile
@@ -266,7 +266,6 @@ KIND ?= kind
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
-GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.6.0
@@ -275,7 +274,8 @@ CONTROLLER_TOOLS_VERSION ?= v0.18.0
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
-GOLANGCI_LINT_VERSION ?= v2.1.0
+
+include $(shell git rev-parse --show-toplevel)/tools/golangci-lint.mk
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -299,11 +299,6 @@ setup-envtest: envtest ## Download the binaries required for ENVTEST in the loca
 envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))
-
-.PHONY: golangci-lint
-golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
-$(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/osac-csi-driver/AGENTS.md
+++ b/osac-csi-driver/AGENTS.md
@@ -20,7 +20,7 @@ CSI meta-driver that presents a single CSI identity (`csi.osac.openshift.io`) to
 ```bash
 make build                     # Build binary to bin/osac-csi-driver (CGO_ENABLED=0)
 make test                      # Unit tests + CSI sanity tests (go test ./... with coverage)
-make lint                      # golangci-lint (auto-downloads to bin/)
+make lint                      # golangci-lint (auto-downloads to shared tools/bin/, see ../tools/golangci-lint.mk)
 make lint-fix                  # golangci-lint --fix
 make fmt                       # go fmt
 make vet                       # go vet

--- a/osac-csi-driver/Makefile
+++ b/osac-csi-driver/Makefile
@@ -81,34 +81,4 @@ image-push: ## Push the container image.
 
 ##@ Dependencies
 
-## Location to install dependencies to
-LOCALBIN ?= $(shell pwd)/bin
-$(LOCALBIN):
-	mkdir -p $(LOCALBIN)
-
-## Tool Binaries
-GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
-
-## Tool Versions
-GOLANGCI_LINT_VERSION ?= v2.12.1
-
-.PHONY: golangci-lint
-golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
-$(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
-
-# go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
-# $1 - target path with name of binary
-# $2 - package url which can be installed
-# $3 - specific version of package
-define go-install-tool
-@[ -f "$(1)-$(3)" ] || { \
-set -e; \
-package=$(2)@$(3) ;\
-echo "Downloading $${package}" ;\
-rm -f $(1) || true ;\
-GOTOOLCHAIN=$(GOTOOLCHAIN) GOBIN=$(LOCALBIN) go install $${package} ;\
-mv $(1) $(1)-$(3) ;\
-} ;\
-ln -sf $(1)-$(3) $(1)
-endef
+include $(shell git rev-parse --show-toplevel)/tools/golangci-lint.mk

--- a/osac-metering/adapters/Makefile
+++ b/osac-metering/adapters/Makefile
@@ -8,10 +8,8 @@
 GO_VERSION ?= $(shell grep '^go ' go.mod | cut -d' ' -f2)
 GOTOOLCHAIN ?= go$(GO_VERSION)
 GINKGO ?= go run github.com/onsi/ginkgo/v2/ginkgo
-GOLANGCI_LINT_VERSION ?= v2.12.1
 
-LOCALBIN ?= $(shell pwd)/bin
-GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
+include $(shell git rev-parse --show-toplevel)/tools/golangci-lint.mk
 
 .PHONY: all build-echo-adapter build-m360-adapter test lint clean
 
@@ -28,12 +26,8 @@ build-m360-adapter:
 test:
 	$(GINKGO) run -r .
 
-lint: $(GOLANGCI_LINT)
+lint: golangci-lint
 	$(GOLANGCI_LINT) run ./...
-
-$(GOLANGCI_LINT):
-	@mkdir -p $(LOCALBIN)
-	GOTOOLCHAIN=$(GOTOOLCHAIN) GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 clean:
 	rm -rf bin/

--- a/osac-metering/metering-service/Makefile
+++ b/osac-metering/metering-service/Makefile
@@ -10,10 +10,8 @@ IMG ?= ghcr.io/osac-project/metering-service:latest
 GO_VERSION ?= $(shell grep '^go ' go.mod | cut -d' ' -f2)
 GOTOOLCHAIN ?= go$(GO_VERSION)
 GINKGO ?= go run github.com/onsi/ginkgo/v2/ginkgo
-GOLANGCI_LINT_VERSION ?= v2.12.1
 
-LOCALBIN ?= $(shell pwd)/bin
-GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
+include $(shell git rev-parse --show-toplevel)/tools/golangci-lint.mk
 
 .PHONY: build test lint generate image-build clean
 
@@ -23,12 +21,8 @@ build:
 test:
 	$(GINKGO) run -r internal
 
-lint: $(GOLANGCI_LINT)
+lint: golangci-lint
 	$(GOLANGCI_LINT) run ./...
-
-$(GOLANGCI_LINT):
-	@mkdir -p $(LOCALBIN)
-	GOTOOLCHAIN=$(GOTOOLCHAIN) GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 generate:
 	buf generate

--- a/osac-metering/schema/Makefile
+++ b/osac-metering/schema/Makefile
@@ -8,10 +8,8 @@
 GO_VERSION ?= $(shell grep '^go ' go.mod | cut -d' ' -f2)
 GOTOOLCHAIN ?= go$(GO_VERSION)
 GINKGO ?= go run github.com/onsi/ginkgo/v2/ginkgo
-GOLANGCI_LINT_VERSION ?= v2.12.1
 
-LOCALBIN ?= $(shell pwd)/bin
-GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
+include $(shell git rev-parse --show-toplevel)/tools/golangci-lint.mk
 
 .PHONY: all test lint clean
 
@@ -20,12 +18,8 @@ all: test lint
 test:
 	$(GINKGO) run -r .
 
-lint: $(GOLANGCI_LINT)
+lint: golangci-lint
 	$(GOLANGCI_LINT) run ./...
-
-$(GOLANGCI_LINT):
-	@mkdir -p $(LOCALBIN)
-	GOTOOLCHAIN=$(GOTOOLCHAIN) GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 clean:
 	rm -rf bin/

--- a/osac-operator/AGENTS.md
+++ b/osac-operator/AGENTS.md
@@ -134,7 +134,7 @@ hack/sync-helm-crds.py     # Script invoked by `make helm-crds` to sync CRDs to 
 
 ## Code Quality
 
-- **golangci-lint** (see `Makefile` for pinned version) configured in `.golangci.yml`: dupl, errcheck, ginkgolinter, goconst, gocyclo, govet, ineffassign, lll, misspell, prealloc, revive, staticcheck, unconvert, unused
+- **golangci-lint** (see `../tools/golangci-lint.mk` for pinned version) configured in `.golangci.yml`: dupl, errcheck, ginkgolinter, goconst, gocyclo, govet, ineffassign, lll, misspell, prealloc, revive, staticcheck, unconvert, unused
 - Formatters: gofmt, goimports
 - Pre-commit hooks (trailing-whitespace, check-merge-conflict, end-of-file-fixer, yamllint --strict, detect-private-key, plus an `osac-operator-golangci-lint` hook scoped to this component's `.go` files) are defined in the root-level `.pre-commit-config.yaml` — there is no `osac-operator`-local pre-commit/yamllint config anymore.
 - Run manually from the repo root: `pre-commit run --all-files`

--- a/osac-operator/Makefile
+++ b/osac-operator/Makefile
@@ -305,13 +305,13 @@ KUBECTL ?= kubectl
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
-GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.20.0
 ENVTEST_VERSION ?= release-0.19
-GOLANGCI_LINT_VERSION ?= v2.12.1
+
+include $(shell git rev-parse --show-toplevel)/tools/golangci-lint.mk
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -327,11 +327,6 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 envtest: $(ENVTEST) ## Download setup-envtest locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))
-
-.PHONY: golangci-lint
-golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
-$(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/tools/golangci-lint.mk
+++ b/tools/golangci-lint.mk
@@ -1,0 +1,37 @@
+# Shared golangci-lint installation for osac mono-repo components.
+#
+# Include this file from a component Makefile:
+#   include $(shell git rev-parse --show-toplevel)/tools/golangci-lint.mk
+# and reference $(GOLANGCI_LINT) from lint/lint-fix/lint-config targets (depend
+# on the `golangci-lint` target to trigger the download). The binary installs
+# once into a repo-root-level bin/ directory shared by every component,
+# instead of each component downloading its own copy.
+
+# Named GOLANGCI_LINT_BIN rather than LOCALBIN (the name component Makefiles
+# use) to make clear this directory is shared across every component, not
+# scoped to one.
+GOLANGCI_LINT_BIN ?= $(shell git rev-parse --show-toplevel)/tools/bin
+GOLANGCI_LINT = $(GOLANGCI_LINT_BIN)/golangci-lint
+GOLANGCI_LINT_VERSION ?= v2.12.1
+
+$(GOLANGCI_LINT_BIN):
+	mkdir -p $(GOLANGCI_LINT_BIN)
+
+# FORCE (rather than a plain file prerequisite) makes this recipe run on every
+# invocation, so a GOLANGCI_LINT_VERSION change always re-checks/re-links —
+# otherwise, once the $(GOLANGCI_LINT) symlink exists, make would consider it
+# up to date against $(GOLANGCI_LINT_BIN) forever and never revisit it.
+.PHONY: golangci-lint FORCE
+FORCE:
+
+golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
+$(GOLANGCI_LINT): FORCE | $(GOLANGCI_LINT_BIN)
+	@[ -f "$(GOLANGCI_LINT)-$(GOLANGCI_LINT_VERSION)" ] || { \
+	set -e; \
+	package=github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION) ;\
+	echo "Downloading $${package}" ;\
+	rm -f $(GOLANGCI_LINT) || true ;\
+	GOBIN=$(GOLANGCI_LINT_BIN) go install $${package} ;\
+	mv $(GOLANGCI_LINT) $(GOLANGCI_LINT)-$(GOLANGCI_LINT_VERSION) ;\
+	} ;\
+	ln -sf $(GOLANGCI_LINT)-$(GOLANGCI_LINT_VERSION) $(GOLANGCI_LINT)


### PR DESCRIPTION
Wire the pre-commit hooks to run through each component's own Makefile targets, so golangci-lint is installed automatically instead of requiring a manual install step in CI/workflows.

Each of osac-operator, bare-metal-fulfillment-operator, osac-csi-driver, and both osac-metering Makefiles previously downloaded and cached its own separate copy of golangci-lint, a leftover from before these components were merged into one mono-repo. Consolidate that into a single shared tools/golangci-lint.mk, included by each component Makefile, that installs one copy into a repo-root tools/bin/ shared by all of them. Also aligns bare-metal-fulfillment-operator on the same v2.12.1 version already used everywhere else (was v2.1.0).

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Standardized linting across project components with a shared, version-controlled configuration.
  - Centralized downloaded linting tools with reuse and caching support.
  - Updated pre-commit checks to use component-specific lint-fix commands.
  - Removed redundant lint workflow steps while preserving other validation and secret-scanning checks.
  - Added generated tool binaries to repository ignore rules.

- **Documentation**
  - Updated development guidance to reflect the shared linting configuration and centralized tool location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->