### PR TITLE
OSAC-4076: Adopt orphaned HostedCluster to prevent Lease conflict after crash

### DIFF
--- a/osac-operator/internal/controller/clusterorder_controller.go
+++ b/osac-operator/internal/controller/clusterorder_controller.go
@@ -339,6 +339,20 @@ func (r *ClusterOrderReconciler) handleUpdate(ctx context.Context, _ reconcile.R
 		return ctrl.Result{}, err
 	}
 
+	// Detect HC before provisioning so crash recovery can adopt an orphaned
+	// HostedCluster (job never flushed) instead of re-triggering AAP.
+	ns, err := r.findNamespace(ctx, instance)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if hc, _ := r.findHostedCluster(ctx, instance, ns.GetName()); hc != nil {
+		if err := r.handleHostedCluster(ctx, instance, hc); err != nil {
+			return ctrl.Result{}, err
+		}
+		r.adoptOrphanedHostedCluster(ctx, instance)
+	}
+
 	// Handle provisioning via provider (hybrid approach: job tracking + HC watching)
 	provisionResult, err := r.handleProvisioning(ctx, instance)
 	if err != nil {
@@ -352,17 +366,6 @@ func (r *ClusterOrderReconciler) handleUpdate(ctx context.Context, _ reconcile.R
 	}
 	if agentResult.RequeueAfter > 0 {
 		return agentResult, nil
-	}
-
-	ns, err := r.findNamespace(ctx, instance)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if hc, _ := r.findHostedCluster(ctx, instance, ns.GetName()); hc != nil {
-		if err := r.handleHostedCluster(ctx, instance, hc); err != nil {
-			return ctrl.Result{}, err
-		}
 	}
 
 	// If provision job needs polling, requeue for status updates
@@ -389,6 +392,14 @@ func (r *ClusterOrderReconciler) handleHostedCluster(ctx context.Context, instan
 		if hostedClusterIsReady(hc) {
 			log.Info("hosted cluster is ready", "clusterorder", instance.GetName())
 			instance.SetStatusCondition(v1alpha1.ConditionClusterAvailable, metav1.ConditionTrue, "", v1alpha1.ReasonAsExpected)
+			// Crash recovery: when the latest provision job is an adopted orphan,
+			// EvaluateAction returns Skip and OnSuccess is never called. Set Ready
+			// here so the phase converges on every reconcile as the HC becomes healthy.
+			latestJob := provisioning.FindLatestJobByType(instance.Status.ProvisioningJobs, v1alpha1.JobTypeProvision)
+			if provisioning.HasJobID(latestJob) && latestJob.JobID == "adopted-orphan" {
+				instance.Status.Phase = v1alpha1.ClusterOrderPhaseReady
+				instance.SetStatusCondition(v1alpha1.ConditionProgressing, metav1.ConditionFalse, "", v1alpha1.ReasonAsExpected)
+			}
 		}
 	}
 
@@ -693,6 +704,32 @@ func (r *ClusterOrderReconciler) provisioningCallbacks(instance *v1alpha1.Cluste
 			instance.SetStatusCondition(v1alpha1.ConditionProgressing, metav1.ConditionFalse, "", v1alpha1.ReasonAsExpected)
 		},
 	}
