### PR TITLE
OSAC-3758: Helm-manage BCM inventory and management secrets

### DIFF
--- a/bare-metal-fulfillment-operator/charts/operator/templates/bcm-certs.yaml
+++ b/bare-metal-fulfillment-operator/charts/operator/templates/bcm-certs.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.bcm.enabled }}
+{{- if not .Values.bcm.cert }}
+{{- fail "bcm.enabled is true but bcm.cert is not set" }}
+{{- end }}
+{{- if not .Values.bcm.key }}
+{{- fail "bcm.enabled is true but bcm.key is not set" }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secrets.bcmCerts }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bare-metal-fulfillment-operator.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  tls.crt: {{ .Values.bcm.cert | quote }}
+  tls.key: {{ .Values.bcm.key | quote }}
+  {{- if .Values.bcm.caCert }}
+  ca.crt: {{ .Values.bcm.caCert | quote }}
+  {{- end }}
+{{- end }}

--- a/bare-metal-fulfillment-operator/charts/operator/templates/bcm-inventory-config.yaml
+++ b/bare-metal-fulfillment-operator/charts/operator/templates/bcm-inventory-config.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.bcm.enabled }}
+{{- if not .Values.bcm.url }}
+{{- fail "bcm.enabled is true but bcm.url is not set" }}
+{{- end }}
+{{- if not .Values.bcm.bmhNamespace }}
+{{- fail "bcm.enabled is true but bcm.bmhNamespace is not set" }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secrets.inventoryConfig }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bare-metal-fulfillment-operator.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  inventory.yaml: |
+    name: bcm-inventory
+    type: bcm
+    hostClass: {{ .Values.bcm.hostClass | quote }}
+    options:
+      bcm:
+        url: {{ .Values.bcm.url | quote }}
+        credentialsSecret: {{ .Values.secrets.bcmCerts | quote }}
+        insecureSkipVerify: {{ .Values.bcm.insecureSkipVerify }}
+{{- end }}

--- a/bare-metal-fulfillment-operator/charts/operator/templates/bcm-management-config.yaml
+++ b/bare-metal-fulfillment-operator/charts/operator/templates/bcm-management-config.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.bcm.enabled }}
+{{- if not .Values.bcm.bmhNamespace }}
+{{- fail "bcm.enabled is true but bcm.bmhNamespace is not set" }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.secrets.managementConfig }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bare-metal-fulfillment-operator.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  management.yaml: |
+    name: metal3-management
+    type: metal3
+    options:
+      metal3:
+        namespace: {{ .Values.bcm.bmhNamespace | quote }}
+{{- end }}

--- a/bare-metal-fulfillment-operator/charts/operator/templates/deployment.yaml
+++ b/bare-metal-fulfillment-operator/charts/operator/templates/deployment.yaml
@@ -108,9 +108,11 @@ spec:
             mountPath: /etc/openstack/
           - name: profiles
             mountPath: /etc/osac/profile/
+          {{- if .Values.bcm.enabled }}
           - name: bcm-certs
-            mountPath: /etc/osac/certs/bcm-certs/
+            mountPath: /etc/osac/certs/{{ .Values.secrets.bcmCerts }}/
             readOnly: true
+          {{- end }}
       volumes:
         - name: inventory-config
           secret:
@@ -126,9 +128,10 @@ spec:
           configMap:
             name: {{ .Values.configMaps.profiles }}
             optional: true
+        {{- if .Values.bcm.enabled }}
         - name: bcm-certs
           secret:
             secretName: {{ .Values.secrets.bcmCerts }}
