### PR TITLE
OSAC-4030: default ocp_ci_small to SingleReplica infrastructure availability

### DIFF
--- a/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_ci_small/tasks/install.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/ocp_ci_small/tasks/install.yaml
@@ -40,6 +40,7 @@
       ssh_public_key: "{{ template_parameters.ssh_public_key }}"
     hosted_cluster_node_requests: "{{ cluster_order.spec.nodeRequests | unique(attribute='resourceClass') }}"
     hosted_cluster_state: present
+    hosted_cluster_infrastructure_availability_policy: "{{ lookup('env', 'HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY', default='SingleReplica') }}"
 
 - name: Step - Create cluster infrastructure
   ansible.builtin.include_role:


### PR DESCRIPTION
## Summary

- `ocp_ci_small` always provisions 1 worker from the catalog (no way to override `numberOfNodes`).
- The global default for `infrastructureAvailabilityPolicy` is `HighlyAvailable`, which requires multiple workers for ingress, image-registry, and monitoring.
- With 1 worker, those ClusterOperators stay degraded and the AAP "Wait for ClusterOperators" step hangs indefinitely.
- While `HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY=SingleReplica` can be set in the `cluster-fulfillment-ig` ConfigMap, relying on that global config means every new environment deploying `ocp_ci_small` will fail out of the box unless the operator knows to set it — which is easy to forget or simply not know about.
- This adds a task-level `vars:` override in `ocp_ci_small/install.yaml` that defaults to `SingleReplica` while still respecting the env var from the ConfigMap if explicitly set.

## Test plan

- [x] Deploy `ocp_ci_small` from catalog without setting `HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY` in ConfigMap — should use `SingleReplica` and ClusterOperators should not degrade
- [x] Deploy with `HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY=HighlyAvailable` in ConfigMap — should override to `HighlyAvailable`
- [x] Verify no other templates are affected (change is scoped to `ocp_ci_small/tasks/install.yaml`)

Closes: https://redhat.atlassian.net/browse/OSAC-4030

Assisted-by: Claude Code <noreply@anthropic.com>