### PR TITLE
OSAC-2987: Fetch secret data when output specified and when editing

### DIFF
--- a/fulfillment-service/internal/cmd/cli/describe/describe_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/describe/describe_cmd.go
@@ -27,6 +27,7 @@ import (
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/describe/instancetype"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/describe/natgateway"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/describe/networkclass"
+	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/describe/secret"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/describe/securitygroup"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/describe/storagebackend"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/describe/storagetier"
@@ -54,6 +55,7 @@ func Cmd() *cobra.Command {
 	result.AddCommand(networkclass.Cmd())
 	result.AddCommand(virtualnetwork.Cmd())
 	result.AddCommand(subnet.Cmd())
+	result.AddCommand(secret.Cmd())
 	result.AddCommand(securitygroup.Cmd())
 	result.AddCommand(help.MarkPrivateAPI(storagebackend.Cmd()))
 	result.AddCommand(help.MarkPrivateAPI(storagetier.Cmd()))

--- a/fulfillment-service/internal/cmd/cli/describe/describe_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/describe/describe_cmd_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/describe/clusterversion"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/describe/computeinstance"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/describe/networkclass"
+	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/describe/secret"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/describe/securitygroup"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/describe/subnet"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/describe/virtualnetwork"
@@ -44,6 +45,7 @@ var _ = Describe("Describe command", func() {
 		Entry("networkclass", networkclass.Cmd, "networkclasses"),
 		Entry("virtualnetwork", virtualnetwork.Cmd, "virtualnetworks"),
 		Entry("subnet", subnet.Cmd, "subnets"),
+		Entry("secret", secret.Cmd, "secrets"),
 		Entry("securitygroup", securitygroup.Cmd, "securitygroups"),
 	)
 
@@ -57,7 +59,7 @@ var _ = Describe("Describe command", func() {
 				subcommandNames = append(subcommandNames, subcmd.Name())
 			}
 
-			Expect(subcommandNames).To(ContainElements("baremetalinstancetype", "cluster", "clusterversion", "computeinstance", "networkclass", "virtualnetwork", "subnet", "securitygroup"))
+			Expect(subcommandNames).To(ContainElements("baremetalinstancetype", "cluster", "clusterversion", "computeinstance", "networkclass", "secret", "virtualnetwork", "subnet", "securitygroup"))
 		})
 	})
 

--- a/fulfillment-service/internal/cmd/cli/describe/secret/describe_secret_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/describe/secret/describe_secret_cmd.go
@@ -16,7 +16,6 @@ package secret
 import (
 	"fmt"
 	"io"
-	"log/slog"
 	"sort"
 	"text/tabwriter"
 
@@ -26,7 +25,6 @@ import (
 	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/lookup"
 	"github.com/osac-project/osac/fulfillment-service/internal/config"
-	"github.com/osac-project/osac/fulfillment-service/internal/logging"
 	"github.com/osac-project/osac/fulfillment-service/internal/terminal"
 )
 
@@ -45,7 +43,6 @@ func Cmd() *cobra.Command {
 }
 
 type runnerContext struct {
-	logger  *slog.Logger
 	console *terminal.Console
 }
 
@@ -54,7 +51,6 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 
 	ctx := cmd.Context()
 
-	c.logger = logging.LoggerFromContext(ctx)
 	c.console = terminal.ConsoleFromContext(ctx)
 
 	cfg := config.SettingsFromContext(ctx)

--- a/fulfillment-service/internal/cmd/cli/describe/secret/describe_secret_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/describe/secret/describe_secret_cmd.go
@@ -1,0 +1,179 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package secret
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+
+	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/lookup"
+	"github.com/osac-project/osac/fulfillment-service/internal/config"
+	"github.com/osac-project/osac/fulfillment-service/internal/logging"
+	"github.com/osac-project/osac/fulfillment-service/internal/terminal"
+)
+
+func Cmd() *cobra.Command {
+	runner := &runnerContext{}
+	result := &cobra.Command{
+		Use:                   "secret [FLAG...] ID|NAME",
+		Aliases:               []string{"secrets"},
+		Short:                 shortHelp,
+		Long:                  longHelp,
+		DisableFlagsInUseLine: true,
+		Args:                  cobra.ExactArgs(1),
+		RunE:                  runner.run,
+	}
+	return result
+}
+
+type runnerContext struct {
+	logger  *slog.Logger
+	console *terminal.Console
+}
+
+func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
+	ref := args[0]
+
+	ctx := cmd.Context()
+
+	c.logger = logging.LoggerFromContext(ctx)
+	c.console = terminal.ConsoleFromContext(ctx)
+
+	cfg := config.SettingsFromContext(ctx)
+	if !cfg.Armed() {
+		return fmt.Errorf("there is no configuration, run the 'login' command")
+	}
+
+	conn, err := cfg.Connect(ctx, cmd.Flags())
+	if err != nil {
+		return fmt.Errorf("failed to create gRPC connection: %w", err)
+	}
+	defer conn.Close()
+
+	client := publicv1.NewSecretsClient(conn)
+
+	matched, err := lookup.Find(ref, "secret", func(filter string, limit int32) ([]*publicv1.Secret, error) {
+		resp, listErr := client.List(ctx, publicv1.SecretsListRequest_builder{
+			Filter: proto.String(filter),
+			Limit:  proto.Int32(limit),
+		}.Build())
+		if listErr != nil {
+			return nil, fmt.Errorf("failed to describe secret: %w", listErr)
+		}
+		return resp.GetItems(), nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Fetch the full secret via Get to include data keys.
+	getResp, err := client.Get(ctx, publicv1.SecretsGetRequest_builder{
+		Id: matched.GetId(),
+	}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to get secret details: %w", err)
+	}
+
+	RenderSecret(c.console, getResp.GetObject())
+
+	return nil
+}
+
+// RenderSecret writes a formatted description of a secret to w.
+func RenderSecret(w io.Writer, secret *publicv1.Secret) {
+	writer := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+
+	name := "-"
+	if v := secret.GetMetadata().GetName(); v != "" {
+		name = v
+	}
+
+	project := "-"
+	if v := secret.GetMetadata().GetProject(); v != "" {
+		project = v
+	}
+
+	created := "-"
+	if v := secret.GetMetadata().GetCreationTimestamp(); v != nil {
+		created = v.AsTime().Format("2006-01-02T15:04:05Z")
+	}
+
+	fmt.Fprintf(writer, "ID:\t%s\n", secret.GetId())
+	fmt.Fprintf(writer, "Name:\t%s\n", name)
+	fmt.Fprintf(writer, "Project:\t%s\n", project)
+	fmt.Fprintf(writer, "Created:\t%s\n", created)
+	writer.Flush()
+
+	labels := secret.GetMetadata().GetLabels()
+	if len(labels) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Labels:")
+		lw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		keys := make([]string, 0, len(labels))
+		for k := range labels {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Fprintf(lw, "  %s:\t%s\n", k, labels[k])
+		}
+		lw.Flush()
+	} else {
+		fmt.Fprintln(w, "Labels:  (none)")
+	}
+
+	data := secret.GetData()
+	if len(data) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Data:")
+		keys := make([]string, 0, len(data))
+		for k := range data {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Fprintf(w, "  %s  (%d bytes)\n", k, len(data[k]))
+		}
+	} else {
+		fmt.Fprintln(w, "Data:  (none)")
+	}
+}
+
+const shortHelp = `Describe a secret`
+
+const longHelp = `
+Display detailed information about a secret, referenced by identifier or name.
+
+The output shows metadata and data key names with their sizes. Secret values are not displayed;
+use {{ bt }}get secret <name> -o yaml{{ bt }} to retrieve actual values.
+
+Examples:
+
+{{ bt 3 }}shell
+# Describe a secret by name:
+{{ binary }} describe secret my-tls-cert
+{{ bt 3 }}
+
+{{ bt 3 }}shell
+# Describe a secret by identifier:
+{{ binary }} describe secret 019e5fee-0742-78b7-8c4a-e2501f44783a
+{{ bt 3 }}
+`

