### PR TITLE
OSAC-4097: Install protoc-gen-cleanapi

### DIFF
--- a/fulfillment-service/dev/setup.py
+++ b/fulfillment-service/dev/setup.py
@@ -36,6 +36,7 @@ def setup() -> None:
     """
     install_golangci_lint()
     install_protoc_gen_cleanapi()
+    install_cleanapi_proto()
 
 
 def install_golangci_lint() -> None:
@@ -217,3 +218,39 @@ def install_artifact(path: pathlib.Path, extracted_name: str, tool_name: str) ->
     bin_stat = bin_file.stat()
     bin_file.chmod(bin_stat.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     logging.info(f"Successfully installed '{tool_name}' to '{bin_file}'")
+
+
+def install_cleanapi_proto() -> None:
+    """
+    Downloads the cleanapi.proto file from the protoc-gen-cleanapi repository.
+    """
+    proto_dir = dirs.project() / "proto" / "cleanapi"
+    proto_file = proto_dir / "cleanapi.proto"
+
+    # Check if already installed
+    if proto_file.exists():
+        logging.info(f"cleanapi.proto is already installed at '{proto_file}'")
+        return
+
+    logging.info("Installing cleanapi.proto")
+
+    # Create directory
+    proto_dir.mkdir(parents=True, exist_ok=True)
+
+    # Download the proto file
+    url = f"https://raw.githubusercontent.com/jhernand/protoc-gen-cleanapi/v{tools.PROTOC_GEN_CLEANAPI.version}/proto/cleanapi/cleanapi.proto"
+    commands.run(
+        args=[
+            "curl",
+            "--connect-timeout", "10",
+            "--max-time", "30",
+            "--location",
+            "--proto", "=https",
+            "--silent",
+            "--fail",
+            "--output", str(proto_file),
+            url,
+        ],
+        check=True,
+    )
+    logging.info(f"Successfully installed cleanapi.proto to '{proto_file}'")

--- a/fulfillment-service/dev/setup.py
+++ b/fulfillment-service/dev/setup.py
@@ -35,6 +35,7 @@ def setup() -> None:
     Prepares the development environment.
     """
     install_golangci_lint()
+    install_protoc_gen_cleanapi()
 
 
 def install_golangci_lint() -> None:
