### PR TITLE
OSAC-2986: Create Secret CLI cmd

### DIFF
--- a/fulfillment-service/internal/cmd/cli/create/create_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/create_cmd.go
@@ -43,6 +43,7 @@ import (
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/hub"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/instancetype"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/natgateway"
+	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/secret"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/securitygroup"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/storagebackend"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/storagetier"
@@ -80,6 +81,7 @@ func Cmd() *cobra.Command {
 	result.AddCommand(natgateway.Cmd())
 	result.AddCommand(virtualnetwork.Cmd())
 	result.AddCommand(subnet.Cmd())
+	result.AddCommand(secret.Cmd())
 	result.AddCommand(securitygroup.Cmd())
 	result.AddCommand(help.MarkPrivateAPI(storagebackend.Cmd()))
 	result.AddCommand(help.MarkPrivateAPI(storagetier.Cmd()))

--- a/fulfillment-service/internal/cmd/cli/create/create_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/create/create_cmd_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/computeinstance"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/computeinstancecatalogitem"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/hub"
+	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/secret"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/securitygroup"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/subnet"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/virtualnetwork"
@@ -52,6 +53,7 @@ var _ = Describe("Create command", func() {
 		Entry("hub", hub.Cmd, (*privatev1.Hub)(nil)),
 		Entry("virtualnetwork", virtualnetwork.Cmd, (*publicv1.VirtualNetwork)(nil)),
 		Entry("subnet", subnet.Cmd, (*publicv1.Subnet)(nil)),
+		Entry("secret", secret.Cmd, (*publicv1.Secret)(nil)),
 		Entry("securitygroup", securitygroup.Cmd, (*publicv1.SecurityGroup)(nil)),
 	)
 
@@ -65,7 +67,20 @@ var _ = Describe("Create command", func() {
 				subcommandNames = append(subcommandNames, subcmd.Name())
 			}
 
-			Expect(subcommandNames).To(ContainElements("baremetalinstancecatalogitem", "baremetalinstancetype", "cluster", "clustercatalogitem", "clusterversion", "computeinstance", "computeinstancecatalogitem", "hub", "virtualnetwork", "subnet", "securitygroup"))
+			Expect(subcommandNames).To(ContainElements(
+				"baremetalinstancecatalogitem",
+				"baremetalinstancetype",
+				"cluster",
+				"clustercatalogitem",
+				"clusterversion",
+				"computeinstance",
+				"computeinstancecatalogitem",
+				"hub",
+				"virtualnetwork",
+				"subnet",
+				"secret",
+				"securitygroup",
+			))
 		})
 	})
 

--- a/fulfillment-service/internal/cmd/cli/create/secret/create_secret_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/secret/create_secret_cmd.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2025 Red Hat Inc.
+Copyright (c) 2026 Red Hat Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
 License. You may obtain a copy of the License at

