### PR TITLE
OSAC-3276: fix volume reconciler test — drop obsolete PVCRef assertion

### DIFF
--- a/fulfillment-service/internal/controllers/volume/volume_reconciler_function_test.go
+++ b/fulfillment-service/internal/controllers/volume/volume_reconciler_function_test.go
@@ -100,7 +100,6 @@ var _ = Describe("buildSpec", func() {
 		Expect(spec.StorageTier).To(Equal("gold"))
 		Expect(spec.SizeGiB).To(Equal(int64(100)))
 		Expect(spec.AccessMode).To(Equal(osacv1alpha1.VolumeAccessModeReadWriteOnce))
-		Expect(spec.PVCRef).To(BeNil())
 	})
 
 	It("maps ReadWriteMany access mode", func() {


### PR DESCRIPTION
## Problem
  
  `main` is currently red on **Run unit tests** and **Check Go and proto code**. The `volume` package fails to
  compile:

  internal/controllers/volume/volume_reconciler_function_test.go:103:15:
    spec.PVCRef undefined (type "…/osac-operator/api/v1alpha1".VolumeSpec
    has no field or method PVCRef)

  ## Root cause

  A semantic merge conflict between two PRs (both by @akshaynadkarni), each green in isolation but incompatible
  once both landed:

  - **#341** ([OSAC-3274](https://redhat.atlassian.net/browse/OSAC-3274)) removed `pvcRef`/`pvRef` from `VolumeSpec` — merged first (2026-08-17).
  - **#339** ([OSAC-3276](https://redhat.atlassian.net/browse/OSAC-3276)) added the reconciler test asserting `spec.PVCRef` — merged second (2026-08-18), off a
  branch that predated #341 and was not re-validated against the updated `main`.

  ## Fix

  Remove the stale `Expect(spec.PVCRef).To(BeNil())` assertion. `PVCRef` no longer exists on `VolumeSpec`; PVC/PV
  tracking is planned for a future `VolumeAttachment` resource ([OSAC-3278](https://redhat.atlassian.net/browse/OSAC-3278)), not the `Volume` itself, so there is
  nothing to re-point the assertion at.

  - 1 line removed
  - `go vet ./internal/controllers/volume/` passes; `gofmt` clean