### PR TITLE
OSAC-3891: Add missing idp url override when installing osac

### DIFF
--- a/osac-installer/Makefile
+++ b/osac-installer/Makefile
@@ -93,6 +93,7 @@ install-osac: helm-deps install-secrets check-postgres ## Phase 3: Install OSAC
 		--set service.externalHostname=fulfillment-api-$(INSTALLER_NAMESPACE).$(DOMAIN) \
 		--set service.internalHostname=fulfillment-internal-api-$(INSTALLER_NAMESPACE).$(DOMAIN) \
 		--set service.auth.issuerUrl=https://keycloak-keycloak.$(DOMAIN)/realms/osac \
+		--set service.idp.url=https://keycloak-keycloak.$(DOMAIN) \
 		$(EXTRA_HELM_ARGS) \
 		--timeout 40m --wait
 


### PR DESCRIPTION
In the event a custom domain is used, the IdP url
needs to be overridden with this domain as well.

Updates the helm install command in the makefile
to pass in the arg to idp.url.