### PR TITLE
OSAC-3436: Implement DLQ handling with DLQ Kafka topic

### DIFF
--- a/osac-metering/AGENTS.md
+++ b/osac-metering/AGENTS.md
@@ -110,7 +110,7 @@ The `adapters/` package is a standalone Go module that provides everything a bil
 - `osac_adapter_dlq_events_total` (provider)
 - `osac_adapter_dlq_send_errors_total` (provider)
 - `osac_adapter_dlq_bytes_total` (provider)
-- `osac_adapter_dlq_depth` (provider) — events this adapter process has sent to the DLQ
+- `osac_adapter_dlq_depth` (provider) — records currently retained in the DLQ topic (sum of newest−oldest offsets; not consumer lag). Scraped periodically from Kafka. Multiple replicas export the same value; aggregate with `max` or `avg`, not `sum`.
 
 ### Echo Adapter
 

--- a/osac-metering/AGENTS.md
+++ b/osac-metering/AGENTS.md
@@ -56,7 +56,7 @@ metering-service (event mapping, heartbeats, reconciliation)
   ↓ CloudEvents
 Kafka Topics
   ↓ Sarama consumer group
-adapters.Runner (dedup → out-of-order check → retry → Submit [→ DLQ on failure] → Flush → offset commit)
+adapters.Runner (deserialize → [DLQ on deserialization failure] → dedup → out-of-order check → retry → Submit [→ DLQ on failure] → Flush → offset commit)
   ↓ ProviderAdapter interface
 Concrete Adapters (echo-adapter, m360-adapter, billing providers)
 ```

--- a/osac-metering/AGENTS.md
+++ b/osac-metering/AGENTS.md
@@ -110,7 +110,7 @@ The `adapters/` package is a standalone Go module that provides everything a bil
 - `osac_adapter_dlq_events_total` (provider)
 - `osac_adapter_dlq_send_errors_total` (provider)
 - `osac_adapter_dlq_bytes_total` (provider)
-- `osac_adapter_dlq_depth` (provider) — records currently retained in the DLQ topic (sum of newest−oldest offsets; not consumer lag). Scraped periodically from Kafka. Multiple replicas export the same value; aggregate with `max` or `avg`, not `sum`.
+- `osac_metering_dlq_depth` (topic) — records currently retained in the DLQ topic (sum of newest−oldest offsets; not consumer lag). Scraped periodically from Kafka by each DLQ-enabled adapter. Multiple processes export the same value; aggregate with `max` or `avg`, not `sum`.
 
 ### Echo Adapter
 

--- a/osac-metering/AGENTS.md
+++ b/osac-metering/AGENTS.md
@@ -9,7 +9,7 @@ Metering pipeline for OSAC — collects resource usage events from the fulfillme
 - **Always `make helm-lint`** from `osac-metering/` before committing chart changes
 - **Kafka cluster required** — metering subsystem needs AMQ Streams and Kafka (deployed via osac-installer phases 1-2)
 - **CloudEvents format** — all metering events use CloudEvents specification for consistency
-- **Implement `ProviderAdapter`** — new billing integrations implement the `ProviderAdapter` interface in `adapters/adapter.go`; the `Runner` handles Kafka consumption, dedup, retry, and offset management
+- **Implement `ProviderAdapter`** — new billing integrations implement the `ProviderAdapter` interface in `adapters/adapter.go`; the `Runner` handles Kafka consumption, dedup, retry, DLQ routing, and offset management
 
 ## Dev Environment
 
@@ -56,7 +56,7 @@ metering-service (event mapping, heartbeats, reconciliation)
   ↓ CloudEvents
 Kafka Topics
   ↓ Sarama consumer group
-adapters.Runner (dedup → out-of-order check → retry → Submit → Flush → offset commit)
+adapters.Runner (dedup → out-of-order check → retry → Submit [→ DLQ on failure] → Flush → offset commit)
   ↓ ProviderAdapter interface
 Concrete Adapters (echo-adapter, m360-adapter, billing providers)
 ```
@@ -83,15 +83,20 @@ The `adapters/` package is a standalone Go module that provides everything a bil
 - `HealthCheck(ctx)` — verify provider connectivity
 - `Close()` — release resources after final flush
 
-**`Runner`** (`runner.go`) — manages the full Kafka consumer lifecycle:
+**`Runner`** (`runner.go`, `runner_process.go`) — manages the full Kafka consumer lifecycle:
 - Sarama consumer group with manual offset commits (offsets committed only after successful `Flush`)
 - TTL-based dedup cache suppresses duplicate CloudEvent IDs
 - Out-of-order detection tracks per-resource `transition_time` ordering
 - Exponential backoff retry (1s→5m, ±25% jitter, configurable max attempts)
 - `NonRetryableError` / `RetryableError` error classification
+- DLQ routing for failed events (non-retryable, retries exhausted, deserialization); DLQ send failure halts partition consumption to prevent data loss
 - Graceful shutdown: final flush with 30s timeout, adapter close with 10s timeout
 
 **Kafka configuration** (`kafka.go`, `kafka_env.go`) — TLS with custom CA, SASL/SCRAM-SHA-512 authentication; `KafkaConfigFromEnv()` reads `KAFKA_*` env vars with TLS enabled by default
+
+**DLQ configuration** — `DLQOptionFromEnv()` reads DLQ environment variables:
+- `DLQ_ENABLED` — set to `true` to enable DLQ (default: disabled). Helm adapter deployments set this to `true`.
+- `DLQ_TOPIC` — override the DLQ topic name (default: `osac.metering.dlq`)
 
 **Prometheus metrics** (`metrics.go`):
 - `osac_adapter_events_submitted_total` (provider, topic)
@@ -101,6 +106,11 @@ The `adapters/` package is a standalone Go module that provides everything a bil
 - `osac_adapter_flush_duration_seconds` (provider)
 - `osac_adapter_flush_errors_total` (provider)
 - `osac_adapter_retry_duration_seconds` (provider)
+- `osac_adapter_events_dropped_total` (provider)
+- `osac_adapter_dlq_events_total` (provider)
+- `osac_adapter_dlq_send_errors_total` (provider)
+- `osac_adapter_dlq_bytes_total` (provider)
+- `osac_adapter_dlq_depth` (provider) — events this adapter process has sent to the DLQ
 
 ### Echo Adapter
 

--- a/osac-metering/AGENTS.md
+++ b/osac-metering/AGENTS.md
@@ -98,18 +98,18 @@ The `adapters/` package is a standalone Go module that provides everything a bil
 - `DLQ_ENABLED` — set to `true` to enable DLQ (default: disabled). Helm adapter deployments set this to `true`.
 - `DLQ_TOPIC` — override the DLQ topic name (default: `osac.metering.dlq`)
 
-**Prometheus metrics** (`metrics.go`):
-- `osac_adapter_events_submitted_total` (provider, topic)
-- `osac_adapter_events_failed_total` (provider, error_type)
-- `osac_adapter_duplicates_suppressed_total` (provider)
-- `osac_adapter_out_of_order_events_total` (provider)
-- `osac_adapter_flush_duration_seconds` (provider)
-- `osac_adapter_flush_errors_total` (provider)
-- `osac_adapter_retry_duration_seconds` (provider)
-- `osac_adapter_events_dropped_total` (provider)
-- `osac_adapter_dlq_events_total` (provider)
-- `osac_adapter_dlq_send_errors_total` (provider)
-- `osac_adapter_dlq_bytes_total` (provider)
+**Prometheus metrics** (`metrics.go`) — adapter process series use `osac_metering_adapter_*`; shared DLQ occupancy is `osac_metering_dlq_depth`:
+- `osac_metering_adapter_events_submitted_total` (provider, topic)
+- `osac_metering_adapter_events_failed_total` (provider, error_type)
+- `osac_metering_adapter_duplicates_suppressed_total` (provider)
+- `osac_metering_adapter_out_of_order_events_total` (provider)
+- `osac_metering_adapter_flush_duration_seconds` (provider)
+- `osac_metering_adapter_flush_errors_total` (provider)
+- `osac_metering_adapter_retry_duration_seconds` (provider)
+- `osac_metering_adapter_events_dropped_total` (provider)
+- `osac_metering_adapter_dlq_events_total` (provider)
+- `osac_metering_adapter_dlq_send_errors_total` (provider)
+- `osac_metering_adapter_dlq_bytes_total` (provider)
 - `osac_metering_dlq_depth` (topic) — records currently retained in the DLQ topic (sum of newest−oldest offsets; not consumer lag). Scraped periodically from Kafka by each DLQ-enabled adapter. Multiple processes export the same value; aggregate with `max` or `avg`, not `sum`.
 
 ### Echo Adapter

--- a/osac-metering/README.md
+++ b/osac-metering/README.md
@@ -13,7 +13,7 @@ Metering pipeline for OSAC — collects resource usage events and publishes them
 |-----------|-------------|
 | `schema/` | Shared metering event schema — lifecycle data types, resource type constants, CloudEvent extension names |
 | `metering-service/` | Watch Consumer: connects to fulfillment-service gRPC Watch stream, maps lifecycle events to CloudEvents, publishes to Kafka |
-| `adapters/` | Provider Adapter framework (`Runner`, Kafka consumer, dedup, retry) and concrete adapters (`echo-adapter`, `m360-adapter`) |
+| `adapters/` | Provider Adapter framework (`Runner`, Kafka consumer, dedup, retry, DLQ routing) and concrete adapters (`echo-adapter`, `m360-adapter`) |
 | `charts/osac-metering/` | Helm umbrella chart for the metering subsystem |
 
 ## Build and Test

