### PR TITLE
OSAC-3617: UI chart - change default api url to internal

### DIFF
--- a/osac-installer/charts/osac/values.schema.json
+++ b/osac-installer/charts/osac/values.schema.json
@@ -994,7 +994,7 @@
                 "url": {
                   "type": "string",
                   "description": "Fulfillment API URL",
-                  "default": "https://fulfillment-api:8000"
+                  "default": "https://fulfillment-internal-api:8001"
                 },
                 "certs": {
                   "type": "object",

--- a/osac-installer/charts/osac/values.yaml
+++ b/osac-installer/charts/osac/values.yaml
@@ -201,7 +201,7 @@ ui:
   externalHostname: ""
   api:
     fulfillment:
-      url: https://fulfillment-api:8000
+      url: https://fulfillment-internal-api:8001
       certs:
         caBundle:
           configMap: ca-bundle


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the UI fulfillment service connection to use the correct internal endpoint and port, improving reliable communication within the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->