### PR TITLE
OSAC-4140: add BMO prerequisite validation for Metal3 backend

### DIFF
--- a/osac-installer/charts/osac/templates/hooks/pre-install-validate.yaml
+++ b/osac-installer/charts/osac/templates/hooks/pre-install-validate.yaml
@@ -48,6 +48,36 @@ spec:
             echo "Some components (PostgreSQL, Keycloak) may fail to create PVCs."
           fi
 
+          {{- if .Values.bmf.metal3.enabled }}
+          # Check that Metal3 BareMetalHost CRD exists
+          echo "Checking for Metal3 BareMetalHost CRD..."
+          if kubectl get crd baremetalhosts.metal3.io >/dev/null; then
+            echo "  BareMetalHost CRD found."
+          else
+            echo "ERROR: BareMetalHost CRD (baremetalhosts.metal3.io) not found."
+            echo "Metal3 backend is configured but BareMetalOperator is not installed."
+            echo "Install BareMetalOperator before deploying OSAC with Metal3 backend."
+            exit 1
+          fi
+
+          # Check that the Provisioning CR has watchAllNamespaces enabled
+          echo "Checking Provisioning CR watchAllNamespaces setting..."
+          WATCH_ALL=$(kubectl get provisioning -o jsonpath='{.items[0].spec.watchAllNamespaces}' 2>/dev/null || true)
+          if [ -z "$WATCH_ALL" ]; then
+            echo "ERROR: No Provisioning CR found."
+            echo "Metal3 backend requires a Provisioning CR with watchAllNamespaces: true."
+            echo "Configure BareMetalOperator to watch all namespaces for BareMetalHost resources."
+            exit 1
+          elif [ "$WATCH_ALL" != "true" ]; then
+            echo "ERROR: Provisioning CR has watchAllNamespaces: ${WATCH_ALL}."
+            echo "Metal3 backend requires watchAllNamespaces: true on the Provisioning CR."
+            echo "Set spec.watchAllNamespaces to true so BMO can discover BareMetalHost resources across namespaces."
+            exit 1
+          else
+            echo "  Provisioning CR watchAllNamespaces: true."
+          fi
+          {{- end }}
+
           echo "=== Validation passed ==="
   backoffLimit: 0
 ---
@@ -80,6 +110,11 @@ rules:
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
   verbs: ["list"]
+{{- if .Values.bmf.metal3.enabled }}
+- apiGroups: ["metal3.io"]
+  resources: ["provisionings"]
+  verbs: ["list"]
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## [OSAC-4140](https://redhat.atlassian.net/browse/OSAC-4140): Add BMO prerequisite validation for Metal3 backend

**Jira:** https://redhat.atlassian.net/browse/OSAC-4140
**Story type:** [DEV]

### Summary

Extends the existing pre-install validation Helm hook to check BareMetalOperator prerequisites when the Metal3 backend is configured (`bmf.metal3.enabled`). Catches missing BMO installation and misconfigured Provisioning CR at install time rather than letting the operator silently fail at runtime.

### Changes

- **`osac-installer/charts/osac/templates/hooks/pre-install-validate.yaml`:**
  - Added conditional check for `baremetalhosts.metal3.io` CRD existence (hard fail)
  - Added conditional check for Provisioning CR `watchAllNamespaces: true` (hard fail)
  - Both checks gated by nil-safe `bmf.metal3.enabled` conditional
  - Extended ClusterRole RBAC with conditional `metal3.io/provisionings:list` permission
  - Clear error messages describe the problem and how to fix it

### Testing

- **Unit tests:** N/A — Helm-only repository, no test framework
- **Structural validation:** `helm template` rendering verified for all values files with Metal3 disabled (default) and with Metal3 enabled
- **Coverage:** Both conditional paths (enabled/disabled) validated via template rendering

### Acceptance Criteria

- [x] AC-1: Pre-install validation checks for metal3.io CRDs when Metal3 backend is configured
- [x] AC-2: Pre-install validation checks Provisioning CR watchAllNamespaces setting
- [x] AC-3: Clear error messages guide the deployer to fix missing prerequisites
- [x] AC-4: Validation is skipped when Metal3 backend is not configured


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced pre-install validation for Metal3-enabled deployments.
  * Validates that the Metal3 BareMetalHost resource is available.
  * Confirms the Provisioning configuration watches all namespaces.
  * Installations now fail with validation errors when these requirements are not met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->