--- a/osac-metering/adapters/adapter.go
+++ b/osac-metering/adapters/adapter.go
@@ -34,7 +34,8 @@ type SubmitResult struct {
 type ProviderAdapter interface {
 	// Name returns the provider name used as a Prometheus label.
 	Name() string
-	// Submit processes a single metering event.
+	// Submit processes a single metering event. Error messages may be
+	// stored in DLQ record headers — do not include secrets.
 	Submit(ctx context.Context, event MeteringEvent) error
 	// Flush uploads any buffered events. Called on the flush ticker
 	// (default 10s) and on graceful shutdown.

--- a/osac-metering/adapters/cmd/echo-adapter/main.go
+++ b/osac-metering/adapters/cmd/echo-adapter/main.go
@@ -116,6 +116,23 @@ func main() {
 
 	logger := stdr.New(log.New(os.Stderr, "", log.LstdFlags))
 
+	kafkaCfg := adapters.KafkaConfigFromEnv()
+
+	dlqOpt, dlqClose, err := adapters.DLQOptionFromEnv(brokers, kafkaCfg)
+	if err != nil {
+		log.Fatalf("setting up DLQ: %v", err)
+	}
+	defer func() {
+		if err := dlqClose(); err != nil {
+			log.Printf("DLQ producer close failed: %v", err)
+		}
+	}()
+	var opts []adapters.RunnerOption
+	if dlqOpt != nil {
+		opts = append(opts, dlqOpt)
+		log.Printf("DLQ enabled: topic=%s", envutil.EnvOrDefault("DLQ_TOPIC", adapters.TopicDLQ))
+	}
+
 	store := newEventStore(bufferSize)
 	adapter := &echoAdapter{store: store}
 	runner := adapters.NewRunner(adapter, adapters.RunnerConfig{
@@ -123,8 +140,8 @@ func main() {
 		ConsumerGroup: group,
 		Topics:        adapters.AllTopics,
 		FlushInterval: flushInterval,
-		Kafka:         adapters.KafkaConfigFromEnv(),
-	}, logger)
+		Kafka:         kafkaCfg,
+	}, logger, opts...)
 
 	// Serve metrics, health, and event query endpoints.
 	go func() {
@@ -141,8 +158,16 @@ func main() {
 		mux.HandleFunc("DELETE /events", store.handleDeleteEvents)
 		mux.HandleFunc("GET /events/count", store.handleCount)
 		mux.HandleFunc("GET /events/{id}", store.handleEventByID)
+		httpServer := &http.Server{
+			Addr:              metricsAddr,
+			Handler:           mux,
+			ReadHeaderTimeout: 10 * time.Second,
+			ReadTimeout:       10 * time.Second,
+			WriteTimeout:      10 * time.Second,
+			IdleTimeout:       60 * time.Second,
+		}
 		log.Printf("HTTP server listening on %s", metricsAddr)
-		if err := http.ListenAndServe(metricsAddr, mux); err != nil {
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Printf("metrics server error: %v", err)
 		}
 	}()

--- a/osac-metering/adapters/cmd/m360-adapter/client.go
+++ b/osac-metering/adapters/cmd/m360-adapter/client.go
@@ -109,7 +109,7 @@ func (c *m360Client) post(ctx context.Context, endpoint string, payload map[stri
 // Any HTTP response (regardless of status code) means M360 is reachable.
 // Only connection-level errors (timeout, refused, DNS) cause failure.
 // Auth and API route failures surface as post() errors /
-// osac_adapter_events_failed_total, not here.
+// osac_metering_adapter_events_failed_total, not here.
 func (c *m360Client) healthCheck(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, healthCheckTimeout)
 	defer cancel()

--- a/osac-metering/adapters/cmd/m360-adapter/main.go
+++ b/osac-metering/adapters/cmd/m360-adapter/main.go
@@ -90,6 +90,23 @@ func main() {
 
 	logger := stdr.New(log.New(os.Stderr, "", log.LstdFlags))
 
+	kafkaCfg := adapters.KafkaConfigFromEnv()
+
+	dlqOpt, dlqClose, err := adapters.DLQOptionFromEnv(brokers, kafkaCfg)
+	if err != nil {
+		log.Fatalf("setting up DLQ: %v", err)
+	}
+	defer func() {
+		if err := dlqClose(); err != nil {
+			log.Printf("DLQ producer close failed: %v", err)
+		}
+	}()
+	var opts []adapters.RunnerOption
+	if dlqOpt != nil {
+		opts = append(opts, dlqOpt)
+		log.Printf("DLQ enabled: topic=%s", envutil.EnvOrDefault("DLQ_TOPIC", adapters.TopicDLQ))
+	}
+
 	client := newM360Client(m360URL, apiVersion, apiKey)
 	client.logger = logger
 
@@ -99,8 +116,8 @@ func main() {
 		ConsumerGroup: group,
 		Topics:        topics,
 		FlushInterval: flushInterval,
-		Kafka:         adapters.KafkaConfigFromEnv(),
-	}, logger)
+		Kafka:         kafkaCfg,
+	}, logger, opts...)
 
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", runner.MetricsHandler())
@@ -118,6 +135,9 @@ func main() {
 		Addr:              metricsAddr,
 		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 	go func() {
 		log.Print("HTTP server listening")

--- a/osac-metering/adapters/dlq.go
+++ b/osac-metering/adapters/dlq.go
@@ -28,9 +28,10 @@ type DLQSender interface {
 	Close() error
 }
 
-// DLQOccupier reports how many records are currently retained in the DLQ topic.
+// DLQOccupier reports how many records are currently retained in a DLQ topic.
 type DLQOccupier interface {
 	Occupancy() (int64, error)
+	Topic() string
 }
 
 // kafkaOffsets is the subset of sarama.Client used to scrape DLQ log occupancy.
@@ -75,6 +76,11 @@ func NewDLQProducer(brokers string, topic string, kafkaCfg KafkaConfig) (*DLQPro
 // Sarama SyncProducer. Useful for testing with mock producers.
 func NewDLQProducerFromSyncProducer(producer sarama.SyncProducer, topic string) *DLQProducer {
 	return &DLQProducer{producer: producer, topic: topic}
+}
+
+// Topic returns the DLQ topic this producer writes to.
+func (d *DLQProducer) Topic() string {
+	return d.topic
 }
 
 // Send publishes a failed consumer message to the DLQ topic. The original

--- a/osac-metering/adapters/dlq.go
+++ b/osac-metering/adapters/dlq.go
@@ -1,0 +1,122 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package adapters
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/IBM/sarama"
+)
+
+const maxReasonLen = 1024
+
+// DLQSender sends failed events to a dead letter queue.
+type DLQSender interface {
+	Send(msg *sarama.ConsumerMessage, reason string, attempts int) error
+	Close() error
+}
+
+// DLQProducer publishes failed events to a Kafka DLQ topic.
+type DLQProducer struct {
+	producer sarama.SyncProducer
+	topic    string
+}
+
+// NewDLQProducer creates a DLQ producer connected to the given brokers.
+func NewDLQProducer(brokers string, topic string, kafkaCfg KafkaConfig) (*DLQProducer, error) {
+	sc, err := newProducerConfig(kafkaCfg)
+	if err != nil {
+		return nil, fmt.Errorf("creating DLQ producer config: %w", err)
+	}
+
+	addrs := splitAndTrimBrokers(brokers, ",")
+	producer, err := sarama.NewSyncProducer(addrs, sc)
+	if err != nil {
+		return nil, fmt.Errorf("creating DLQ sync producer: %w", err)
+	}
+
+	return &DLQProducer{producer: producer, topic: topic}, nil
+}
+
+// NewDLQProducerFromSyncProducer creates a DLQ producer from an existing
+// Sarama SyncProducer. Useful for testing with mock producers.
+func NewDLQProducerFromSyncProducer(producer sarama.SyncProducer, topic string) *DLQProducer {
+	return &DLQProducer{producer: producer, topic: topic}
+}
+
+// Send publishes a failed consumer message to the DLQ topic. The original
+// message value is preserved as-is; failure metadata is stored in Kafka
+// record headers.
+func (d *DLQProducer) Send(msg *sarama.ConsumerMessage, reason string, attempts int) error {
+	if len(reason) > maxReasonLen {
+		runes := []rune(reason)
+		if len(runes) > maxReasonLen {
+			reason = string(runes[:maxReasonLen])
+		}
+	}
+	headers := []sarama.RecordHeader{
+		{Key: []byte("original-topic"), Value: []byte(msg.Topic)},
+		{Key: []byte("original-partition"), Value: []byte(strconv.FormatInt(int64(msg.Partition), 10))},
+		{Key: []byte("original-offset"), Value: []byte(strconv.FormatInt(msg.Offset, 10))},
+		{Key: []byte("failure-reason"), Value: []byte(reason)},
+		{Key: []byte("failure-count"), Value: []byte(strconv.Itoa(attempts))},
+		{Key: []byte("failed-at"), Value: []byte(time.Now().UTC().Format(time.RFC3339))},
+	}
+
+	pm := &sarama.ProducerMessage{
+		Topic:   d.topic,
+		Value:   sarama.ByteEncoder(msg.Value),
+		Headers: headers,
+	}
+
+	if msg.Key != nil {
+		pm.Key = sarama.ByteEncoder(msg.Key)
+	}
+
+	_, _, err := d.producer.SendMessage(pm)
+	if err != nil {
+		return fmt.Errorf("sending to DLQ topic %s: %w", d.topic, err)
+	}
+
+	return nil
+}
+
+// Close shuts down the underlying Kafka producer.
+func (d *DLQProducer) Close() error {
+	return d.producer.Close()
+}
+
+// DLQOptionFromEnv creates a DLQ RunnerOption from environment variables.
+// Returns (nil, noop, nil) unless DLQ_ENABLED is true (case-insensitive).
+// Chart deployments set DLQ_ENABLED=true; requiring opt-in keeps image-before-chart
+// upgrades on the previous drop-and-continue path until matching KafkaUser ACLs exist.
+// The caller must defer the returned close function to release resources.
+func DLQOptionFromEnv(brokers string, kafkaCfg KafkaConfig) (RunnerOption, func() error, error) {
+	noop := func() error { return nil }
+	if !strings.EqualFold(os.Getenv("DLQ_ENABLED"), "true") {
+		return nil, noop, nil
+	}
+
+	topic := os.Getenv("DLQ_TOPIC")
+	if topic == "" {
+		topic = TopicDLQ
+	}
+
+	dlq, err := NewDLQProducer(brokers, topic, kafkaCfg)
+	if err != nil {
+		return nil, noop, fmt.Errorf("creating DLQ producer: %w", err)
+	}
+
+	return WithDLQ(dlq), dlq.Close, nil
+}

--- a/osac-metering/adapters/dlq.go
+++ b/osac-metering/adapters/dlq.go
@@ -10,6 +10,7 @@ in compliance with the License. You may obtain a copy of the License at
 package adapters
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -27,9 +28,24 @@ type DLQSender interface {
 	Close() error
 }
 
+// DLQOccupier reports how many records are currently retained in the DLQ topic.
+type DLQOccupier interface {
+	Occupancy() (int64, error)
+}
+
+// kafkaOffsets is the subset of sarama.Client used to scrape DLQ log occupancy.
+type kafkaOffsets interface {
+	Partitions(topic string) ([]int32, error)
+	GetOffset(topic string, partitionID int32, time int64) (int64, error)
+}
+
+var _ kafkaOffsets = sarama.Client(nil)
+
 // DLQProducer publishes failed events to a Kafka DLQ topic.
 type DLQProducer struct {
 	producer sarama.SyncProducer
+	client   sarama.Client
+	offsets  kafkaOffsets
 	topic    string
 }
 
@@ -41,12 +57,18 @@ func NewDLQProducer(brokers string, topic string, kafkaCfg KafkaConfig) (*DLQPro
 	}
 
 	addrs := splitAndTrimBrokers(brokers, ",")
-	producer, err := sarama.NewSyncProducer(addrs, sc)
+	client, err := sarama.NewClient(addrs, sc)
 	if err != nil {
+		return nil, fmt.Errorf("creating DLQ Kafka client: %w", err)
+	}
+
+	producer, err := sarama.NewSyncProducerFromClient(client)
+	if err != nil {
+		_ = client.Close()
 		return nil, fmt.Errorf("creating DLQ sync producer: %w", err)
 	}
 
-	return &DLQProducer{producer: producer, topic: topic}, nil
+	return &DLQProducer{producer: producer, client: client, offsets: client, topic: topic}, nil
 }
 
 // NewDLQProducerFromSyncProducer creates a DLQ producer from an existing
@@ -92,9 +114,47 @@ func (d *DLQProducer) Send(msg *sarama.ConsumerMessage, reason string, attempts 
 	return nil
 }
 
-// Close shuts down the underlying Kafka producer.
+// Occupancy returns the number of records currently retained in the DLQ topic
+// (sum over partitions of OffsetNewest − OffsetOldest). It does not measure
+// consumer lag. Test-only producers constructed without a Kafka client return
+// an error.
+func (d *DLQProducer) Occupancy() (int64, error) {
+	if d.offsets == nil {
+		return 0, fmt.Errorf("DLQ occupancy requires a Kafka client")
+	}
+
+	partitions, err := d.offsets.Partitions(d.topic)
+	if err != nil {
+		return 0, fmt.Errorf("listing DLQ partitions for %s: %w", d.topic, err)
+	}
+
+	var total int64
+	for _, p := range partitions {
+		newest, err := d.offsets.GetOffset(d.topic, p, sarama.OffsetNewest)
+		if err != nil {
+			return 0, fmt.Errorf("newest offset for %s/%d: %w", d.topic, p, err)
+		}
+		oldest, err := d.offsets.GetOffset(d.topic, p, sarama.OffsetOldest)
+		if err != nil {
+			return 0, fmt.Errorf("oldest offset for %s/%d: %w", d.topic, p, err)
+		}
+		if newest > oldest {
+			total += newest - oldest
+		}
+	}
+	return total, nil
+}
+
+// Close shuts down the underlying Kafka producer and client.
 func (d *DLQProducer) Close() error {
-	return d.producer.Close()
+	var errs []error
+	if d.producer != nil {
+		errs = append(errs, d.producer.Close())
+	}
+	if d.client != nil {
+		errs = append(errs, d.client.Close())
+	}
+	return errors.Join(errs...)
 }
 
 // DLQOptionFromEnv creates a DLQ RunnerOption from environment variables.

--- a/osac-metering/adapters/dlq_test.go
+++ b/osac-metering/adapters/dlq_test.go
@@ -1,0 +1,272 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package adapters
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/IBM/sarama/mocks"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DLQProducer", func() {
+	var (
+		mockProducer *mocks.SyncProducer
+		dlq          *DLQProducer
+	)
+
+	BeforeEach(func() {
+		mockProducer = mocks.NewSyncProducer(GinkgoT(), nil)
+		dlq = NewDLQProducerFromSyncProducer(mockProducer, TopicDLQ)
+	})
+
+	AfterEach(func() {
+		if err := mockProducer.Close(); err != nil {
+			GinkgoT().Logf("mock producer close: %v", err)
+		}
+	})
+
+	Describe("Send", func() {
+		It("preserves original message value bytes", func() {
+			originalValue := []byte(`{"specversion":"1.0","id":"evt-1","type":"test"}`)
+			msg := &sarama.ConsumerMessage{
+				Topic:     TopicLifecycle,
+				Partition: 2,
+				Offset:    42,
+				Value:     originalValue,
+				Key:       []byte("resource-123"),
+			}
+
+			var sentMsg *sarama.ProducerMessage
+			mockProducer.ExpectSendMessageWithMessageCheckerFunctionAndSucceed(
+				func(pm *sarama.ProducerMessage) error {
+					sentMsg = pm
+					return nil
+				},
+			)
+
+			err := dlq.Send(msg, "bad schema", 1)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(sentMsg).NotTo(BeNil())
+			value, encErr := sentMsg.Value.Encode()
+			Expect(encErr).NotTo(HaveOccurred())
+			Expect(value).To(Equal(originalValue))
+		})
+
+		It("includes correct failure metadata headers", func() {
+			msg := &sarama.ConsumerMessage{
+				Topic:     TopicLifecycle,
+				Partition: 3,
+				Offset:    100,
+				Value:     []byte(`{}`),
+				Key:       []byte("res-1"),
+			}
+
+			var sentMsg *sarama.ProducerMessage
+			mockProducer.ExpectSendMessageWithMessageCheckerFunctionAndSucceed(
+				func(pm *sarama.ProducerMessage) error {
+					sentMsg = pm
+					return nil
+				},
+			)
+
+			err := dlq.Send(msg, "retries exhausted", 10)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(sentMsg).NotTo(BeNil())
+			Expect(sentMsg.Topic).To(Equal(TopicDLQ))
+
+			headers := headerMap(sentMsg.Headers)
+			Expect(headers["original-topic"]).To(Equal(TopicLifecycle))
+			Expect(headers["original-offset"]).To(Equal("100"))
+			Expect(headers["original-partition"]).To(Equal("3"))
+			Expect(headers["failure-reason"]).To(Equal("retries exhausted"))
+			Expect(headers["failure-count"]).To(Equal("10"))
+
+			failedAt, err := time.Parse(time.RFC3339, headers["failed-at"])
+			Expect(err).NotTo(HaveOccurred())
+			Expect(failedAt).To(BeTemporally("~", time.Now().UTC(), 2*time.Second))
+		})
+
+		It("preserves original message key", func() {
+			msg := &sarama.ConsumerMessage{
+				Topic:     TopicLifecycle,
+				Partition: 0,
+				Offset:    0,
+				Value:     []byte(`{}`),
+				Key:       []byte("my-resource-key"),
+			}
+
+			var sentMsg *sarama.ProducerMessage
+			mockProducer.ExpectSendMessageWithMessageCheckerFunctionAndSucceed(
+				func(pm *sarama.ProducerMessage) error {
+					sentMsg = pm
+					return nil
+				},
+			)
+
+			err := dlq.Send(msg, "test", 1)
+			Expect(err).NotTo(HaveOccurred())
+
+			key, keyErr := sentMsg.Key.Encode()
+			Expect(keyErr).NotTo(HaveOccurred())
+			Expect(string(key)).To(Equal("my-resource-key"))
+		})
+
+		It("handles nil key gracefully", func() {
+			msg := &sarama.ConsumerMessage{
+				Topic:     TopicLifecycle,
+				Partition: 0,
+				Offset:    0,
+				Value:     []byte(`{}`),
+			}
+
+			mockProducer.ExpectSendMessageAndSucceed()
+
+			err := dlq.Send(msg, "test", 1)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("truncates long failure-reason header", func() {
+			msg := &sarama.ConsumerMessage{
+				Topic:     TopicLifecycle,
+				Partition: 0,
+				Offset:    0,
+				Value:     []byte(`{}`),
+			}
+
+			longReason := strings.Repeat("x", maxReasonLen+500)
+
+			var sentMsg *sarama.ProducerMessage
+			mockProducer.ExpectSendMessageWithMessageCheckerFunctionAndSucceed(
+				func(pm *sarama.ProducerMessage) error {
+					sentMsg = pm
+					return nil
+				},
+			)
+
+			err := dlq.Send(msg, longReason, 1)
+			Expect(err).NotTo(HaveOccurred())
+
+			headers := headerMap(sentMsg.Headers)
+			Expect(len([]rune(headers["failure-reason"]))).To(Equal(maxReasonLen))
+		})
+
+		It("truncates at UTF-8 rune boundary", func() {
+			msg := &sarama.ConsumerMessage{
+				Topic:     TopicLifecycle,
+				Partition: 0,
+				Offset:    0,
+				Value:     []byte(`{}`),
+			}
+
+			reasonWithUTF8 := strings.Repeat("a", maxReasonLen-1) + "🎉" + "x"
+
+			var sentMsg *sarama.ProducerMessage
+			mockProducer.ExpectSendMessageWithMessageCheckerFunctionAndSucceed(
+				func(pm *sarama.ProducerMessage) error {
+					sentMsg = pm
+					return nil
+				},
+			)
+
+			err := dlq.Send(msg, reasonWithUTF8, 1)
+			Expect(err).NotTo(HaveOccurred())
+
+			headers := headerMap(sentMsg.Headers)
+			reason := headers["failure-reason"]
+			_, err = json.Marshal(reason)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns error when producer send fails", func() {
+			msg := &sarama.ConsumerMessage{
+				Topic:     TopicLifecycle,
+				Partition: 0,
+				Offset:    0,
+				Value:     []byte(`{}`),
+			}
+
+			mockProducer.ExpectSendMessageAndFail(errors.New("broker unavailable"))
+
+			err := dlq.Send(msg, "test", 1)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("broker unavailable"))
+		})
+	})
+
+	Describe("DLQSender interface", func() {
+		It("is implemented by DLQProducer", func() {
+			var sender DLQSender = dlq
+			Expect(sender).NotTo(BeNil())
+		})
+	})
+})
+
+var _ = Describe("DLQOptionFromEnv", func() {
+	It("returns a no-op when DLQ_ENABLED is unset", func() {
+		GinkgoT().Setenv("DLQ_ENABLED", "")
+		opt, closeFn, err := DLQOptionFromEnv("localhost:9092", KafkaConfig{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(opt).To(BeNil())
+		Expect(closeFn).NotTo(BeNil())
+		Expect(closeFn()).To(Succeed())
+	})
+
+	It("returns a no-op when DLQ_ENABLED is not true", func() {
+		GinkgoT().Setenv("DLQ_ENABLED", "false")
+		opt, closeFn, err := DLQOptionFromEnv("localhost:9092", KafkaConfig{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(opt).To(BeNil())
+		Expect(closeFn()).To(Succeed())
+	})
+
+	It("returns a no-op for common falsy values", func() {
+		GinkgoT().Setenv("DLQ_ENABLED", "0")
+		opt, _, err := DLQOptionFromEnv("localhost:9092", KafkaConfig{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(opt).To(BeNil())
+	})
+})
+
+func headerMap(headers []sarama.RecordHeader) map[string]string {
+	m := make(map[string]string, len(headers))
+	for _, h := range headers {
+		m[string(h.Key)] = string(h.Value)
+	}
+	return m
+}
+
+var _ = Describe("newProducerConfig", func() {
+	It("creates an idempotent producer config", func() {
+		cfg := KafkaConfig{TLSEnabled: false}
+		sc, err := newProducerConfig(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sc.Producer.Idempotent).To(BeTrue())
+		Expect(sc.Producer.RequiredAcks).To(Equal(sarama.WaitForAll))
+		Expect(sc.Producer.Return.Successes).To(BeTrue())
+		Expect(sc.Net.MaxOpenRequests).To(Equal(1))
+	})
+
+	It("enables TLS when configured", func() {
+		cfg := KafkaConfig{TLSEnabled: true}
+		sc, err := newProducerConfig(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sc.Net.TLS.Enable).To(BeTrue())
+	})
+})
+
+var _ DLQSender = (*DLQProducer)(nil)

--- a/osac-metering/adapters/dlq_test.go
+++ b/osac-metering/adapters/dlq_test.go
@@ -242,6 +242,116 @@ var _ = Describe("DLQOptionFromEnv", func() {
 	})
 })
 
+type fakeOffsets struct {
+	partitions    []int32
+	newest        map[int32]int64
+	oldest        map[int32]int64
+	partitionsErr error
+	offsetErr     error
+}
+
+func (f *fakeOffsets) Partitions(string) ([]int32, error) {
+	if f.partitionsErr != nil {
+		return nil, f.partitionsErr
+	}
+	return f.partitions, nil
+}
+
+func (f *fakeOffsets) GetOffset(_ string, partitionID int32, time int64) (int64, error) {
+	if f.offsetErr != nil {
+		return 0, f.offsetErr
+	}
+	switch time {
+	case sarama.OffsetNewest:
+		return f.newest[partitionID], nil
+	case sarama.OffsetOldest:
+		return f.oldest[partitionID], nil
+	default:
+		return 0, errors.New("unexpected offset time")
+	}
+}
+
+var _ = Describe("DLQProducer Occupancy", func() {
+	It("sums newest minus oldest across partitions", func() {
+		dlq := &DLQProducer{
+			topic: TopicDLQ,
+			offsets: &fakeOffsets{
+				partitions: []int32{0, 1, 2},
+				newest:     map[int32]int64{0: 10, 1: 5, 2: 20},
+				oldest:     map[int32]int64{0: 3, 1: 5, 2: 12},
+			},
+		}
+
+		n, err := dlq.Occupancy()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n).To(Equal(int64(15))) // (10-3) + (5-5) + (20-12)
+	})
+
+	It("treats empty partitions as zero", func() {
+		dlq := &DLQProducer{
+			topic: TopicDLQ,
+			offsets: &fakeOffsets{
+				partitions: []int32{0},
+				newest:     map[int32]int64{0: 0},
+				oldest:     map[int32]int64{0: 0},
+			},
+		}
+
+		n, err := dlq.Occupancy()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n).To(Equal(int64(0)))
+	})
+
+	It("clamps inverted offsets to zero for that partition", func() {
+		dlq := &DLQProducer{
+			topic: TopicDLQ,
+			offsets: &fakeOffsets{
+				partitions: []int32{0, 1},
+				newest:     map[int32]int64{0: 4, 1: 1},
+				oldest:     map[int32]int64{0: 8, 1: 0},
+			},
+		}
+
+		n, err := dlq.Occupancy()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(n).To(Equal(int64(1)))
+	})
+
+	It("returns an error when no Kafka client is attached", func() {
+		dlq := NewDLQProducerFromSyncProducer(nil, TopicDLQ)
+		_, err := dlq.Occupancy()
+		Expect(err).To(MatchError(ContainSubstring("Kafka client")))
+	})
+
+	It("returns an error when partition listing fails", func() {
+		dlq := &DLQProducer{
+			topic: TopicDLQ,
+			offsets: &fakeOffsets{
+				partitionsErr: errors.New("broker down"),
+			},
+		}
+
+		_, err := dlq.Occupancy()
+		Expect(err).To(MatchError(ContainSubstring("listing DLQ partitions")))
+	})
+
+	It("returns an error when GetOffset fails and does not report a partial total", func() {
+		dlq := &DLQProducer{
+			topic: TopicDLQ,
+			offsets: &fakeOffsets{
+				partitions: []int32{0, 1},
+				newest:     map[int32]int64{0: 10},
+				oldest:     map[int32]int64{0: 0},
+				offsetErr:  errors.New("offset unavailable"),
+			},
+		}
+
+		n, err := dlq.Occupancy()
+		Expect(err).To(HaveOccurred())
+		Expect(n).To(Equal(int64(0)))
+	})
+})
+
 func headerMap(headers []sarama.RecordHeader) map[string]string {
 	m := make(map[string]string, len(headers))
 	for _, h := range headers {
@@ -270,3 +380,4 @@ var _ = Describe("newProducerConfig", func() {
 })
 
 var _ DLQSender = (*DLQProducer)(nil)
+var _ DLQOccupier = (*DLQProducer)(nil)

--- a/osac-metering/adapters/kafka.go
+++ b/osac-metering/adapters/kafka.go
@@ -32,19 +32,19 @@ func newConsumerConfig(cfg KafkaConfig) (*sarama.Config, error) {
 	}
 
 	if cfg.TLSEnabled {
-		if err := configureConsumerTLS(sc, cfg.TLSCACert); err != nil {
+		if err := configureTLS(sc, cfg.TLSCACert); err != nil {
 			return nil, err
 		}
 	}
 	if cfg.SASLUser != "" {
-		if err := configureConsumerSASL(sc, cfg.SASLUser, cfg.SASLPassFile); err != nil {
+		if err := configureSASL(sc, cfg.SASLUser, cfg.SASLPassFile); err != nil {
 			return nil, err
 		}
 	}
 	return sc, nil
 }
 
-func configureConsumerTLS(sc *sarama.Config, caCertPath string) error {
+func configureTLS(sc *sarama.Config, caCertPath string) error {
 	sc.Net.TLS.Enable = true
 	tlsCfg := &tls.Config{MinVersion: tls.VersionTLS12}
 	if caCertPath != "" {
@@ -62,7 +62,7 @@ func configureConsumerTLS(sc *sarama.Config, caCertPath string) error {
 	return nil
 }
 
-func configureConsumerSASL(sc *sarama.Config, user, passFile string) error {
+func configureSASL(sc *sarama.Config, user, passFile string) error {
 	password, err := os.ReadFile(passFile)
 	if err != nil {
 		return fmt.Errorf("reading SASL password file %s: %w", passFile, err)
@@ -100,6 +100,27 @@ func (c *adapterScramClient) Step(challenge string) (string, error) {
 
 func (c *adapterScramClient) Done() bool {
 	return c.conversation.Done()
+}
+
+func newProducerConfig(cfg KafkaConfig) (*sarama.Config, error) {
+	sc := sarama.NewConfig()
+	sc.Version = sarama.V3_9_0_0
+	sc.Producer.RequiredAcks = sarama.WaitForAll
+	sc.Producer.Idempotent = true
+	sc.Producer.Return.Successes = true
+	sc.Net.MaxOpenRequests = 1
+
+	if cfg.TLSEnabled {
+		if err := configureTLS(sc, cfg.TLSCACert); err != nil {
+			return nil, err
+		}
+	}
+	if cfg.SASLUser != "" {
+		if err := configureSASL(sc, cfg.SASLUser, cfg.SASLPassFile); err != nil {
+			return nil, err
+		}
+	}
+	return sc, nil
 }
 
 func splitAndTrimBrokers(s, sep string) []string {

--- a/osac-metering/adapters/metrics.go
+++ b/osac-metering/adapters/metrics.go
@@ -79,9 +79,9 @@ func newAdapterMetrics() *adapterMetrics {
 			Help: "Total DLQ send failures.",
 		}, []string{"provider"}),
 		dlqDepth: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "osac_adapter_dlq_depth",
-			Help: "Records currently retained in the DLQ topic (log occupancy).",
-		}, []string{"provider"}),
+			Name: "osac_metering_dlq_depth",
+			Help: "Records currently retained in the DLQ topic (log occupancy, not consumer lag).",
+		}, []string{"topic"}),
 		dlqSize: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "osac_adapter_dlq_bytes_total",
 			Help: "Total payload bytes sent to the DLQ.",

--- a/osac-metering/adapters/metrics.go
+++ b/osac-metering/adapters/metrics.go
@@ -80,7 +80,7 @@ func newAdapterMetrics() *adapterMetrics {
 		}, []string{"provider"}),
 		dlqDepth: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "osac_adapter_dlq_depth",
-			Help: "Events this adapter process has sent to the DLQ.",
+			Help: "Records currently retained in the DLQ topic (log occupancy).",
 		}, []string{"provider"}),
 		dlqSize: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "osac_adapter_dlq_bytes_total",

--- a/osac-metering/adapters/metrics.go
+++ b/osac-metering/adapters/metrics.go
@@ -37,45 +37,45 @@ func newAdapterMetrics() *adapterMetrics {
 
 	m := &adapterMetrics{
 		eventsSubmitted: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "osac_adapter_events_submitted_total",
+			Name: "osac_metering_adapter_events_submitted_total",
 			Help: "Total events successfully submitted to the provider.",
 		}, []string{"provider", "topic"}),
 		eventsFailed: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "osac_adapter_events_failed_total",
+			Name: "osac_metering_adapter_events_failed_total",
 			Help: "Total events that failed processing.",
 		}, []string{"provider", "error_type"}),
 		retryDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "osac_adapter_retry_duration_seconds",
+			Name:    "osac_metering_adapter_retry_duration_seconds",
 			Help:    "Duration of retry attempts for Submit calls.",
 			Buckets: prometheus.ExponentialBuckets(1, 2, 10),
 		}, []string{"provider"}),
 		duplicatesSuppressed: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "osac_adapter_duplicates_suppressed_total",
+			Name: "osac_metering_adapter_duplicates_suppressed_total",
 			Help: "Total duplicate events suppressed by the dedup cache.",
 		}, []string{"provider"}),
 		outOfOrderEvents: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "osac_adapter_out_of_order_events_total",
+			Name: "osac_metering_adapter_out_of_order_events_total",
 			Help: "Total out-of-order events detected.",
 		}, []string{"provider"}),
 		flushDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "osac_adapter_flush_duration_seconds",
+			Name:    "osac_metering_adapter_flush_duration_seconds",
 			Help:    "Duration of flush operations.",
 			Buckets: prometheus.DefBuckets,
 		}, []string{"provider"}),
 		flushErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "osac_adapter_flush_errors_total",
