### PR TITLE
OSAC-4145: emit events to M360 Kafka topics

### DIFF
--- a/osac-metering/AGENTS.md
+++ b/osac-metering/AGENTS.md
@@ -119,17 +119,21 @@ Deployed via Helm with `echoAdapter.enabled: true` (disabled by default; enabled
 
 ### M360 Adapter
 
-`adapters/cmd/m360-adapter/` forwards OSAC metering CloudEvents to the Monetize360 (M360) Usage API via REST. It translates nested CloudEvents to M360's flat payload format and routes to the correct M360 endpoint by resource type (`/vmaas/event`, `/caas/event`, `/maas/event`).
+`adapters/cmd/m360-adapter/` forwards OSAC metering CloudEvents to the Monetize360 (M360) Usage API via REST or Kafka. It translates nested CloudEvents to M360's flat payload format and routes by resource type via protocol-neutral route keys (`vmaas`, `caas`, `maas`).
 
-- Per-event submit (M360 API is per-event; no batch endpoint)
-- Bearer token auth from K8s Secret file mount
-- Error classification: 4xx → non-retryable (except 408/429), 5xx → retryable
-- TLS enabled by default, configurable API version (default `v1`)
+**Output protocol** is configured per-deployment via `M360_OUTPUT_PROTOCOL` (default `rest`):
+
+- **REST** — POST to M360 Usage API endpoints (`/vmaas/event`, `/caas/event`, `/maas/event`), Bearer token auth from K8s Secret
+- **Kafka** — Produce flat M360 JSON to M360 Kafka topics (`m360.metering.vmaas`, etc.), resource_id as message key, idempotent SyncProducer
+
+Common features:
+- Per-event submit, error classification: 4xx → non-retryable (except 408/429), 5xx → retryable
 - `GET /healthz` — liveness probe (always 200)
-- `GET /readyz` — readiness probe (TCP/TLS reachability check to M360 base URL)
+- `GET /readyz` — readiness probe (REST: TCP/TLS to M360 base URL; Kafka: metadata refresh)
 - `GET /metrics` — Prometheus metrics
+- `submitter` interface abstracts output protocol (`restSubmitter`, `kafkaSubmitter`)
 
-Deployed via Helm with `m360Adapter.enabled: true` (disabled by default).
+Deployed via Helm with `m360Adapter.enabled: true` (disabled by default). Set `m360Adapter.output.protocol: kafka` and configure `m360Adapter.output.kafka.*` for Kafka output.
 
 ## Deployment
 
@@ -155,9 +159,14 @@ Key configuration parameters in `charts/osac-metering/values.yaml`:
 - `certs.caBundle.configMap` — CA bundle ConfigMap name
 - `echoAdapter.enabled` — Deploy the echo-adapter (default `false`)
 - `m360Adapter.enabled` — Deploy the m360-adapter (default `false`)
-- `m360Adapter.m360.apiUrl` — M360 Usage API base URL
-- `m360Adapter.m360.apiKeySecret` — K8s Secret name containing the M360 API key
+- `m360Adapter.m360.apiUrl` — M360 Usage API base URL (required when protocol=rest)
+- `m360Adapter.m360.apiKeySecret` — K8s Secret name containing the M360 API key (required when protocol=rest)
 - `m360Adapter.m360.apiVersion` — M360 API version (default `v1`)
+- `m360Adapter.output.protocol` — Output protocol: `rest` or `kafka` (default `rest`)
+- `m360Adapter.output.kafka.brokers` — M360 Kafka bootstrap servers (required when protocol=kafka)
+- `m360Adapter.output.kafka.tls.*` — TLS config for M360 Kafka (enabled by default)
+- `m360Adapter.output.kafka.sasl.*` — SASL/SCRAM config for M360 Kafka
+- `m360Adapter.output.kafka.topics.*` — Topic name overrides (defaults: `m360.metering.vmaas/caas/maas`)
 
 ## CI Integration
 

--- a/osac-metering/adapters/adapter.go
+++ b/osac-metering/adapters/adapter.go
@@ -60,7 +60,7 @@ type NonRetryableError struct{ Err error }
 func (e *NonRetryableError) Error() string { return e.Err.Error() }
 func (e *NonRetryableError) Unwrap() error { return e.Err }
 
-// KafkaConfig configures the Kafka consumer connection.
+// KafkaConfig configures Kafka connections (consumer and producer).
 type KafkaConfig struct {
 	TLSEnabled   bool   // Enable TLS for broker connections
 	TLSCACert    string // Path to CA certificate file (empty = system CAs)

--- a/osac-metering/adapters/cmd/m360-adapter/client.go
+++ b/osac-metering/adapters/cmd/m360-adapter/client.go
@@ -35,8 +35,15 @@ const (
 	maxBodyLog = 256
 )
 
-// m360Client sends events to the M360 Usage API.
-type m360Client struct {
+// routeEndpoints maps protocol-neutral route keys to M360 REST endpoints.
+var routeEndpoints = map[string]string{
+	routeVMaaS: "/vmaas/event",
+	routeCaaS:  "/caas/event",
+	routeMaaS:  "/maas/event",
+}
+
+// restSubmitter sends events to the M360 Usage API via REST.
+type restSubmitter struct {
 	httpClient *http.Client
 	baseURL    string
 	apiVersion string
@@ -44,21 +51,32 @@ type m360Client struct {
 	logger     logr.Logger
 }
 
-// newM360Client creates a client for the M360 Usage API.
-func newM360Client(baseURL, apiVersion, apiKey string) *m360Client {
-	return &m360Client{
+// newRESTSubmitter creates a REST submitter for the M360 Usage API.
+func newRESTSubmitter(baseURL, apiVersion, apiKey string, logger logr.Logger) *restSubmitter {
+	return &restSubmitter{
 		httpClient: &http.Client{Timeout: httpTimeout},
 		baseURL:    baseURL,
 		apiVersion: apiVersion,
 		apiKey:     apiKey,
-		logger:     logr.Discard(),
+		logger:     logger,
 	}
+}
+
+// submit looks up the REST endpoint for the given route key and posts the payload.
+func (s *restSubmitter) submit(ctx context.Context, route string, payload map[string]any) error {
+	endpoint, ok := routeEndpoints[route]
+	if !ok {
+		return &adapters.NonRetryableError{
+			Err: fmt.Errorf("unknown route %q", route),
+		}
+	}
+	return s.post(ctx, endpoint, payload)
 }
 
 // post sends a flat M360 payload to the given endpoint.
 // Returns NonRetryableError for 4xx responses (except 408 and 429,
 // which are retryable), plain error for 5xx.
-func (c *m360Client) post(ctx context.Context, endpoint string, payload map[string]any) error {
+func (s *restSubmitter) post(ctx context.Context, endpoint string, payload map[string]any) error {
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return &adapters.NonRetryableError{
@@ -66,16 +84,16 @@ func (c *m360Client) post(ctx context.Context, endpoint string, payload map[stri
 		}
 	}
 
-	url := fmt.Sprintf("%s/api/%s/external/run%s", c.baseURL, c.apiVersion, endpoint)
+	url := fmt.Sprintf("%s/api/%s/external/run%s", s.baseURL, s.apiVersion, endpoint)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("create M360 request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Authorization", "Bearer "+s.apiKey)
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("M360 request to %s: %w", endpoint, err)
 	}
@@ -87,7 +105,7 @@ func (c *m360Client) post(ctx context.Context, endpoint string, payload map[stri
 	}
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		c.logResponse(respBody)
+		s.logResponse(respBody)
 		return nil
 	}
 
@@ -110,16 +128,16 @@ func (c *m360Client) post(ctx context.Context, endpoint string, payload map[stri
 // Only connection-level errors (timeout, refused, DNS) cause failure.
 // Auth and API route failures surface as post() errors /
 // osac_adapter_events_failed_total, not here.
-func (c *m360Client) healthCheck(ctx context.Context) error {
+func (s *restSubmitter) healthCheck(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, healthCheckTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, c.baseURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, s.baseURL, nil)
 	if err != nil {
 		return fmt.Errorf("create health check request: %w", err)
 	}
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("M360 health check: %w", err)
 	}
@@ -127,14 +145,17 @@ func (c *m360Client) healthCheck(ctx context.Context) error {
 	return nil
 }
 
+// close releases resources held by the REST submitter.
+func (s *restSubmitter) close() error { return nil }
+
 // logResponse extracts event_id from a successful M360 response for debug logging.
-func (c *m360Client) logResponse(body []byte) {
+func (s *restSubmitter) logResponse(body []byte) {
 	var resp struct {
 		Output struct {
 			EventID string `json:"event_id"`
 		} `json:"output"`
 	}
 	if err := json.Unmarshal(body, &resp); err == nil && resp.Output.EventID != "" {
-		c.logger.V(1).Info("M360 event accepted", "m360_event_id", resp.Output.EventID)
+		s.logger.V(1).Info("M360 event accepted", "m360_event_id", resp.Output.EventID)
 	}
 }

--- a/osac-metering/adapters/cmd/m360-adapter/client_test.go
+++ b/osac-metering/adapters/cmd/m360-adapter/client_test.go
@@ -17,16 +17,17 @@ import (
 	"net/http"
 	"net/http/httptest"
 
+	"github.com/go-logr/logr"
 	"github.com/osac-project/osac-metering/adapters"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("m360Client", func() {
+var _ = Describe("restSubmitter", func() {
 	var (
 		server *httptest.Server
-		client *m360Client
+		sub    *restSubmitter
 	)
 
 	AfterEach(func() {
@@ -35,7 +36,7 @@ var _ = Describe("m360Client", func() {
 		}
 	})
 
-	Describe("post", func() {
+	Describe("submit", func() {
 		It("sends POST with correct URL, auth header, and body", func() {
 			var capturedReq *http.Request
 			var capturedBody []byte
@@ -45,10 +46,10 @@ var _ = Describe("m360Client", func() {
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{"output":{"event_id":"m360-ev-1"}}`))
 			}))
-			client = newM360Client(server.URL, "v1", "test-api-key")
+			sub = newRESTSubmitter(server.URL, "v1", "test-api-key", logr.Discard())
 
 			payload := map[string]any{"event_id": "ce-123", "resource_type": "compute_instance"}
-			err := client.post(context.Background(), "/vmaas/event", payload)
+			err := sub.submit(context.Background(), "vmaas", payload)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(capturedReq.Method).To(Equal("POST"))
@@ -68,9 +69,9 @@ var _ = Describe("m360Client", func() {
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{"output":{"event_id":"ev-1"}}`))
 			}))
-			client = newM360Client(server.URL, "v2", "key")
+			sub = newRESTSubmitter(server.URL, "v2", "key", logr.Discard())
 
-			err := client.post(context.Background(), "/caas/event", map[string]any{})
+			err := sub.submit(context.Background(), "caas", map[string]any{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(capturedPath).To(Equal("/api/v2/external/run/caas/event"))
 		})
@@ -80,9 +81,9 @@ var _ = Describe("m360Client", func() {
 				w.WriteHeader(http.StatusBadRequest)
 				_, _ = w.Write([]byte(`{"error":"bad request"}`))
 			}))
-			client = newM360Client(server.URL, "v1", "key")
+			sub = newRESTSubmitter(server.URL, "v1", "key", logr.Discard())
 
-			err := client.post(context.Background(), "/vmaas/event", map[string]any{})
+			err := sub.submit(context.Background(), "vmaas", map[string]any{})
 
 			Expect(err).To(HaveOccurred())
 			var nonRetryable *adapters.NonRetryableError
@@ -93,9 +94,9 @@ var _ = Describe("m360Client", func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusUnauthorized)
 			}))
-			client = newM360Client(server.URL, "v1", "bad-key")
+			sub = newRESTSubmitter(server.URL, "v1", "bad-key", logr.Discard())
 
-			err := client.post(context.Background(), "/vmaas/event", map[string]any{})
+			err := sub.submit(context.Background(), "vmaas", map[string]any{})
 
 			var nonRetryable *adapters.NonRetryableError
 			Expect(errors.As(err, &nonRetryable)).To(BeTrue())
@@ -105,9 +106,9 @@ var _ = Describe("m360Client", func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusRequestTimeout)
 			}))
-			client = newM360Client(server.URL, "v1", "key")
+			sub = newRESTSubmitter(server.URL, "v1", "key", logr.Discard())
 
-			err := client.post(context.Background(), "/vmaas/event", map[string]any{})
+			err := sub.submit(context.Background(), "vmaas", map[string]any{})
 
 			Expect(err).To(HaveOccurred())
 			var nonRetryable *adapters.NonRetryableError
@@ -118,9 +119,9 @@ var _ = Describe("m360Client", func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusTooManyRequests)
 			}))
-			client = newM360Client(server.URL, "v1", "key")
+			sub = newRESTSubmitter(server.URL, "v1", "key", logr.Discard())
 
-			err := client.post(context.Background(), "/vmaas/event", map[string]any{})
+			err := sub.submit(context.Background(), "vmaas", map[string]any{})
 
 			Expect(err).To(HaveOccurred())
 			var nonRetryable *adapters.NonRetryableError
@@ -131,9 +132,9 @@ var _ = Describe("m360Client", func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
 			}))
-			client = newM360Client(server.URL, "v1", "key")
+			sub = newRESTSubmitter(server.URL, "v1", "key", logr.Discard())
 
-			err := client.post(context.Background(), "/vmaas/event", map[string]any{})
+			err := sub.submit(context.Background(), "vmaas", map[string]any{})
 
 			Expect(err).To(HaveOccurred())
 			var nonRetryable *adapters.NonRetryableError
@@ -144,13 +145,26 @@ var _ = Describe("m360Client", func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			}))
-			client = newM360Client(server.URL, "v1", "key")
+			sub = newRESTSubmitter(server.URL, "v1", "key", logr.Discard())
 
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel() // cancel immediately
 
-			err := client.post(ctx, "/vmaas/event", map[string]any{})
+			err := sub.submit(ctx, "vmaas", map[string]any{})
 			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns NonRetryableError for unknown route", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			sub = newRESTSubmitter(server.URL, "v1", "key", logr.Discard())
+
+			err := sub.submit(context.Background(), "unknown-route", map[string]any{})
+
+			Expect(err).To(HaveOccurred())
+			var nonRetryable *adapters.NonRetryableError
+			Expect(errors.As(err, &nonRetryable)).To(BeTrue())
 		})
 	})
 
@@ -159,9 +173,9 @@ var _ = Describe("m360Client", func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			}))
-			client = newM360Client(server.URL, "v1", "key")
+			sub = newRESTSubmitter(server.URL, "v1", "key", logr.Discard())
 