--- a/fulfillment-service/internal/cmd/cli/describe/secret/describe_secret_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/describe/secret/describe_secret_cmd.go
@@ -71,12 +71,12 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	client := publicv1.NewSecretsClient(conn)
 
 	matched, err := lookup.Find(ref, "secret", func(filter string, limit int32) ([]*publicv1.Secret, error) {
-		resp, listErr := client.List(ctx, publicv1.SecretsListRequest_builder{
+		resp, err := client.List(ctx, publicv1.SecretsListRequest_builder{
 			Filter: proto.String(filter),
 			Limit:  proto.Int32(limit),
 		}.Build())
-		if listErr != nil {
-			return nil, fmt.Errorf("failed to describe secret: %w", listErr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to describe secret: %w", err)
 		}
 		return resp.GetItems(), nil
 	})

--- a/fulfillment-service/internal/cmd/cli/describe/secret/describe_secret_suite_test.go
+++ b/fulfillment-service/internal/cmd/cli/describe/secret/describe_secret_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package secret
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestDescribeSecret(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Describe secret command")
+}

--- a/fulfillment-service/internal/cmd/cli/describe/secret/describe_secret_test.go
+++ b/fulfillment-service/internal/cmd/cli/describe/secret/describe_secret_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package secret
+
+import (
+	"bytes"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
+)
+
+func formatSecret(s *publicv1.Secret) string {
+	var buf bytes.Buffer
+	RenderSecret(&buf, s)
+	return buf.String()
+}
+
+var _ = Describe("Describe Secret", func() {
+	Describe("Rendering tests", func() {
+		It("should show '-' for optional fields when not set", func() {
+			s := publicv1.Secret_builder{
+				Id: "sec-001",
+			}.Build()
+
+			output := formatSecret(s)
+			Expect(output).To(MatchRegexp(`Name:\s+-`))
+			Expect(output).To(MatchRegexp(`Project:\s+-`))
+			Expect(output).To(MatchRegexp(`Created:\s+-`))
+			Expect(output).To(ContainSubstring("Labels:  (none)"))
+			Expect(output).To(ContainSubstring("Data:  (none)"))
+		})
+
+		It("should display all metadata fields when set", func() {
+			s := publicv1.Secret_builder{
+				Id: "sec-002",
+				Metadata: publicv1.Metadata_builder{
+					Name:              "my-tls-cert",
+					Project:           "my-project",
+					CreationTimestamp: timestamppb.Now(),
+					Labels: map[string]string{
+						"env":  "production",
+						"team": "platform",
+					},
+				}.Build(),
+			}.Build()
+
+			output := formatSecret(s)
+			Expect(output).To(ContainSubstring("sec-002"))
+			Expect(output).To(ContainSubstring("my-tls-cert"))
+			Expect(output).To(ContainSubstring("my-project"))
+			Expect(output).To(ContainSubstring("Labels:"))
+			Expect(output).To(ContainSubstring("env:"))
+			Expect(output).To(ContainSubstring("production"))
+			Expect(output).To(ContainSubstring("team:"))
+			Expect(output).To(ContainSubstring("platform"))
+		})
+
+		It("should show data keys with byte sizes", func() {
+			s := publicv1.Secret_builder{
+				Id: "sec-003",
+				Data: map[string][]byte{
+					"tls.crt": []byte("cert-data-here"),
+					"tls.key": []byte("key-data"),
+				},
+			}.Build()
+
+			output := formatSecret(s)
+			Expect(output).To(ContainSubstring("Data:"))
+			Expect(output).To(ContainSubstring("tls.crt  (14 bytes)"))
+			Expect(output).To(ContainSubstring("tls.key  (8 bytes)"))
+		})
+
+		It("should sort labels alphabetically", func() {
+			s := publicv1.Secret_builder{
+				Id: "sec-004",
+				Metadata: publicv1.Metadata_builder{
+					Labels: map[string]string{
+						"z-label": "last",
+						"a-label": "first",
+					},
+				}.Build(),
+			}.Build()
+
+			output := formatSecret(s)
+			aIdx := bytes.Index([]byte(output), []byte("a-label"))
+			zIdx := bytes.Index([]byte(output), []byte("z-label"))
+			Expect(aIdx).To(BeNumerically("<", zIdx))
+		})
+
+		It("should sort data keys alphabetically", func() {
+			s := publicv1.Secret_builder{
+				Id: "sec-005",
+				Data: map[string][]byte{
+					"z-key": []byte("z"),
+					"a-key": []byte("a"),
+				},
+			}.Build()
+
+			output := formatSecret(s)
+			aIdx := bytes.Index([]byte(output), []byte("a-key"))
+			zIdx := bytes.Index([]byte(output), []byte("z-key"))
+			Expect(aIdx).To(BeNumerically("<", zIdx))
+		})
+
+		It("should have correct command alias", func() {
+			cmd := Cmd()
+			Expect(cmd.Aliases).To(ContainElement("secrets"))
+		})
+	})
+})

--- a/fulfillment-service/internal/cmd/cli/edit/edit_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/edit/edit_cmd.go
@@ -163,6 +163,13 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// For resource types that rae flagged with UseGetForStructuredOutput,
+	// fetch each object individually via Get.
+	object, err = c.helper.Get(ctx, c.helper.GetId(object))
+	if err != nil {
+		return fmt.Errorf("failed to get full object: %w", err)
+	}
+
 	// Render the object:
 	var render func(proto.Message) ([]byte, error)
 	switch c.format {

--- a/fulfillment-service/internal/cmd/cli/edit/edit_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/edit/edit_cmd.go
@@ -118,6 +118,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		SetConnection(c.conn).
 		AddPackages(cfg.Packages()).
 		SetTenantFunc(config.TenantFromContext).
+		UseGetForStructuredOutput(&publicv1.Secret{}).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create reflection tool: %w", err)
@@ -277,8 +278,8 @@ func (c *runnerContext) findEditor(ctx context.Context) string {
 }
 
 // fetchObject resolves a key to an object via FindObject, then re-fetches via Get for resource
-// types flagged with UseGetForStructuredOutput. This is done after FindObject rather than in
-// place of, as FindObject handles filtering and error messaging for cases like ambiguous matches.
+// types configured to use Get for structured output (e.g. secrets, where List redacts data).
+// Re-fetch happens after FindObject because FindObject handles ambiguous-match error messaging.
 func (c *runnerContext) fetchObject(ctx context.Context, key string) (proto.Message, error) {
 	object, err := c.helper.FindObject(ctx, key, c.console)
 	if err != nil {

--- a/fulfillment-service/internal/cmd/cli/edit/edit_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/edit/edit_cmd.go
@@ -163,11 +163,16 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// For resource types that rae flagged with UseGetForStructuredOutput,
-	// fetch each object individually via Get.
-	object, err = c.helper.Get(ctx, c.helper.GetId(object))
-	if err != nil {
-		return fmt.Errorf("failed to get full object: %w", err)
+	// For resource types that are flagged with UseGetForStructuredOutput,
+	// fetch the object individually via Get.
+	//
+	// Note: this is done after FindObject rather than in place of, as FindObject
+	// handles filtering and error messaging for cases like ambiguous matches.
+	if c.helper.UseGetForStructuredOutput() {
+		object, err = c.helper.Get(ctx, c.helper.GetId(object))
+		if err != nil {
+			return fmt.Errorf("failed to get full object: %w", err)
+		}
 	}
 
 	// Render the object:

--- a/fulfillment-service/internal/cmd/cli/edit/edit_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/edit/edit_cmd.go
@@ -158,21 +158,9 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	key := args[1]
 
 	// Find the object by identifier or name:
-	object, err := c.helper.FindObject(ctx, key, c.console)
+	object, err := c.fetchObject(ctx, key)
 	if err != nil {
 		return err
-	}
-
-	// For resource types that are flagged with UseGetForStructuredOutput,
-	// fetch the object individually via Get.
-	//
-	// Note: this is done after FindObject rather than in place of, as FindObject
-	// handles filtering and error messaging for cases like ambiguous matches.
-	if c.helper.UseGetForStructuredOutput() {
-		object, err = c.helper.Get(ctx, c.helper.GetId(object))
-		if err != nil {
-			return fmt.Errorf("failed to get full object: %w", err)
-		}
 	}
 
 	// Render the object:
@@ -286,6 +274,23 @@ func (c *runnerContext) findEditor(ctx context.Context) string {
 		slog.String("default", defaultEditor),
 	)
 	return defaultEditor
+}
+
+// fetchObject resolves a key to an object via FindObject, then re-fetches via Get for resource
+// types flagged with UseGetForStructuredOutput. This is done after FindObject rather than in
+// place of, as FindObject handles filtering and error messaging for cases like ambiguous matches.
+func (c *runnerContext) fetchObject(ctx context.Context, key string) (proto.Message, error) {
+	object, err := c.helper.FindObject(ctx, key, c.console)
+	if err != nil {
+		return nil, err
+	}
+	if c.helper.UseGetForStructuredOutput() {
+		object, err = c.helper.Get(ctx, c.helper.GetId(object))
+		if err != nil {
+			return nil, fmt.Errorf("failed to get full object: %w", err)
+		}
+	}
+	return object, nil
 }
 
 func (c *runnerContext) update(ctx context.Context, object proto.Message) (result proto.Message, err error) {

--- a/fulfillment-service/internal/cmd/cli/edit/edit_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/edit/edit_cmd_test.go
@@ -16,13 +16,16 @@ package edit
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"log/slog"
 
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/ginkgo/v2/dsl/table"
 	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/proto"
 
 	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/reflection"
@@ -106,6 +109,60 @@ var _ = Describe("Edit command", func() {
 		Entry("public identity provider is not watchable", "identityprovider", map[string]int{"osac.public.v1": 0}, false),
 		Entry("private hub is watchable", "hub", map[string]int{"osac.private.v1": 0}, true),
 	)
+
+	Describe("fetchObject", func() {
+		var (
+			ctrl       *gomock.Controller
+			mockHelper *reflection.MockObjectHelper
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			DeferCleanup(ctrl.Finish)
+			mockHelper = reflection.NewMockObjectHelper(ctrl)
+		})
+
+		It("should call Get after FindObject when UseGetForStructuredOutput is true", func() {
+			listObject := &publicv1.Cluster{Id: "cluster-1", Metadata: &publicv1.Metadata{Name: "my-cluster"}}
+			fullObject := &publicv1.Cluster{Id: "cluster-1", Metadata: &publicv1.Metadata{Name: "my-cluster"}}
+
+			mockHelper.EXPECT().FindObject(gomock.Any(), "my-cluster", gomock.Any()).Return(listObject, nil)
+			mockHelper.EXPECT().UseGetForStructuredOutput().Return(true)
+			mockHelper.EXPECT().GetId(listObject).Return("cluster-1")
+			mockHelper.EXPECT().Get(gomock.Any(), "cluster-1").Return(fullObject, nil)
+
+			runner := &runnerContext{helper: mockHelper, console: console}
+			result, err := runner.fetchObject(ctx, "my-cluster")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(proto.Equal(result, fullObject)).To(BeTrue())
+		})
+
+		It("should return error when Get fails with UseGetForStructuredOutput enabled", func() {
+			listObject := &publicv1.Cluster{Id: "cluster-1"}
+
+			mockHelper.EXPECT().FindObject(gomock.Any(), "my-cluster", gomock.Any()).Return(listObject, nil)
+			mockHelper.EXPECT().UseGetForStructuredOutput().Return(true)
+			mockHelper.EXPECT().GetId(listObject).Return("cluster-1")
+			mockHelper.EXPECT().Get(gomock.Any(), "cluster-1").Return(nil, fmt.Errorf("not found"))
+
+			runner := &runnerContext{helper: mockHelper, console: console}
+			_, err := runner.fetchObject(ctx, "my-cluster")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get full object"))
+		})
+
+		It("should not call Get when UseGetForStructuredOutput is false", func() {
+			listObject := &publicv1.Cluster{Id: "cluster-1", Metadata: &publicv1.Metadata{Name: "my-cluster"}}
+
+			mockHelper.EXPECT().FindObject(gomock.Any(), "my-cluster", gomock.Any()).Return(listObject, nil)
+			mockHelper.EXPECT().UseGetForStructuredOutput().Return(false)
+
+			runner := &runnerContext{helper: mockHelper, console: console}
+			result, err := runner.fetchObject(ctx, "my-cluster")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(proto.Equal(result, listObject)).To(BeTrue())
+		})
+	})
 
 	Describe("showWatchSuggestion", func() {
 		It("should render watch suggestion with object type and ID", func() {

--- a/fulfillment-service/internal/cmd/cli/get/get_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/get/get_cmd.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
+	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/get/externalippool"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/get/kubeconfig"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/get/password"
@@ -146,6 +147,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		SetConnection(c.conn).
 		AddPackages(cfg.Packages()).
 		SetTenantFunc(config.TenantFromContext).
+		UseGetForStructuredOutput(&publicv1.Secret{}).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to create reflection tool: %w", err)
@@ -202,9 +204,17 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	return render(ctx, objects)
 }
 
-// fetchObjects returns objects for the given keys. When specific keys are provided with structured
-// output for resource types flagged with UseGetForStructuredOutput, each object is fetched
-// individually via Get to obtain the full representation.
+// fetchObjects returns objects for the given keys.
+// For cases when:
+//  1. Object names or identifiers are provided
+//  2. The output format is specified as yaml or json
+//  3. The resource type is configured to use Get for structured output
+//
+// We fetch the objects individually via Get to obtain the full representation.
+//
+// Otherwise, we fetch the objects via List.
+// This can result in partial data for resources like secrets where the data field is redacted
+// when list is called and no names or identifiers are provided.
 func (c *runnerContext) fetchObjects(ctx context.Context, keys []string) ([]proto.Message, error) {
 	if len(keys) > 0 && c.args.format != outputFormatTable && c.objectHelper.UseGetForStructuredOutput() {
 		return c.getByKeys(ctx, keys)
@@ -222,7 +232,7 @@ func (c *runnerContext) getByKeys(ctx context.Context, keys []string) ([]proto.M
 		id := c.objectHelper.GetId(obj)
 		result, err := c.objectHelper.Get(ctx, id)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to get object: %w", err)
 		}
 		results[i] = result
 	}

--- a/fulfillment-service/internal/cmd/cli/get/get_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/get/get_cmd.go
@@ -182,15 +182,9 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		return c.watch(ctx, args[1:])
 	}
 
-	// Get the objects. When specific keys are provided with structured output for resource types
-	// that are flagged with UseGetForStructuredOutput, fetch each object individually via Get.
+	// Get the objects:
 	keys := args[1:]
-	var objects []proto.Message
-	if len(keys) > 0 && c.args.format != outputFormatTable && c.objectHelper.UseGetForStructuredOutput() {
-		objects, err = c.getByKeys(ctx, keys)
-	} else {
-		objects, err = c.list(ctx, keys)
-	}
+	objects, err := c.fetchObjects(ctx, keys)
 	if err != nil {
 		return err
 	}
@@ -206,6 +200,16 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		render = c.renderTable
 	}
 	return render(ctx, objects)
+}
+
+// fetchObjects returns objects for the given keys. When specific keys are provided with structured
+// output for resource types flagged with UseGetForStructuredOutput, each object is fetched
+// individually via Get to obtain the full representation.
+func (c *runnerContext) fetchObjects(ctx context.Context, keys []string) ([]proto.Message, error) {
+	if len(keys) > 0 && c.args.format != outputFormatTable && c.objectHelper.UseGetForStructuredOutput() {
+		return c.getByKeys(ctx, keys)
+	}
+	return c.list(ctx, keys)
 }
 
 func (c *runnerContext) getByKeys(ctx context.Context, keys []string) ([]proto.Message, error) {

--- a/fulfillment-service/internal/cmd/cli/get/get_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/get/get_cmd.go
@@ -182,8 +182,15 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		return c.watch(ctx, args[1:])
 	}
 
-	// Get the objects using the list method, which will handle filtering by identifiers or names if provided.
-	objects, err := c.list(ctx, args[1:])
+	// Get the objects. When specific keys are provided with structured output for resource types
+	// that are flagged with UseGetForStructuredOutput, fetch each object individually via Get.
+	keys := args[1:]
+	var objects []proto.Message
+	if len(keys) > 0 && c.args.format != outputFormatTable && c.objectHelper.UseGetForStructuredOutput() {
+		objects, err = c.getByKeys(ctx, keys)
+	} else {
+		objects, err = c.list(ctx, keys)
+	}
 	if err != nil {
 		return err
 	}
@@ -199,6 +206,23 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		render = c.renderTable
 	}
 	return render(ctx, objects)
+}
+
+func (c *runnerContext) getByKeys(ctx context.Context, keys []string) ([]proto.Message, error) {
+	listResults, err := c.list(ctx, keys)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]proto.Message, len(listResults))
+	for i, obj := range listResults {
+		id := c.objectHelper.GetId(obj)
+		result, err := c.objectHelper.Get(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		results[i] = result
+	}
+	return results, nil
 }
 
 func (c *runnerContext) list(ctx context.Context, keys []string) (results []proto.Message, err error) {

--- a/fulfillment-service/internal/cmd/cli/get/get_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/get/get_cmd_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package get
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
+
+	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/osac/fulfillment-service/internal/reflection"
+)
+
+var _ = Describe("Get command", func() {
+	var (
+		ctx        context.Context
+		ctrl       *gomock.Controller
+		mockHelper *reflection.MockObjectHelper
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		ctrl = gomock.NewController(GinkgoT())
+		DeferCleanup(ctrl.Finish)
+		mockHelper = reflection.NewMockObjectHelper(ctrl)
+	})
+
+	Describe("fetchObjects", func() {
+		It("should call Get for each object when UseGetForStructuredOutput is true", func() {
+			listObject := &publicv1.Cluster{Id: "cluster-1", Metadata: &publicv1.Metadata{Name: "my-cluster"}}
+			fullObject := &publicv1.Cluster{Id: "cluster-1", Metadata: &publicv1.Metadata{Name: "my-cluster"}}
+
+			mockHelper.EXPECT().UseGetForStructuredOutput().Return(true)
+			mockHelper.EXPECT().List(gomock.Any(), gomock.Any()).
+				Return(reflection.ListResult{Items: []proto.Message{listObject}, Total: 1}, nil)
+			mockHelper.EXPECT().GetId(listObject).Return("cluster-1")
+			mockHelper.EXPECT().Get(gomock.Any(), "cluster-1").Return(fullObject, nil)
+
+			runner := &runnerContext{
+				objectHelper: mockHelper,
+			}
+			runner.args.format = outputFormatYaml
+
+			results, err := runner.fetchObjects(ctx, []string{"my-cluster"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results).To(HaveLen(1))
+			Expect(proto.Equal(results[0], fullObject)).To(BeTrue())
+		})
+
+		It("should not call Get when UseGetForStructuredOutput is false", func() {
+			listObject := &publicv1.Cluster{Id: "cluster-1", Metadata: &publicv1.Metadata{Name: "my-cluster"}}
+
+			mockHelper.EXPECT().UseGetForStructuredOutput().Return(false)
+			mockHelper.EXPECT().List(gomock.Any(), gomock.Any()).
+				Return(reflection.ListResult{Items: []proto.Message{listObject}, Total: 1}, nil)
+
+			runner := &runnerContext{
+				objectHelper: mockHelper,
+			}
+			runner.args.format = outputFormatYaml
+
+			results, err := runner.fetchObjects(ctx, []string{"my-cluster"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results).To(HaveLen(1))
+			Expect(proto.Equal(results[0], listObject)).To(BeTrue())
+		})
+
+		It("should not check UseGetForStructuredOutput for table format", func() {
+			listObject := &publicv1.Cluster{Id: "cluster-1"}
+
+			mockHelper.EXPECT().List(gomock.Any(), gomock.Any()).
+				Return(reflection.ListResult{Items: []proto.Message{listObject}, Total: 1}, nil)
+
+			runner := &runnerContext{
+				objectHelper: mockHelper,
+			}
+			runner.args.format = outputFormatTable
+
+			results, err := runner.fetchObjects(ctx, []string{"my-cluster"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results).To(HaveLen(1))
+		})
+
+		It("should return error when Get fails", func() {
+			listObject := &publicv1.Cluster{Id: "cluster-1"}
+
+			mockHelper.EXPECT().UseGetForStructuredOutput().Return(true)
+			mockHelper.EXPECT().List(gomock.Any(), gomock.Any()).
+				Return(reflection.ListResult{Items: []proto.Message{listObject}, Total: 1}, nil)
+			mockHelper.EXPECT().GetId(listObject).Return("cluster-1")
+			mockHelper.EXPECT().Get(gomock.Any(), "cluster-1").Return(nil, fmt.Errorf("not found"))
+
+			runner := &runnerContext{
+				objectHelper: mockHelper,
+			}
+			runner.args.format = outputFormatJson
+
+			_, err := runner.fetchObjects(ctx, []string{"my-cluster"})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/fulfillment-service/internal/reflection/reflection_helper.go
+++ b/fulfillment-service/internal/reflection/reflection_helper.go
@@ -84,20 +84,22 @@ type ObjectHelper interface {
 //
 // Don't create instances of this type directly, use the NewHelper function instead.
 type HelperBuilder struct {
-	logger     *slog.Logger
-	connection *grpc.ClientConn
-	packages   map[string]int
-	tenantFunc any
+	logger                     *slog.Logger
+	connection                 *grpc.ClientConn
+	packages                   map[string]int
+	tenantFunc                 any
+	getForStructuredOutputTypes map[protoreflect.Name]bool
 }
 
 // helper is the default implementation of the Helper interface.
 type helper struct {
-	logger     *slog.Logger
-	connection *grpc.ClientConn
-	packages   map[protoreflect.FullName]int
-	scanOnce   *sync.Once
-	helpers    []objectHelper
-	tenantFunc func(context.Context) (string, error)
+	logger                      *slog.Logger
+	connection                  *grpc.ClientConn
+	packages                    map[protoreflect.FullName]int
+	scanOnce                    *sync.Once
+	helpers                     []objectHelper
+	tenantFunc                  func(context.Context) (string, error)
+	getForStructuredOutputTypes map[protoreflect.Name]bool
 }
 
 // NewHelper creates a builder that can then be used to configure a reflection helper.
@@ -154,6 +156,20 @@ func (b *HelperBuilder) SetTenantFunc(value any) *HelperBuilder {
 	return b
 }
 
+// UseGetForStructuredOutput marks the given proto message types as requiring the Get RPC instead
+// of List when fetching specific objects for structured output (yaml/json). Callers pass generated
+// proto message pointers so that a proto rename produces a compile error rather than a silent
+// dead entry.
+func (b *HelperBuilder) UseGetForStructuredOutput(msgs ...proto.Message) *HelperBuilder {
+	if b.getForStructuredOutputTypes == nil {
+		b.getForStructuredOutputTypes = make(map[protoreflect.Name]bool)
+	}
+	for _, msg := range msgs {
+		b.getForStructuredOutputTypes[msg.ProtoReflect().Descriptor().Name()] = true
+	}
+	return b
+}
+
 // Build uses the data stored in the builder to create a new reflection helper.
 func (b *HelperBuilder) Build() (result Helper, err error) {
 	// Check the parameters:
@@ -187,12 +203,13 @@ func (b *HelperBuilder) Build() (result Helper, err error) {
 
 	// Create and populate the object:
 	result = &helper{
-		logger:     b.logger,
-		packages:   packages,
-		connection: b.connection,
-		scanOnce:   &sync.Once{},
-		helpers:    []objectHelper{},
-		tenantFunc: tenantFunc,
+		logger:                      b.logger,
+		packages:                    packages,
+		connection:                  b.connection,
+		scanOnce:                    &sync.Once{},
+		helpers:                     []objectHelper{},
+		tenantFunc:                  tenantFunc,
+		getForStructuredOutputTypes: b.getForStructuredOutputTypes,
 	}
 	return
 }
@@ -360,13 +377,14 @@ func (h *helper) scanService(serviceDesc protoreflect.ServiceDescriptor) {
 
 	// This is a supported object type:
 	helper := objectHelper{
-		parent:        h,
-		descriptor:    objectDesc,
-		idField:       idFieldDesc,
-		metadataField: metadataFieldDesc,
-		singular:      objectNameSingular,
-		plural:        objectNamePlural,
-		tenantScoped:  !platformScopedTypes[objectDesc.Name()],
+		parent:                    h,
+		descriptor:                objectDesc,
+		idField:                   idFieldDesc,
+		metadataField:             metadataFieldDesc,
+		singular:                  objectNameSingular,
+		plural:                    objectNamePlural,
+		tenantScoped:              !platformScopedTypes[objectDesc.Name()],
+		useGetForStructuredOutput: h.getForStructuredOutputTypes[objectDesc.Name()],
 		template:      objectTemplate,
 		get: getInfo{
 			methodInfo: methodInfo{
@@ -570,19 +588,20 @@ func (h *helper) makeTemplate(messageDesc protoreflect.MessageDescriptor) proto.
 
 // objectHelper is the default implementation of the ObjectHelper interface.
 type objectHelper struct {
-	parent        *helper
-	descriptor    protoreflect.MessageDescriptor
-	singular      string
-	plural        string
-	tenantScoped  bool
-	template      proto.Message
-	list          listInfo
-	get           getInfo
-	create        createInfo
-	update        updateInfo
-	delete        deleteInfo
-	idField       protoreflect.FieldDescriptor
-	metadataField protoreflect.FieldDescriptor
+	parent                     *helper
+	descriptor                 protoreflect.MessageDescriptor
+	singular                   string
+	plural                     string
+	tenantScoped               bool
+	useGetForStructuredOutput  bool
+	template                   proto.Message
+	list                       listInfo
+	get                        getInfo
+	create                     createInfo
+	update                     updateInfo
+	delete                     deleteInfo
+	idField                    protoreflect.FieldDescriptor
+	metadataField              protoreflect.FieldDescriptor
 }
 
 type methodInfo struct {
@@ -780,15 +799,9 @@ func (h *objectHelper) IsTenantScoped() bool {
 }
 
 // UseGetForStructuredOutput returns true if the Get RPC should be used instead of List when
-// fetching specific objects for structured output (yaml/json).
+// fetching specific objects for structured output (yaml/json). Configured via the HelperBuilder.
 func (h *objectHelper) UseGetForStructuredOutput() bool {
-	return objectTypesUsingGetForOutput[h.descriptor.Name()]
-}
-
-// objectTypesUsingGetForOutput lists resource types where the Get RPC should be used
-// instead of List when fetching specific objects for structured output (yaml/json).
-var objectTypesUsingGetForOutput = map[protoreflect.Name]bool{
-	"Secret": true,
+	return h.useGetForStructuredOutput
 }
 
 func (h *objectHelper) setId(message proto.Message, field protoreflect.FieldDescriptor, value string) {

--- a/fulfillment-service/internal/reflection/reflection_helper.go
+++ b/fulfillment-service/internal/reflection/reflection_helper.go
@@ -84,10 +84,10 @@ type ObjectHelper interface {
 //
 // Don't create instances of this type directly, use the NewHelper function instead.
 type HelperBuilder struct {
-	logger                     *slog.Logger
-	connection                 *grpc.ClientConn
-	packages                   map[string]int
-	tenantFunc                 any
+	logger                      *slog.Logger
+	connection                  *grpc.ClientConn
+	packages                    map[string]int
+	tenantFunc                  any
 	getForStructuredOutputTypes map[protoreflect.Name]bool
 }
 
@@ -385,7 +385,7 @@ func (h *helper) scanService(serviceDesc protoreflect.ServiceDescriptor) {
 		plural:                    objectNamePlural,
 		tenantScoped:              !platformScopedTypes[objectDesc.Name()],
 		useGetForStructuredOutput: h.getForStructuredOutputTypes[objectDesc.Name()],
-		template:      objectTemplate,
+		template:                  objectTemplate,
 		get: getInfo{
 			methodInfo: methodInfo{
 				path:     h.makeMethodPath(getDesc),
@@ -588,20 +588,20 @@ func (h *helper) makeTemplate(messageDesc protoreflect.MessageDescriptor) proto.
 
 // objectHelper is the default implementation of the ObjectHelper interface.
 type objectHelper struct {
-	parent                     *helper
-	descriptor                 protoreflect.MessageDescriptor
-	singular                   string
-	plural                     string
-	tenantScoped               bool
-	useGetForStructuredOutput  bool
-	template                   proto.Message
-	list                       listInfo
-	get                        getInfo
-	create                     createInfo
-	update                     updateInfo
-	delete                     deleteInfo
-	idField                    protoreflect.FieldDescriptor
-	metadataField              protoreflect.FieldDescriptor
+	parent                    *helper
+	descriptor                protoreflect.MessageDescriptor
+	singular                  string
+	plural                    string
+	tenantScoped              bool
+	useGetForStructuredOutput bool
+	template                  proto.Message
+	list                      listInfo
+	get                       getInfo
+	create                    createInfo
+	update                    updateInfo
+	delete                    deleteInfo
+	idField                   protoreflect.FieldDescriptor
+	metadataField             protoreflect.FieldDescriptor
 }
 
 type methodInfo struct {

--- a/fulfillment-service/internal/reflection/reflection_helper.go
+++ b/fulfillment-service/internal/reflection/reflection_helper.go
@@ -77,6 +77,7 @@ type ObjectHelper interface {
 	SetTenant(object proto.Message, tenant string)
 	GetTenant(object proto.Message) string
 	IsTenantScoped() bool
+	UseGetForStructuredOutput() bool
 }
 
 // HelperBuilder contains the data and logic needed to create a reflection helper.
@@ -776,6 +777,18 @@ func (h *objectHelper) GetTenant(object proto.Message) string {
 // IsTenantScoped returns true if this resource type is scoped to a tenant.
 func (h *objectHelper) IsTenantScoped() bool {
 	return h.tenantScoped
+}
+
+// UseGetForStructuredOutput returns true if the Get RPC should be used instead of List when
+// fetching specific objects for structured output (yaml/json).
+func (h *objectHelper) UseGetForStructuredOutput() bool {
+	return objectTypesUsingGetForOutput[h.descriptor.Name()]
+}
+
+// objectTypesUsingGetForOutput lists resource types where the Get RPC should be used
+// instead of List when fetching specific objects for structured output (yaml/json).
+var objectTypesUsingGetForOutput = map[protoreflect.Name]bool{
+	"Secret": true,
 }
 
 func (h *objectHelper) setId(message proto.Message, field protoreflect.FieldDescriptor, value string) {

--- a/fulfillment-service/internal/reflection/reflection_object_helper_mock.go
+++ b/fulfillment-service/internal/reflection/reflection_object_helper_mock.go
@@ -296,3 +296,17 @@ func (mr *MockObjectHelperMockRecorder) Update(ctx, object any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockObjectHelper)(nil).Update), ctx, object)
 }
+
+// UseGetForStructuredOutput mocks base method.
+func (m *MockObjectHelper) UseGetForStructuredOutput() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UseGetForStructuredOutput")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// UseGetForStructuredOutput indicates an expected call of UseGetForStructuredOutput.
+func (mr *MockObjectHelperMockRecorder) UseGetForStructuredOutput() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UseGetForStructuredOutput", reflect.TypeOf((*MockObjectHelper)(nil).UseGetForStructuredOutput))
+}


### PR DESCRIPTION
Adds functionality to fetch Secret data via `Get` requests to populate underlying secret data when interacting with the CLI.

Important notes:
1.  Data is only fetched when -o flags (yaml or json) are used and specific object names are passed, OR when explicitly editing an object
2. Currently when we display the fetched secret data it is displayed as a b64 encoded string.  I believe we can add some better UX here (via --decode/plaintext flags or some other methodology when editing) as a follow up but that is lower priority.

Usage:

List secrets metadata (does not fetch underlying data):
```bash
$ osac get secrets
TENANT       DELETING  PROJECT  ID                                    NAME                 CREATED                      LABELS
engineering  -         -        01a01aa2-9b54-72fc-a9c8-efc61f061145  test-secret-for-cli  2026-08-19T15:27:39.190897Z  -
```

Get metadata for a specific secret (does not fetch underlying data):
```bash
$ osac get secret test-secret-for-cli
TENANT       DELETING  PROJECT  ID                                    NAME                 CREATED                      LABELS
engineering  -         -        01a01aa2-9b54-72fc-a9c8-efc61f061145  test-secret-for-cli  2026-08-19T15:27:39.190897Z  -
```

Get secret for a specific secret while specifying output type (fetches and populates underlying data, b64 encoded):
```bash
$ osac get secret test-secret-for-cli -o yaml
'@type': type.googleapis.com/osac.public.v1.Secret
data:
  password: czNjcjN0LXBhc3N3MHJk
  username: YWRtaW4=
id: 01a01aa2-9b54-72fc-a9c8-efc61f061145
metadata:
  creation_timestamp: "2026-08-19T15:27:39.190897Z"
  creator: 01a01a9c-1cb1-7a91-bacd-583faf1846e3
  name: test-secret-for-cli
  tenant: engineering
```

Print a decoded secret value:
```bash
$ osac get secret test-secret-for-cli -o yaml | yq .data.password | base64 --decode 
s3cr3t-passw0rd
```
Edit a secret value (fetches and populates underlying data, b64 encoded):
```bash
$ osac edit secret test-secret-for-cli
...
# Opens Editor, displays the secret in YAML format with data populated:
# Users will need to paste b64 encoded strings inline the editor to properly update the secret via this method
data:
  password: bmV3LXBhc3N3b3JkLXZhbHVlCg==
  username: YWRtaW4=
id: 01a01aa2-9b54-72fc-a9c8-efc61f061145
metadata:
  creation_timestamp: "2026-08-19T15:27:39.190897Z"
  creator: 01a01a9c-1cb1-7a91-bacd-583faf1846e3
  name: test-secret-for-cli
  tenant: engineering
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `describe secret` CLI command with lookup by ID or name.
  - Displays secret metadata, labels, and data-key sizes without revealing secret values.
  - Added the `secrets` alias and usage examples.
  - Structured JSON and YAML output now includes complete secret details.

- **Bug Fixes**
  - Improved edit and structured-output commands to retrieve complete resource details.
  - Enhanced error handling when retrieving individual resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->