+			Name: "osac_metering_adapter_flush_errors_total",
 			Help: "Total flush operation failures.",
 		}, []string{"provider"}),
 		eventsDropped: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "osac_adapter_events_dropped_total",
+			Name: "osac_metering_adapter_events_dropped_total",
 			Help: "Total events permanently dropped (no DLQ configured).",
 		}, []string{"provider"}),
 		dlqEventsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "osac_adapter_dlq_events_total",
+			Name: "osac_metering_adapter_dlq_events_total",
 			Help: "Total events sent to the dead letter queue.",
 		}, []string{"provider"}),
 		dlqSendErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "osac_adapter_dlq_send_errors_total",
+			Name: "osac_metering_adapter_dlq_send_errors_total",
 			Help: "Total DLQ send failures.",
 		}, []string{"provider"}),
 		dlqDepth: prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -83,7 +83,7 @@ func newAdapterMetrics() *adapterMetrics {
 			Help: "Records currently retained in the DLQ topic (log occupancy, not consumer lag).",
 		}, []string{"topic"}),
 		dlqSize: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "osac_adapter_dlq_bytes_total",
+			Name: "osac_metering_adapter_dlq_bytes_total",
 			Help: "Total payload bytes sent to the DLQ.",
 		}, []string{"provider"}),
 		registry: reg,

