### PR TITLE
NO-ISSUE: fix Volume reconciler test referencing removed VolumeSpec.PVCRef

### DIFF
--- a/fulfillment-service/internal/controllers/volume/volume_reconciler_function_test.go
+++ b/fulfillment-service/internal/controllers/volume/volume_reconciler_function_test.go
@@ -100,7 +100,6 @@ var _ = Describe("buildSpec", func() {
 		Expect(spec.StorageTier).To(Equal("gold"))
 		Expect(spec.SizeGiB).To(Equal(int64(100)))
 		Expect(spec.AccessMode).To(Equal(osacv1alpha1.VolumeAccessModeReadWriteOnce))
-		Expect(spec.PVCRef).To(BeNil())
 	})
 
 	It("maps ReadWriteMany access mode", func() {


### PR DESCRIPTION
## What

Removes an orphaned test assertion that broke the build on `main`:

```
fulfillment-service/internal/controllers/volume/volume_reconciler_function_test.go:103:15:
  spec.PVCRef undefined (type v1alpha1.VolumeSpec has no field or method PVCRef)
```

## Why — cross-package semantic merge conflict

Two PRs merged back-to-back with a conflict that neither CI could catch:

- https://github.com/osac-project/osac/pull/341 ([OSAC-3274](https://redhat.atlassian.net/browse/OSAC-3274)) removed `pvcRef`/`pvRef` from `VolumeSpec` in `osac-operator/api/v1alpha1`.
- https://github.com/osac-project/osac/pull/339 ([OSAC-3276](https://redhat.atlassian.net/browse/OSAC-3276)) added a Volume reconciler test in `fulfillment-service` asserting `spec.PVCRef`.

PR 339 was branched **before** PR 341 merged, so it compiled against a `VolumeSpec` that still had `PVCRef` and passed its own CI. After both landed, the combined tree no longer compiles. `git` merges both textually clean because they touch different files — the breakage only surfaces when the test package is built.

## Fix

Drop the stale `Expect(spec.PVCRef).To(BeNil())` assertion. `buildSpec()` never populated `PVCRef` and nothing else in the repo references it, so removal is the correct resolution (not restoring the field).

## Verification

- `go vet ./internal/controllers/volume/` — clean
- `go test ./internal/controllers/volume/` — pass

## FYI

- Original author of both PRs: @akshaynadkarni
- LGTM on #341: @zszabo-rh · LGTM on #339: @rgolangh

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated volume reconciliation test expectations by removing an outdated nil assertion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->