### PR TITLE
NO-ISSUE: add control for m360 adapter to installer values

### DIFF
--- a/osac-installer/values/caas-ci/instance.yaml
+++ b/osac-installer/values/caas-ci/instance.yaml
@@ -174,6 +174,16 @@ metering:
       repository: ghcr.io/osac-project/metering-echo-adapter
       tag: latest
       pullPolicy: Always
+  m360Adapter:
+    enabled: false
+    image:
+      repository: ghcr.io/osac-project/metering-m360-adapter
+      tag: latest
+      pullPolicy: Always
+    m360:
+      apiUrl: "api-url"          # Set to your Monetize360 Usage API endpoint
+      apiKeySecret: "m360-api-key"  # K8s Secret with key "api-key" — create before deploying
+      apiVersion: "v1"
   database:
     connection:
     - secret:

--- a/osac-installer/values/vmaas-ci/instance.yaml
+++ b/osac-installer/values/vmaas-ci/instance.yaml
@@ -175,6 +175,16 @@ metering:
       repository: ghcr.io/osac-project/metering-echo-adapter
       tag: latest
       pullPolicy: Always
+  m360Adapter:
+    enabled: false
+    image:
+      repository: ghcr.io/osac-project/metering-m360-adapter
+      tag: latest
+      pullPolicy: Always
+    m360:
+      apiUrl: "api-url"          # Set to your Monetize360 Usage API endpoint
+      apiKeySecret: "m360-api-key"  # K8s Secret with key "api-key" — create before deploying
+      apiVersion: "v1"
   database:
     connection:
     - secret:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kafka-based metering configuration to the CaaS CI environment.
  * Added optional Monetize360 adapter settings to both CaaS CI and VMaaS CI environments, including image and API connection configuration.
  * The Monetize360 adapter is disabled by default and can be enabled when required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->