--- a/osac-metering/adapters/metrics.go
+++ b/osac-metering/adapters/metrics.go
@@ -24,6 +24,11 @@ type adapterMetrics struct {
 	outOfOrderEvents     *prometheus.CounterVec
 	flushDuration        *prometheus.HistogramVec
 	flushErrors          *prometheus.CounterVec
+	eventsDropped        *prometheus.CounterVec
+	dlqEventsTotal       *prometheus.CounterVec
+	dlqSendErrors        *prometheus.CounterVec
+	dlqDepth             *prometheus.GaugeVec
+	dlqSize              *prometheus.CounterVec
 	registry             *prometheus.Registry
 }
 
@@ -61,6 +66,26 @@ func newAdapterMetrics() *adapterMetrics {
 			Name: "osac_adapter_flush_errors_total",
 			Help: "Total flush operation failures.",
 		}, []string{"provider"}),
+		eventsDropped: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "osac_adapter_events_dropped_total",
+			Help: "Total events permanently dropped (no DLQ configured).",
+		}, []string{"provider"}),
+		dlqEventsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "osac_adapter_dlq_events_total",
+			Help: "Total events sent to the dead letter queue.",
+		}, []string{"provider"}),
+		dlqSendErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "osac_adapter_dlq_send_errors_total",
+			Help: "Total DLQ send failures.",
+		}, []string{"provider"}),
+		dlqDepth: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "osac_adapter_dlq_depth",
+			Help: "Events this adapter process has sent to the DLQ.",
+		}, []string{"provider"}),
+		dlqSize: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "osac_adapter_dlq_bytes_total",
+			Help: "Total payload bytes sent to the DLQ.",
+		}, []string{"provider"}),
 		registry: reg,
 	}
 