-			err := client.healthCheck(context.Background())
+			err := sub.healthCheck(context.Background())
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -169,9 +183,9 @@ var _ = Describe("m360Client", func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
 			}))
-			client = newM360Client(server.URL, "v1", "key")
+			sub = newRESTSubmitter(server.URL, "v1", "key", logr.Discard())
 
-			err := client.healthCheck(context.Background())
+			err := sub.healthCheck(context.Background())
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -183,18 +197,18 @@ var _ = Describe("m360Client", func() {
 				capturedPath = r.URL.Path
 				w.WriteHeader(http.StatusOK)
 			}))
-			client = newM360Client(server.URL, "v1", "key")
+			sub = newRESTSubmitter(server.URL, "v1", "key", logr.Discard())
 
-			err := client.healthCheck(context.Background())
+			err := sub.healthCheck(context.Background())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(capturedMethod).To(Equal("HEAD"))
 			Expect(capturedPath).To(Equal("/"))
 		})
 
 		It("returns error when server is unreachable", func() {
-			client = newM360Client("http://127.0.0.1:1", "v1", "key")
+			sub = newRESTSubmitter("http://127.0.0.1:1", "v1", "key", logr.Discard())
 
-			err := client.healthCheck(context.Background())
+			err := sub.healthCheck(context.Background())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("M360 health check"))
 		})