@@ -42,6 +43,13 @@ def install_golangci_lint() -> None:
     Installs the 'golangci-lint' tool.
     """
     install_tool(tool=tools.GOLANGCI_LINT)
+
+
+def install_protoc_gen_cleanapi() -> None:
+    """
+    Installs the 'protoc-gen-cleanapi' tool.
+    """
+    install_tool(tool=tools.PROTOC_GEN_CLEANAPI)
 
 
 def install_tool(tool: tools.Tool) -> None:

--- a/fulfillment-service/dev/setup.py
+++ b/fulfillment-service/dev/setup.py
@@ -16,7 +16,6 @@
 import hashlib
 import logging
 import pathlib
-import platform
 import re
 import shutil
 import stat
@@ -42,99 +41,40 @@ def install_golangci_lint() -> None:
     """
     Installs the 'golangci-lint' tool.
     """
+    install_tool(tool=tools.GOLANGCI_LINT)
+
+
+def install_tool(tool: tools.Tool) -> None:
+    """
+    Installs the given tool.
+    """
     # First check if it is already installed:
-    tool = tools.GOLANGCI_LINT
     if is_installed(tool):
         return
 
-    # Download and check the file that contains the checksums:
+    # Log the installation start:
     logging.info(f"Installing version '{tool.version}' of '{tool.name}'")
-    checksums_artifact = f"golangci-lint-{tool.version}-checksums.txt"
-    checksums_url = (
-        f"https://github.com"
-        f"/golangci/golangci-lint/releases/download/v{tool.version}"
-        f"/{checksums_artifact}"
-    )
-    checksums_response = requests.get(checksums_url, timeout=30)
-    checksums_response.raise_for_status()
-    checksums_content = checksums_response.content
-    expected_checksum = tool.checksums[checksums_artifact]
-    actual_checksum = hashlib.sha256(checksums_content).hexdigest()
-    if actual_checksum != expected_checksum:
-        raise Exception(
-            f"Failed to verify checksum of '{checksums_url}', expected '{expected_checksum}' "
-            f"but got '{actual_checksum}'"
-        )
 
-    # Get the system and machine name, mapping to the Go-style architecture names used by golangci-lint releases:
-    os_name = platform.system().lower()
-    arch_name = platform.machine().lower()
-    arch_map = {"x86_64": "amd64", "aarch64": "arm64"}
-    arch_name = arch_map.get(arch_name, arch_name)
-
-    # Extract the checksum of the artifact from the downloaded checksums:
-    artifact_name = f"golangci-lint-{tool.version}-{os_name}-{arch_name}.tar.gz"
-    artifact_pattern = re.escape(artifact_name)
-    artifact_match = re.search(
-        pattern=fr'^(?P<checksum>[0-9a-fA-F]+)\s+{artifact_pattern}$',
-        string=checksums_content.decode("utf-8"),
-        flags=re.MULTILINE,
+    # Download and check the file that contains the checksums:
+    artifact_checksum = verify_checksum(
+        url=tool.checksums_url,
+        expected_checksum=tool.checksums[tool.checksums_artifact],
+        artifact_name=tool.compressed_artifact_name,
     )
-    if artifact_match is None:
-        raise Exception(f"Failed to find checksum for artifact '{artifact_name}' inside '{checksums_url}'")
-    expected_checksum = artifact_match.group("checksum")
-    logging.info(f"Expected checksum for artifact '{artifact_name}' is '{expected_checksum}'")
 
     # Create a temporary directory for the downloaded files:
     tmp_dir = pathlib.Path(tempfile.mkdtemp())
     try:
         # Download the artifact and verify its checksum:
-        artifact_url = (
-            f"https://github.com"
-            f"/golangci/golangci-lint/releases/download/v{tool.version}"
-            f"/{artifact_name}"
-        )
-        artifact_file = tmp_dir / artifact_name
-        commands.run(
-            args=[
-                "curl",
-                "--connect-timeout", "10",
-                "--max-time", "120",
-                "--location",
-                "--silent",
-                "--fail",
-                "--output", str(artifact_file),
-                artifact_url,
-            ],
-            check=True,
-        )
-        checksum_file = tmp_dir / f"{artifact_name}.txt"
-        with open(file=checksum_file, encoding="utf-8", mode="w") as file:
-            file.write(f"{expected_checksum} {artifact_file}\n")
-        commands.run(
-            args=["sha256sum", "--check", str(checksum_file)],
-            check=True,
-        )
+        artifact_name = tool.compressed_artifact_name
+        download_artifact(url=tool.artifact_url, path=tmp_dir, filename=artifact_name)
+        verify_downloaded_artifact(path=tmp_dir, filename=artifact_name, expected_checksum=artifact_checksum)
 
-        # Extract the tarball and install the binary:
-        commands.run(
-            args=[
-                "tar",
-                "--directory", str(tmp_dir),
-                "--extract",
-                "--file", str(artifact_file),
-            ],
-            check=True,
-        )
-        bin_dir = dirs.bin()
-        if not bin_dir.exists():
-            bin_dir.mkdir(parents=True)
-        extracted_name = f"golangci-lint-{tool.version}-{os_name}-{arch_name}"
-        extracted_bin = tmp_dir / extracted_name / tool.name
-        bin_file = bin_dir / tool.name
-        shutil.move(extracted_bin, bin_file)
-        bin_stat = bin_file.stat()
-        bin_file.chmod(bin_stat.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        # Extract the artifact:
+        extract_artifact(artifact_path=str(tmp_dir / artifact_name), tmp_dir=str(tmp_dir))
+
+        # Install the artifact:
+        install_artifact(path=tmp_dir, extracted_name=tool.extracted_name, tool_name=tool.name)
     finally:
         shutil.rmtree(tmp_dir)
 
@@ -176,3 +116,96 @@ def is_installed(tool: tools.Tool) -> bool:
         f"instead of '{tool.version}'"
     )
     return False
+
+
+def verify_checksum(url: str, expected_checksum: str, artifact_name: str) -> str:
+    """
+    Verifies the checksum of the given URL.
+    """
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    content = response.content
+    actual_checksum = hashlib.sha256(content).hexdigest()
+    if actual_checksum != expected_checksum:
+        raise Exception(
+            f"Failed to verify checksum of '{url}': "
+            f"expected '{expected_checksum}', but got '{actual_checksum}'"
+        )
+
+    artifact_pattern = re.escape(artifact_name)
+    pattern = fr"(?i)^(?P<checksum>[0-9a-fA-F]{{64}})\s+[*]?{artifact_pattern}$"
+    text = content.decode("utf-8").replace("\r\n", "\n").replace("\r", "")
+    artifact_match = re.search(
+        pattern=pattern,
+        string=text,
+        flags=re.MULTILINE,
+    )
+    if artifact_match is None:
+        raise Exception(f"Failed to find checksum for artifact '{artifact_name}' inside '{url}'")
+
+    artifact_checksum = artifact_match.group("checksum")
+    logging.info(f"Expected checksum for artifact '{artifact_name}' is '{artifact_checksum}'")
+
+    return artifact_checksum
+
+
+def download_artifact(url: str, path: pathlib.Path, filename: str) -> None:
+    """
+    Downloads the artifact from the given URL to the specified path.
+    """
+    commands.run(
+        args=[
+            "curl",
+            "--connect-timeout", "10",
+            "--max-time", "120",
+            "--location",
+            "--proto", "=https",
+            "--silent",
+            "--fail",
+            "--output", str(path / filename),
+            url,
+        ],
+        check=True,
+    )
+
+
+def verify_downloaded_artifact(path: pathlib.Path, filename: str, expected_checksum: str) -> None:
+    """
+    Verifies the checksum of the downloaded artifact.
+    """
+    file_path = path / filename
+    sha256_hash = hashlib.sha256()
+    with open(file=file_path, mode="rb") as file:
+        for chunk in iter(lambda: file.read(4096), b""):
+            sha256_hash.update(chunk)
+    actual_checksum = sha256_hash.hexdigest()
+    if actual_checksum != expected_checksum:
+        raise ValueError(
+            f"Checksum mismatch for {filename}: expected {expected_checksum}, got {actual_checksum}"
+        )
+
+
+def extract_artifact(artifact_path: str, tmp_dir: str) -> None:
+    """
+    Extracts the artifact from the given artifact path into the parent directory.
+    """
+    logging.info(f"Extracting artifact from '{artifact_path}'")
+    commands.run(
+        args=["tar", "--directory", tmp_dir, "--extract", "--file", artifact_path],
+        check=True,
+    )
+
+
+def install_artifact(path: pathlib.Path, extracted_name: str, tool_name: str) -> None:
+    """
+    Installs the artifact from the given path.
+    """
+    bin_dir = dirs.bin()
+    if not bin_dir.exists():
+        bin_dir.mkdir(parents=True)
+    extracted_bin = path / extracted_name
+    bin_file = bin_dir / tool_name
+    shutil.move(extracted_bin, bin_file)
+    bin_stat = bin_file.stat()
+    bin_file.chmod(bin_stat.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    logging.info(f"Successfully installed '{tool_name}' to '{bin_file}'")

--- a/fulfillment-service/dev/tools.py
+++ b/fulfillment-service/dev/tools.py
@@ -131,3 +131,19 @@ GOLANGCI_LINT = Tool(
         "golangci-lint-{version}-checksums.txt": "9accc7943a5b4be44416a7d4efa7efb3d18c7f1919d6581cc3536e185301a2d4",
     },
 )
+
+PROTOC_GEN_CLEANAPI = Tool(
+    name="protoc-gen-cleanapi",
+    version="0.0.7",
+    github_repo="jhernand/protoc-gen-cleanapi",
+    version_command=["protoc-gen-cleanapi", "--version"],
+    version_pattern=r"^(?P<version>\S+)",
+    checksums={
+        "protoc-gen-cleanapi_{version}_checksums.txt":
+        "af25eaa156208b1c69f9459dad198dc709de9a6f1124eb8cacb429cfd2f71ffe",
+    },
+    # Override defaults - this tool uses underscores and no version in artifact name
+    checksums_artifact="protoc-gen-cleanapi_{version}_checksums.txt",
+    compressed_artifact_name="protoc-gen-cleanapi_{sys_os}_{sys_arch}.tar.gz",
+    extracted_name="protoc-gen-cleanapi",  # Binary extracted directly, not in versioned dir
+)

--- a/fulfillment-service/dev/tools.py
+++ b/fulfillment-service/dev/tools.py
@@ -13,23 +13,107 @@
 # specific language governing permissions and limitations under the License.
 #
 
+import platform
+
+# Platform detection - computed once at module load time
+_SYSTEM_OS = platform.system().lower()
+_SYSTEM_ARCH = platform.machine().lower()
+
+# Architecture name mapping from system names to Go-style names used in releases
+_ARCH_MAP = {
+    "x86_64": "amd64",
+    "aarch64": "arm64",
+    "arm64": "arm64",  # macOS reports as arm64
+    "amd64": "amd64",  # Already in target format
+}
 
 class Tool:
     def __init__(
         self,
         name: str,
-        version: str = "",
-        version_command: list[str] = [],
-        version_pattern: str = "",
-        checksums: dict[str, str] = {},
+        version: str,
+        version_pattern: str,
+        checksums: dict[str, str],
+        github_repo: str = "",
+        version_command: list[str] | None = None,
+        # Override defaults below only if tool doesn't follow standard patterns
+        checksums_artifact: str = "",
+        compressed_artifact_name: str = "",
+        extracted_name: str = "",
+        checksums_url: str = "",
+        artifact_url: str = "",
     ):
-        # Save the values:
+        """
+        Initialize a Tool definition.
+        """
+        # Validate required fields
+        if not name:
+            raise ValueError("Tool name is required")
+        if not version:
+            raise ValueError(f"Tool version is required for '{name}'")
+        if not version_pattern:
+            raise ValueError(f"Tool version_pattern is required for '{name}'")
+        if not checksums:
+            raise ValueError(f"Tool checksums are required for '{name}'")
+
+        # Get normalized architecture name
+        arch_name = _ARCH_MAP.get(_SYSTEM_ARCH)
+        if arch_name is None:
+            raise ValueError(
+                f"Unsupported architecture '{_SYSTEM_ARCH}' for tool '{name}'. "
+                f"Supported architectures: {', '.join(_ARCH_MAP.keys())}"
+            )
+
+        # Save basic metadata
         self.name = name
         self.version = version
-        self.version_command = version_command
+        self.version_command = version_command if version_command is not None else [name, "version"]
         self.version_pattern = version_pattern
+        self.sys_os = _SYSTEM_OS
+        self.sys_arch = arch_name
 
-        # The keys of the checksums dictionary can reference the name or the version:
+        # Apply defaults for standard artifact naming patterns
+        if not checksums_artifact:
+            checksums_artifact = "{name}-{version}-checksums.txt"
+        if not compressed_artifact_name:
+            compressed_artifact_name = "{name}-{version}-{sys_os}-{sys_arch}.tar.gz"
+        if not extracted_name:
+            extracted_name = "{name}-{version}-{sys_os}-{sys_arch}/{name}"
+
+        # Apply GitHub release URL pattern if github_repo is provided
+        if github_repo and not checksums_url:
+            checksums_url = f"https://github.com/{github_repo}/releases/download/v{{version}}/{{checksums_artifact}}"
+        if github_repo and not artifact_url:
+            artifact_url = f"https://github.com/{github_repo}/releases/download/v{{version}}/{{artifact_name}}"
+
+        # Format all template strings
+        self.checksums_artifact = checksums_artifact.format(name=name, version=version)
+        self.compressed_artifact_name = compressed_artifact_name.format(
+            name=name,
+            version=version,
+            sys_os=self.sys_os,
+            sys_arch=self.sys_arch,
+        )
+        self.extracted_name = extracted_name.format(
+            name=name,
+            version=version,
+            sys_os=self.sys_os,
+            sys_arch=self.sys_arch,
+        )
+        self.checksums_url = checksums_url.format(
+            version=version,
+            checksums_artifact=self.checksums_artifact,
+        ) if checksums_url else ""
+        self.artifact_url = artifact_url.format(
+            version=version,
+            artifact_name=self.compressed_artifact_name,
+        ) if artifact_url else ""
+
+        if not self.checksums_url or not self.artifact_url:
+            raise ValueError(
+                f"Tool '{name}' requires 'github_repo', or explicit 'checksums_url' and 'artifact_url'"
+            )
+        # Process checksums dictionary (keys can reference name/version placeholders)
         self.checksums = {}
         for artifact_name, artifact_checksum in checksums.items():
             artifact_name = artifact_name.format(
@@ -41,7 +125,7 @@ class Tool:
 GOLANGCI_LINT = Tool(
     name="golangci-lint",
     version="2.12.2",
-    version_command=["golangci-lint", "version"],
+    github_repo="golangci/golangci-lint",
     version_pattern=r"^golangci-lint has version (?P<version>\S+) built",
     checksums={
         "golangci-lint-{version}-checksums.txt": "9accc7943a5b4be44416a7d4efa7efb3d18c7f1919d6581cc3536e185301a2d4",


### PR DESCRIPTION
The [protoc-gen-cleanapi](https://github.com/jhernand/protoc-gen-cleanapi) tool will be used to generate public protos from the private protos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated installation support for Protoc Gen CleanAPI alongside GolangCI-Lint.
  * Added platform-aware artifact selection for supported operating systems and architectures.
  * Added customizable release package handling for development tools.

* **Improvements**
  * Standardized downloading, checksum verification, extraction, and installation.
  * Improved setup reliability with secure HTTPS downloads and more flexible checksum parsing.
  * Simplified configuration for adding and managing development tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->