@@ -68,6 +93,8 @@ func newAdapterMetrics() *adapterMetrics {
 		m.eventsSubmitted, m.eventsFailed, m.retryDuration,
 		m.duplicatesSuppressed, m.outOfOrderEvents,
 		m.flushDuration, m.flushErrors,
+		m.eventsDropped, m.dlqEventsTotal, m.dlqSendErrors,
+		m.dlqDepth, m.dlqSize,
 	)
 
 	return m

--- a/osac-metering/adapters/metrics_test.go
+++ b/osac-metering/adapters/metrics_test.go
@@ -86,5 +86,19 @@ var _ = Describe("adapterMetrics", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(strings.Contains(string(body), "osac_adapter_events_submitted_total")).To(BeTrue())
 		})
+
+		It("exposes osac_metering_dlq_depth labeled by topic", func() {
+			m.dlqDepth.WithLabelValues(TopicDLQ).Set(7)
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+			m.handler().ServeHTTP(w, req)
+
+			body, err := io.ReadAll(w.Result().Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(body)).To(ContainSubstring("osac_metering_dlq_depth"))
+			Expect(string(body)).To(ContainSubstring(`topic="osac.metering.dlq"`))
+			Expect(string(body)).NotTo(ContainSubstring("osac_adapter_dlq_depth"))
+		})
 	})
 })

--- a/osac-metering/adapters/metrics_test.go
+++ b/osac-metering/adapters/metrics_test.go
@@ -84,7 +84,7 @@ var _ = Describe("adapterMetrics", func() {
 
 			body, err := io.ReadAll(w.Result().Body)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(strings.Contains(string(body), "osac_adapter_events_submitted_total")).To(BeTrue())
+			Expect(strings.Contains(string(body), "osac_metering_adapter_events_submitted_total")).To(BeTrue())
 		})
 
 		It("exposes osac_metering_dlq_depth labeled by topic", func() {
@@ -98,7 +98,7 @@ var _ = Describe("adapterMetrics", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(body)).To(ContainSubstring("osac_metering_dlq_depth"))
 			Expect(string(body)).To(ContainSubstring(`topic="osac.metering.dlq"`))
-			Expect(string(body)).NotTo(ContainSubstring("osac_adapter_dlq_depth"))
+			Expect(string(body)).NotTo(ContainSubstring("osac_metering_adapter_dlq_depth"))
 		})
 	})
 })