--- a/fulfillment-service/internal/cmd/cli/create/secret/create_secret_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/secret/create_secret_cmd.go
@@ -1,0 +1,266 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package secret
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+
+	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/osac/fulfillment-service/internal/config"
+	"github.com/osac-project/osac/fulfillment-service/internal/logging"
+	"github.com/osac-project/osac/fulfillment-service/internal/terminal"
+)
+
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:                   "secret [FLAG...]",
+		Aliases:               []string{string(proto.MessageName((*publicv1.Secret)(nil)))},
+		Short:                 shortHelp,
+		Long:                  longHelp,
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.NoArgs,
+		RunE:                  runner.run,
+	}
+	flags := result.Flags()
+	flags.StringVarP(
+		&runner.args.name,
+		"name",
+		"n",
+		"",
+		nameFlagHelp,
+	)
+	flags.StringArrayVar(
+		&runner.args.fromFile,
+		"from-file",
+		nil,
+		fromFileFlagHelp,
+	)
+	flags.StringArrayVar(
+		&runner.args.labels,
+		"label",
+		nil,
+		labelFlagHelp,
+	)
+	return result
+}
+
+type runnerContext struct {
+	args struct {
+		name     string
+		fromFile []string
+		labels   []string
+	}
+	logger   *slog.Logger
+	console  *terminal.Console
+	settings *config.Settings
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	c.logger = logging.LoggerFromContext(ctx)
+	c.console = terminal.ConsoleFromContext(ctx)
+
+	c.settings = config.SettingsFromContext(ctx)
+	if !c.settings.Armed() {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	if len(c.args.fromFile) == 0 {
+		return fmt.Errorf("at least one --from-file flag is required")
+	}
+
+	data, err := parseFromFileFlags(c.args.fromFile)
+	if err != nil {
+		return err
+	}
+
+	labels, err := parseLabels(c.args.labels)
+	if err != nil {
+		return err
+	}
+
+	conn, err := c.settings.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	client := publicv1.NewSecretsClient(conn)
+
+	secret := publicv1.Secret_builder{
+		Metadata: publicv1.Metadata_builder{
+			Name:   c.args.name,
+			Tenant: c.settings.Tenant(),
+			Labels: labels,
+		}.Build(),
+		Data: data,
+	}.Build()
+
+	response, err := client.Create(ctx, publicv1.SecretsCreateRequest_builder{Object: secret}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to create secret: %w", err)
+	}
+
+	c.console.Infof(ctx, "Created secret '%s' (ID: %s).\n",
+		response.GetObject().GetMetadata().GetName(), response.GetObject().GetId())
+
+	return nil
+}
+
+// parseFromFileSpec parses a single --from-file flag value into a key and path.
+// Formats: "key=path", "path" (key derived from filename), "-" (stdin, key="stdin").
+func parseFromFileSpec(value string) (key, path string, err error) {
+	if value == "" {
+		return "", "", fmt.Errorf("--from-file value must not be empty")
+	}
+
+	if k, p, ok := strings.Cut(value, "="); ok {
+		key = k
+		path = p
+		if key == "" {
+			return "", "", fmt.Errorf("--from-file key must not be empty in %q", value)
+		}
+		if path == "" {
+			return "", "", fmt.Errorf("--from-file path must not be empty in %q", value)
+		}
+	} else {
+		path = value
+		if path == "-" {
+			return "", "", fmt.Errorf("--from-file key is required when reading from stdin (use --from-file=KEY=-)")
+		}
+		key = filepath.Base(path)
+	}
+
+	return key, path, nil
+}
+
+// parseFromFileFlags parses all --from-file flag values into a map of key to raw bytes.
+func parseFromFileFlags(fromFile []string) (map[string][]byte, error) {
+	data := make(map[string][]byte, len(fromFile))
+	stdinUsed := false
+
+	for _, value := range fromFile {
+		key, path, err := parseFromFileSpec(value)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, exists := data[key]; exists {
+			return nil, fmt.Errorf("duplicate key %q in --from-file flags", key)
+		}
+
+		var content []byte
+		if path == "-" {
+			if stdinUsed {
+				return nil, fmt.Errorf("stdin (-) can only be referenced once in --from-file flags")
+			}
+			stdinUsed = true
+			content, err = io.ReadAll(os.Stdin)
+		} else {
+			content, err = os.ReadFile(filepath.Clean(path))
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to read %q: %w", path, err)
+		}
+
+		data[key] = content
+	}
+
+	return data, nil
+}
+
+// parseLabels parses --label flag values in "key=value" format into a map.
+func parseLabels(labels []string) (map[string]string, error) {
+	if len(labels) == 0 {
+		return nil, nil
+	}
+
+	result := make(map[string]string, len(labels))
+	for _, label := range labels {
+		key, value, ok := strings.Cut(label, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid label %q: must be in key=value format", label)
+		}
+		if key == "" {
+			return nil, fmt.Errorf("invalid label %q: key must not be empty", label)
+		}
+		if _, exists := result[key]; exists {
+			return nil, fmt.Errorf("duplicate label key %q", key)
+		}
+		result[key] = value
+	}
+
+	return result, nil
+}
+
+const shortHelp = `Create a secret from file contents`
+
+const longHelp = `
+Create a secret from one or more files. Each {{ bt }}--from-file{{ bt }} flag adds a key-value
+entry to the secret, where the value is the raw file content.
+
+To create a secret with an explicit key:
+
+{{ bt 3 }}shell
+{{ binary }} create secret --name my-tls-secret --from-file=tls.crt=/path/to/cert.pem
+{{ bt 3 }}
+
+To use the filename as the key:
+
+{{ bt 3 }}shell
+{{ binary }} create secret --name my-secret --from-file=/path/to/config.yaml
+{{ bt 3 }}
+
+To create a secret with multiple keys:
+
+{{ bt 3 }}shell
+{{ binary }} create secret --name my-tls --from-file=tls.crt=/path/to/cert.pem --from-file=tls.key=/path/to/key.pem
+{{ bt 3 }}
+
+To read secret data from stdin (an explicit key is required):
+
+{{ bt 3 }}shell
+echo "my-value" | {{ binary }} create secret --name my-secret --from-file=password=-
+{{ bt 3 }}
+
+To create a secret with labels:
+
+{{ bt 3 }}shell
+{{ binary }} create secret --name my-secret --from-file=data.txt --label=env=prod --label=team=backend
+{{ bt 3 }}
+`
+
+const nameFlagHelp = `
+_NAME_ - Name of the secret.
+`
+
+const fromFileFlagHelp = `
+_[KEY=]PATH_ - Read secret data from a file. If {{ bt }}KEY={{ bt }} is omitted,
+the filename is used as the key. Use {{ bt }}KEY=-{{ bt }} to read from standard
+input (an explicit key is required for stdin). Can be specified multiple times.
+`
+
+const labelFlagHelp = `
+_KEY=VALUE_ - Label to set on the secret. Can be specified multiple times.
+`

--- a/fulfillment-service/internal/cmd/cli/create/secret/create_secret_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/create/secret/create_secret_cmd_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2025 Red Hat Inc.
+Copyright (c) 2026 Red Hat Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
 License. You may obtain a copy of the License at

--- a/fulfillment-service/internal/cmd/cli/create/secret/create_secret_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/create/secret/create_secret_cmd_test.go
@@ -1,0 +1,240 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package secret
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/ginkgo/v2/dsl/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("parseFromFileSpec", func() {
+	DescribeTable("valid cases",
+		func(value, expectedKey, expectedPath string) {
+			key, path, err := parseFromFileSpec(value)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(key).To(Equal(expectedKey))
+			Expect(path).To(Equal(expectedPath))
+		},
+		Entry("explicit key and path",
+			"tls.crt=/path/to/cert.pem", "tls.crt", "/path/to/cert.pem",
+		),
+		Entry("path only, basename as key",
+			"/path/to/config.yaml", "config.yaml", "/path/to/config.yaml",
+		),
+		Entry("relative path, basename as key",
+			"data.txt", "data.txt", "data.txt",
+		),
+		Entry("stdin with explicit key",
+			"password=-", "password", "-",
+		),
+		Entry("key with path containing equals",
+			"mykey=path/with=equals", "mykey", "path/with=equals",
+		),
+	)
+
+	DescribeTable("error cases",
+		func(value string, errMatcher OmegaMatcher) {
+			_, _, err := parseFromFileSpec(value)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(errMatcher)
+		},
+		Entry("empty value",
+			"", ContainSubstring("must not be empty"),
+		),
+		Entry("empty key with path",
+			"=/path/to/file", ContainSubstring("key must not be empty"),
+		),
+		Entry("key with empty path",
+			"mykey=", ContainSubstring("path must not be empty"),
+		),
+		Entry("stdin without explicit key",
+			"-", ContainSubstring("key is required when reading from stdin"),
+		),
+	)
+})
+
+var _ = Describe("parseFromFileFlags", func() {
+	var tmpDir string
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "secret-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			os.RemoveAll(tmpDir)
+		})
+	})
+
+	It("should read a single file with explicit key", func() {
+		filePath := filepath.Join(tmpDir, "cert.pem")
+		Expect(os.WriteFile(filePath, []byte("cert-data"), 0644)).To(Succeed())
+
+		data, err := parseFromFileFlags([]string{"tls.crt=" + filePath})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveLen(1))
+		Expect(data["tls.crt"]).To(Equal([]byte("cert-data")))
+	})
+
+	It("should read a file using basename as key", func() {
+		filePath := filepath.Join(tmpDir, "config.yaml")
+		Expect(os.WriteFile(filePath, []byte("config-content"), 0644)).To(Succeed())
+
+		data, err := parseFromFileFlags([]string{filePath})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveLen(1))
+		Expect(data["config.yaml"]).To(Equal([]byte("config-content")))
+	})
+
+	It("should read multiple files", func() {
+		file1 := filepath.Join(tmpDir, "cert.pem")
+		file2 := filepath.Join(tmpDir, "key.pem")
+		Expect(os.WriteFile(file1, []byte("cert"), 0644)).To(Succeed())
+		Expect(os.WriteFile(file2, []byte("key"), 0644)).To(Succeed())
+
+		data, err := parseFromFileFlags([]string{"tls.crt=" + file1, "tls.key=" + file2})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data).To(HaveLen(2))
+		Expect(data["tls.crt"]).To(Equal([]byte("cert")))
+		Expect(data["tls.key"]).To(Equal([]byte("key")))
+	})
+
+	It("should read binary content as raw bytes", func() {
+		filePath := filepath.Join(tmpDir, "binary.bin")
+		binaryData := []byte{0x00, 0x01, 0xFF, 0xFE, 0x80}
+		Expect(os.WriteFile(filePath, binaryData, 0644)).To(Succeed())
+
+		data, err := parseFromFileFlags([]string{"binary=" + filePath})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data["binary"]).To(Equal(binaryData))
+	})
+
+	It("should read an empty file", func() {
+		filePath := filepath.Join(tmpDir, "empty")
+		Expect(os.WriteFile(filePath, []byte{}, 0644)).To(Succeed())
+
+		data, err := parseFromFileFlags([]string{"empty=" + filePath})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(data["empty"]).To(Equal([]byte{}))
+	})
+
+	It("should reject duplicate keys", func() {
+		file1 := filepath.Join(tmpDir, "a.txt")
+		file2 := filepath.Join(tmpDir, "b.txt")
+		Expect(os.WriteFile(file1, []byte("a"), 0644)).To(Succeed())
+		Expect(os.WriteFile(file2, []byte("b"), 0644)).To(Succeed())
+
+		_, err := parseFromFileFlags([]string{"key=" + file1, "key=" + file2})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("duplicate key"))
+	})
+
+	It("should reject multiple stdin references", func() {
+		_, err := parseFromFileFlags([]string{"a=-", "b=-"})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("stdin (-) can only be referenced once"))
+	})
+
+	It("should return error for nonexistent file", func() {
+		_, err := parseFromFileFlags([]string{"key=/nonexistent/file"})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to read"))
+	})
+})
+
+var _ = Describe("parseLabels", func() {
+	DescribeTable("valid cases",
+		func(labels []string, expected map[string]string) {
+			result, err := parseLabels(labels)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(expected))
+		},
+		Entry("nil input returns nil",
+			[]string(nil), nil,
+		),
+		Entry("empty input returns nil",
+			[]string{}, nil,
+		),
+		Entry("single label",
+			[]string{"env=prod"}, map[string]string{"env": "prod"},
+		),
+		Entry("multiple labels",
+			[]string{"env=prod", "team=backend"},
+			map[string]string{"env": "prod", "team": "backend"},
+		),
+		Entry("value containing equals",
+			[]string{"config=key=value"},
+			map[string]string{"config": "key=value"},
+		),
+		Entry("empty value is valid",
+			[]string{"key="},
+			map[string]string{"key": ""},
+		),
+	)
+
+	DescribeTable("error cases",
+		func(labels []string, errMatcher OmegaMatcher) {
+			_, err := parseLabels(labels)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(errMatcher)
+		},
+		Entry("missing equals sign",
+			[]string{"noequalssign"},
+			ContainSubstring("must be in key=value format"),
+		),
+		Entry("empty key",
+			[]string{"=value"},
+			ContainSubstring("key must not be empty"),
+		),
+		Entry("duplicate keys",
+			[]string{"env=prod", "env=staging"},
+			ContainSubstring("duplicate label key"),
+		),
+	)
+})
+
+var _ = Describe("Command registration", func() {
+	It("should create the command", func() {
+		cmd := Cmd()
+		Expect(cmd).NotTo(BeNil())
+		Expect(cmd.Name()).To(Equal("secret"))
+	})
+
+	It("should register the --name flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("name")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.Shorthand).To(Equal("n"))
+	})
+
+	It("should register the --from-file flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("from-file")
+		Expect(flag).NotTo(BeNil())
+	})
+
+	It("should register the --label flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("label")
+		Expect(flag).NotTo(BeNil())
+	})
+
+	It("should have the protobuf alias", func() {
+		cmd := Cmd()
+		Expect(cmd.Aliases).To(ContainElement("osac.public.v1.Secret"))
+	})
+})