@@ -203,12 +217,12 @@ var _ = Describe("m360Client", func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			}))
-			client = newM360Client(server.URL, "v1", "key")
+			sub = newRESTSubmitter(server.URL, "v1", "key", logr.Discard())
 
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 
-			err := client.healthCheck(ctx)
+			err := sub.healthCheck(ctx)
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/osac-metering/adapters/cmd/m360-adapter/kafka_submitter.go
+++ b/osac-metering/adapters/cmd/m360-adapter/kafka_submitter.go
@@ -1,0 +1,115 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/IBM/sarama"
+	"github.com/go-logr/logr"
+	"github.com/osac-project/osac-metering/adapters"
+)
+
+// kafkaChecker is satisfied by sarama.Client — used for health checks
+// and closed on shutdown.
+type kafkaChecker interface {
+	RefreshMetadata(topics ...string) error
+	Close() error
+}
+
+// kafkaSubmitter sends M360 events directly to Kafka topics.
+type kafkaSubmitter struct {
+	producer sarama.SyncProducer
+	client   kafkaChecker
+	topics   map[string]string
+	logger   logr.Logger
+}
+
+// newKafkaSubmitter creates a Kafka submitter that routes events to the
+// given topic map. The client is used for health checks and closed on
+// shutdown; pass the same sarama.Client used to create the producer via
+// sarama.NewSyncProducerFromClient.
+func newKafkaSubmitter(
+	producer sarama.SyncProducer,
+	client kafkaChecker,
+	topics map[string]string,
+	logger logr.Logger,
+) *kafkaSubmitter {
+	return &kafkaSubmitter{
+		producer: producer,
+		client:   client,
+		topics:   topics,
+		logger:   logger,
+	}
+}
+
+// submit JSON-encodes the payload and sends it to the Kafka topic mapped
+// to the given route key. Uses resource_id as the message key for
+// partition affinity. Context is accepted for interface conformance but
+// not honoured — sarama.SyncProducer.SendMessage has no context parameter.
+func (s *kafkaSubmitter) submit(_ context.Context, route string, payload map[string]any) error {
+	topic, ok := s.topics[route]
+	if !ok {
+		return &adapters.NonRetryableError{
+			Err: fmt.Errorf("unknown route %q", route),
+		}
+	}
+
+	value, err := json.Marshal(payload)
+	if err != nil {
+		return &adapters.NonRetryableError{
+			Err: fmt.Errorf("marshal M360 Kafka payload: %w", err),
+		}
+	}
+
+	resourceID, _ := payload["resource_id"].(string)
+
+	msg := &sarama.ProducerMessage{
+		Topic: topic,
+		Key:   sarama.StringEncoder(resourceID),
+		Value: sarama.ByteEncoder(value),
+	}
+
+	partition, offset, err := s.producer.SendMessage(msg)
+	if err != nil {
+		return fmt.Errorf("M360 Kafka send to %s: %w", topic, err)
+	}
+
+	s.logger.V(1).Info("M360 Kafka event sent",
+		"topic", topic, "partition", partition, "offset", offset)
+	return nil
+}
+
+// healthCheck verifies broker connectivity via metadata refresh.
+// Respects context cancellation so K8s probes don't accumulate
+// blocked goroutines when the broker is slow.
+func (s *kafkaSubmitter) healthCheck(ctx context.Context) error {
+	done := make(chan error, 1)
+	go func() {
+		done <- s.client.RefreshMetadata()
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			return fmt.Errorf("M360 Kafka health check: %w", err)
+		}
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("M360 Kafka health check: %w", ctx.Err())
+	}
+}
+
+// close shuts down the Kafka producer, then the underlying client.
+func (s *kafkaSubmitter) close() error {
+	return errors.Join(s.producer.Close(), s.client.Close())
+}