--- a/osac-metering/adapters/runner.go
+++ b/osac-metering/adapters/runner.go
@@ -11,7 +11,6 @@ package adapters
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -19,10 +18,7 @@ import (
 	"time"
 
 	"github.com/IBM/sarama"
-	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/go-logr/logr"
-
-	"github.com/osac-project/osac-metering/schema"
 )
 
 const (
@@ -50,6 +46,14 @@ type topicPartition struct {
 	Partition int32
 }
 
+// RunnerOption configures optional Runner behavior.
+type RunnerOption func(*Runner)
+
+// WithDLQ sets a DLQ sender for routing failed events.
+func WithDLQ(dlq DLQSender) RunnerOption {
+	return func(r *Runner) { r.dlq = dlq }
+}
+
 // Runner manages the Kafka consumer lifecycle for a ProviderAdapter.
 type Runner struct {
 	adapter ProviderAdapter
@@ -58,6 +62,7 @@ type Runner struct {
 	metrics *adapterMetrics
 	dedup   *dedupCache
 	order   *orderTracker
+	dlq     DLQSender
 
 	mu      sync.Mutex
 	offsets map[topicPartition]int64
@@ -65,7 +70,7 @@ type Runner struct {
 }
 
 // NewRunner creates a Runner for the given adapter.
-func NewRunner(adapter ProviderAdapter, cfg RunnerConfig, logger logr.Logger) *Runner {
+func NewRunner(adapter ProviderAdapter, cfg RunnerConfig, logger logr.Logger, opts ...RunnerOption) *Runner {
 	if cfg.FlushInterval == 0 {
 		cfg.FlushInterval = defaultFlushInterval
 	}
@@ -76,7 +81,7 @@ func NewRunner(adapter ProviderAdapter, cfg RunnerConfig, logger logr.Logger) *R
 		cfg.MaxRetries = defaultMaxRetries
 	}
 
-	return &Runner{
+	r := &Runner{
 		adapter: adapter,
 		cfg:     cfg,
 		logger:  logger.WithName("adapter-runner").WithValues("provider", adapter.Name()),
@@ -85,6 +90,10 @@ func NewRunner(adapter ProviderAdapter, cfg RunnerConfig, logger logr.Logger) *R
 		order:   newOrderTracker(cfg.DedupTTL),
 		offsets: make(map[topicPartition]int64),
 	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
 }
 
 // MetricsHandler returns an HTTP handler for Prometheus metrics.
@@ -234,114 +243,12 @@ func (r *Runner) ConsumeClaim(
 	provider := r.adapter.Name()
 
 	for msg := range claim.Messages() {
-		r.processMessage(session.Context(), msg, provider)
+		if !r.processMessage(session.Context(), msg, provider) {
+			r.logger.Info("stopping partition claim after DLQ failure, will retry after rebalance",
+				"topic", claim.Topic(), "partition", claim.Partition(),
+			)
+			return nil
+		}
 	}
 	return nil
-}
-
-func (r *Runner) processMessage(
-	ctx context.Context,
-	msg *sarama.ConsumerMessage,
-	provider string,
-) {
-	var ce cloudevents.Event
-	if err := json.Unmarshal(msg.Value, &ce); err != nil {
-		r.logger.Error(err, "failed to deserialize CloudEvent",
-			"topic", msg.Topic, "partition", msg.Partition, "offset", msg.Offset,
-		)
-		r.metrics.eventsFailed.WithLabelValues(provider, "deserialization").Inc()
-		return
-	}
-
-	eventID := ce.ID()
-
-	if r.dedup.contains(eventID) {
-		r.metrics.duplicatesSuppressed.WithLabelValues(provider).Inc()
-		r.trackOffset(msg)
-		return
-	}
-
-	r.checkOutOfOrder(ce, provider)
-
-	event := MeteringEvent{
-		CloudEvent: ce,
-		Topic:      msg.Topic,
-		Partition:  msg.Partition,
-		Offset:     msg.Offset,
-	}
-
-	result := submitWithRetry(ctx, r.adapter, event, r.cfg.MaxRetries, r.logger)
-
-	if result.TotalDuration > 0 && result.Attempts > 1 {
-		r.metrics.retryDuration.WithLabelValues(provider).Observe(result.TotalDuration.Seconds())
-	}
-
-	if result.Err != nil {
-		if result.NonRetryable {
-			r.metrics.eventsFailed.WithLabelValues(provider, "non_retryable").Inc()
-			r.logger.Error(result.Err, "dropping non-retryable event",
-				"event_id", eventID, "topic", msg.Topic,
-				"partition", msg.Partition, "offset", msg.Offset,
-			)
-		} else if result.Exhausted {
-			r.metrics.eventsFailed.WithLabelValues(provider, "retries_exhausted").Inc()
-			r.logger.Error(result.Err, "dropping event after retries exhausted",
-				"event_id", eventID, "topic", msg.Topic,
-				"partition", msg.Partition, "offset", msg.Offset,
-			)
-		} else {
-			// Context cancelled (e.g., rebalance interrupted retry backoff).
-			// Do NOT track offset — the event will be redelivered to the new
-			// partition owner after rebalance completes.
-			r.logger.V(1).Info("submit interrupted, event will be redelivered",
-				"event_id", eventID, "topic", msg.Topic,
-				"partition", msg.Partition, "offset", msg.Offset,
-				"error", result.Err,
-			)
-			return
-		}
-		// Track the offset for non-retryable and exhausted errors so the
-		// consumer does not redeliver the same poison message on every restart.
-		r.trackOffset(msg)
-		return
-	}
-
-	r.dedup.add(eventID)
-	r.metrics.eventsSubmitted.WithLabelValues(provider, msg.Topic).Inc()
-	r.trackOffset(msg)
-}
-
-func (r *Runner) trackOffset(msg *sarama.ConsumerMessage) {
-	tp := topicPartition{Topic: msg.Topic, Partition: msg.Partition}
-	r.mu.Lock()
-	if current, ok := r.offsets[tp]; !ok || msg.Offset > current {
-		r.offsets[tp] = msg.Offset
-	}
-	r.mu.Unlock()
-}
-
-func (r *Runner) checkOutOfOrder(ce cloudevents.Event, provider string) {
-	resourceID, ok := ce.Extensions()[schema.ExtResourceID]
-	if !ok {
-		return
-	}
-
-	var data map[string]interface{}
-	if err := json.Unmarshal(ce.Data(), &data); err != nil {
-		return
-	}
-
-	ttStr, ok := data["transition_time"].(string)
-	if !ok {
-		return
-	}
-
-	tt, err := time.Parse(time.RFC3339, ttStr)
-	if err != nil {
-		return
-	}
-
-	if r.order.check(fmt.Sprintf("%v", resourceID), tt) {
-		r.metrics.outOfOrderEvents.WithLabelValues(provider).Inc()
-	}
 }

--- a/osac-metering/adapters/runner.go
+++ b/osac-metering/adapters/runner.go
@@ -207,7 +207,7 @@ func (r *Runner) updateDLQDepthMetrics(occ DLQOccupier) {
 		r.logger.Error(err, "failed to scrape DLQ topic occupancy")
 		return
 	}
-	r.metrics.dlqDepth.WithLabelValues(r.adapter.Name()).Set(float64(n))
+	r.metrics.dlqDepth.WithLabelValues(occ.Topic()).Set(float64(n))
 }
 
 func (r *Runner) flush(ctx context.Context) error {

--- a/osac-metering/adapters/runner.go
+++ b/osac-metering/adapters/runner.go
@@ -28,6 +28,7 @@ const (
 	shutdownFlushTimeout = 30 * time.Second
 	shutdownCloseTimeout = 10 * time.Second
 	consumeErrorBackoff  = 5 * time.Second
+	dlqMetricsInterval   = 30 * time.Second
 )
 
 // RunnerConfig configures the adapter Runner.
@@ -121,6 +122,10 @@ func (r *Runner) Run(ctx context.Context) error {
 	flushDone := make(chan struct{})
 	go r.flushLoop(ctx, flushDone)
 
+	if occ, ok := r.dlq.(DLQOccupier); ok {
+		go r.dlqDepthMetricsLoop(ctx, occ)
+	}
+
 	r.logger.Info("starting consumer group", "topics", r.cfg.Topics)
 
 	for {
@@ -178,6 +183,31 @@ func (r *Runner) flushLoop(ctx context.Context, done chan<- struct{}) {
 			}
 		}
 	}
+}
+
+func (r *Runner) dlqDepthMetricsLoop(ctx context.Context, occ DLQOccupier) {
+	r.updateDLQDepthMetrics(occ)
+
+	ticker := time.NewTicker(dlqMetricsInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.updateDLQDepthMetrics(occ)
+		}
+	}
+}
+
+func (r *Runner) updateDLQDepthMetrics(occ DLQOccupier) {
+	n, err := occ.Occupancy()
+	if err != nil {
+		r.logger.Error(err, "failed to scrape DLQ topic occupancy")
+		return
+	}
+	r.metrics.dlqDepth.WithLabelValues(r.adapter.Name()).Set(float64(n))
 }
 
 func (r *Runner) flush(ctx context.Context) error {

--- a/osac-metering/adapters/runner_process.go
+++ b/osac-metering/adapters/runner_process.go
@@ -1,0 +1,165 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package adapters
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/IBM/sarama"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	"github.com/osac-project/osac-metering/schema"
+)
+
+// processMessage handles a single Kafka message. Returns true to continue
+// processing, false to stop the partition claim (e.g., DLQ send failure).
+func (r *Runner) processMessage(
+	ctx context.Context,
+	msg *sarama.ConsumerMessage,
+	provider string,
+) bool {
+	var ce cloudevents.Event
+	if err := json.Unmarshal(msg.Value, &ce); err != nil {
+		r.logger.Error(err, "failed to deserialize CloudEvent",
+			"topic", msg.Topic, "partition", msg.Partition, "offset", msg.Offset,
+		)
+		r.metrics.eventsFailed.WithLabelValues(provider, "deserialization").Inc()
+		if err := r.sendToDLQ(msg, "deserialization", 1, provider); err != nil {
+			return false
+		}
+		r.trackOffset(msg)
+		return true
+	}
+
+	eventID := ce.ID()
+
+	if r.dedup.contains(eventID) {
+		r.metrics.duplicatesSuppressed.WithLabelValues(provider).Inc()
+		r.trackOffset(msg)
+		return true
+	}
+
+	r.checkOutOfOrder(ce, provider)
+
+	event := MeteringEvent{
+		CloudEvent: ce,
+		Topic:      msg.Topic,
+		Partition:  msg.Partition,
+		Offset:     msg.Offset,
+	}
+
+	result := submitWithRetry(ctx, r.adapter, event, r.cfg.MaxRetries, r.logger)
+
+	if result.TotalDuration > 0 && result.Attempts > 1 {
+		r.metrics.retryDuration.WithLabelValues(provider).Observe(result.TotalDuration.Seconds())
+	}
+
+	if result.Err != nil {
+		if result.NonRetryable {
+			r.metrics.eventsFailed.WithLabelValues(provider, "non_retryable").Inc()
+			r.logger.Error(result.Err, "non-retryable error processing event",
+				"event_id", eventID, "topic", msg.Topic,
+				"partition", msg.Partition, "offset", msg.Offset,
+			)
+			if err := r.sendToDLQ(msg, result.Err.Error(), result.Attempts, provider); err != nil {
+				return false
+			}
+		} else if result.Exhausted {
+			r.metrics.eventsFailed.WithLabelValues(provider, "retries_exhausted").Inc()
+			r.logger.Error(result.Err, "retries exhausted processing event",
+				"event_id", eventID, "topic", msg.Topic,
+				"partition", msg.Partition, "offset", msg.Offset,
+			)
+			if err := r.sendToDLQ(msg, result.Err.Error(), result.Attempts, provider); err != nil {
+				return false
+			}
+		} else {
+			// Context cancelled (e.g., rebalance interrupted retry backoff).
+			// Do NOT track offset — the event will be redelivered to the new
+			// partition owner after rebalance completes.
+			r.logger.V(1).Info("submit interrupted, event will be redelivered",
+				"event_id", eventID, "topic", msg.Topic,
+				"partition", msg.Partition, "offset", msg.Offset,
+				"error", result.Err,
+			)
+			return true
+		}
+		r.trackOffset(msg)
+		return true
+	}
+
+	r.dedup.add(eventID)
+	r.metrics.eventsSubmitted.WithLabelValues(provider, msg.Topic).Inc()
+	r.trackOffset(msg)
+	return true
+}
+
+// sendToDLQ attempts to send a failed message to the dead letter queue.
+// Returns nil when the DLQ is not configured (event permanently dropped)
+// or when the send succeeds. Returns an error when the DLQ send fails —
+// callers must NOT commit the offset so the message is redelivered.
+func (r *Runner) sendToDLQ(msg *sarama.ConsumerMessage, reason string, attempts int, provider string) error {
+	if r.dlq == nil {
+		r.logger.Error(nil, "event permanently dropped, no DLQ configured",
+			"topic", msg.Topic, "partition", msg.Partition, "offset", msg.Offset,
+		)
+		r.metrics.eventsDropped.WithLabelValues(provider).Inc()
+		return nil
+	}
+	if err := r.dlq.Send(msg, reason, attempts); err != nil {
+		r.logger.Error(err, "failed to send event to DLQ, event will be redelivered",
+			"topic", msg.Topic, "partition", msg.Partition, "offset", msg.Offset,
+		)
+		r.metrics.dlqSendErrors.WithLabelValues(provider).Inc()
+		return err
+	}
+	r.metrics.dlqEventsTotal.WithLabelValues(provider).Inc()
+	r.metrics.dlqDepth.WithLabelValues(provider).Inc()
+	r.metrics.dlqSize.WithLabelValues(provider).Add(float64(len(msg.Value)))
+	return nil
+}
+
+func (r *Runner) trackOffset(msg *sarama.ConsumerMessage) {
+	tp := topicPartition{Topic: msg.Topic, Partition: msg.Partition}
+	r.mu.Lock()
+	if current, ok := r.offsets[tp]; !ok || msg.Offset > current {
+		r.offsets[tp] = msg.Offset
+	}
+	r.mu.Unlock()
+}
+
+func (r *Runner) checkOutOfOrder(ce cloudevents.Event, provider string) {
+	resourceID, ok := ce.Extensions()[schema.ExtResourceID]
+	if !ok {
+		return
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(ce.Data(), &data); err != nil {
+		return
+	}
+
+	ttStr, ok := data["transition_time"].(string)
+	if !ok {
+		return
+	}
+
+	tt, err := time.Parse(time.RFC3339, ttStr)
+	if err != nil {
+		return
+	}
+
+	if r.order.check(fmt.Sprintf("%v", resourceID), tt) {
+		r.metrics.outOfOrderEvents.WithLabelValues(provider).Inc()
+	}
+}

--- a/osac-metering/adapters/runner_process.go
+++ b/osac-metering/adapters/runner_process.go
@@ -124,7 +124,6 @@ func (r *Runner) sendToDLQ(msg *sarama.ConsumerMessage, reason string, attempts 
 		return err
 	}
 	r.metrics.dlqEventsTotal.WithLabelValues(provider).Inc()
-	r.metrics.dlqDepth.WithLabelValues(provider).Inc()
 	r.metrics.dlqSize.WithLabelValues(provider).Add(float64(len(msg.Value)))
 	return nil
 }

--- a/osac-metering/adapters/runner_test.go
+++ b/osac-metering/adapters/runner_test.go
@@ -134,6 +134,16 @@ func (m *mockDLQSender) Close() error {
 	return nil
 }
 
+type mockDLQOccupier struct {
+	mockDLQSender
+	occupancy    int64
+	occupancyErr error
+}
+
+func (m *mockDLQOccupier) Occupancy() (int64, error) {
+	return m.occupancy, m.occupancyErr
+}
+
 // --- Helpers ---
 
 func newTestMessage(id, resourceID string, offset int64) *sarama.ConsumerMessage {
@@ -630,7 +640,7 @@ var _ = Describe("Runner DLQ integration", func() {
 			Expect(runner.offsets[tp]).To(Equal(int64(7)))
 		})
 
-		It("increments dlq_events_total and dlq_depth metrics", func() {
+		It("increments dlq_events_total without changing occupancy-based dlq_depth", func() {
 			adapter.submitErr = &NonRetryableError{Err: errors.New("bad")}
 			feedMessages(claim, newTestMessage("evt-1", "res-1", 0))
 
@@ -640,7 +650,7 @@ var _ = Describe("Runner DLQ integration", func() {
 			val := testutil.ToFloat64(runner.metrics.dlqEventsTotal.WithLabelValues("test-provider"))
 			Expect(val).To(Equal(float64(1)))
 			depth := testutil.ToFloat64(runner.metrics.dlqDepth.WithLabelValues("test-provider"))
-			Expect(depth).To(Equal(float64(1)))
+			Expect(depth).To(Equal(float64(0)))
 		})
 	})
 
@@ -793,5 +803,49 @@ var _ = Describe("Runner DLQ integration", func() {
 			dropped := testutil.ToFloat64(noDLQRunner.metrics.eventsDropped.WithLabelValues("test-provider"))
 			Expect(dropped).To(Equal(float64(1)))
 		})
+	})
+})
+
+var _ = Describe("Runner DLQ occupancy metrics", func() {
+	var (
+		adapter *mockAdapter
+		runner  *Runner
+		occ     *mockDLQOccupier
+	)
+
+	BeforeEach(func() {
+		adapter = &mockAdapter{name: "test-provider"}
+		occ = &mockDLQOccupier{occupancy: 42}
+		runner = NewRunner(adapter, RunnerConfig{
+			Brokers:       "localhost:9092",
+			ConsumerGroup: "test-group",
+			Topics:        []string{TopicLifecycle},
+		}, logr.Discard(), WithDLQ(occ))
+	})
+
+	It("sets dlq_depth from topic occupancy", func() {
+		runner.updateDLQDepthMetrics(occ)
+		depth := testutil.ToFloat64(runner.metrics.dlqDepth.WithLabelValues("test-provider"))
+		Expect(depth).To(Equal(float64(42)))
+	})
+
+	It("keeps the last dlq_depth when occupancy scrape fails", func() {
+		runner.updateDLQDepthMetrics(occ)
+		occ.occupancyErr = errors.New("broker timeout")
+		occ.occupancy = 0
+
+		runner.updateDLQDepthMetrics(occ)
+
+		depth := testutil.ToFloat64(runner.metrics.dlqDepth.WithLabelValues("test-provider"))
+		Expect(depth).To(Equal(float64(42)))
+	})
+
+	It("scrapes occupancy immediately then returns when the context is already cancelled", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		runner.dlqDepthMetricsLoop(ctx, occ)
+
+		depth := testutil.ToFloat64(runner.metrics.dlqDepth.WithLabelValues("test-provider"))
+		Expect(depth).To(Equal(float64(42)))
 	})
 })

--- a/osac-metering/adapters/runner_test.go
+++ b/osac-metering/adapters/runner_test.go
@@ -103,6 +103,37 @@ func (c *mockClaim) InitialOffset() int64                     { return 0 }
 func (c *mockClaim) HighWaterMarkOffset() int64               { return 0 }
 func (c *mockClaim) Messages() <-chan *sarama.ConsumerMessage { return c.messages }
 
+type mockDLQSender struct {
+	mu      sync.Mutex
+	sends   []dlqSendEntry
+	sendErr error
+	sendFn  func(msg *sarama.ConsumerMessage) error
+	closed  bool
+}
+
+type dlqSendEntry struct {
+	msg      *sarama.ConsumerMessage
+	reason   string
+	attempts int
+}
+
+func (m *mockDLQSender) Send(msg *sarama.ConsumerMessage, reason string, attempts int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sends = append(m.sends, dlqSendEntry{msg: msg, reason: reason, attempts: attempts})
+	if m.sendFn != nil {
+		return m.sendFn(msg)
+	}
+	return m.sendErr
+}
+
+func (m *mockDLQSender) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closed = true
+	return nil
+}
+
 // --- Helpers ---
 
 func newTestMessage(id, resourceID string, offset int64) *sarama.ConsumerMessage {
@@ -155,6 +186,17 @@ func newRunner(adapter ProviderAdapter) *Runner {
 		DedupTTL:      10 * time.Minute,
 		MaxRetries:    3,
 	}, logr.Discard())
