### PR TITLE
OSAC-3279: add CSI driver identity to OPA policy for the private Volume API

### DIFF
--- a/fulfillment-service/internal/auth/grpc_authz_interceptor_test.go
+++ b/fulfillment-service/internal/auth/grpc_authz_interceptor_test.go
@@ -545,16 +545,25 @@ var _ = Describe("Rego authorization interceptor", func() {
 		)
 
 		// The CSI driver authenticates as a per-tenant Keycloak client
-		// 'osac-csi-<tenant>', so its service-account username shares the
-		// 'service-account-osac-csi' prefix and its token carries the tenant's
-		// organization claim (OSAC-3279).
+		// 'osac-csi-<tenant>' whose service account is granted the dedicated
+		// 'osac-csi' realm role. Authorization keys on that role - assigned only
+		// by a realm administrator - not on the username, so an ordinary user
+		// cannot obtain CSI permissions by choosing a matching username
+		// (OSAC-3279). The token also carries the tenant's organization claim,
+		// which the application layer uses to scope volumes to that tenant.
+		createCSIToken := func() *jwt.Token {
+			return createKeycloakServiceAccountToken("osac-csi-acme", jwt.MapClaims{
+				"organization": []any{"acme"},
+				"realm_access": map[string]any{
+					"roles": []any{"osac-csi"},
+				},
+			})
+		}
+
 		DescribeTable(
 			"Allows the CSI service account on the permitted private Volume methods",
 			func(ctx context.Context, method string) {
-				token := createKeycloakServiceAccountToken("osac-csi-acme", jwt.MapClaims{
-					"organization": []any{"acme"},
-				})
-				ctx = ContextWithToken(ctx, token)
+				ctx = ContextWithToken(ctx, createCSIToken())
 				handled := false
 				_, err := interceptor.UnaryServer(
 					ctx,
@@ -586,10 +595,7 @@ var _ = Describe("Rego authorization interceptor", func() {
 		DescribeTable(
 			"Denies the CSI service account outside the permitted Volume methods",
 			func(ctx context.Context, method string) {
-				token := createKeycloakServiceAccountToken("osac-csi-acme", jwt.MapClaims{
-					"organization": []any{"acme"},
-				})
-				ctx = ContextWithToken(ctx, token)
+				ctx = ContextWithToken(ctx, createCSIToken())
 				handled := false
 				_, err := interceptor.UnaryServer(
 					ctx,
@@ -619,6 +625,45 @@ var _ = Describe("Rego authorization interceptor", func() {
 			// even for methods a normal client could call.
 			Entry("Public Clusters Create", "/osac.public.v1.Clusters/Create"),
 			Entry("Public Clusters Get", "/osac.public.v1.Clusters/Get"),
+		)
+
+		// Authorization must key on the 'osac-csi' realm role, not the username.
+		// An identity that merely looks like a CSI service account - whether a
+		// regular user with a CSI-shaped username or a service account without the
+		// role - must be denied.
+		DescribeTable(
+			"Denies identities that lack the osac-csi realm role on the Volume API",
+			func(ctx context.Context, token *jwt.Token) {
+				ctx = ContextWithToken(ctx, token)
+				handled := false
+				_, err := interceptor.UnaryServer(
+					ctx,
+					nil,
+					&grpc.UnaryServerInfo{
+						FullMethod: "/osac.private.v1.Volumes/Create",
+					},
+					func(ctx context.Context, req any) (any, error) {
+						handled = true
+						return nil, nil
+					},
+				)
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+				Expect(status.Message()).To(Equal("permission denied"))
+				Expect(handled).To(BeFalse())
+			},
+			Entry(
+				"Regular user with a CSI-shaped username but no role",
+				createKeycloakUserToken("acme", "service-account-osac-csi-acme", nil),
+			),
+			Entry(
+				"Service account with a CSI-shaped name but no role",
+				createKeycloakServiceAccountToken("osac-csi-acme", jwt.MapClaims{
+					"organization": []any{"acme"},
+				}),
+			),
 		)
 
 		DescribeTable(

--- a/fulfillment-service/internal/auth/grpc_authz_interceptor_test.go
+++ b/fulfillment-service/internal/auth/grpc_authz_interceptor_test.go
@@ -544,6 +544,83 @@ var _ = Describe("Rego authorization interceptor", func() {
 			),
 		)
 
+		// The CSI driver authenticates as a per-tenant Keycloak client
+		// 'osac-csi-<tenant>', so its service-account username shares the
+		// 'service-account-osac-csi' prefix and its token carries the tenant's
+		// organization claim (OSAC-3279).
+		DescribeTable(
+			"Allows the CSI service account on the permitted private Volume methods",
+			func(ctx context.Context, method string) {
+				token := createKeycloakServiceAccountToken("osac-csi-acme", jwt.MapClaims{
+					"organization": []any{"acme"},
+				})
+				ctx = ContextWithToken(ctx, token)
+				handled := false
+				_, err := interceptor.UnaryServer(
+					ctx,
+					nil,
+					&grpc.UnaryServerInfo{
+						FullMethod: method,
+					},
+					func(ctx context.Context, req any) (any, error) {
+						subject := SubjectFromContext(ctx)
+						Expect(subject.User).To(Equal("service-account-osac-csi-acme"))
+						// The CSI identity is tenant-scoped, never universal: the
+						// application layer confines volumes to this tenant.
+						Expect(subject.Tenants.Universal()).To(BeFalse())
+						Expect(subject.Tenants.Finite()).To(BeTrue())
+						Expect(subject.Tenants.Inclusions()).To(ConsistOf("acme"))
+						handled = true
+						return nil, nil
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(handled).To(BeTrue())
+			},
+			Entry("Create", "/osac.private.v1.Volumes/Create"),
+			Entry("Get", "/osac.private.v1.Volumes/Get"),
+			Entry("Delete", "/osac.private.v1.Volumes/Delete"),
+			Entry("List", "/osac.private.v1.Volumes/List"),
+		)
+
+		DescribeTable(
+			"Denies the CSI service account outside the permitted Volume methods",
+			func(ctx context.Context, method string) {
+				token := createKeycloakServiceAccountToken("osac-csi-acme", jwt.MapClaims{
+					"organization": []any{"acme"},
+				})
+				ctx = ContextWithToken(ctx, token)
+				handled := false
+				_, err := interceptor.UnaryServer(
+					ctx,
+					nil,
+					&grpc.UnaryServerInfo{
+						FullMethod: method,
+					},
+					func(ctx context.Context, req any) (any, error) {
+						handled = true
+						return nil, nil
+					},
+				)
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
+				Expect(status.Message()).To(Equal("permission denied"))
+				Expect(handled).To(BeFalse())
+			},
+			// Volume methods NOT granted to the CSI identity:
+			Entry("Volumes Update", "/osac.private.v1.Volumes/Update"),
+			Entry("Volumes Signal", "/osac.private.v1.Volumes/Signal"),
+			// Other private services must be denied:
+			Entry("Hubs Create", "/osac.private.v1.Hubs/Create"),
+			Entry("StorageBackends Create", "/osac.private.v1.StorageBackends/Create"),
+			// The CSI identity is not a general client: the public API is denied
+			// even for methods a normal client could call.
+			Entry("Public Clusters Create", "/osac.public.v1.Clusters/Create"),
+			Entry("Public Clusters Get", "/osac.public.v1.Clusters/Get"),
+		)
+
 		DescribeTable(
 			"Allows Keycloak users on the public API",
 			func(ctx context.Context, tenant, name string) {

--- a/fulfillment-service/internal/auth/policies/authz.rego
+++ b/fulfillment-service/internal/auth/policies/authz.rego
@@ -140,12 +140,24 @@ is_tenant_idp_manager if {
   role in tenant_idp_manager_roles
 }
 
-# Check if an account is a regular client (no admin, tenant management roles):
+# CSI driver identity. The OSAC CSI driver authenticates as a per-tenant Keycloak client
+# named "osac-csi-<tenant>", so its service-account username shares the
+# "service-account-osac-csi" prefix. It is a restricted identity - not an admin and not a
+# general client: it may only manage volumes through the private Volume API. Tenant scoping
+# is enforced by the application layer (generic server) via the identity's organization
+# claim; this policy only gates the method set.
+default is_csi = false
+is_csi if {
+  startswith(subject_name, "service-account-osac-csi")
+}
+
+# Check if an account is a regular client (no admin, tenant management, or CSI roles):
 default is_client = false
 is_client if {
   not is_admin
   not is_tenant_admin
   not is_tenant_idp_manager
+  not is_csi
 }
 
 # Check if account has client-level permissions (clients, tenant admins, or IdP managers):
@@ -339,6 +351,20 @@ allow if {
 # Allow everything to admins:
 allow if {
   is_admin
+}
+
+# The CSI driver identity may only manage volumes through the private Volume API
+# (OSAC-3279). Tenant scoping is enforced by the application layer via the identity's
+# organization claim; this rule only gates the permitted method set. Publish/unpublish on
+# the internal Storage Control Plane API is handled separately (OSAC-3278).
+allow if {
+  is_csi
+  grpc_method in {
+    "/osac.private.v1.Volumes/Create",
+    "/osac.private.v1.Volumes/Get",
+    "/osac.private.v1.Volumes/Delete",
+    "/osac.private.v1.Volumes/List",
+  }
 }
 
 # Project authorization

--- a/fulfillment-service/internal/auth/policies/authz.rego
+++ b/fulfillment-service/internal/auth/policies/authz.rego
@@ -140,15 +140,24 @@ is_tenant_idp_manager if {
   role in tenant_idp_manager_roles
 }
 
-# CSI driver identity. The OSAC CSI driver authenticates as a per-tenant Keycloak client
-# named "osac-csi-<tenant>", so its service-account username shares the
-# "service-account-osac-csi" prefix. It is a restricted identity - not an admin and not a
-# general client: it may only manage volumes through the private Volume API. Tenant scoping
-# is enforced by the application layer (generic server) via the identity's organization
-# claim; this policy only gates the method set.
+# CSI driver realm roles. The OSAC CSI driver authenticates as a per-tenant Keycloak client
+# ("osac-csi-<tenant>") whose service account is granted the "osac-csi" realm role.
+csi_client_roles := {
+  "osac-csi",
+}
+
+# CSI driver identity. Authorization keys on the "osac-csi" realm role - assigned only by a
+# realm administrator - rather than on the username. Keying on the username would be unsafe:
+# users and service accounts share the same username field, so an ordinary user could obtain
+# CSI permissions by choosing a matching username. The CSI driver is a restricted identity -
+# not an admin and not a general client: it may only manage volumes through the private
+# Volume API. Tenant scoping is enforced by the application layer (generic server) via the
+# identity's organization claim; this policy only gates the method set.
 default is_csi = false
 is_csi if {
-  startswith(subject_name, "service-account-osac-csi")
+  input.auth.identity.authnMethod == "jwt"
+  some role in subject_realm_roles
+  role in csi_client_roles
 }
 
 # Check if an account is a regular client (no admin, tenant management, or CSI roles):


### PR DESCRIPTION
## Summary

Adds a dedicated, least-privilege OPA identity for the OSAC CSI driver in `fulfillment-service/internal/auth/policies/authz.rego`, permitting it to call only the private Volume API (`osac.private.v1.Volumes` Create, Get, Delete, List) and nothing else. Scope of [OSAC-3279](https://redhat.atlassian.net/browse/OSAC-3279) was narrowed to this private-API surface; the internal Storage Control Plane API (Publish/Unpublish) authorization is deferred to OSAC-3278, which will introduce that API.

## Why

Without a CSI identity in the policy, a CSI service account falls through to the generic client rules and is granted the entire public API client allowlist (Clusters, ComputeInstances, and more). That is far broader than the driver needs and breaks least-privilege. This change is also a prerequisite for [OSAC-4109](https://redhat.atlassian.net/browse/OSAC-4109) (wiring the real CSI to fulfillment gRPC client): once the driver calls the internal Volume API, the server must authorize the CSI identity or every call is denied.

The driver authenticates as a per-tenant Keycloak client named `osac-csi-<tenant>`, so its service-account username shares the `service-account-osac-csi` prefix; `is_csi` matches on that prefix. The identity is excluded from `is_client` so it inherits no general client permissions, and a single `allow` rule grants it only the four private Volume methods. Tenant scoping is intentionally left to the application layer: the generic server confines each volume to the caller's tenant via the identity's `organization` claim, so the policy only gates the method set.

## Testing

All run in `fulfillment-service` on this branch (rebased on `main`):

- `uv run dev.py lint` — Go: 0 issues; proto lint: OK
- `gofmt -s -w . && git diff --exit-code` — clean
- `buf generate && git diff --exit-code` — clean (no proto change)
- `go build ./...` — OK
- `ginkgo run -r internal` — 91 suites passed

New unit tests in `internal/auth/grpc_authz_interceptor_test.go` assert the CSI identity is allowed on Volumes Create/Get/Delete/List (and is tenant-scoped, not universal), and denied on Volumes Update/Signal, other private services, and the public API.

## Ticket

[OSAC-3279](https://redhat.atlassian.net/browse/OSAC-3279)

Assisted-by: Claude Code <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added role-based authorization for CSI identities.
  * CSI identities with the required realm role can create, retrieve, delete, and list private volumes.
  * CSI identities remain restricted from volume updates, signals, other private APIs, and public APIs.
  * Identities without the required role are denied access, even when using CSI-like usernames or service-account names.

* **Tests**
  * Added coverage for permitted and denied CSI authorization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->