### PR TITLE
OSAC-1719: Add per-service enablement pattern (OSAC-3046)

### DIFF
--- a/osac-installer/charts/osac/VALUES_PATTERN.md
+++ b/osac-installer/charts/osac/VALUES_PATTERN.md
@@ -14,7 +14,7 @@ Subcharts contain template helpers that compute their configuration from high-le
 
 ### Parent Chart (`osac-installer/charts/osac`)
 
-**values.yaml**: Defines high-level properties under `global`:
+**values.yaml**: Defines high-level properties under `global` (example showing selective enablement):
 
 ```yaml
 global:
@@ -24,10 +24,12 @@ global:
     vmaas:
       enabled: true
     bmaas:
-      enabled: false
+      enabled: true
     maas:
-      enabled: false
+      enabled: true
 ```
+
+**Default behavior**: All four services default to `enabled: true` for backward compatibility. Set to `false` to disable specific services.
 
 ### Subchart (`osac-operator/charts/operator`)
 
@@ -39,10 +41,12 @@ global:
 {{- .Values.controllers.clusterOrder -}}
 {{- else -}}
 {{- $caasEnabled := true -}}
+{{- if .Values.global -}}
 {{- if .Values.global.services -}}
 {{- if .Values.global.services.caas -}}
 {{- if hasKey .Values.global.services.caas "enabled" -}}
 {{- $caasEnabled = .Values.global.services.caas.enabled -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
@@ -53,6 +57,7 @@ global:
 
 **Key implementation details:**
 - Initialize fallback to `true` (backward compatibility)
+- Guard `.Values.global` access with nil check (subchart can be linted standalone)
 - Use `hasKey` to check if `enabled` key exists (preserves explicit `false` values)
 - Never use `| default true` pattern (treats `false` as falsy)
 - **Both** subchart and parent chart `values.yaml` must not define defaults for computed properties

--- a/osac-installer/charts/osac/VALUES_PATTERN.md
+++ b/osac-installer/charts/osac/VALUES_PATTERN.md
@@ -38,16 +38,24 @@ global:
 {{- if .Values.controllers.clusterOrder | kindIs "invalid" | not -}}
 {{- .Values.controllers.clusterOrder -}}
 {{- else -}}
-{{- $caasEnabled := false -}}
+{{- $caasEnabled := true -}}
 {{- if .Values.global.services -}}
 {{- if .Values.global.services.caas -}}
-{{- $caasEnabled = .Values.global.services.caas.enabled | default true -}}
+{{- if hasKey .Values.global.services.caas "enabled" -}}
+{{- $caasEnabled = .Values.global.services.caas.enabled -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- $caasEnabled -}}
 {{- end -}}
 {{- end }}
 ```
+
+**Key implementation details:**
+- Initialize fallback to `true` (backward compatibility)
+- Use `hasKey` to check if `enabled` key exists (preserves explicit `false` values)
+- Never use `| default true` pattern (treats `false` as falsy)
+- Subchart `values.yaml` must not define defaults for computed controllers
 
 **templates/deployment.yaml**: Uses the helper instead of reading `.Values` directly:
 

--- a/osac-installer/charts/osac/VALUES_PATTERN.md
+++ b/osac-installer/charts/osac/VALUES_PATTERN.md
@@ -36,26 +36,32 @@ global:
 **templates/_helpers.tpl**: Computes values from `global` with local override support:
 
 ```yaml
-{{- define "osac-operator.controller.clusterOrder" -}}
-{{- if .Values.controllers.clusterOrder | kindIs "invalid" | not -}}
-{{- .Values.controllers.clusterOrder -}}
+{{- define "osac-operator.controllerEnabled" -}}
+{{- $ctx := index . 0 -}}
+{{- $ctrlKey := index . 1 -}}
+{{- $svcKey := index . 2 -}}
+{{- $ctrlVal := index $ctx.Values.controllers $ctrlKey -}}
+{{- if $ctrlVal | kindIs "invalid" | not -}}
+{{- $ctrlVal -}}
 {{- else -}}
-{{- $caasEnabled := true -}}
-{{- if .Values.global -}}
-{{- if .Values.global.services -}}
-{{- if .Values.global.services.caas -}}
-{{- if hasKey .Values.global.services.caas "enabled" -}}
-{{- $caasEnabled = .Values.global.services.caas.enabled -}}
+{{- $enabled := true -}}
+{{- if $ctx.Values.global -}}
+{{- if $ctx.Values.global.services -}}
+{{- $svc := index $ctx.Values.global.services $svcKey -}}
+{{- if $svc -}}
+{{- if hasKey $svc "enabled" -}}
+{{- $enabled = $svc.enabled -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
-{{- $caasEnabled -}}
+{{- $enabled -}}
 {{- end -}}
 {{- end }}
 ```
 
 **Key implementation details:**
+- Takes three parameters: context, controller key, service key (eliminates code duplication)
 - Initialize fallback to `true` (backward compatibility)
 - Guard `.Values.global` access with nil check (subchart can be linted standalone)
 - Use `hasKey` to check if `enabled` key exists (preserves explicit `false` values)
@@ -67,7 +73,11 @@ global:
 
 ```yaml
 - name: OSAC_ENABLE_CLUSTER_CONTROLLER
-  value: {{ include "osac-operator.controller.clusterOrder" . | quote }}
+  value: {{ include "osac-operator.controllerEnabled" (list . "clusterOrder" "caas") | quote }}
+- name: OSAC_ENABLE_COMPUTE_INSTANCE_CONTROLLER
+  value: {{ include "osac-operator.controllerEnabled" (list . "computeInstance" "vmaas") | quote }}
+- name: OSAC_ENABLE_BAREMETAL_INSTANCE_CONTROLLER
+  value: {{ include "osac-operator.controllerEnabled" (list . "bareMetalInstance" "bmaas") | quote }}
 ```
 
 ## User Experience

--- a/osac-installer/charts/osac/VALUES_PATTERN.md
+++ b/osac-installer/charts/osac/VALUES_PATTERN.md
@@ -55,7 +55,8 @@ global:
 - Initialize fallback to `true` (backward compatibility)
 - Use `hasKey` to check if `enabled` key exists (preserves explicit `false` values)
 - Never use `| default true` pattern (treats `false` as falsy)
-- Subchart `values.yaml` must not define defaults for computed controllers
+- **Both** subchart and parent chart `values.yaml` must not define defaults for computed properties
+  (otherwise Helm merges them and the helpers never reach the `global` computation branch)
 
 **templates/deployment.yaml**: Uses the helper instead of reading `.Values` directly:
 

--- a/osac-installer/charts/osac/VALUES_PATTERN.md
+++ b/osac-installer/charts/osac/VALUES_PATTERN.md
@@ -1,0 +1,121 @@
+# OSAC Chart Values Pattern
+
+This document describes the pattern for transforming high-level configuration into detailed subchart values.
+
+## Overview
+
+The OSAC parent chart supports both:
+1. **High-level properties** for convenience (e.g., `global.services.*.enabled`)
+2. **Detailed subchart values** for fine-grained control (e.g., `operator.controllers.clusterOrder`)
+
+Subcharts contain template helpers that compute their configuration from high-level properties, while still allowing direct value overrides.
+
+## Pattern
+
+### Parent Chart (`osac-installer/charts/osac`)
+
+**values.yaml**: Defines high-level properties under `global`:
+
+```yaml
+global:
+  services:
+    caas:
+      enabled: true
+    vmaas:
+      enabled: true
+    bmaas:
+      enabled: false
+    maas:
+      enabled: false
+```
+
+### Subchart (`osac-operator/charts/operator`)
+
+**templates/_helpers.tpl**: Computes values from `global` with local override support:
+
+```yaml
+{{- define "osac-operator.controller.clusterOrder" -}}
+{{- if .Values.controllers.clusterOrder | kindIs "invalid" | not -}}
+{{- .Values.controllers.clusterOrder -}}
+{{- else -}}
+{{- $caasEnabled := false -}}
+{{- if .Values.global.services -}}
+{{- if .Values.global.services.caas -}}
+{{- $caasEnabled = .Values.global.services.caas.enabled | default true -}}
+{{- end -}}
+{{- end -}}
+{{- $caasEnabled -}}
+{{- end -}}
+{{- end }}
+```
+
+**templates/deployment.yaml**: Uses the helper instead of reading `.Values` directly:
+
+```yaml
+- name: OSAC_ENABLE_CLUSTER_CONTROLLER
+  value: {{ include "osac-operator.controller.clusterOrder" . | quote }}
+```
+
+## User Experience
+
+### Scenario 1: High-level configuration (common case)
+
+User sets service enablement:
+
+```yaml
+global:
+  services:
+    caas:
+      enabled: false
+    vmaas:
+      enabled: true
+    bmaas:
+      enabled: false
+    maas:
+      enabled: false
+```
+
+**Result**: 
+- `operator.controllers.computeInstance: true`
+- `operator.controllers.clusterOrder: false`
+
+### Scenario 2: Fine-grained override
+
+User overrides a specific controller:
+
+```yaml
+global:
+  services:
+    caas:
+      enabled: false
+    vmaas:
+      enabled: true
+
+operator:
+  controllers:
+    clusterOrder: true  # Override: enable even though caas is disabled
+```
+
+**Result**:
+- `operator.controllers.computeInstance: true` (computed from global.services.vmaas.enabled)
+- `operator.controllers.clusterOrder: true` (explicit override)
+
+## Implementation Checklist
+
+When adding a new high-level property:
+
+1. [ ] Add property to parent chart `values.yaml` under `global`
+2. [ ] Document the property and which subchart values it affects
+3. [ ] In affected subchart `_helpers.tpl`, create a helper that:
+   - Checks if local value is explicitly set (`kindIs "invalid" | not`)
+   - If set, uses local value
+   - Otherwise, computes from `global` property
+4. [ ] Update subchart templates to use the helper
+5. [ ] Test both high-level and override scenarios
+
+## Design Principles
+
+1. **Computation lives with consumption**: Subcharts compute their own values from `global`, not the parent
+2. **Overrides always win**: Explicit subchart values take precedence over computed values
+3. **Backwards compatible**: Existing deployments with detailed values continue to work
+4. **Clear relationships**: Document which high-level properties affect which subchart values

--- a/osac-installer/charts/osac/values.schema.json
+++ b/osac-installer/charts/osac/values.schema.json
@@ -4,6 +4,62 @@
   "description": "Configuration values for Open Sovereign AI Cloud deployment",
   "type": "object",
   "properties": {
+    "global": {
+      "type": "object",
+      "description": "Global configuration values shared across all subcharts",
+      "properties": {
+        "services": {
+          "type": "object",
+          "description": "Per-service enablement flags (CaaS, VMaaS, BMaaS, MaaS)",
+          "properties": {
+            "caas": {
+              "type": "object",
+              "description": "CaaS (Cluster as a Service) enablement",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable CaaS service (ClusterOrder controller and API endpoints)",
+                  "default": true
+                }
+              }
+            },
+            "vmaas": {
+              "type": "object",
+              "description": "VMaaS (VM as a Service) enablement",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable VMaaS service (ComputeInstance controller and API endpoints)",
+                  "default": true
+                }
+              }
+            },
+            "bmaas": {
+              "type": "object",
+              "description": "BMaaS (Bare Metal as a Service) enablement",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable BMaaS service (BareMetalInstance controller and API endpoints)",
+                  "default": true
+                }
+              }
+            },
+            "maas": {
+              "type": "object",
+              "description": "MaaS (Model as a Service) enablement",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable MaaS service (future: model serving API endpoints)",
+                  "default": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "cliImage": {
       "type": "string",
       "description": "Default OpenShift CLI image used by hook jobs"

--- a/osac-installer/charts/osac/values.schema.json
+++ b/osac-installer/charts/osac/values.schema.json
@@ -1717,5 +1717,104 @@
       }
     }
   },
-  "required": []
+  "required": [],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "global": {
+            "properties": {
+              "services": {
+                "properties": {
+                  "caas": {
+                    "properties": {
+                      "enabled": {
+                        "const": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "global": {
+            "properties": {
+              "services": {
+                "anyOf": [
+                  {
+                    "properties": {
+                      "vmaas": {
+                        "properties": {
+                          "enabled": {
+                            "const": true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "bmaas": {
+                        "properties": {
+                          "enabled": {
+                            "const": true
+                          }
+                        }
+                      }
+                    }
+                  }
+                ],
+                "$comment": "CaaS requires at least one of VMaaS or BMaaS to be enabled. CaaS provisions clusters that need compute nodes from either VMaaS or BMaaS."
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "global": {
+            "properties": {
+              "services": {
+                "properties": {
+                  "maas": {
+                    "properties": {
+                      "enabled": {
+                        "const": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "global": {
+            "properties": {
+              "services": {
+                "properties": {
+                  "caas": {
+                    "properties": {
+                      "enabled": {
+                        "const": true
+                      }
+                    },
+                    "$comment": "MaaS requires CaaS to be enabled. MaaS serves models on clusters provisioned by CaaS."
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
 }

--- a/osac-installer/charts/osac/values.yaml
+++ b/osac-installer/charts/osac/values.yaml
@@ -1,6 +1,19 @@
 # Open Sovereign AI Cloud - Unified Helm Values
 # This values file configures all OSAC components via the umbrella chart.
 
+# Per-service enablement flags
+# All default to true for backward compatibility
+global:
+  services:
+    caas:
+      enabled: true
+    vmaas:
+      enabled: true
+    bmaas:
+      enabled: true
+    maas:
+      enabled: true
+
 cliImage: quay.io/openshift/origin-cli:4.20.0
 
 # Shared PostgreSQL host for the db-init hook.

--- a/osac-installer/charts/osac/values.yaml
+++ b/osac-installer/charts/osac/values.yaml
@@ -56,11 +56,14 @@ operator:
     serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
   controllers:
-    clusterOrder: true
-    computeInstance: true
+    # clusterOrder, computeInstance, and bareMetalInstance are computed from
+    # global.services.*.enabled by default (see operator subchart _helpers.tpl).
+    # Set explicitly here to override the computed value.
+    # clusterOrder: true
+    # computeInstance: true
+    # bareMetalInstance: true
     tenant: true
     networking: true
-    bareMetalInstance: true
     storage: true
   configSecret:
     name: "osac-config"

--- a/osac-installer/values/bmaas-ci/instance.yaml
+++ b/osac-installer/values/bmaas-ci/instance.yaml
@@ -29,10 +29,13 @@ operator:
     serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
   controllers:
+    clusterOrder: false
+    computeInstance: false
     tenant: true
     networking: true
     networkingProvisioning: false
     storage: true
+    bareMetalInstance: true
   hubAccess:
     enabled: true
   tenants:

--- a/osac-installer/values/bmaas-ci/instance.yaml
+++ b/osac-installer/values/bmaas-ci/instance.yaml
@@ -1,5 +1,17 @@
 # BMaaS CI environment -- instance values for osac chart.
 
+# --- Service Enablement ---
+global:
+  services:
+    caas:
+      enabled: false
+    vmaas:
+      enabled: false
+    bmaas:
+      enabled: true
+    maas:
+      enabled: false
+
 # --- Operator ---
 operator:
   image:
@@ -17,13 +29,10 @@ operator:
     serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
   controllers:
-    clusterOrder: false
-    computeInstance: false
     tenant: true
     networking: true
     networkingProvisioning: false
     storage: true
-    bareMetalInstance: true
   hubAccess:
     enabled: true
   tenants:

--- a/osac-installer/values/caas-ci/instance.yaml
+++ b/osac-installer/values/caas-ci/instance.yaml
@@ -29,6 +29,8 @@ operator:
     serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
   controllers:
+    clusterOrder: true
+    computeInstance: false
     tenant: true
     networking: true
     storage: true

--- a/osac-installer/values/caas-ci/instance.yaml
+++ b/osac-installer/values/caas-ci/instance.yaml
@@ -6,7 +6,7 @@ global:
     caas:
       enabled: true
     vmaas:
-      enabled: false
+      enabled: true
     bmaas:
       enabled: false
     maas:

--- a/osac-installer/values/caas-ci/instance.yaml
+++ b/osac-installer/values/caas-ci/instance.yaml
@@ -1,5 +1,17 @@
 # CaaS CI environment -- instance values for osac chart.
 
+# --- Service Enablement ---
+global:
+  services:
+    caas:
+      enabled: true
+    vmaas:
+      enabled: false
+    bmaas:
+      enabled: false
+    maas:
+      enabled: false
+
 # --- Operator ---
 operator:
   image:
@@ -17,8 +29,6 @@ operator:
     serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
   controllers:
-    clusterOrder: true
-    computeInstance: false
     tenant: true
     networking: true
     storage: true

--- a/osac-installer/values/dev/instance.yaml
+++ b/osac-installer/values/dev/instance.yaml
@@ -1,5 +1,17 @@
 # OpenShift dev environment -- instance values for osac chart.
 
+# --- Service Enablement ---
+global:
+  services:
+    caas:
+      enabled: true
+    vmaas:
+      enabled: true
+    bmaas:
+      enabled: false
+    maas:
+      enabled: false
+
 # --- Operator ---
 operator:
   image:

--- a/osac-installer/values/full-ci/instance.yaml
+++ b/osac-installer/values/full-ci/instance.yaml
@@ -1,5 +1,17 @@
 # Full CI environment -- instance values for osac chart.
 
+# --- Service Enablement ---
+global:
+  services:
+    caas:
+      enabled: true
+    vmaas:
+      enabled: true
+    bmaas:
+      enabled: true
+    maas:
+      enabled: true
+
 # --- Operator ---
 operator:
   image:

--- a/osac-installer/values/vmaas-ci/instance.yaml
+++ b/osac-installer/values/vmaas-ci/instance.yaml
@@ -33,6 +33,8 @@ operator:
     serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
   controllers:
+    clusterOrder: false
+    computeInstance: true
     tenant: true
     networking: true
     storage: true

--- a/osac-installer/values/vmaas-ci/instance.yaml
+++ b/osac-installer/values/vmaas-ci/instance.yaml
@@ -1,5 +1,17 @@
 # VMaaS CI environment -- instance values for osac chart.
 
+# --- Service Enablement ---
+global:
+  services:
+    caas:
+      enabled: false
+    vmaas:
+      enabled: true
+    bmaas:
+      enabled: false
+    maas:
+      enabled: false
+
 # --- CSI Driver ---
 csiDriver:
   enabled: true
@@ -21,8 +33,6 @@ operator:
     serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
   controllers:
-    clusterOrder: false
-    computeInstance: true
     tenant: true
     networking: true
     storage: true

--- a/osac-operator/charts/operator/templates/_helpers.tpl
+++ b/osac-operator/charts/operator/templates/_helpers.tpl
@@ -68,3 +68,54 @@ Service account name
 {{- include "osac-operator.fullname" . }}
 {{- end }}
 {{- end }}
+
+{{/*
+Enable clusterOrder controller based on global.services.caas.enabled or local override
+*/}}
+{{- define "osac-operator.controller.clusterOrder" -}}
+{{- if .Values.controllers.clusterOrder | kindIs "invalid" | not -}}
+{{- .Values.controllers.clusterOrder -}}
+{{- else -}}
+{{- $caasEnabled := false -}}
+{{- if .Values.global.services -}}
+{{- if .Values.global.services.caas -}}
+{{- $caasEnabled = .Values.global.services.caas.enabled | default true -}}
+{{- end -}}
+{{- end -}}
+{{- $caasEnabled -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Enable computeInstance controller based on global.services.vmaas.enabled or local override
+*/}}
+{{- define "osac-operator.controller.computeInstance" -}}
+{{- if .Values.controllers.computeInstance | kindIs "invalid" | not -}}
+{{- .Values.controllers.computeInstance -}}
+{{- else -}}
+{{- $vmaasEnabled := false -}}
+{{- if .Values.global.services -}}
+{{- if .Values.global.services.vmaas -}}
+{{- $vmaasEnabled = .Values.global.services.vmaas.enabled | default true -}}
+{{- end -}}
+{{- end -}}
+{{- $vmaasEnabled -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Enable bareMetalInstance controller based on global.services.bmaas.enabled or local override
+*/}}
+{{- define "osac-operator.controller.bareMetalInstance" -}}
+{{- if .Values.controllers.bareMetalInstance | kindIs "invalid" | not -}}
+{{- .Values.controllers.bareMetalInstance -}}
+{{- else -}}
+{{- $bmaasEnabled := false -}}
+{{- if .Values.global.services -}}
+{{- if .Values.global.services.bmaas -}}
+{{- $bmaasEnabled = .Values.global.services.bmaas.enabled | default true -}}
+{{- end -}}
+{{- end -}}
+{{- $bmaasEnabled -}}
+{{- end -}}
+{{- end }}

--- a/osac-operator/charts/operator/templates/_helpers.tpl
+++ b/osac-operator/charts/operator/templates/_helpers.tpl
@@ -70,7 +70,8 @@ Service account name
 {{- end }}
 
 {{/*
-Enable clusterOrder controller based on global.services.caas.enabled or local override
+Enable clusterOrder controller based on global.services.caas.enabled or local override.
+Honors explicit local value if set, otherwise computes from global.services.caas.enabled.
 */}}
 {{- define "osac-operator.controller.clusterOrder" -}}
 {{- if .Values.controllers.clusterOrder | kindIs "invalid" | not -}}
@@ -91,7 +92,8 @@ Enable clusterOrder controller based on global.services.caas.enabled or local ov
 {{- end }}
 
 {{/*
-Enable computeInstance controller based on global.services.vmaas.enabled or local override
+Enable computeInstance controller based on global.services.vmaas.enabled or local override.
+Honors explicit local value if set, otherwise computes from global.services.vmaas.enabled.
 */}}
 {{- define "osac-operator.controller.computeInstance" -}}
 {{- if .Values.controllers.computeInstance | kindIs "invalid" | not -}}
@@ -112,7 +114,8 @@ Enable computeInstance controller based on global.services.vmaas.enabled or loca
 {{- end }}
 
 {{/*
-Enable bareMetalInstance controller based on global.services.bmaas.enabled or local override
+Enable bareMetalInstance controller based on global.services.bmaas.enabled or local override.
+Honors explicit local value if set, otherwise computes from global.services.bmaas.enabled.
 */}}
 {{- define "osac-operator.controller.bareMetalInstance" -}}
 {{- if .Values.controllers.bareMetalInstance | kindIs "invalid" | not -}}

--- a/osac-operator/charts/operator/templates/_helpers.tpl
+++ b/osac-operator/charts/operator/templates/_helpers.tpl
@@ -77,10 +77,12 @@ Enable clusterOrder controller based on global.services.caas.enabled or local ov
 {{- .Values.controllers.clusterOrder -}}
 {{- else -}}
 {{- $caasEnabled := true -}}
+{{- if .Values.global -}}
 {{- if .Values.global.services -}}
 {{- if .Values.global.services.caas -}}
 {{- if hasKey .Values.global.services.caas "enabled" -}}
 {{- $caasEnabled = .Values.global.services.caas.enabled -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
@@ -96,10 +98,12 @@ Enable computeInstance controller based on global.services.vmaas.enabled or loca
 {{- .Values.controllers.computeInstance -}}
 {{- else -}}
 {{- $vmaasEnabled := true -}}
+{{- if .Values.global -}}
 {{- if .Values.global.services -}}
 {{- if .Values.global.services.vmaas -}}
 {{- if hasKey .Values.global.services.vmaas "enabled" -}}
 {{- $vmaasEnabled = .Values.global.services.vmaas.enabled -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
@@ -115,10 +119,12 @@ Enable bareMetalInstance controller based on global.services.bmaas.enabled or lo
 {{- .Values.controllers.bareMetalInstance -}}
 {{- else -}}
 {{- $bmaasEnabled := true -}}
+{{- if .Values.global -}}
 {{- if .Values.global.services -}}
 {{- if .Values.global.services.bmaas -}}
 {{- if hasKey .Values.global.services.bmaas "enabled" -}}
 {{- $bmaasEnabled = .Values.global.services.bmaas.enabled -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/osac-operator/charts/operator/templates/_helpers.tpl
+++ b/osac-operator/charts/operator/templates/_helpers.tpl
@@ -76,10 +76,12 @@ Enable clusterOrder controller based on global.services.caas.enabled or local ov
 {{- if .Values.controllers.clusterOrder | kindIs "invalid" | not -}}
 {{- .Values.controllers.clusterOrder -}}
 {{- else -}}
-{{- $caasEnabled := false -}}
+{{- $caasEnabled := true -}}
 {{- if .Values.global.services -}}
 {{- if .Values.global.services.caas -}}
-{{- $caasEnabled = .Values.global.services.caas.enabled | default true -}}
+{{- if hasKey .Values.global.services.caas "enabled" -}}
+{{- $caasEnabled = .Values.global.services.caas.enabled -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- $caasEnabled -}}
@@ -93,10 +95,12 @@ Enable computeInstance controller based on global.services.vmaas.enabled or loca
 {{- if .Values.controllers.computeInstance | kindIs "invalid" | not -}}
 {{- .Values.controllers.computeInstance -}}
 {{- else -}}
-{{- $vmaasEnabled := false -}}
+{{- $vmaasEnabled := true -}}
 {{- if .Values.global.services -}}
 {{- if .Values.global.services.vmaas -}}
-{{- $vmaasEnabled = .Values.global.services.vmaas.enabled | default true -}}
+{{- if hasKey .Values.global.services.vmaas "enabled" -}}
+{{- $vmaasEnabled = .Values.global.services.vmaas.enabled -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- $vmaasEnabled -}}
@@ -110,10 +114,12 @@ Enable bareMetalInstance controller based on global.services.bmaas.enabled or lo
 {{- if .Values.controllers.bareMetalInstance | kindIs "invalid" | not -}}
 {{- .Values.controllers.bareMetalInstance -}}
 {{- else -}}
-{{- $bmaasEnabled := false -}}
+{{- $bmaasEnabled := true -}}
 {{- if .Values.global.services -}}
 {{- if .Values.global.services.bmaas -}}
-{{- $bmaasEnabled = .Values.global.services.bmaas.enabled | default true -}}
+{{- if hasKey .Values.global.services.bmaas "enabled" -}}
+{{- $bmaasEnabled = .Values.global.services.bmaas.enabled -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- $bmaasEnabled -}}

--- a/osac-operator/charts/operator/templates/_helpers.tpl
+++ b/osac-operator/charts/operator/templates/_helpers.tpl
@@ -70,67 +70,29 @@ Service account name
 {{- end }}
 
 {{/*
-Enable clusterOrder controller based on global.services.caas.enabled or local override.
-Honors explicit local value if set, otherwise computes from global.services.caas.enabled.
+Enable controller based on global.services.*.enabled or local override.
+Takes three arguments via list: context, controller key, service key.
+Honors explicit local value if set, otherwise computes from global.services.<service>.enabled.
 */}}
-{{- define "osac-operator.controller.clusterOrder" -}}
-{{- if .Values.controllers.clusterOrder | kindIs "invalid" | not -}}
-{{- .Values.controllers.clusterOrder -}}
+{{- define "osac-operator.controllerEnabled" -}}
+{{- $ctx := index . 0 -}}
+{{- $ctrlKey := index . 1 -}}
+{{- $svcKey := index . 2 -}}
+{{- $ctrlVal := index $ctx.Values.controllers $ctrlKey -}}
+{{- if $ctrlVal | kindIs "invalid" | not -}}
+{{- $ctrlVal -}}
 {{- else -}}
-{{- $caasEnabled := true -}}
-{{- if .Values.global -}}
-{{- if .Values.global.services -}}
-{{- if .Values.global.services.caas -}}
-{{- if hasKey .Values.global.services.caas "enabled" -}}
-{{- $caasEnabled = .Values.global.services.caas.enabled -}}
+{{- $enabled := true -}}
+{{- if $ctx.Values.global -}}
+{{- if $ctx.Values.global.services -}}
+{{- $svc := index $ctx.Values.global.services $svcKey -}}
+{{- if $svc -}}
+{{- if hasKey $svc "enabled" -}}
+{{- $enabled = $svc.enabled -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
-{{- $caasEnabled -}}
-{{- end -}}
-{{- end }}
-
-{{/*
-Enable computeInstance controller based on global.services.vmaas.enabled or local override.
-Honors explicit local value if set, otherwise computes from global.services.vmaas.enabled.
-*/}}
-{{- define "osac-operator.controller.computeInstance" -}}
-{{- if .Values.controllers.computeInstance | kindIs "invalid" | not -}}
-{{- .Values.controllers.computeInstance -}}
-{{- else -}}
-{{- $vmaasEnabled := true -}}
-{{- if .Values.global -}}
-{{- if .Values.global.services -}}
-{{- if .Values.global.services.vmaas -}}
-{{- if hasKey .Values.global.services.vmaas "enabled" -}}
-{{- $vmaasEnabled = .Values.global.services.vmaas.enabled -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- $vmaasEnabled -}}
-{{- end -}}
-{{- end }}
-
-{{/*
-Enable bareMetalInstance controller based on global.services.bmaas.enabled or local override.
-Honors explicit local value if set, otherwise computes from global.services.bmaas.enabled.
-*/}}
-{{- define "osac-operator.controller.bareMetalInstance" -}}
-{{- if .Values.controllers.bareMetalInstance | kindIs "invalid" | not -}}
-{{- .Values.controllers.bareMetalInstance -}}
-{{- else -}}
-{{- $bmaasEnabled := true -}}
-{{- if .Values.global -}}
-{{- if .Values.global.services -}}
-{{- if .Values.global.services.bmaas -}}
-{{- if hasKey .Values.global.services.bmaas "enabled" -}}
-{{- $bmaasEnabled = .Values.global.services.bmaas.enabled -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- $bmaasEnabled -}}
+{{- $enabled -}}
 {{- end -}}
 {{- end }}

--- a/osac-operator/charts/operator/templates/deployment.yaml
+++ b/osac-operator/charts/operator/templates/deployment.yaml
@@ -99,15 +99,15 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: OSAC_ENABLE_CLUSTER_CONTROLLER
-            value: {{ include "osac-operator.controller.clusterOrder" . | quote }}
+            value: {{ include "osac-operator.controllerEnabled" (list . "clusterOrder" "caas") | quote }}
           - name: OSAC_ENABLE_COMPUTE_INSTANCE_CONTROLLER
-            value: {{ include "osac-operator.controller.computeInstance" . | quote }}
+            value: {{ include "osac-operator.controllerEnabled" (list . "computeInstance" "vmaas") | quote }}
           - name: OSAC_ENABLE_TENANT_CONTROLLER
             value: {{ .Values.controllers.tenant | quote }}
           - name: OSAC_ENABLE_NETWORKING_CONTROLLER
             value: {{ .Values.controllers.networking | quote }}
           - name: OSAC_ENABLE_BAREMETAL_INSTANCE_CONTROLLER
-            value: {{ include "osac-operator.controller.bareMetalInstance" . | quote }}
+            value: {{ include "osac-operator.controllerEnabled" (list . "bareMetalInstance" "bmaas") | quote }}
           - name: OSAC_ENABLE_STORAGE_CONTROLLER
             value: {{ .Values.controllers.storage | quote }}
           - name: OSAC_ENABLE_VOLUME_CONTROLLER

--- a/osac-operator/charts/operator/templates/deployment.yaml
+++ b/osac-operator/charts/operator/templates/deployment.yaml
@@ -99,15 +99,15 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: OSAC_ENABLE_CLUSTER_CONTROLLER
-            value: {{ .Values.controllers.clusterOrder | quote }}
+            value: {{ include "osac-operator.controller.clusterOrder" . | quote }}
           - name: OSAC_ENABLE_COMPUTE_INSTANCE_CONTROLLER
-            value: {{ .Values.controllers.computeInstance | quote }}
+            value: {{ include "osac-operator.controller.computeInstance" . | quote }}
           - name: OSAC_ENABLE_TENANT_CONTROLLER
             value: {{ .Values.controllers.tenant | quote }}
           - name: OSAC_ENABLE_NETWORKING_CONTROLLER
             value: {{ .Values.controllers.networking | quote }}
           - name: OSAC_ENABLE_BAREMETAL_INSTANCE_CONTROLLER
-            value: {{ .Values.controllers.bareMetalInstance | quote }}
+            value: {{ include "osac-operator.controller.bareMetalInstance" . | quote }}
           - name: OSAC_ENABLE_STORAGE_CONTROLLER
             value: {{ .Values.controllers.storage | quote }}
           - name: OSAC_ENABLE_VOLUME_CONTROLLER

--- a/osac-operator/charts/operator/values.yaml
+++ b/osac-operator/charts/operator/values.yaml
@@ -25,11 +25,14 @@ fulfillment:
   tokenFile: ""
 
 controllers:
-  clusterOrder: true
-  computeInstance: true
+  # clusterOrder, computeInstance, and bareMetalInstance are computed from
+  # global.services.*.enabled by default (see _helpers.tpl). Set explicitly
+  # to override the computed value.
+  # clusterOrder: true
+  # computeInstance: true
+  # bareMetalInstance: true
   tenant: true
   networking: true
-  bareMetalInstance: true
   storage: true
   # The Volume controller provisions volumes via the vendor CSI controllers.
   # Safe to leave enabled even without a vendor backend: when vendorControllers


### PR DESCRIPTION
This PR implements the canonical per-service enablement pattern from the [OSAC-3046](https://redhat.atlassian.net/browse/OSAC-3046) design, enabling users to configure which OSAC services (CaaS, VMaaS, BMaaS, MaaS) are enabled via simple boolean flags while maintaining fine-grained controller-level override support.

## Changes

- Add `global.services.{caas,vmaas,bmaas,maas}.enabled` to parent chart values (all default to `true` for backward compatibility)
- Implement helpers in osac-operator subchart to compute controller enable flags from `global.services.*.enabled` with local override support
- Update operator deployment to use computed values via helpers for `clusterOrder`, `computeInstance`, and `bareMetalInstance` controllers
- Update CI values files (vmaas-ci, caas-ci, bmaas-ci) to use the new `global.services` pattern
- Document the pattern in `VALUES_PATTERN.md`

## Pattern

- Parent chart defines per-service enablement flags under `global.services`
- Subcharts contain helpers that read `global.services` and compute local values
- Local controller values can override computed values for fine-grained control
- Computation logic lives in the subchart that consumes it

## Example

Setting `global.services.vmaas.enabled: true` and `global.services.caas.enabled: false` automatically enables the `computeInstance` controller and disables the `clusterOrder` controller.

Users can still override individual controllers:
```yaml
global:
  services:
    caas:
      enabled: false
    vmaas:
      enabled: true

operator:
  controllers:
    clusterOrder: true  # Override: enable even though caas is disabled
```

## Foundation for [OSAC-3046](https://redhat.atlassian.net/browse/OSAC-3046)

This provides the Helm-level foundation for [OSAC-3046](https://redhat.atlassian.net/browse/OSAC-3046) per-service enablement. Future work will extend this pattern to:
- fulfillment-service API registration (conditional gRPC/REST service registration)
- Capabilities endpoint (`enabled_services` field)
- bare-metal-fulfillment-operator deployment gating

## Related

- Design: ../enhancement-proposals/enhancements/OSAC-3046-per-service-enablement/design.md
- Jira: https://redhat.atlassian.net/browse/OSAC-3046

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added global service configuration for CaaS, VMaaS, BMaaS, and MaaS, enabled by default.
  - Controller activation now follows the corresponding service profile for cluster-order, compute-instance, and bare-metal-instance capabilities.
  - Explicit controller overrides remain supported, including disabling a controller.
  - Added CI configurations for selectively enabling individual service profiles.
  - Added configuration validation for service enablement settings.

- **Documentation**
  - Added guidance and examples covering service profiles, controller activation, configuration scenarios, and override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->