+}
+
+func newRunnerWithDLQ(adapter ProviderAdapter, dlq DLQSender) *Runner {
+	return NewRunner(adapter, RunnerConfig{
+		Brokers:       "localhost:9092",
+		ConsumerGroup: "test-group",
+		Topics:        []string{TopicLifecycle},
+		FlushInterval: 10 * time.Second,
+		DedupTTL:      10 * time.Minute,
+		MaxRetries:    3,
+	}, logr.Discard(), WithDLQ(dlq))
 }
 
 func feedMessages(claim *mockClaim, msgs ...*sarama.ConsumerMessage) {
@@ -323,6 +365,15 @@ var _ = Describe("Runner", func() {
 
 			val := testutil.ToFloat64(runner.metrics.eventsFailed.WithLabelValues("test-provider", "deserialization"))
 			Expect(val).To(Equal(float64(1)))
+
+			dropped := testutil.ToFloat64(runner.metrics.eventsDropped.WithLabelValues("test-provider"))
+			Expect(dropped).To(Equal(float64(1)))
+
+			runner.mu.Lock()
+			offset, ok := runner.offsets[topicPartition{Topic: TopicLifecycle, Partition: 0}]
+			runner.mu.Unlock()
+			Expect(ok).To(BeTrue())
+			Expect(offset).To(Equal(int64(0)))
 		})
 
 		It("increments non_retryable metric on NonRetryableError", func() {
@@ -525,6 +576,222 @@ var _ = Describe("Runner", func() {
 			Expect(session.marks).To(HaveLen(1))
 			Expect(session.marks[0].offset).To(Equal(int64(3))) // highest offset (2) + 1
 			Expect(session.committed).To(Equal(1))
+		})
+	})
+})
+
+var _ = Describe("Runner DLQ integration", func() {
+	var (
+		adapter   *mockAdapter
+		dlqSender *mockDLQSender
+		runner    *Runner
+		session   *mockSession
+		claim     *mockClaim
+	)
+
+	BeforeEach(func() {
+		adapter = &mockAdapter{name: "test-provider"}
+		dlqSender = &mockDLQSender{}
+		runner = newRunnerWithDLQ(adapter, dlqSender)
+		session = &mockSession{ctx: context.Background()}
+		claim = &mockClaim{
+			topic:     TopicLifecycle,
+			partition: 0,
+			messages:  make(chan *sarama.ConsumerMessage, 10),
+		}
+		_ = runner.Setup(session)
+	})
+
+	Describe("non-retryable errors", func() {
+		It("routes to DLQ with correct metadata", func() {
+			adapter.submitErr = &NonRetryableError{Err: errors.New("bad schema")}
+			feedMessages(claim, newTestMessage("evt-1", "res-1", 5))
+
+			err := runner.ConsumeClaim(session, claim)
+			Expect(err).NotTo(HaveOccurred())
+
+			dlqSender.mu.Lock()
+			defer dlqSender.mu.Unlock()
+			Expect(dlqSender.sends).To(HaveLen(1))
+			Expect(dlqSender.sends[0].reason).To(ContainSubstring("bad schema"))
+			Expect(dlqSender.sends[0].attempts).To(Equal(1))
+		})
+
+		It("tracks offset after DLQ send", func() {
+			adapter.submitErr = &NonRetryableError{Err: errors.New("bad")}
+			feedMessages(claim, newTestMessage("evt-1", "res-1", 7))
+
+			err := runner.ConsumeClaim(session, claim)
+			Expect(err).NotTo(HaveOccurred())
+
+			runner.mu.Lock()
+			defer runner.mu.Unlock()
+			tp := topicPartition{Topic: TopicLifecycle, Partition: 0}
+			Expect(runner.offsets[tp]).To(Equal(int64(7)))
+		})
+
+		It("increments dlq_events_total and dlq_depth metrics", func() {
+			adapter.submitErr = &NonRetryableError{Err: errors.New("bad")}
+			feedMessages(claim, newTestMessage("evt-1", "res-1", 0))
+
+			err := runner.ConsumeClaim(session, claim)
+			Expect(err).NotTo(HaveOccurred())
+
+			val := testutil.ToFloat64(runner.metrics.dlqEventsTotal.WithLabelValues("test-provider"))
+			Expect(val).To(Equal(float64(1)))
+			depth := testutil.ToFloat64(runner.metrics.dlqDepth.WithLabelValues("test-provider"))
+			Expect(depth).To(Equal(float64(1)))
+		})
+	})
+
+	Describe("exhausted retries", func() {
+		It("routes to DLQ after all retries exhausted", func() {
+			adapter.submitErr = errors.New("always fails")
+			feedMessages(claim, newTestMessage("evt-1", "res-1", 10))
+
+			err := runner.ConsumeClaim(session, claim)
+			Expect(err).NotTo(HaveOccurred())
+
+			dlqSender.mu.Lock()
+			defer dlqSender.mu.Unlock()
+			Expect(dlqSender.sends).To(HaveLen(1))
+			Expect(dlqSender.sends[0].reason).To(ContainSubstring("always fails"))
+			Expect(dlqSender.sends[0].attempts).To(Equal(3)) // maxRetries=3
+		})
+	})
+
+	Describe("deserialization errors", func() {
+		It("routes raw bytes to DLQ", func() {
+			msg := &sarama.ConsumerMessage{
+				Topic:     TopicLifecycle,
+				Partition: 0,
+				Offset:    42,
+				Value:     []byte("not valid json{{{"),
+			}
+			feedMessages(claim, msg)
+
+			err := runner.ConsumeClaim(session, claim)
+			Expect(err).NotTo(HaveOccurred())
+
+			dlqSender.mu.Lock()
+			defer dlqSender.mu.Unlock()
+			Expect(dlqSender.sends).To(HaveLen(1))
+			Expect(dlqSender.sends[0].reason).To(Equal("deserialization"))
+			Expect(dlqSender.sends[0].attempts).To(Equal(1))
+			Expect(string(dlqSender.sends[0].msg.Value)).To(Equal("not valid json{{{"))
+		})
+
+		It("stops partition claim when DLQ send fails for deserialization errors", func() {
+			dlqSender.sendErr = errors.New("DLQ broker down")
+			msg := &sarama.ConsumerMessage{
+				Topic:     TopicLifecycle,
+				Partition: 0,
+				Offset:    42,
+				Value:     []byte("not valid json{{{"),
+			}
+			feedMessages(claim, msg, newTestMessage("evt-2", "res-2", 43))
+
+			err := runner.ConsumeClaim(session, claim)
+			Expect(err).NotTo(HaveOccurred())
+
+			runner.mu.Lock()
+			defer runner.mu.Unlock()
+			tp := topicPartition{Topic: TopicLifecycle, Partition: 0}
+			_, tracked := runner.offsets[tp]
+			Expect(tracked).To(BeFalse(), "offset must not be tracked when DLQ send fails")
+		})
+
+		It("tracks offset after DLQ send for deserialization errors", func() {
+			msg := &sarama.ConsumerMessage{
+				Topic:     TopicLifecycle,
+				Partition: 0,
+				Offset:    99,
+				Value:     []byte("bad"),
+			}
+			feedMessages(claim, msg)
+
+			err := runner.ConsumeClaim(session, claim)
+			Expect(err).NotTo(HaveOccurred())
+
+			runner.mu.Lock()
+			defer runner.mu.Unlock()
+			tp := topicPartition{Topic: TopicLifecycle, Partition: 0}
+			Expect(runner.offsets[tp]).To(Equal(int64(99)))
+		})
+	})
+
+	Describe("DLQ send failures", func() {
+		It("stops partition claim and does not track offset when DLQ send fails", func() {
+			adapter.submitErr = &NonRetryableError{Err: errors.New("bad")}
+			dlqSender.sendErr = errors.New("DLQ broker down")
+
+			feedMessages(claim,
+				newTestMessage("evt-1", "res-1", 5),
+				newTestMessage("evt-2", "res-2", 6),
+			)
+
+			err := runner.ConsumeClaim(session, claim)
+			Expect(err).NotTo(HaveOccurred())
+
+			runner.mu.Lock()
+			defer runner.mu.Unlock()
+			tp := topicPartition{Topic: TopicLifecycle, Partition: 0}
+			_, tracked := runner.offsets[tp]
+			Expect(tracked).To(BeFalse(), "offset must not be tracked when DLQ send fails")
+		})
+
+		It("does not process subsequent messages after DLQ send failure", func() {
+			adapter.submitErr = &NonRetryableError{Err: errors.New("bad")}
+			dlqSender.sendErr = errors.New("DLQ broker down")
+
+			feedMessages(claim,
+				newTestMessage("evt-1", "res-1", 5),
+				newTestMessage("evt-2", "res-2", 6),
+			)
+
+			err := runner.ConsumeClaim(session, claim)
+			Expect(err).NotTo(HaveOccurred())
+
+			adapter.mu.Lock()
+			defer adapter.mu.Unlock()
+			Expect(adapter.submitCalls).To(HaveLen(1), "second message must not be processed")
+		})
+
+		It("increments dlq_send_errors metric", func() {
+			adapter.submitErr = &NonRetryableError{Err: errors.New("bad")}
+			dlqSender.sendErr = errors.New("DLQ broker down")
+
+			feedMessages(claim, newTestMessage("evt-1", "res-1", 0))
+
+			err := runner.ConsumeClaim(session, claim)
+			Expect(err).NotTo(HaveOccurred())
+
+			val := testutil.ToFloat64(runner.metrics.dlqSendErrors.WithLabelValues("test-provider"))
+			Expect(val).To(Equal(float64(1)))
+		})
+	})
+
+	Describe("backward compatibility", func() {
+		It("still works without DLQ (nil sender)", func() {
+			noDLQRunner := newRunner(adapter)
+			_ = noDLQRunner.Setup(session)
+			noDLQClaim := &mockClaim{
+				topic:     TopicLifecycle,
+				partition: 0,
+				messages:  make(chan *sarama.ConsumerMessage, 10),
+			}
+
+			adapter.submitErr = &NonRetryableError{Err: errors.New("bad")}
+			feedMessages(noDLQClaim, newTestMessage("evt-1", "res-1", 0))
+
+			err := noDLQRunner.ConsumeClaim(session, noDLQClaim)
+			Expect(err).NotTo(HaveOccurred())
+
+			val := testutil.ToFloat64(noDLQRunner.metrics.eventsFailed.WithLabelValues("test-provider", "non_retryable"))
+			Expect(val).To(Equal(float64(1)))
+
+			dropped := testutil.ToFloat64(noDLQRunner.metrics.eventsDropped.WithLabelValues("test-provider"))
+			Expect(dropped).To(Equal(float64(1)))
 		})
 	})
 })

