### PR TITLE
OSAC-2968: add bundled OpenBao template to osac-installer

### DIFF
--- a/osac-installer/charts/osac/templates/bundled-openbao.yaml
+++ b/osac-installer/charts/osac/templates/bundled-openbao.yaml
@@ -1,0 +1,288 @@
+{{- if .Values.bundledVault.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: openbao-server
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+spec:
+  issuerRef:
+    kind: {{ .Values.service.certs.issuerRef.kind }}
+    name: {{ .Values.service.certs.issuerRef.name }}
+  dnsNames:
+  - openbao
+  - openbao.{{ .Release.Namespace }}
+  - openbao.{{ .Release.Namespace }}.svc.cluster.local
+  - localhost
+  secretName: openbao-server-cert
+  privateKey:
+    rotationPolicy: Always
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openbao-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+data:
+  config.hcl: |
+    ui = false
+    disable_mlock = true
+
+    # No storage stanza: this deployment relies on `bao server -dev`
+    # (see the Deployment command) for its in-memory storage backend.
+    # Do not add a storage stanza here without also dropping -dev.
+
+    listener "tcp" {
+      address     = "0.0.0.0:8200"
+      tls_cert_file = "/vault/tls/tls.crt"
+      tls_key_file  = "/vault/tls/tls.key"
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openbao-init
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+data:
+  init.sh: |
+    #!/usr/bin/env sh
+    set -eu
+
+    export BAO_ADDR="https://localhost:8200"
+    export BAO_TOKEN="{{ required "bundledVault.devRootToken must be set" .Values.bundledVault.devRootToken }}"
+    export BAO_CACERT="/vault/tls/ca.crt"
+
+    echo "Waiting for OpenBao to become ready..."
+    until bao status >/dev/null 2>&1; do
+      sleep 1
+    done
+    echo "OpenBao is ready."
+
+    echo "Creating parent namespace 'osac'..."
+    bao namespace create osac 2>/dev/null || echo "Namespace 'osac' already exists."
+
+    echo "Enabling JWT auth in osac namespace..."
+    bao auth enable -namespace=osac -path=jwt jwt 2>/dev/null || echo "JWT auth already enabled."
+
+    echo "Writing lifecycle policy..."
+    bao policy write -namespace=osac lifecycle - <<'POLICY'
+    path "sys/namespaces/*" {
+      capabilities = ["create", "read", "update", "delete", "list"]
+    }
+    path "sys/namespaces" {
+      capabilities = ["list"]
+    }
+    path "sys/mounts/*" {
+      capabilities = ["create", "read", "update", "delete"]
+    }
+    path "sys/mounts" {
+      capabilities = ["read", "list"]
+    }
+    path "auth/*" {
+      capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+    }
+    POLICY
+
+    {{- if .Values.service.vault.keycloakIssuerUrl }}
+    echo "Configuring JWT auth with Keycloak OIDC discovery..."
+    attempts=0
+    max_attempts=30
+    until [ $attempts -ge $max_attempts ]; do
+      {{- if .Values.service.certs.caBundle.configMap }}
+      if bao write -namespace=osac auth/jwt/config \
+        oidc_discovery_url="${KEYCLOAK_ISSUER_URL}" \
+        oidc_discovery_ca_pem=@/vault/ca/bundle.pem \
+        default_role="lifecycle"; then
+        break
+      fi
+      {{- else }}
+      if bao write -namespace=osac auth/jwt/config \
+        oidc_discovery_url="${KEYCLOAK_ISSUER_URL}" \
+        default_role="lifecycle"; then
+        break
+      fi
+      {{- end }}
+      attempts=$((attempts + 1))
+      echo "OIDC discovery not reachable yet (attempt $attempts/$max_attempts), retrying in 10s..."
+      sleep 10
+    done
+    if [ $attempts -ge $max_attempts ]; then
+      echo "WARNING: Failed to configure OIDC discovery after $max_attempts attempts. Continuing without it."
+    else
+      echo "Creating lifecycle role..."
+      bao write -namespace=osac auth/jwt/role/lifecycle \
+        role_type="jwt" \
+        bound_audiences="${KEYCLOAK_AUDIENCE}" \
+        user_claim="sub" \
+        policies="lifecycle" \
+        token_ttl="1h"
+    fi
+    {{- end }}
+
+    echo "OpenBao bootstrap complete."
+    unset BAO_TOKEN
+    sleep infinity
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: openbao
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: openbao
+  ports:
+  - name: api
+    port: 8200
+    targetPort: api
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openbao
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: openbao
+    {{- include "osac.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: openbao
+  template:
+    metadata:
+      labels:
+        app: openbao
+        {{- include "osac.labels" . | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+      volumes:
+      - name: server-cert
+        secret:
+          secretName: openbao-server-cert
+          defaultMode: 0444
+      - name: config
+        configMap:
+          name: openbao-config
+      - name: init-script
+        configMap:
+          name: openbao-init
+          defaultMode: 0755
+      {{- if .Values.service.certs.caBundle.configMap }}
+      - name: ca-bundle
+        configMap:
+          name: {{ .Values.service.certs.caBundle.configMap }}
+      {{- end }}
+      - name: data
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+      containers:
+      - name: server
+        image: {{ .Values.bundledVault.image }}
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          {{- toYaml .Values.bundledVault.resources | nindent 10 }}
+        command:
+        - bao
+        - server
+        - -dev
+        - -dev-no-store-token
+        - -dev-root-token-id={{ required "bundledVault.devRootToken must be set" .Values.bundledVault.devRootToken }}
+        - -dev-listen-address=127.0.0.1:8202
+        - -config=/vault/config/config.hcl
+        env:
+        - name: BAO_ADDR
+          value: "https://127.0.0.1:8200"
+        - name: BAO_CACERT
+          {{- if .Values.service.certs.caBundle.configMap }}
+          value: "/vault/ca/bundle.pem"
+          {{- else }}
+          value: "/vault/tls/ca.crt"
+          {{- end }}
+        - name: SKIP_SETCAP
+          value: "true"
+        volumeMounts:
+        - name: server-cert
+          mountPath: /vault/tls
+        - name: config
+          mountPath: /vault/config
+        {{- if .Values.service.certs.caBundle.configMap }}
+        - name: ca-bundle
+          mountPath: /vault/ca
+        {{- end }}
+        - name: data
+          mountPath: /vault/data
+        - name: tmp
+          mountPath: /tmp
+        ports:
+        - name: api
+          protocol: TCP
+          containerPort: 8200
+        livenessProbe:
+          httpGet:
+            path: /v1/sys/health
+            port: api
+            scheme: HTTPS
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /v1/sys/health
+            port: api
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      - name: bootstrap
+        image: {{ .Values.bundledVault.image }}
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        command:
+        - /bin/sh
+        - /scripts/init.sh
+        env:
+        - name: KEYCLOAK_ISSUER_URL
+          value: {{ .Values.service.vault.keycloakIssuerUrl | default "" | quote }}
+        - name: KEYCLOAK_AUDIENCE
+          value: {{ .Values.service.vault.keycloakAudience | default "" | quote }}
+        volumeMounts:
+        - name: init-script
+          mountPath: /scripts
+        - name: server-cert
+          mountPath: /vault/tls
+        {{- if .Values.service.certs.caBundle.configMap }}
+        - name: ca-bundle
+          mountPath: /vault/ca
+        {{- end }}
+        - name: tmp
+          mountPath: /tmp
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
+{{- end }}

--- a/osac-installer/charts/osac/templates/bundled-openbao.yaml
+++ b/osac-installer/charts/osac/templates/bundled-openbao.yaml
@@ -53,10 +53,6 @@ data:
     #!/usr/bin/env sh
     set -eu
 
-    export BAO_ADDR="https://localhost:8200"
-    export BAO_TOKEN="{{ required "bundledVault.devRootToken must be set" .Values.bundledVault.devRootToken }}"
-    export BAO_CACERT="/vault/tls/ca.crt"
-
     echo "Waiting for OpenBao to become ready..."
     until bao status >/dev/null 2>&1; do
       sleep 1
@@ -112,7 +108,8 @@ data:
       sleep 10
     done
     if [ $attempts -ge $max_attempts ]; then
-      echo "WARNING: Failed to configure OIDC discovery after $max_attempts attempts. Continuing without it."
+      echo "ERROR: Failed to configure OIDC discovery after $max_attempts attempts. Bootstrap cannot complete."
+      exit 1
     else
       echo "Creating lifecycle role..."
       bao write -namespace=osac auth/jwt/role/lifecycle \
@@ -263,6 +260,16 @@ spec:
         - /bin/sh
         - /scripts/init.sh
         env:
+        - name: BAO_ADDR
+          value: "https://localhost:8200"
+        - name: BAO_TOKEN
+          value: {{ required "bundledVault.devRootToken must be set" .Values.bundledVault.devRootToken | quote }}
+        - name: BAO_CACERT
+          {{- if .Values.service.certs.caBundle.configMap }}
+          value: "/vault/ca/bundle.pem"
+          {{- else }}
+          value: "/vault/tls/ca.crt"
+          {{- end }}
         - name: KEYCLOAK_ISSUER_URL
           value: {{ .Values.service.vault.keycloakIssuerUrl | default "" | quote }}
         - name: KEYCLOAK_AUDIENCE

--- a/osac-installer/charts/osac/values.schema.json
+++ b/osac-installer/charts/osac/values.schema.json
@@ -1389,6 +1389,46 @@
         }
       }
     },
+    "bundledVault": {
+      "type": "object",
+      "description": "Bundled OpenBao (Vault-compatible) secret store for dev/CI environments. When enabled, deploys a single-replica OpenBao instance in dev mode with emptyDir storage.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Deploy a bundled OpenBao instance for development/CI use",
+          "default": false
+        },
+        "devRootToken": {
+          "type": "string",
+          "description": "Root token for OpenBao dev mode (required when enabled)"
+        },
+        "image": {
+          "type": "string",
+          "description": "OpenBao container image (must be 2.5+ for namespace support)",
+          "default": "ghcr.io/openbao/openbao:2.6.1"
+        },
+        "resources": {
+          "type": "object",
+          "description": "Container resource requests and limits",
+          "properties": {
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu": { "type": "string", "description": "CPU limit" },
+                "memory": { "type": "string", "description": "Memory limit" }
+              }
+            },
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": { "type": "string", "description": "CPU request" },
+                "memory": { "type": "string", "description": "Memory request" }
+              }
+            }
+          }
+        }
+      }
+    },
     "clusterVersions": {
       "type": "object",
       "description": "Seed ClusterVersion records in the fulfillment-service after install",

--- a/osac-installer/charts/osac/values.yaml
+++ b/osac-installer/charts/osac/values.yaml
@@ -302,6 +302,18 @@ metallb:
 hubAccess:
   enabled: false
 
+bundledVault:
+  enabled: false
+  devRootToken: ""
+  image: "ghcr.io/openbao/openbao:2.6.1"
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+
 clusterVersions:
   enabled: false
   versions: []

--- a/osac-installer/values/bmaas-ci/infra.yaml
+++ b/osac-installer/values/bmaas-ci/infra.yaml
@@ -36,7 +36,7 @@ bundledPostgres:
     user: service
 
 # --- Bundled OpenBao ---
-# Single-pod ephemeral Vault-compatible secret store for testing. Dev mode —
+# Single-pod ephemeral Vault-compatible secret store for testing. Dev mode --
 # data is lost on restart. Not for production.
 bundledVault:
   enabled: true

--- a/osac-installer/values/bmaas-ci/infra.yaml
+++ b/osac-installer/values/bmaas-ci/infra.yaml
@@ -34,3 +34,10 @@ bundledPostgres:
   database:
     name: service
     user: service
+
+# --- Bundled OpenBao ---
+# Single-pod ephemeral Vault-compatible secret store for testing. Dev mode —
+# data is lost on restart. Not for production.
+bundledVault:
+  enabled: true
+  devRootToken: "dev-root-token"

--- a/osac-installer/values/bmaas-ci/instance.yaml
+++ b/osac-installer/values/bmaas-ci/instance.yaml
@@ -88,6 +88,23 @@ service:
           param: sslrootcert
   log:
     level: debug
+  vault:
+    endpoint: "https://openbao.osac.svc.cluster.local:8200"
+    namespace: osac
+    kvMountPath: secret
+    lifecycleRole: lifecycle
+    lifecycleMountPath: jwt
+    keycloakClientId: osac-controller
+    keycloakIssuerUrl: "https://keycloak.keycloak.svc.cluster.local/realms/osac"
+    keycloakAudience: osac-api
+    caBundle:
+      configMap: ca-bundle
+    credentials:
+    - secret:
+        name: fulfillment-controller-credentials
+        items:
+        - key: client-secret
+          param: client-secret
 
 # --- UI ---
 ui:

--- a/osac-installer/values/caas-ci/infra.yaml
+++ b/osac-installer/values/caas-ci/infra.yaml
@@ -40,3 +40,10 @@ bundledPostgres:
   enabled: true
   database:
     name: service
+
+# --- Bundled OpenBao ---
+# Single-pod ephemeral Vault-compatible secret store for testing. Dev mode —
+# data is lost on restart. Not for production.
+bundledVault:
+  enabled: true
+  devRootToken: "dev-root-token"

--- a/osac-installer/values/caas-ci/infra.yaml
+++ b/osac-installer/values/caas-ci/infra.yaml
@@ -42,7 +42,7 @@ bundledPostgres:
     name: service
 
 # --- Bundled OpenBao ---
-# Single-pod ephemeral Vault-compatible secret store for testing. Dev mode —
+# Single-pod ephemeral Vault-compatible secret store for testing. Dev mode --
 # data is lost on restart. Not for production.
 bundledVault:
   enabled: true

--- a/osac-installer/values/caas-ci/instance.yaml
+++ b/osac-installer/values/caas-ci/instance.yaml
@@ -87,6 +87,23 @@ service:
           param: sslrootcert
   log:
     level: debug
+  vault:
+    endpoint: "https://openbao.osac.svc.cluster.local:8200"
+    namespace: osac
+    kvMountPath: secret
+    lifecycleRole: lifecycle
+    lifecycleMountPath: jwt
+    keycloakClientId: osac-controller
+    keycloakIssuerUrl: "https://keycloak.keycloak.svc.cluster.local/realms/osac"
+    keycloakAudience: osac-api
+    caBundle:
+      configMap: ca-bundle
+    credentials:
+    - secret:
+        name: fulfillment-controller-credentials
+        items:
+        - key: client-secret
+          param: client-secret
 
 # --- AAP ---
 aap:

--- a/osac-installer/values/full-ci/infra.yaml
+++ b/osac-installer/values/full-ci/infra.yaml
@@ -39,7 +39,7 @@ bundledPostgres:
     user: service
 
 # --- Bundled OpenBao ---
-# Single-pod ephemeral Vault-compatible secret store for testing. Dev mode —
+# Single-pod ephemeral Vault-compatible secret store for testing. Dev mode --
 # data is lost on restart. Not for production.
 bundledVault:
   enabled: true

--- a/osac-installer/values/full-ci/infra.yaml
+++ b/osac-installer/values/full-ci/infra.yaml
@@ -37,3 +37,10 @@ bundledPostgres:
   database:
     name: service
     user: service
+
+# --- Bundled OpenBao ---
+# Single-pod ephemeral Vault-compatible secret store for testing. Dev mode —
+# data is lost on restart. Not for production.
+bundledVault:
+  enabled: true
+  devRootToken: "dev-root-token"

--- a/osac-installer/values/full-ci/instance.yaml
+++ b/osac-installer/values/full-ci/instance.yaml
@@ -88,6 +88,23 @@ service:
           param: sslrootcert
   log:
     level: debug
+  vault:
+    endpoint: "https://openbao.osac.svc.cluster.local:8200"
+    namespace: osac
+    kvMountPath: secret
+    lifecycleRole: lifecycle
+    lifecycleMountPath: jwt
+    keycloakClientId: osac-controller
+    keycloakIssuerUrl: "https://keycloak.keycloak.svc.cluster.local/realms/osac"
+    keycloakAudience: osac-api
+    caBundle:
+      configMap: ca-bundle
+    credentials:
+    - secret:
+        name: fulfillment-controller-credentials
+        items:
+        - key: client-secret
+          param: client-secret
 
 # --- UI ---
 ui:

--- a/osac-installer/values/vmaas-ci/infra.yaml
+++ b/osac-installer/values/vmaas-ci/infra.yaml
@@ -36,3 +36,10 @@ bundledPostgres:
   database:
     name: service
     user: service
+
+# --- Bundled OpenBao ---
+# Single-pod ephemeral Vault-compatible secret store for testing. Dev mode —
+# data is lost on restart. Not for production.
+bundledVault:
+  enabled: true
+  devRootToken: "dev-root-token"

--- a/osac-installer/values/vmaas-ci/infra.yaml
+++ b/osac-installer/values/vmaas-ci/infra.yaml
@@ -38,7 +38,7 @@ bundledPostgres:
     user: service
 
 # --- Bundled OpenBao ---
-# Single-pod ephemeral Vault-compatible secret store for testing. Dev mode —
+# Single-pod ephemeral Vault-compatible secret store for testing. Dev mode --
 # data is lost on restart. Not for production.
 bundledVault:
   enabled: true

--- a/osac-installer/values/vmaas-ci/instance.yaml
+++ b/osac-installer/values/vmaas-ci/instance.yaml
@@ -91,6 +91,23 @@ service:
           param: sslrootcert
   log:
     level: debug
+  vault:
+    endpoint: "https://openbao.osac.svc.cluster.local:8200"
+    namespace: osac
+    kvMountPath: secret
+    lifecycleRole: lifecycle
+    lifecycleMountPath: jwt
+    keycloakClientId: osac-controller
+    keycloakIssuerUrl: "https://keycloak.keycloak.svc.cluster.local/realms/osac"
+    keycloakAudience: osac-api
+    caBundle:
+      configMap: ca-bundle
+    credentials:
+    - secret:
+        name: fulfillment-controller-credentials
+        items:
+        - key: client-secret
+          param: client-secret
 
 # --- UI ---
 ui:


### PR DESCRIPTION
Adds a dev/CI-only OpenBao deployment to the OSAC Helm chart, gated behind bundledVault.enabled. Provides a TLS-enabled, self-bootstrapping Vault-compatible secret store so CI environments get a working secret store without manual setup.

Template resources:
- Certificate (cert-manager) with localhost SAN for sidecar access
- ConfigMap (server config.hcl with TLS listener on 0.0.0.0:8200)
- ConfigMap (bootstrap init.sh: namespace + JWT auth + lifecycle policy)
- Service (port 8200)
- Deployment (server + bootstrap sidecar)

Dev mode listener binds to 127.0.0.1:8202 to avoid port conflict with the config.hcl TLS listener. Bootstrap configures OIDC discovery with cluster CA bundle for Keycloak connectivity.

Also adds bundledVault section to values.yaml, values.schema.json, and enables it in all CI values files (vmaas-ci, caas-ci, bmaas-ci, full-ci).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional bundled OpenBao support for development and CI environments.
  * Configured secure TLS access, ephemeral storage, JWT authentication, lifecycle permissions, and optional Keycloak integration.
  * Added deployment settings for images, resource limits, root tokens, namespaces, and certificate bundles.
  * Configured fulfillment services to use OpenBao for secrets, authentication, lifecycle roles, and controller credentials.
  * Enabled bundled OpenBao by default in selected CI profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->