--- a/osac-metering/adapters/cmd/m360-adapter/kafka_submitter_test.go
+++ b/osac-metering/adapters/cmd/m360-adapter/kafka_submitter_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/IBM/sarama"
+	"github.com/IBM/sarama/mocks"
+	"github.com/go-logr/logr"
+	"github.com/osac-project/osac-metering/adapters"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type fakeKafkaChecker struct {
+	err   error
+	block chan struct{} // if non-nil, RefreshMetadata blocks until closed
+}
+
+func (f *fakeKafkaChecker) RefreshMetadata(_ ...string) error {
+	if f.block != nil {
+		<-f.block
+	}
+	return f.err
+}
+
+func (f *fakeKafkaChecker) Close() error {
+	return nil
+}
+
+var _ = Describe("kafkaSubmitter", func() {
+	var (
+		producer *mocks.SyncProducer
+		sub      *kafkaSubmitter
+	)
+
+	BeforeEach(func() {
+		producer = mocks.NewSyncProducer(GinkgoT(), nil)
+		sub = newKafkaSubmitter(
+			producer,
+			&fakeKafkaChecker{},
+			map[string]string{
+				"vmaas": "m360.metering.vmaas",
+				"caas":  "m360.metering.caas",
+				"maas":  "m360.metering.maas",
+			},
+			logr.Discard(),
+		)
+	})
+
+	Describe("submit", func() {
+		It("sends JSON payload to the correct topic", func() {
+			producer.ExpectSendMessageAndSucceed()
+
+			payload := map[string]any{
+				"event_id":      "ce-123",
+				"resource_type": "compute_instance",
+				"resource_id":   "vm-001",
+			}
+			err := sub.submit(context.Background(), "vmaas", payload)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("uses resource_id as message key", func() {
+			var capturedMsg *sarama.ProducerMessage
+			producer.ExpectSendMessageWithMessageCheckerFunctionAndSucceed(
+				func(msg *sarama.ProducerMessage) error {
+					capturedMsg = msg
+					return nil
+				},
+			)
+
+			payload := map[string]any{
+				"event_id":    "ce-456",
+				"resource_id": "vm-002",
+			}
+			err := sub.submit(context.Background(), "vmaas", payload)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(capturedMsg.Topic).To(Equal("m360.metering.vmaas"))
+			key, _ := capturedMsg.Key.Encode()
+			Expect(string(key)).To(Equal("vm-002"))
+		})
+
+		It("sends valid JSON as message value", func() {
+			producer.ExpectSendMessageWithMessageCheckerFunctionAndSucceed(
+				func(msg *sarama.ProducerMessage) error {
+					val, _ := msg.Value.Encode()
+					var decoded map[string]any
+					Expect(json.Unmarshal(val, &decoded)).To(Succeed())
+					Expect(decoded["event_id"]).To(Equal("ce-789"))
+					return nil
+				},
+			)
+
+			payload := map[string]any{"event_id": "ce-789", "resource_id": "vm-003"}
+			err := sub.submit(context.Background(), "vmaas", payload)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns NonRetryableError for unknown route", func() {
+			err := sub.submit(context.Background(), "unknown", map[string]any{})
+
+			Expect(err).To(HaveOccurred())
+			var nonRetryable *adapters.NonRetryableError
+			Expect(errors.As(err, &nonRetryable)).To(BeTrue())
+		})
+
+		It("returns retryable error on send failure", func() {
+			producer.ExpectSendMessageAndFail(sarama.ErrBrokerNotAvailable)
+
+			payload := map[string]any{"event_id": "ce-fail", "resource_id": "vm-fail"}
+			err := sub.submit(context.Background(), "vmaas", payload)
+
+			Expect(err).To(HaveOccurred())
+			var nonRetryable *adapters.NonRetryableError
+			Expect(errors.As(err, &nonRetryable)).To(BeFalse())
+		})
+
+		It("uses empty key when resource_id is missing", func() {
+			producer.ExpectSendMessageWithMessageCheckerFunctionAndSucceed(
+				func(msg *sarama.ProducerMessage) error {
+					key, _ := msg.Key.Encode()
+					Expect(string(key)).To(BeEmpty())
+					return nil
+				},
+			)
+
+			payload := map[string]any{"event_id": "ce-no-rid"}
+			err := sub.submit(context.Background(), "vmaas", payload)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("healthCheck", func() {
+		It("returns nil when metadata refresh succeeds", func() {
+			sub.client = &fakeKafkaChecker{}
+			err := sub.healthCheck(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns error when metadata refresh fails", func() {
+			sub.client = &fakeKafkaChecker{err: errors.New("broker unreachable")}
+			err := sub.healthCheck(context.Background())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("M360 Kafka health check"))
+		})
+
+		It("returns error when context is cancelled", func() {
+			sub.client = &fakeKafkaChecker{block: make(chan struct{})}
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			err := sub.healthCheck(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("M360 Kafka health check"))
+		})
+	})
+
+	Describe("close", func() {
+		It("closes the producer without error", func() {
+			err := sub.close()
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/osac-metering/adapters/cmd/m360-adapter/main.go
+++ b/osac-metering/adapters/cmd/m360-adapter/main.go
@@ -33,17 +33,17 @@ import (
 )
 
 type m360Adapter struct {
-	client *m360Client
+	sub submitter
 }
 
 func (a *m360Adapter) Name() string { return "m360" }
 
 func (a *m360Adapter) Submit(ctx context.Context, event adapters.MeteringEvent) error {
-	endpoint, payload, err := translateEvent(event.CloudEvent)
+	route, payload, err := translateEvent(event.CloudEvent)
 	if err != nil {
 		return err
 	}
-	return a.client.post(ctx, endpoint, payload)
+	return a.sub.submit(ctx, route, payload)
 }
 
 func (a *m360Adapter) Flush(_ context.Context) (adapters.SubmitResult, error) {
@@ -51,10 +51,10 @@ func (a *m360Adapter) Flush(_ context.Context) (adapters.SubmitResult, error) {
 }
 
 func (a *m360Adapter) HealthCheck(ctx context.Context) error {
-	return a.client.healthCheck(ctx)
+	return a.sub.healthCheck(ctx)
 }
 
-func (a *m360Adapter) Close() error { return nil }
+func (a *m360Adapter) Close() error { return a.sub.close() }
 
 func main() {
 	brokers := envutil.RequireEnv("KAFKA_BROKERS")
@@ -90,10 +90,9 @@ func main() {
 
 	logger := stdr.New(log.New(os.Stderr, "", log.LstdFlags))
 
-	client := newM360Client(m360URL, apiVersion, apiKey)
-	client.logger = logger
+	sub := newRESTSubmitter(m360URL, apiVersion, apiKey, logger)
 
-	adapter := &m360Adapter{client: client}
+	adapter := &m360Adapter{sub: sub}
 	runner := adapters.NewRunner(adapter, adapters.RunnerConfig{
 		Brokers:       brokers,
 		ConsumerGroup: group,

--- a/osac-metering/adapters/cmd/m360-adapter/main.go
+++ b/osac-metering/adapters/cmd/m360-adapter/main.go
@@ -8,13 +8,20 @@ in compliance with the License. You may obtain a copy of the License at
 */
 
 // m360-adapter consumes OSAC metering CloudEvents from Kafka and
-// forwards them to the Monetize360 (M360) Usage API via REST.
+// forwards them to the Monetize360 (M360) Usage API via REST or Kafka.
 //
-// Usage:
+// Usage (REST — default):
 //
 //	export KAFKA_BROKERS="localhost:9092"
 //	export M360_API_URL="https://m360.example.com"
 //	export M360_API_KEY_FILE="/path/to/api-key"
+//	go run ./cmd/m360-adapter/
+//
+// Usage (Kafka):
+//
+//	export KAFKA_BROKERS="localhost:9092"
+//	export M360_OUTPUT_PROTOCOL="kafka"
+//	export M360_KAFKA_BROKERS="m360-kafka:9093"
 //	go run ./cmd/m360-adapter/
 package main
 
@@ -27,6 +34,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/IBM/sarama"
 	"github.com/go-logr/stdr"
 	"github.com/osac-project/osac-metering/adapters"
 	"github.com/osac-project/osac-metering/adapters/envutil"
@@ -58,11 +66,60 @@ func (a *m360Adapter) Close() error { return a.sub.close() }
 
 func main() {
 	brokers := envutil.RequireEnv("KAFKA_BROKERS")
-	m360URL := envutil.RequireEnv("M360_API_URL")
-	apiKeyFile := envutil.RequireEnv("M360_API_KEY_FILE")
+	logger := stdr.New(log.New(os.Stderr, "", log.LstdFlags))
 
-	apiKey := envutil.ReadFileOrFatal(apiKeyFile)
-	apiVersion := envutil.EnvOrDefault("M360_API_VERSION", "v1")
+	protocol := envutil.EnvOrDefault("M360_OUTPUT_PROTOCOL", "rest")
+
+	var sub submitter
+
+	switch protocol {
+	case "rest":
+		m360URL := envutil.RequireEnv("M360_API_URL")
+		apiKeyFile := envutil.RequireEnv("M360_API_KEY_FILE")
+		apiKey := envutil.ReadFileOrFatal(apiKeyFile)
+		apiVersion := envutil.EnvOrDefault("M360_API_VERSION", "v1")
+
+		sub = newRESTSubmitter(m360URL, apiVersion, apiKey, logger)
+		log.Printf("M360 output: REST api_version=%s", apiVersion)
+
+	case "kafka":
+		m360Brokers := envutil.RequireEnv("M360_KAFKA_BROKERS")
+		m360Cfg := adapters.KafkaConfig{
+			TLSEnabled:   os.Getenv("M360_KAFKA_TLS_ENABLED") != "false",
+			TLSCACert:    os.Getenv("M360_KAFKA_TLS_CA_CERT"),
+			SASLUser:     os.Getenv("M360_KAFKA_SASL_USERNAME"),
+			SASLPassFile: os.Getenv("M360_KAFKA_SASL_PASSWORD_FILE"),
+		}
+
+		producerCfg, err := adapters.NewProducerConfig(m360Cfg)
+		if err != nil {
+			log.Fatalf("M360 Kafka producer config: %v", err)
+		}
+
+		m360BrokerList := envutil.SplitAndTrim(m360Brokers, ",")
+		client, err := sarama.NewClient(m360BrokerList, producerCfg)
+		if err != nil {
+			log.Fatalf("M360 Kafka client: %v", err)
+		}
+
+		producer, err := sarama.NewSyncProducerFromClient(client)
+		if err != nil {
+			_ = client.Close()
+			log.Fatalf("M360 Kafka producer: %v", err)
+		}
+
+		m360Topics := map[string]string{
+			routeVMaaS: envutil.EnvOrDefault("M360_KAFKA_TOPIC_VMAAS", "m360.metering.vmaas"),
+			routeCaaS:  envutil.EnvOrDefault("M360_KAFKA_TOPIC_CAAS", "m360.metering.caas"),
+			routeMaaS:  envutil.EnvOrDefault("M360_KAFKA_TOPIC_MAAS", "m360.metering.maas"),
+		}
+
+		sub = newKafkaSubmitter(producer, client, m360Topics, logger)
+		log.Printf("M360 output: Kafka brokers=%v topics=%v", m360BrokerList, m360Topics)
+
+	default:
+		log.Fatalf("unknown M360_OUTPUT_PROTOCOL %q (expected rest or kafka)", protocol)
+	}
 
 	topics := adapters.AllTopics
 	if v := os.Getenv("KAFKA_TOPICS"); v != "" {
@@ -87,10 +144,6 @@ func main() {
 	}
 
 	metricsAddr := envutil.EnvOrDefault("METRICS_ADDR", ":2112")
-
-	logger := stdr.New(log.New(os.Stderr, "", log.LstdFlags))
-
-	sub := newRESTSubmitter(m360URL, apiVersion, apiKey, logger)
 
 	adapter := &m360Adapter{sub: sub}
 	runner := adapters.NewRunner(adapter, adapters.RunnerConfig{
@@ -129,8 +182,8 @@ func main() {
 		syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
-	log.Printf("starting m360 adapter: topics=%v group=%s api_version=%s flush=%s",
-		topics, group, apiVersion, flushInterval)
+	log.Printf("starting m360 adapter: protocol=%s topics=%v group=%s flush=%s",
+		protocol, topics, group, flushInterval)
 
 	runErr := runner.Run(ctx)
 

--- a/osac-metering/adapters/cmd/m360-adapter/submitter.go
+++ b/osac-metering/adapters/cmd/m360-adapter/submitter.go
@@ -1,0 +1,19 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package main
+
+import "context"
+
+// submitter abstracts the M360 output protocol (REST or Kafka).
+type submitter interface {
+	submit(ctx context.Context, route string, payload map[string]any) error
+	healthCheck(ctx context.Context) error
+	close() error
+}

--- a/osac-metering/adapters/cmd/m360-adapter/translate.go
+++ b/osac-metering/adapters/cmd/m360-adapter/translate.go
@@ -20,18 +20,25 @@ import (
 	"github.com/osac-project/osac-metering/schema"
 )
 
-// resourceTypeEndpoints maps OSAC resource types to M360 API endpoints.
-var resourceTypeEndpoints = map[string]string{
-	schema.ResourceTypeComputeInstance: "/vmaas/event",
-	schema.ResourceTypeClusterOrder:    "/caas/event",
-	"maas_inference":                   "/maas/event",
+// Route key constants — each submitter maps these to its own destination format.
+const (
+	routeVMaaS = "vmaas"
+	routeCaaS  = "caas"
+	routeMaaS  = "maas"
+)
+
+// resourceTypeRoutes maps OSAC resource types to protocol-neutral route keys.
+var resourceTypeRoutes = map[string]string{
+	schema.ResourceTypeComputeInstance: routeVMaaS,
+	schema.ResourceTypeClusterOrder:    routeCaaS,
+	"maas_inference":                   routeMaaS,
 }
 
 // spaceString is the M360 convention for non-applicable fields.
 const spaceString = " "
 
 // translateEvent converts a canonical OSAC CloudEvent to a flat M360
-// Usage API payload and returns the target endpoint path.
+// Usage API payload and returns the route key for destination selection.
 func translateEvent(ce cloudevents.Event) (string, map[string]any, error) {
 	if ce.ID() == "" {
 		return "", nil, &adapters.NonRetryableError{
@@ -52,7 +59,7 @@ func translateEvent(ce cloudevents.Event) (string, map[string]any, error) {
 	}
 
 	resourceType, _ := data["resource_type"].(string)
-	endpoint, ok := resourceTypeEndpoints[resourceType]
+	route, ok := resourceTypeRoutes[resourceType]
 	if !ok {
 		return "", nil, &adapters.NonRetryableError{
 			Err: fmt.Errorf("unknown resource_type %q", resourceType),
@@ -95,7 +102,7 @@ func translateEvent(ce cloudevents.Event) (string, map[string]any, error) {
 		}
 	}
 
-	return endpoint, payload, nil
+	return route, payload, nil
 }
 
 // nullToSpace replaces nil and empty string with the M360 space string.

--- a/osac-metering/adapters/cmd/m360-adapter/translate_test.go
+++ b/osac-metering/adapters/cmd/m360-adapter/translate_test.go
@@ -70,10 +70,10 @@ var _ = Describe("translateEvent", func() {
 				},
 			)
 
-			endpoint, payload, err := translateEvent(ce)
+			route, payload, err := translateEvent(ce)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(endpoint).To(Equal("/vmaas/event"))
+			Expect(route).To(Equal("vmaas"))
 			Expect(payload["event_id"]).To(Equal("ce-abc123"))
 			Expect(payload["event_time"]).To(Equal("2026-07-20T10:00:00Z"))
 			Expect(payload["resource_type"]).To(Equal("compute_instance"))
@@ -127,10 +127,10 @@ var _ = Describe("translateEvent", func() {
 				nil,
 			)
 
-			endpoint, payload, err := translateEvent(ce)
+			route, payload, err := translateEvent(ce)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(endpoint).To(Equal("/vmaas/event"))
+			Expect(route).To(Equal("vmaas"))
 			Expect(payload).NotTo(HaveKey("instance_type"))
 		})
 
@@ -184,7 +184,7 @@ var _ = Describe("translateEvent", func() {
 	})
 
 	Describe("CaaS events", func() {
-		It("translates a cluster_order event to /caas/event", func() {
+		It("translates a cluster_order event to caas route", func() {
 			ce := buildCloudEvent(
 				"ce-caas-001",
 				"osac.resource.created.v1",
@@ -201,10 +201,10 @@ var _ = Describe("translateEvent", func() {
 				},
 			)
 
-			endpoint, payload, err := translateEvent(ce)
+			route, payload, err := translateEvent(ce)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(endpoint).To(Equal("/caas/event"))
+			Expect(route).To(Equal("caas"))
 			Expect(payload["cluster_template"]).To(Equal("ocp-ci-small"))
 			Expect(payload["component"]).To(Equal("control_plane"))
 			Expect(payload["node_count"]).To(BeEquivalentTo(1))
@@ -212,7 +212,7 @@ var _ = Describe("translateEvent", func() {
 	})
 
 	Describe("MaaS events", func() {
-		It("translates a maas_inference event to /maas/event", func() {
+		It("translates a maas_inference event to maas route", func() {
 			ce := buildCloudEvent(
 				"ce-maas-001",
 				"osac.inference.usage.v1",
@@ -236,10 +236,10 @@ var _ = Describe("translateEvent", func() {
 				},
 			)
 
-			endpoint, payload, err := translateEvent(ce)
+			route, payload, err := translateEvent(ce)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(endpoint).To(Equal("/maas/event"))
+			Expect(route).To(Equal("maas"))
 			Expect(payload["provider"]).To(Equal("anthropic"))
 			Expect(payload["prompt_tokens"]).To(BeEquivalentTo(1500))
 			Expect(payload["total_tokens"]).To(BeEquivalentTo(2300))

--- a/osac-metering/adapters/kafka.go
+++ b/osac-metering/adapters/kafka.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/IBM/sarama"
 	"github.com/xdg-go/scram"
@@ -32,19 +33,45 @@ func newConsumerConfig(cfg KafkaConfig) (*sarama.Config, error) {
 	}
 
 	if cfg.TLSEnabled {
-		if err := configureConsumerTLS(sc, cfg.TLSCACert); err != nil {
+		if err := configureTLS(sc, cfg.TLSCACert); err != nil {
 			return nil, err
 		}
 	}
 	if cfg.SASLUser != "" {
-		if err := configureConsumerSASL(sc, cfg.SASLUser, cfg.SASLPassFile); err != nil {
+		if err := configureSASL(sc, cfg.SASLUser, cfg.SASLPassFile); err != nil {
 			return nil, err
 		}
 	}
 	return sc, nil
 }
 
-func configureConsumerTLS(sc *sarama.Config, caCertPath string) error {
+// NewProducerConfig creates a Sarama config for a Kafka producer.
+// Idempotent, acks=all, synchronous — suitable for at-least-once delivery.
+func NewProducerConfig(cfg KafkaConfig) (*sarama.Config, error) {
+	sc := sarama.NewConfig()
+	sc.Version = sarama.V3_9_0_0
+	sc.Producer.RequiredAcks = sarama.WaitForAll
+	sc.Producer.Idempotent = true
+	sc.Producer.Return.Successes = true
+	sc.Net.MaxOpenRequests = 1
+	sc.Net.DialTimeout = 5 * time.Second
+	sc.Net.ReadTimeout = 5 * time.Second
+	sc.Net.WriteTimeout = 5 * time.Second
+
+	if cfg.TLSEnabled {
+		if err := configureTLS(sc, cfg.TLSCACert); err != nil {
+			return nil, err
+		}
+	}
+	if cfg.SASLUser != "" {
+		if err := configureSASL(sc, cfg.SASLUser, cfg.SASLPassFile); err != nil {
+			return nil, err
+		}
+	}
+	return sc, nil
+}
+
+func configureTLS(sc *sarama.Config, caCertPath string) error {
 	sc.Net.TLS.Enable = true
 	tlsCfg := &tls.Config{MinVersion: tls.VersionTLS12}
 	if caCertPath != "" {
@@ -62,7 +89,7 @@ func configureConsumerTLS(sc *sarama.Config, caCertPath string) error {
 	return nil
 }
 
-func configureConsumerSASL(sc *sarama.Config, user, passFile string) error {
+func configureSASL(sc *sarama.Config, user, passFile string) error {
 	password, err := os.ReadFile(passFile)
 	if err != nil {
 		return fmt.Errorf("reading SASL password file %s: %w", passFile, err)

--- a/osac-metering/adapters/kafka_test.go
+++ b/osac-metering/adapters/kafka_test.go
@@ -10,6 +10,9 @@ in compliance with the License. You may obtain a copy of the License at
 package adapters
 
 import (
+	"time"
+
+	"github.com/IBM/sarama"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -33,6 +36,28 @@ var _ = Describe("newConsumerConfig", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(sc.Consumer.Return.Errors).To(BeTrue())
 		Expect(sc.Consumer.Offsets.AutoCommit.Enable).To(BeFalse())
+	})
+})
+
+var _ = Describe("NewProducerConfig", func() {
+	It("returns idempotent producer config with no TLS or SASL", func() {
+		sc, err := NewProducerConfig(KafkaConfig{TLSEnabled: false})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sc.Producer.RequiredAcks).To(Equal(sarama.WaitForAll))
+		Expect(sc.Producer.Idempotent).To(BeTrue())
+		Expect(sc.Producer.Return.Successes).To(BeTrue())
+		Expect(sc.Net.MaxOpenRequests).To(Equal(1))
+		Expect(sc.Net.DialTimeout).To(Equal(5 * time.Second))
+		Expect(sc.Net.ReadTimeout).To(Equal(5 * time.Second))
+		Expect(sc.Net.WriteTimeout).To(Equal(5 * time.Second))
+		Expect(sc.Net.TLS.Enable).To(BeFalse())
+	})
+
+	It("enables TLS when TLSEnabled is true", func() {
+		sc, err := NewProducerConfig(KafkaConfig{TLSEnabled: true})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sc.Net.TLS.Enable).To(BeTrue())
+		Expect(sc.Net.TLS.Config).NotTo(BeNil())
 	})
 })
 

--- a/osac-metering/charts/osac-metering/templates/m360-adapter-deployment.yaml
+++ b/osac-metering/charts/osac-metering/templates/m360-adapter-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.m360Adapter.enabled }}
+{{- $protocol := default "rest" .Values.m360Adapter.output.protocol -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -30,9 +31,32 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 1Mi
+        {{- if eq $protocol "rest" }}
         - name: m360-api-key
           secret:
-            secretName: {{ required "m360Adapter.m360.apiKeySecret is required when m360Adapter is enabled" .Values.m360Adapter.m360.apiKeySecret }}
+            secretName: {{ required "m360Adapter.m360.apiKeySecret is required when output.protocol=rest" .Values.m360Adapter.m360.apiKeySecret }}
+        {{- end }}
+        {{- if eq $protocol "kafka" }}
+        {{- if or .Values.m360Adapter.output.kafka.tls.caCertSecret .Values.m360Adapter.output.kafka.sasl.passwordSecret }}
+        - name: m360-kafka-secrets
+          projected:
+            sources:
+              {{- if .Values.m360Adapter.output.kafka.tls.caCertSecret }}
+              - secret:
+                  name: {{ .Values.m360Adapter.output.kafka.tls.caCertSecret }}
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+              {{- end }}
+              {{- if .Values.m360Adapter.output.kafka.sasl.passwordSecret }}
+              - secret:
+                  name: {{ .Values.m360Adapter.output.kafka.sasl.passwordSecret }}
+                  items:
+                    - key: password
+                      path: password
+              {{- end }}
+        {{- end }}
+        {{- end }}
         - name: tmp
           emptyDir:
             sizeLimit: 10Mi
@@ -108,21 +132,56 @@ spec:
               value: osac-metering-m360-adapter
             - name: KAFKA_SASL_PASSWORD_FILE
               value: /etc/kafka-secrets/password
+            - name: M360_OUTPUT_PROTOCOL
+              value: {{ $protocol | quote }}
+            {{- if eq $protocol "rest" }}
             - name: M360_API_URL
-              value: {{ required "m360Adapter.m360.apiUrl is required when m360Adapter is enabled" .Values.m360Adapter.m360.apiUrl | quote }}
+              value: {{ required "m360Adapter.m360.apiUrl is required when output.protocol=rest" .Values.m360Adapter.m360.apiUrl | quote }}
             - name: M360_API_KEY_FILE
               value: /etc/m360/api-key
             - name: M360_API_VERSION
               value: {{ .Values.m360Adapter.m360.apiVersion | default "v1" | quote }}
+            {{- end }}
+            {{- if eq $protocol "kafka" }}
+            - name: M360_KAFKA_BROKERS
+              value: {{ required "m360Adapter.output.kafka.brokers is required when output.protocol=kafka" .Values.m360Adapter.output.kafka.brokers | quote }}
+            - name: M360_KAFKA_TLS_ENABLED
+              value: {{ .Values.m360Adapter.output.kafka.tls.enabled | quote }}
+            {{- if .Values.m360Adapter.output.kafka.tls.caCertSecret }}
+            - name: M360_KAFKA_TLS_CA_CERT
+              value: /etc/m360-kafka-secrets/ca.crt
+            {{- end }}
+            {{- if and .Values.m360Adapter.output.kafka.sasl.username .Values.m360Adapter.output.kafka.sasl.passwordSecret }}
+            - name: M360_KAFKA_SASL_USERNAME
+              value: {{ .Values.m360Adapter.output.kafka.sasl.username | quote }}
+            - name: M360_KAFKA_SASL_PASSWORD_FILE
+              value: /etc/m360-kafka-secrets/password
+            {{- end }}
+            - name: M360_KAFKA_TOPIC_VMAAS
+              value: {{ .Values.m360Adapter.output.kafka.topics.vmaas | default "m360.metering.vmaas" | quote }}
+            - name: M360_KAFKA_TOPIC_CAAS
+              value: {{ .Values.m360Adapter.output.kafka.topics.caas | default "m360.metering.caas" | quote }}
+            - name: M360_KAFKA_TOPIC_MAAS
+              value: {{ .Values.m360Adapter.output.kafka.topics.maas | default "m360.metering.maas" | quote }}
+            {{- end }}
             - name: METRICS_ADDR
               value: ":8080"
           volumeMounts:
             - name: kafka-secrets
               mountPath: /etc/kafka-secrets
               readOnly: true
+            {{- if eq $protocol "rest" }}
             - name: m360-api-key
               mountPath: /etc/m360
               readOnly: true
+            {{- end }}
+            {{- if eq $protocol "kafka" }}
+            {{- if or .Values.m360Adapter.output.kafka.tls.caCertSecret .Values.m360Adapter.output.kafka.sasl.passwordSecret }}
+            - name: m360-kafka-secrets
+              mountPath: /etc/m360-kafka-secrets
+              readOnly: true
+            {{- end }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/osac-metering/charts/osac-metering/values.yaml
+++ b/osac-metering/charts/osac-metering/values.yaml
@@ -47,3 +47,17 @@ m360Adapter:
     apiUrl: ""
     apiKeySecret: ""     # name of K8s Secret with key "api-key"
     apiVersion: "v1"
+  output:
+    protocol: "rest"       # "rest" or "kafka"
+    kafka:
+      brokers: ""          # M360 Kafka bootstrap servers (required when protocol=kafka)
+      tls:
+        enabled: true
+        caCertSecret: ""   # K8s Secret name with key "ca.crt"
+      sasl:
+        username: ""
+        passwordSecret: "" # K8s Secret name with key "password"
+      topics:
+        vmaas: "m360.metering.vmaas"
+        caas: "m360.metering.caas"
+        maas: "m360.metering.maas"


### PR DESCRIPTION
## Summary

Adds Kafka as an alternative output protocol to the M360 metering adapter (`osac-metering/adapters/cmd/m360-adapter/`). The adapter can now produce flat M360 JSON to M360-owned Kafka topics instead of (or in addition to) calling the REST API, configurable per-deployment via `M360_OUTPUT_PROTOCOL=rest|kafka`.

- Introduces a `submitter` interface abstracting output protocol (`restSubmitter`, `kafkaSubmitter`)
- Refactors `translateEvent` to return protocol-neutral route keys (`vmaas`, `caas`, `maas`)
- `kafkaSubmitter` uses idempotent `SyncProducer` with `acks=all` and `resource_id` as message key
- M360 Kafka is a separate cluster from OSAC's metering Kafka — independent `M360_KAFKA_*` config
- TLS enabled by default, optional SASL/SCRAM-SHA-512
- Context-aware health check for K8s readiness probes
- Helm chart supports conditional env vars, volumes, and mounts per protocol

## Changes

- **`adapters/kafka.go`** — Renamed TLS/SASL helpers to shared, added `NewProducerConfig`
- **`adapters/cmd/m360-adapter/submitter.go`** — New `submitter` interface
- **`adapters/cmd/m360-adapter/client.go`** — Renamed `m360Client` → `restSubmitter`, added route-to-endpoint map
- **`adapters/cmd/m360-adapter/kafka_submitter.go`** — New Kafka submitter with `kafkaChecker` interface
- **`adapters/cmd/m360-adapter/translate.go`** — Route keys instead of REST paths
- **`adapters/cmd/m360-adapter/main.go`** — Protocol switch wiring
- **`charts/osac-metering/values.yaml`** — `m360Adapter.output.*` config
- **`charts/osac-metering/templates/m360-adapter-deployment.yaml`** — Conditional rendering per protocol

## Test plan

- [x] 137 unit tests pass (`ginkgo run -r .` in adapters/)
- [x] New `kafkaSubmitter` tests (10 specs) cover submit, key routing, JSON encoding, unknown route, send failure, health check, context cancellation, close
- [x] `NewProducerConfig` tests cover TLS/no-TLS paths
- [x] Updated `restSubmitter` and `translateEvent` tests for refactored interfaces
- [x] Build clean (`make build-m360-adapter`)
- [x] Lint clean (`make lint` — 0 issues)
- [x] Helm lint clean (`make helm-lint`)
- [ ] E2E validation with M360 Kafka cluster (requires deployed environment)