--- a/osac-metering/adapters/runner_test.go
+++ b/osac-metering/adapters/runner_test.go
@@ -138,10 +138,18 @@ type mockDLQOccupier struct {
 	mockDLQSender
 	occupancy    int64
 	occupancyErr error
+	topic        string
 }
 
 func (m *mockDLQOccupier) Occupancy() (int64, error) {
 	return m.occupancy, m.occupancyErr
+}
+
+func (m *mockDLQOccupier) Topic() string {
+	if m.topic == "" {
+		return TopicDLQ
+	}
+	return m.topic
 }
 
 // --- Helpers ---
@@ -649,7 +657,7 @@ var _ = Describe("Runner DLQ integration", func() {
 
 			val := testutil.ToFloat64(runner.metrics.dlqEventsTotal.WithLabelValues("test-provider"))
 			Expect(val).To(Equal(float64(1)))
-			depth := testutil.ToFloat64(runner.metrics.dlqDepth.WithLabelValues("test-provider"))
+			depth := testutil.ToFloat64(runner.metrics.dlqDepth.WithLabelValues(TopicDLQ))
 			Expect(depth).To(Equal(float64(0)))
 		})
 	})
@@ -825,8 +833,16 @@ var _ = Describe("Runner DLQ occupancy metrics", func() {
 
 	It("sets dlq_depth from topic occupancy", func() {
 		runner.updateDLQDepthMetrics(occ)
-		depth := testutil.ToFloat64(runner.metrics.dlqDepth.WithLabelValues("test-provider"))
+		depth := testutil.ToFloat64(runner.metrics.dlqDepth.WithLabelValues(TopicDLQ))
 		Expect(depth).To(Equal(float64(42)))
+	})
+
+	It("labels dlq_depth by topic, not provider", func() {
+		occ.topic = "custom.dlq"
+		runner.updateDLQDepthMetrics(occ)
+
+		Expect(testutil.ToFloat64(runner.metrics.dlqDepth.WithLabelValues("custom.dlq"))).To(Equal(float64(42)))
+		Expect(testutil.ToFloat64(runner.metrics.dlqDepth.WithLabelValues("test-provider"))).To(Equal(float64(0)))
 	})
 
 	It("keeps the last dlq_depth when occupancy scrape fails", func() {
@@ -836,7 +852,7 @@ var _ = Describe("Runner DLQ occupancy metrics", func() {
 
 		runner.updateDLQDepthMetrics(occ)
 
-		depth := testutil.ToFloat64(runner.metrics.dlqDepth.WithLabelValues("test-provider"))
+		depth := testutil.ToFloat64(runner.metrics.dlqDepth.WithLabelValues(TopicDLQ))
 		Expect(depth).To(Equal(float64(42)))
 	})
 
@@ -845,7 +861,7 @@ var _ = Describe("Runner DLQ occupancy metrics", func() {
 		cancel()
 		runner.dlqDepthMetricsLoop(ctx, occ)
 
-		depth := testutil.ToFloat64(runner.metrics.dlqDepth.WithLabelValues("test-provider"))
+		depth := testutil.ToFloat64(runner.metrics.dlqDepth.WithLabelValues(TopicDLQ))
 		Expect(depth).To(Equal(float64(42)))
 	})
 })

--- a/osac-metering/adapters/topics.go
+++ b/osac-metering/adapters/topics.go
@@ -14,6 +14,7 @@ const (
 	TopicHeartbeat   = "osac.metering.heartbeat"
 	TopicCorrections = "osac.metering.corrections"
 	TopicInference   = "osac.metering.inference"
+	TopicDLQ         = "osac.metering.dlq"
 )
 
 var AllTopics = []string{TopicLifecycle, TopicHeartbeat, TopicCorrections, TopicInference}

--- a/osac-metering/charts/osac-metering/templates/echo-adapter-deployment.yaml
+++ b/osac-metering/charts/osac-metering/templates/echo-adapter-deployment.yaml
@@ -105,6 +105,10 @@ spec:
               value: osac-metering-echo-adapter
             - name: KAFKA_SASL_PASSWORD_FILE
               value: /etc/kafka-secrets/password
+            - name: DLQ_TOPIC
+              value: "osac.metering.dlq"
+            - name: DLQ_ENABLED
+              value: "true"
             - name: METRICS_ADDR
               value: ":8080"
           volumeMounts:

--- a/osac-metering/charts/osac-metering/templates/echo-adapter-kafka-user.yaml
+++ b/osac-metering/charts/osac-metering/templates/echo-adapter-kafka-user.yaml
@@ -21,6 +21,20 @@ spec:
           - Describe
         host: "*"
       - resource:
+          type: topic
+          name: osac.metering.dlq
+          patternType: literal
+        operations:
+          - Write
+        host: "*"
+      - resource:
+          type: cluster
+          name: kafka-cluster
+          patternType: literal
+        operations:
+          - IdempotentWrite
+        host: "*"
+      - resource:
           type: group
           name: osac-metering-echo-adapter
           patternType: literal

--- a/osac-metering/charts/osac-metering/templates/kafka-topics.yaml
+++ b/osac-metering/charts/osac-metering/templates/kafka-topics.yaml
@@ -7,7 +7,7 @@
   (dict "name" "osac.metering.heartbeat"    "partitions" 3 "retentionDays" 30)
   (dict "name" "osac.metering.inference"    "partitions" 3 "retentionDays" 30)
   (dict "name" "osac.metering.corrections"  "partitions" 3 "retentionDays" 30)
-  (dict "name" "osac.metering.dlq"          "partitions" 1 "retentionDays" 90)
+  (dict "name" "osac.metering.dlq"          "partitions" 6 "retentionDays" 90)
 }}
 apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic

--- a/osac-metering/charts/osac-metering/templates/m360-adapter-deployment.yaml
+++ b/osac-metering/charts/osac-metering/templates/m360-adapter-deployment.yaml
@@ -114,6 +114,10 @@ spec:
               value: /etc/m360/api-key
             - name: M360_API_VERSION
               value: {{ .Values.m360Adapter.m360.apiVersion | default "v1" | quote }}
+            - name: DLQ_TOPIC
+              value: "osac.metering.dlq"
+            - name: DLQ_ENABLED
+              value: "true"
             - name: METRICS_ADDR
               value: ":8080"
           volumeMounts:

--- a/osac-metering/charts/osac-metering/templates/m360-adapter-kafka-user.yaml
+++ b/osac-metering/charts/osac-metering/templates/m360-adapter-kafka-user.yaml
@@ -21,6 +21,20 @@ spec:
           - Describe
         host: "*"
       - resource:
+          type: topic
+          name: osac.metering.dlq
+          patternType: literal
+        operations:
+          - Write
+        host: "*"
+      - resource:
+          type: cluster
+          name: kafka-cluster
+          patternType: literal
+        operations:
+          - IdempotentWrite
+        host: "*"
+      - resource:
           type: group
           name: osac-metering-m360-adapter
           patternType: literal


### PR DESCRIPTION
## Summary

- Add dead letter queue (DLQ) support to the metering adapter framework for routing failed events (non-retryable errors, retries exhausted, deserialization failures) to a dedicated Kafka DLQ topic
- On DLQ send failure, stop the partition claim so no subsequent offsets are committed past the failed message — prevents silent data loss
- Extract shared `DLQOptionFromEnv` helper to eliminate DLQ init duplication across adapter binaries
- Fix metric naming: use `osac_adapter_` prefix consistently, use Counter (not Gauge) for DLQ event count

## Changes

- `adapters/dlq.go` — `DLQSender` interface, `DLQProducer` implementation, `DLQOptionFromEnv` helper
- `adapters/runner_process.go` — extracted message processing logic from `runner.go`; `sendToDLQ` returns error, `processMessage` returns bool to stop partition on DLQ failure
- `adapters/runner.go` — `ConsumeClaim` stops partition loop on DLQ failure
- `adapters/metrics.go` — `osac_adapter_dlq_events_total` (Counter), `osac_adapter_dlq_send_errors_total`
- `adapters/kafka.go` — renamed `configureConsumerTLS/SASL` → `configureTLS/SASL` (used by both consumer and producer)
- `adapters/cmd/echo-adapter/main.go`, `adapters/cmd/m360-adapter/main.go` — use `DLQOptionFromEnv`
- `AGENTS.md` — document new DLQ metrics

## Test plan

- [ ] `make test` in `osac-metering/adapters/` passes (Ginkgo)
- [ ] DLQ send failure stops partition claim and does not track offset
- [ ] Subsequent messages are not processed after DLQ send failure
- [ ] DLQ events counter increments on successful DLQ send
- [ ] DLQ send errors counter increments on failed DLQ send
- [ ] Backward compatibility: runner works without DLQ configured (nil sender)
- [ ] CI `run-osac-metering-adapters-tests` job passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dead-letter queue handling for deserialization, processing, and retry-exhaustion failures while preserving payloads and failure details.
  * Added DLQ occupancy and delivery metrics with topic-based depth reporting.
* **Bug Fixes**
  * Failed DLQ deliveries now pause offset tracking and partition consumption for safe retries.
  * Improved metrics server shutdown and request timeout handling.
* **Configuration**
  * Enabled DLQ support and required access for deployed adapters.
  * Increased DLQ topic capacity to six partitions.
* **Documentation**
  * Standardized metric names and documented DLQ configuration, behavior, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->