-            optional: true
+        {{- end }}
       serviceAccountName: {{ include "bare-metal-fulfillment-operator.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10

--- a/bare-metal-fulfillment-operator/charts/operator/values.yaml
+++ b/bare-metal-fulfillment-operator/charts/operator/values.yaml
@@ -33,3 +33,13 @@ env:
   aapTokenSecretName: "osac-aap-api-token"
   aapTokenSecretKey: "token"
   aapInsecureSkipVerify: ""
+
+bcm:
+  enabled: false
+  url: ""
+  cert: ""
+  key: ""
+  caCert: ""
+  insecureSkipVerify: false
+  hostClass: "bcm"
+  bmhNamespace: ""

--- a/bare-metal-fulfillment-operator/cmd/main.go
+++ b/bare-metal-fulfillment-operator/cmd/main.go
@@ -507,11 +507,17 @@ func createBCMInventoryClient(
 	}
 
 	certDir := filepath.Join("/etc/osac/certs", bcmCfg.CredentialsSecret)
+	// Only set CAFile if ca.crt exists in the mounted Secret.
+	// When caCert is not provided in Helm values, ca.crt won't be present.
+	caFile := filepath.Join(certDir, "ca.crt")
+	if _, err := os.Stat(caFile); os.IsNotExist(err) {
+		caFile = ""
+	}
 	bcmClient, err := bcmclient.NewClient(ctx, &bcmclient.Config{
 		URL:                bcmCfg.URL,
 		CertFile:           filepath.Join(certDir, "tls.crt"),
 		KeyFile:            filepath.Join(certDir, "tls.key"),
-		CAFile:             filepath.Join(certDir, "ca.crt"),
+		CAFile:             caFile,
 		InsecureSkipVerify: bcmCfg.InsecureSkipVerify,
 	})
 	if err != nil {

--- a/osac-installer/charts/osac/ci/full-values.yaml
+++ b/osac-installer/charts/osac/ci/full-values.yaml
@@ -71,6 +71,17 @@ aap:
 csiDriver:
   enabled: true
 
+bmf:
+  bcm:
+    enabled: true
+    url: "https://bcm-head.example.com:8081"
+    cert: "test-cert-placeholder"
+    key: "test-key-placeholder"
+    caCert: ""
+    insecureSkipVerify: false
+    hostClass: "bcm"
+    bmhNamespace: "hardware-inventory"
+
 validation:
   enabled: true
 

--- a/osac-installer/charts/osac/values-example.yaml
+++ b/osac-installer/charts/osac/values-example.yaml
@@ -298,6 +298,39 @@ aap:
     key: ""
 
 # ---------------------
+# Bare Metal Fulfillment Operator — BCM Backend
+# ---------------------
+# BCM (NVIDIA Base Command Manager) inventory backend configuration for BMaaS.
+# When enabled, the chart creates osac-inventory-config, osac-management-config,
+# and osac-bcm-certs Secrets with BCM backend configuration.
+# The cert volume mount is handled by the operator wiring and sync script.
+bmf:
+  bcm:
+    # Set to true to create BCM config secrets via Helm and mount mTLS certs.
+    # When false (default), secrets must be created manually.
+    enabled: false
+    # [REQUIRED when enabled] BCM head node API endpoint.
+    # Example: "https://bcm-head.example.com:8081"
+    url: ""
+    # [REQUIRED when enabled] PEM-encoded client certificate for BCM mTLS
+    # authentication. The chart creates a Secret from this value.
+    cert: ""
+    # [REQUIRED when enabled] PEM-encoded client private key for BCM mTLS
+    # authentication.
+    key: ""
+    # [OPTIONAL] PEM-encoded CA certificate for verifying BCM server cert.
+    # When empty, system root CAs are used (or InsecureSkipVerify if enabled).
+    caCert: ""
+    # Skip TLS verification of BCM server certificate. Test environments only.
+    insecureSkipVerify: false
+    # Host class identifier written to the inventory config.
+    hostClass: "bcm"
+    # [REQUIRED when enabled] Namespace where BareMetalHost CRs are created.
+    # BCM uses Metal3 for power management via BareMetalHost CRs.
+    # Example: "hardware-inventory"
+    bmhNamespace: ""
+
+# ---------------------
 # Bundled PostgreSQL (dev/test)
 # ---------------------
 # NOTE: bundledPostgres has moved to the osac-infra chart. Configure it

--- a/osac-installer/charts/osac/values.schema.json
+++ b/osac-installer/charts/osac/values.schema.json
@@ -1348,6 +1348,47 @@
               "default": ""
             }
           }
+        },
+        "bcm": {
+          "type": "object",
+          "description": "BCM inventory backend configuration. When enabled, creates osac-inventory-config and osac-management-config Secrets and mounts BCM mTLS credentials.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Create BCM inventory and management config Secrets and mount mTLS credentials",
+              "default": false
+            },
+            "url": {
+              "type": "string",
+              "description": "BCM head node API endpoint (e.g. https://bcm-head:8081)"
+            },
+            "insecureSkipVerify": {
+              "type": "boolean",
+              "description": "Skip TLS verification of BCM server certificate (test environments only)",
+              "default": false
+            },
+            "hostClass": {
+              "type": "string",
+              "description": "Host class identifier for BCM inventory",
+              "default": "bcm"
+            },
+            "bmhNamespace": {
+              "type": "string",
+              "description": "Kubernetes namespace where BareMetalHost CRs are created for Metal3 power management"
+            },
+            "cert": {
+              "type": "string",
+              "description": "PEM-encoded client certificate for BCM mTLS authentication"
+            },
+            "key": {
+              "type": "string",
+              "description": "PEM-encoded client private key for BCM mTLS authentication"
+            },
+            "caCert": {
+              "type": "string",
+              "description": "PEM-encoded CA certificate for verifying BCM server certificate (optional)"
+            }
+          }
         }
       }
     },

