### PR TITLE
OSAC-4112: Require mandatory Jira Component in design:sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,19 @@ fulfillment-service (proto)
 
 For deployment coordination (image tags, submodules), see `osac-installer/AGENTS.md`.
 
+## Jira Conventions
+
+OSAC requires a **Component** on every created issue — Jira rejects creates
+without one. Any automation creating an OSAC issue must set it:
+
+- Inherit from the parent: epics/stories take the parent Feature's component(s)
+  (parent has multiple → give each child the matching subset from the parent's
+  set; confirm with the driver before creating).
+- **Never invent a component** or use one the parent lacks. If none fits, or the
+  parent has none, stop and ask the driver.
+- Set on create — MCP `fields: {"components": [{"name": "<name>"}]}` / `jira` CLI
+  `-C "<name>"`; match component strings exactly.
+
 ## Knowledge Graph (graphify brain)
 
 CI keeps a structural code graph of this mono-repo fresh (`.github/workflows/graphify-brain-refresh.yaml`) and publishes it for pickup. After `graphify` is installed (see below), a `SessionStart` hook (`.claude/hooks/fetch-graphify-brain.sh`) fetches the latest published bundle into `graphify-out/` automatically at the start of every session — no manual fetch step — and it fails open (falls back to normal cold exploration with a one-line warning) if the fetch fails, `graphify` isn't installed, or the graph is otherwise unavailable.


### PR DESCRIPTION
## What

OSAC now makes the Jira **Component** field mandatory on every created issue — Jira rejects any create that omits it. The agentic SDLC `design:sync` phase creates Epics/Stories under a Feature without setting a Component, so sync against OSAC fails.

This adds a concise **Jira Conventions** section to the mono-repo `AGENTS.md`:

- Any automation creating an OSAC issue must set a Component by **inheriting the parent Feature's component(s)**.
- Multi-component Feature → each child gets the matching subset from the parent's set; confirm in the sync dry-run.
- **Never invent a component** (governance/ownership), and never use one the parent lacks.
- Feature has none (legacy) → stop and ask the driver.
- Set on create via MCP `fields: {"components": [{"name": "<name>"}]}` / `jira` CLI `-C`, overriding `sync.md`'s default sync-owned-fields list.

## Why here

The mandatory-Component requirement is OSAC-wide, so the convention belongs in the shared osac mono-repo's `AGENTS.md` (read by the design workflow controller at runtime) rather than only in an individual meta-workspace. No change to the generic flightctl/ai-workflows skills — this is the AGENTS.md approach agreed on Slack (Amir Yogev + Liat Gamliel: keep it in AGENTS.md, never auto-create components, inherit from the Feature).

## Validation

Confirmed against live Jira: OSAC defines 17 components; of the 100 most-recent Features, 91 already carry one and 16 are multi-component — so inherit-from-Feature is sound and multi-component is handled.

Jira: https://redhat.atlassian.net/browse/OSAC-4112