+}
+
+// adoptOrphanedHostedCluster inserts a synthetic provision job when an HC exists
+// but no job is tracked — the operator crashed before statusFlush. This prevents
+// EvaluateAction from re-triggering a duplicate AAP job. Phase transitions are
+// handled by handleHostedCluster, which checks HC readiness on every reconcile.
+func (r *ClusterOrderReconciler) adoptOrphanedHostedCluster(ctx context.Context, instance *v1alpha1.ClusterOrder) {
+	log := ctrllog.FromContext(ctx)
+	latestJob := provisioning.FindLatestJobByType(instance.Status.ProvisioningJobs, v1alpha1.JobTypeProvision)
+	if provisioning.HasJobID(latestJob) {
+		return
+	}
+	log.Info("adopting orphaned HostedCluster — operator likely crashed before statusFlush",
+		"hostedCluster", instance.Status.ClusterReference.HostedClusterName)
+	instance.Status.ProvisioningJobs = provisioning.AppendJob(
+		instance.Status.ProvisioningJobs,
+		v1alpha1.JobStatus{
+			Type:          v1alpha1.JobTypeProvision,
+			JobID:         "adopted-orphan",
+			State:         v1alpha1.JobStateSucceeded,
+			Message:       "Adopted from orphaned HostedCluster (crash recovery)",
+			ConfigVersion: instance.Status.DesiredConfigVersion,
+			Timestamp:     metav1.NewTime(time.Now().UTC()),
+		},
+		r.MaxJobHistory,
+	)
 }
 
 func (r *ClusterOrderReconciler) handleProvisioning(ctx context.Context, instance *v1alpha1.ClusterOrder) (ctrl.Result, error) {

--- a/osac-operator/internal/controller/clusterorder_controller_test.go
+++ b/osac-operator/internal/controller/clusterorder_controller_test.go
@@ -692,6 +692,116 @@ var _ = Describe("ClusterOrder Controller", func() {
 			Expect(cond.Message).To(Equal("provisioning in progress"))
 		})
 
+		It("should adopt orphaned HostedCluster when no provision job is tracked (OSAC-4076)", func() {
+			instance := &v1alpha1.ClusterOrder{
+				Status: v1alpha1.ClusterOrderStatus{
+					Phase:                v1alpha1.ClusterOrderPhaseProgressing,
+					DesiredConfigVersion: "abc123",
+					ClusterReference:     &v1alpha1.ClusterOrderClusterReferenceType{HostedClusterName: "orphaned-hc"},
+				},
+			}
+
+			reconciler := &ClusterOrderReconciler{MaxJobHistory: provisioning.DefaultMaxJobHistory}
+			reconciler.adoptOrphanedHostedCluster(context.Background(), instance)
+
+			Expect(instance.Status.ProvisioningJobs).To(HaveLen(1))
+			job := instance.Status.ProvisioningJobs[0]
+			Expect(job.JobID).To(Equal("adopted-orphan"))
+			Expect(job.State).To(Equal(v1alpha1.JobStateSucceeded))
+			Expect(job.Type).To(Equal(v1alpha1.JobTypeProvision))
+			Expect(job.ConfigVersion).To(Equal("abc123"))
+			Expect(instance.Status.Phase).To(Equal(v1alpha1.ClusterOrderPhaseProgressing),
+				"adoption only inserts a job — phase transition is handled by handleHostedCluster")
+		})
+
+		It("should not adopt when a provision job already exists (OSAC-4076)", func() {
+			instance := &v1alpha1.ClusterOrder{
+				Status: v1alpha1.ClusterOrderStatus{
+					Phase: v1alpha1.ClusterOrderPhaseProgressing,
+					ProvisioningJobs: []v1alpha1.JobStatus{
+						{
+							Type:  v1alpha1.JobTypeProvision,
+							JobID: "real-job",
+							State: v1alpha1.JobStateSucceeded,
+						},
+					},
+					ClusterReference: &v1alpha1.ClusterOrderClusterReferenceType{HostedClusterName: "some-hc"},
+				},
+			}
+
+			reconciler := &ClusterOrderReconciler{MaxJobHistory: provisioning.DefaultMaxJobHistory}
+			reconciler.adoptOrphanedHostedCluster(context.Background(), instance)
+
+			Expect(instance.Status.ProvisioningJobs).To(HaveLen(1))
+			Expect(instance.Status.ProvisioningJobs[0].JobID).To(Equal("real-job"))
+		})
+
+		It("should set Phase=Ready when HC becomes ready after adoption (OSAC-4076)", func() {
+			instance := &v1alpha1.ClusterOrder{
+				Status: v1alpha1.ClusterOrderStatus{
+					Phase: v1alpha1.ClusterOrderPhaseProgressing,
+					ProvisioningJobs: []v1alpha1.JobStatus{
+						{
+							Type:  v1alpha1.JobTypeProvision,
+							JobID: "adopted-orphan",
+							State: v1alpha1.JobStateSucceeded,
+						},
+					},
+				},
+			}
+			hc := &hypershiftv1beta1.HostedCluster{
+				Status: hypershiftv1beta1.HostedClusterStatus{
+					Conditions: []metav1.Condition{
+						{Type: "Available", Status: metav1.ConditionTrue, Reason: "AsExpected", LastTransitionTime: metav1.Now()},
+						{Type: "ClusterVersionSucceeding", Status: metav1.ConditionTrue, Reason: "AsExpected", LastTransitionTime: metav1.Now()},
+						{Type: "Degraded", Status: metav1.ConditionFalse, Reason: "AsExpected", LastTransitionTime: metav1.Now()},
+					},
+				},
+			}
+			hc.SetName("adopted-hc")
+
+			reconciler := &ClusterOrderReconciler{Client: k8sClient, MaxJobHistory: provisioning.DefaultMaxJobHistory}
+			err := reconciler.handleHostedCluster(context.Background(), instance, hc)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(instance.Status.Phase).To(Equal(v1alpha1.ClusterOrderPhaseReady))
+			cond := apimeta.FindStatusCondition(instance.Status.Conditions, v1alpha1.ConditionProgressing)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		})
+
+		It("should NOT set Phase=Ready in handleHostedCluster for normal (non-adopted) jobs (OSAC-2024 preservation)", func() {
+			instance := &v1alpha1.ClusterOrder{
+				Status: v1alpha1.ClusterOrderStatus{
+					Phase: v1alpha1.ClusterOrderPhaseProgressing,
+					ProvisioningJobs: []v1alpha1.JobStatus{
+						{
+							Type:  v1alpha1.JobTypeProvision,
+							JobID: "real-aap-job-42",
+							State: v1alpha1.JobStateSucceeded,
+						},
+					},
+				},
+			}
+			hc := &hypershiftv1beta1.HostedCluster{
+				Status: hypershiftv1beta1.HostedClusterStatus{
+					Conditions: []metav1.Condition{
+						{Type: "Available", Status: metav1.ConditionTrue, Reason: "AsExpected", LastTransitionTime: metav1.Now()},
+						{Type: "ClusterVersionSucceeding", Status: metav1.ConditionTrue, Reason: "AsExpected", LastTransitionTime: metav1.Now()},
+						{Type: "Degraded", Status: metav1.ConditionFalse, Reason: "AsExpected", LastTransitionTime: metav1.Now()},
+					},
+				},
+			}
+			hc.SetName("real-hc")
+
+			reconciler := &ClusterOrderReconciler{Client: k8sClient, MaxJobHistory: provisioning.DefaultMaxJobHistory}
+			err := reconciler.handleHostedCluster(context.Background(), instance, hc)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(instance.Status.Phase).To(Equal(v1alpha1.ClusterOrderPhaseProgressing),
+				"handleHostedCluster must NOT set Ready for normal jobs — OnSuccess handles that")
+		})
+
 		It("should set Phase=Ready and Progressing=False on OnSuccess", func() {
 			instance := &v1alpha1.ClusterOrder{
 				Status: v1alpha1.ClusterOrderStatus{


### PR DESCRIPTION
## Bug

Operator crash during early CaaS provisioning (after AAP job trigger, before `statusFlush`) leaves ClusterOrder stuck in `Progressing` permanently.

### Proof

`clusterorder_controller.go:327` calls `handleProvisioning` BEFORE `findHostedCluster` at line 337. On crash recovery:

```
handleProvisioning                     findHostedCluster
       |                                      |
  EvaluateAction: no jobs → Trigger           |
  Launch AAP job #2                           |
  Job #2: Lease conflict (orphan holds it)    |
  OnFailed: HC exists → skip Failed           |
  Backoff → retry → same conflict → forever   |
                                        (never reached first)
```

ComputeInstance controller does NOT have this bug — it checks for VMs before calling `handleProvisioning`.

### Fix

Move HC detection before `handleProvisioning`. If HC exists but `provisioningJobs` is empty, adopt the orphaned state with a synthetic `Succeeded` job. `EvaluateAction` then returns `Skip`, no duplicate job triggered, no Lease conflict.

[OSAC-2024](https://redhat.atlassian.net/browse/OSAC-2024) behavior preserved: that case has a tracked provision job AND an HC, so the adoption logic does not trigger.

### Validation

```bash
cd osac-operator && make test    # 669 passed, 0 failed
```

Discovered by: CaaS operator restart disruptive E2E test (osac-test-infra#373)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when a cluster is discovered after an interrupted reconciliation.
  * Existing HostedClusters without a recorded provisioning job are now correctly recognized as adopted.
  * Adoption records the desired configuration version and current timestamp, preventing unnecessary reprovisioning.
  * Adopted clusters that are already ready now correctly transition to the Ready phase, while ongoing provisioning continues to show Progressing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->