### PR TITLE
OSAC-4193: Add build protos command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ __pycache__
 /fulfillment-service/logs
 /fulfillment-service/osac
 /fulfillment-service/osac-dev
+/fulfillment-service/.buf
 
 # osac-operator
 /osac-operator/bin/*

--- a/fulfillment-service/AGENTS.md
+++ b/fulfillment-service/AGENTS.md
@@ -62,9 +62,14 @@ ginkgo run -r internal --skip="database"
 # Lint
 uv run dev.py lint
 
-# Proto: lint and generate
-uv run dev.py lint proto
+# Proto: full build pipeline (public from private, lint, generate)
+uv run dev.py build protos
+
+# Proto: incremental - just generate Go code (skip public proto generation)
 buf generate
+
+# Proto: just lint
+uv run dev.py lint proto
 
 # Run all tests including integration (requires kind cluster)
 ginkgo run -r
@@ -100,7 +105,10 @@ uv run dev.py lint
 # Lint proto files
 uv run dev.py lint proto
 
-# Generate Go code from proto
+# Full proto build pipeline (generate public from private, lint, generate Go code)
+uv run dev.py build protos
+
+# Incremental: just generate Go code from proto (skip public proto generation)
 buf generate
 
 # Regenerate mocks
@@ -113,7 +121,18 @@ uv run ruff check
 go mod tidy
 ```
 
-**CRITICAL**: Always run `uv run dev.py lint proto && buf generate` after any `.proto` file change. Generated code lands in `internal/api/` (never edit manually). Buf is installed via `buf-action` in CI (see the root-level `.github/workflows/check-pull-request.yaml`); for local use, install buf separately following the [official installation guide](https://buf.build/docs/installation).
+**CRITICAL**: After any `.proto` file change:
+- Run `uv run dev.py build protos` for the complete workflow (generates public API from private API, lints, and generates Go code)
+- Or run `uv run dev.py lint proto && buf generate` for incremental builds (skips public proto generation)
+
+Generated code lands in `internal/api/` (never edit manually).
+
+**Proto Workflow**:
+- **Private protos** (`proto/private/`): Full API with internal implementation details. Some resources have `[(cleanapi.field).private = true]` annotations to filter sensitive fields from the public API.
+- **Public protos** (`proto/public/`): Generated from private protos using protoc-gen-cleanapi. Private fields/messages are removed. This is the API published to buf.build.
+- **cleanapi**: The proto file defining annotations is exported from `buf.build/cleanapi/cleanapi:v0.0.7` to `.buf/deps/cleanapi` when running `uv run dev.py build protos`. This directory is gitignored and not committed.
+
+Buf and protoc are installed separately - see the [buf installation guide](https://buf.build/docs/installation) and install protoc with `brew install protobuf` on macOS.
 
 For extending `dev.py` with new commands, see [dev/README.md](dev/README.md).
 
@@ -151,12 +170,14 @@ running tests with specific options, or installing a tool), refer to [dev/README
 Protos are split into public and private APIs under `proto/`:
 
 ```text
-proto/public/osac/public/v1/   - User-facing API (read-heavy, limited write)
-proto/private/osac/private/v1/ - Admin/controller API (full CRUD + Signal RPC)
-proto/tests/osac/tests/v1/     - Test-only proto definitions
+proto/public/osac/public/v1/          - User-facing API (generated from private)
+proto/private/osac/private/v1/        - Admin/controller API (source of truth, full CRUD + Signal RPC)
+proto/tests/osac/tests/v1/            - Test-only proto definitions
 ```
 
 Each resource has `<resource>_type.proto` (message definitions) and `<resource>s_service.proto` (RPC methods). Generated Go code lands in `internal/api/osac/{public,private}/v1/`.
+
+**Public from Private**: The public API is generated from private API using protoc-gen-cleanapi. Fields/messages marked with `[(cleanapi.field).private = true]` are filtered out. Run `uv run dev.py build protos` to regenerate public protos after changing private protos with cleanapi annotations.
 
 ### Server Implementation Pattern
 

--- a/fulfillment-service/dev/build.py
+++ b/fulfillment-service/dev/build.py
@@ -13,13 +13,18 @@
 # specific language governing permissions and limitations under the License.
 #
 
+import glob
 import logging
+import os
+import pathlib
+import shutil
 import sys
 
 import click
 
 from . import commands
 from . import dirs
+from . import setup
 
 
 @click.group(invoke_without_command=True)
@@ -78,3 +83,90 @@ def images() -> None:
     if result.returncode != 0:
         logging.error("Failed to build container image")
         sys.exit(1)
+
+
+@build.command()
+def protos() -> None:
+    """
+    Generates public proto files from private proto files using protoc-gen-cleanapi,
+    lints them with buf, and generates Go code.
+
+    Requires protoc to be installed.
+    """
+    # Ensure dependencies are installed
+    setup.install_protoc_gen_cleanapi()
+
+    # Check if required tools are available
+    if not shutil.which("protoc"):
+        logging.error(
+            "protoc is not installed. Install it with:\n"
+            "  macOS: brew install protobuf\n"
+            "  Ubuntu/Debian: apt-get install protobuf-compiler\n"
+            "  Or download from: https://github.com/protocolbuffers/protobuf/releases"
+        )
+        sys.exit(1)
+
+    if not shutil.which("buf"):
+        logging.error(
+            "buf is not installed. Install it with:\n"
+            "  macOS: brew install bufbuild/buf/buf\n"
+            "  Or download from: https://buf.build/docs/installation"
+        )
+        sys.exit(1)
+
+    logging.info("Generating public proto from private proto")
+
+    # Export buf dependencies to a local directory for protoc to use
+    deps_dir = dirs.project() / ".buf" / "deps"
+    deps_dir.mkdir(parents=True, exist_ok=True)
+
+    # Export each dependency
+    for dep in ["buf.build/bufbuild/protovalidate",
+        "buf.build/googleapis/googleapis",
+        "buf.build/grpc-ecosystem/grpc-gateway",
+        "buf.build/cleanapi/cleanapi:v0.0.7"]:
+        dep_name = dep.split("/")[-1].split(":")[0]
+        dep_path = deps_dir / dep_name
+        if not dep_path.exists():
+            logging.info(f"Exporting {dep}")
+            commands.run(args=["buf", "export", dep, "--output", str(dep_path)], check=True)
+
+    # Get all private proto files (use absolute paths then convert to relative)
+    project_dir = dirs.project()
+    proto_pattern = project_dir / "proto" / "private" / "osac" / "private" / "v1" / "*.proto"
+    proto_files_abs = glob.glob(str(proto_pattern))
+    if not proto_files_abs:
+        logging.error("No proto files found in proto/private/osac/private/v1/")
+        sys.exit(1)
+
+    # Convert to relative paths for protoc
+    proto_files = [str(pathlib.Path(f).relative_to(project_dir)) for f in proto_files_abs]
+
+    # Set up environment with plugin in PATH
+    bin_dir = dirs.bin()
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+
+    # Call protoc with the cleanapi plugin
+    # Include buf dependencies and proto/ (for cleanapi) in proto_path
+    # Use proto/private as the main source, not proto/ to avoid duplicate imports
+    commands.run(
+        args=[
+            "protoc",
+            "--proto_path=proto/private",
+            "--proto_path=proto",  # for cleanapi/cleanapi.proto
+            "--proto_path=.buf/deps/protovalidate",
+            "--proto_path=.buf/deps/googleapis",
+            "--proto_path=.buf/deps/grpc-gateway",
+            "--proto_path=.buf/deps/cleanapi",
+            f"--plugin=protoc-gen-cleanapi={bin_dir}/protoc-gen-cleanapi",
+            "--cleanapi_out=proto/public",
+            "--cleanapi_opt=proto_root=proto/private",  # Where to find original files
+        ] + proto_files,
+        env=env,
+        check=True,
+    )
+
+    logging.info(f"Public proto generation complete - processed {len(proto_files)} files")
+    # TODO: Add functions to lint all proto files and generate Go code.
+    # Currently not added because all private proto files are not annotated with cleanapi yet.


### PR DESCRIPTION
Runs protoc with the protoc-gen-cleanapi plugin to generate public protos from private protos.

```sh
uv run dev.py build protos
```

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a development command to generate public protocol files from private definitions.
  * Added setup and validation for required protocol-generation tools and dependencies.
  * Added clear reporting for missing files, unavailable tools, and generation failures.

* **Documentation**
  * Expanded guidance for full and incremental protocol-generation workflows.

* **Chores**
  * Excluded local tooling files from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->