--- a/fulfillment-service/internal/cmd/cli/create/secret/create_secret_suite_test.go
+++ b/fulfillment-service/internal/cmd/cli/create/secret/create_secret_suite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2025 Red Hat Inc.
+Copyright (c) 2026 Red Hat Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
 License. You may obtain a copy of the License at

--- a/fulfillment-service/internal/cmd/cli/create/secret/create_secret_suite_test.go
+++ b/fulfillment-service/internal/cmd/cli/create/secret/create_secret_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package secret
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestSecret(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Create secret command")
+}


### PR DESCRIPTION
Adds secret creation to the CLI -

From file:
```bash
$ osac create secret --name test-file --from-file ./tmp-secret
Created secret 'test-file' (ID: 01a01605-c9f4-76c3-bad3-b8fa6e29e056).
```
From stdin (uses a supplied key and specially reserved "-" character for the value from stdin):
```bash
$ printf  "stdin_secret_value" | create secret --name test-from-stdin --from-file=stdin-key=-
Created secret 'test-from-stdin' (ID: 01a01604-b63d-7b8f-8d06-f2e42636785b).
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `create secret` CLI command for creating secrets through file or standard input.
  * Supports multiple secret entries, optional labels, input validation, duplicate detection, and clear error reporting.
  * Added command help and flags for configuring secret creation.

* **Tests**
  * Added comprehensive coverage for input parsing, validation, file handling, labels, flags, and command registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->