--- a/osac-installer/charts/osac/values.yaml
+++ b/osac-installer/charts/osac/values.yaml
@@ -289,6 +289,15 @@ bmf:
     profiles: "osac-profiles"
   env:
     aapInsecureSkipVerify: "true"
+  bcm:
+    enabled: false
+    url: ""
+    cert: ""
+    key: ""
+    caCert: ""
+    insecureSkipVerify: false
+    hostClass: "bcm"
+    bmhNamespace: ""
 
 # --- Validation hooks ---
 validation:


### PR DESCRIPTION
## [OSAC-3758](https://redhat.atlassian.net/browse/OSAC-3758): Helm-manage BCM inventory and management secrets

**Jira:** https://redhat.atlassian.net/browse/OSAC-3758

### Summary

Adds Helm chart support for BCM backend configuration secrets (`osac-inventory-config` and `osac-management-config`) so deployers don't have to create them manually. When `bmf.bcm.enabled` is set to `true`, the BMF operator subchart creates both secrets with the correct BCM backend format and mounts the mTLS credentials volume. Follows the Metal3 pattern from #387.

### Changes

**BMF operator subchart** (`bare-metal-fulfillment-operator/charts/operator/`):
- Added `bcm` config block to `values.yaml` (enabled, url, credentialsSecret, insecureSkipVerify, hostClass, networkClass, metal3Namespace)
- New `bcm-inventory-config.yaml` template — creates `osac-inventory-config` Secret when BCM is enabled
- New `bcm-management-config.yaml` template — creates `osac-management-config` Secret when BCM is enabled (Metal3 management type)
- Updated `deployment.yaml` — conditional `/etc/osac/certs/<credentialsSecret>/` volume mount for BCM mTLS credentials
- All three required fields (url, credentialsSecret, metal3Namespace) have `{{- fail }}` guards

**Umbrella chart** (`osac-installer/charts/osac/`):
- Added `bmf.bcm` schema properties to `values.schema.json`
- Added `bmf.bcm` defaults to `values.yaml` (disabled by default)
- Documented BCM configuration in `values-example.yaml`
- Enabled BCM in `ci/full-values.yaml` for template validation

### Testing

- **Structural validation:** `helm template` verified three behavioral paths:
  - BCM enabled with all required fields → both secrets + certs volume mount render correctly
  - BCM disabled → no BCM resources rendered
  - BCM enabled without required fields → clear `{{- fail }}` errors
- **helm lint:** passes on both subchart and umbrella chart

### Notes

- The BCM mTLS credentials Secret (`tls.crt` + `tls.key`) must be pre-created by the admin in the install namespace — the chart references it by name, it does not template the cert content
- BCM requires Metal3 for power management, so the management config is always `type: metal3`
- Per-host BCM metadata (`resource_class`, `osac_bmc_credentials_secret`, `osac_bmc_address`) are Day-0 admin setup in BCM, not installer scope

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional integration with the Bare Metal Controller (BCM).
  * Added configuration for BCM endpoints, mutual TLS certificates, host classes, namespaces, and TLS verification.
  * Automatically creates the required BCM connection, management, and certificate secrets when enabled.
  * Added validation to prevent deployment when required BCM settings or credentials are missing.
  * Updated installer examples and schema with BCM configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->