### PR TITLE
OSAC-4138: provision block volumes via the vendor CSI controller

### DIFF
--- a/fulfillment-service/internal/controllers/volume/volume_reconciler_function.go
+++ b/fulfillment-service/internal/controllers/volume/volume_reconciler_function.go
@@ -198,6 +198,15 @@ func (t *task) update(ctx context.Context) error {
 		if err != nil {
 			return controllers.HandleK8sWriteError(ctx, t.r.logger, err, t.setFailed)
 		}
+		// Populate status.backend/protocol from the resolved private volume so the
+		// operator can select the vendor controller endpoint and protocol on the
+		// first provisioning reconcile, before any vendor round-trip. Status is a
+		// subresource, so it is set with a separate update after Create.
+		newObject.Status.Backend = t.volume.GetStatus().GetBackend()
+		newObject.Status.Protocol = protoProtocolToCRD(t.volume.GetStatus().GetProtocol())
+		if err = t.hubClient.Status().Update(ctx, newObject); err != nil {
+			return controllers.HandleK8sWriteError(ctx, t.r.logger, err, t.setFailed)
+		}
 		t.r.logger.DebugContext(
 			ctx,
 			"Created volume",
@@ -421,5 +430,19 @@ func protoAccessModeToCRD(mode privatev1.VolumeAccessMode) osacv1alpha1.VolumeAc
 		return osacv1alpha1.VolumeAccessModeReadWriteOncePod
 	default:
 		return osacv1alpha1.VolumeAccessModeReadWriteOnce
+	}
+}
+
+// protoProtocolToCRD maps the resolved storage protocol from the private Volume
+// status onto the CRD status protocol. An unspecified protocol maps to the empty
+// value, which the operator treats as not-yet-resolved.
+func protoProtocolToCRD(protocol privatev1.StorageProtocol) osacv1alpha1.VolumeProtocol {
+	switch protocol {
+	case privatev1.StorageProtocol_STORAGE_PROTOCOL_NFS:
+		return osacv1alpha1.VolumeProtocolNFS
+	case privatev1.StorageProtocol_STORAGE_PROTOCOL_BLOCK:
+		return osacv1alpha1.VolumeProtocolBlock
+	default:
+		return ""
 	}
 }

--- a/fulfillment-service/internal/controllers/volume/volume_reconciler_function_test.go
+++ b/fulfillment-service/internal/controllers/volume/volume_reconciler_function_test.go
@@ -911,3 +911,73 @@ var _ = Describe("Kubernetes validation error handling", func() {
 			Equal(privatev1.VolumeState_VOLUME_STATE_CREATING))
 	})
 })
+
+var _ = Describe("create status population", func() {
+	It("populates status.backend and protocol from the resolved private volume", func() {
+		ctx := context.Background()
+		ctrl := gomock.NewController(GinkgoT())
+		DeferCleanup(ctrl.Finish)
+
+		scheme := runtime.NewScheme()
+		Expect(osacv1alpha1.AddToScheme(scheme)).To(Succeed())
+
+		var capturedStatus *osacv1alpha1.Volume
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&osacv1alpha1.Volume{}).
+			WithInterceptorFuncs(interceptor.Funcs{
+				SubResourceUpdate: func(ctx context.Context, client clnt.Client, subResourceName string, obj clnt.Object, opts ...clnt.SubResourceUpdateOption) error {
+					if v, ok := obj.(*osacv1alpha1.Volume); ok {
+						capturedStatus = v.DeepCopy()
+					}
+					return nil
+				},
+			}).
+			Build()
+
+		hubCache := controllers.NewMockHubCache(ctrl)
+		hubCache.EXPECT().
+			Get(gomock.Any(), "hub-1").
+			Return(&controllers.HubEntry{Namespace: "test-ns", Client: fakeClient}, nil).
+			AnyTimes()
+
+		volumesClient := NewMockVolumesClient(ctrl)
+		volumesClient.EXPECT().
+			Update(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, req *privatev1.VolumesUpdateRequest, opts ...grpc.CallOption) (*privatev1.VolumesUpdateResponse, error) {
+				return &privatev1.VolumesUpdateResponse{Object: req.GetObject()}, nil
+			}).
+			AnyTimes()
+
+		volume := privatev1.Volume_builder{
+			Id: "vol-status-test",
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.Controller},
+				Tenant:     "test-tenant",
+			}.Build(),
+			Spec: privatev1.VolumeSpec_builder{
+				StorageTier: "gold",
+				SizeGib:     100,
+				AccessMode:  privatev1.VolumeAccessMode_VOLUME_ACCESS_MODE_READ_WRITE_ONCE,
+			}.Build(),
+			Status: privatev1.VolumeStatus_builder{
+				State:    privatev1.VolumeState_VOLUME_STATE_CREATING,
+				Hub:      "hub-1",
+				Backend:  "vast",
+				Protocol: privatev1.StorageProtocol_STORAGE_PROTOCOL_BLOCK,
+			}.Build(),
+		}.Build()
+
+		f := &function{
+			logger:         logger,
+			hubCache:       hubCache,
+			volumesClient:  volumesClient,
+			maskCalculator: masks.NewCalculator().Build(),
+		}
+
+		Expect(f.run(ctx, volume)).To(Succeed())
+		Expect(capturedStatus).ToNot(BeNil())
+		Expect(capturedStatus.Status.Backend).To(Equal("vast"))
+		Expect(capturedStatus.Status.Protocol).To(Equal(osacv1alpha1.VolumeProtocolBlock))
+	})
+})

--- a/osac-operator/charts/operator/templates/deployment.yaml
+++ b/osac-operator/charts/operator/templates/deployment.yaml
@@ -112,6 +112,14 @@ spec:
             value: {{ .Values.controllers.storage | quote }}
           - name: OSAC_ENABLE_VOLUME_CONTROLLER
             value: {{ .Values.controllers.volume | quote }}
+{{- if .Values.vendorControllers }}
+{{- $pairs := list }}
+{{- range $k, $v := .Values.vendorControllers }}
+{{- $pairs = append $pairs (printf "%s=%s" $k $v) }}
+{{- end }}
+          - name: OSAC_VENDOR_CONTROLLERS
+            value: {{ join "," $pairs | quote }}
+{{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/osac-operator/charts/operator/values.yaml
+++ b/osac-operator/charts/operator/values.yaml
@@ -31,10 +31,20 @@ controllers:
   networking: true
   bareMetalInstance: true
   storage: true
-  # Disabled until OSAC-4138 wires the vendor CSI provisioner; enabling it now
-  # would only leave Volumes stuck in CREATING (nil provisioner). Flip to true
-  # as part of OSAC-4138.
-  volume: false
+  # The Volume controller provisions volumes via the vendor CSI controllers.
+  # Safe to leave enabled even without a vendor backend: when vendorControllers
+  # is empty the controller starts with provisioning disabled (Volumes stay in
+  # Progressing) and never fails operator startup.
+  volume: true
+
+# vendorControllers maps StorageBackend names to their vendor CSI controller
+# gRPC endpoints, rendered into OSAC_VENDOR_CONTROLLERS for the Volume
+# controller. Optional: leave empty on setups with no vendor storage backend
+# (e.g. LVMS/dev) — provisioning is disabled until a backend is configured.
+# Example:
+#   vendorControllers:
+#     vast: vast-csi-controller.osac-csi-backends.svc:50051
+vendorControllers: {}
 
 configSecret:
   name: "osac-config"

--- a/osac-operator/cmd/main.go
+++ b/osac-operator/cmd/main.go
@@ -84,6 +84,16 @@ const (
 	envAgentNamespace             = "OSAC_AGENT_NAMESPACE"
 	envBareMetalInstanceNamespace = "OSAC_BARE_METAL_INSTANCE_NAMESPACE"
 	envVolumeNamespace            = "OSAC_VOLUME_NAMESPACE"
+	// envStorageConfigNamespace is the namespace holding the per-tenant
+	// "vast-tenant-config-<tenant>" Secrets the Volume controller reads.
+	envStorageConfigNamespace = "OSAC_STORAGE_CONFIG_NAMESPACE"
+	// envVendorControllers maps StorageBackend names to vendor CSI controller
+	// gRPC endpoints, comma-separated (e.g.
+	// "vast=vast-csi-controller.osac-csi-backends.svc:50051").
+	envVendorControllers = "OSAC_VENDOR_CONTROLLERS"
+	// defaultStorageConfigNamespace mirrors the osac-aap/storage controller
+	// default used when OSAC_STORAGE_CONFIG_NAMESPACE is unset.
+	defaultStorageConfigNamespace = "osac-system"
 
 	// AAP configuration
 	envAAPURL                 = "OSAC_AAP_URL"
@@ -175,20 +185,21 @@ func registerControllerFlags() *controllerFlags {
 
 // enableAllIfNoneSet enables all controllers if none are explicitly enabled.
 //
-// The Volume controller is intentionally excluded: its VendorProvisioner is a
-// nil stub until OSAC-4138 wires the real vendor CSI client, so enabling it
-// would only leave Volumes stuck in Progressing/CREATING with no path to
-// success. It stays opt-in (--enable-volume-controller) until then. OSAC-4138
-// adds it back here and flips controllers.volume to true in the Helm values.
+// The Volume controller is included now that it has a real vendor provisioner.
+// When no vendor controllers are configured (OSAC_VENDOR_CONTROLLERS unset), the
+// controller still starts but runs with provisioning disabled: it never fails
+// the operator startup, so an unconfigured vendor backend cannot take down the
+// operator or the other controllers.
 func (f *controllerFlags) enableAllIfNoneSet() {
 	if !f.Tenant && !f.Storage && !f.Volume && !f.ComputeInstance && !f.Cluster && !f.Networking && !f.BareMetalInstance {
 		f.Tenant = true
 		f.Storage = true
+		f.Volume = true
 		f.ComputeInstance = true
 		f.Cluster = true
 		f.Networking = true
 		f.BareMetalInstance = true
-		setupLog.Info("no controller flags set, enabling all controllers except volume (no vendor provisioner configured)")
+		setupLog.Info("no controller flags set, enabling all controllers")
 	}
 }
 
@@ -547,16 +558,74 @@ func setupVolumeControllers(mgr mcmanager.Manager, grpcConn *grpc.ClientConn) er
 		}
 	}
 
-	// VendorProvisioner is nil until the real vendor CSI client is wired.
-	// The controller will set phase to Progressing and skip provisioning.
+	// Construct the vendor provisioner from OSAC_VENDOR_CONTROLLERS. A missing or
+	// invalid configuration is deliberately NOT fatal: the operator runs with
+	// volume provisioning disabled (nil provisioner) rather than crashing, so an
+	// unconfigured or misconfigured vendor backend can never take down the
+	// operator or the other controllers. Most setups (including LVMS/dev) have no
+	// vendor backend configured; their Volumes stay in Progressing until one is.
+	var provisioner controller.VendorProvisioner
+	endpoints, err := parseVendorControllers(os.Getenv(envVendorControllers))
+	switch {
+	case err != nil:
+		setupLog.Error(err, "invalid vendor controller config; volume provisioning disabled",
+			"env", envVendorControllers)
+	case len(endpoints) == 0:
+		setupLog.Info("no vendor controllers configured; volume provisioning disabled",
+			"env", envVendorControllers)
+	default:
+		configNamespace := os.Getenv(envStorageConfigNamespace)
+		if configNamespace == "" {
+			configNamespace = defaultStorageConfigNamespace
+		}
+		p, perr := controller.NewVastVendorProvisioner(
+			localMgr.GetAPIReader(),
+			configNamespace,
+			endpoints,
+		)
+		if perr != nil {
+			setupLog.Error(perr, "vendor provisioner init failed; volume provisioning disabled")
+		} else {
+			provisioner = p
+		}
+	}
+
 	if err := controller.NewVolumeReconciler(
 		mgr,
 		volumeNamespace,
-		nil,
+		provisioner,
 	).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("volume controller: %w", err)
 	}
 	return nil
+}
+
+// parseVendorControllers parses a comma-separated list of backend=endpoint pairs
+// (e.g. "vast=vast-csi-controller.osac-csi-backends.svc:50051") into a map from
+// StorageBackend name to vendor CSI controller gRPC endpoint. An empty input
+// yields an empty map, which the provisioner rejects at startup.
+func parseVendorControllers(s string) (map[string]string, error) {
+	result := make(map[string]string)
+	if s == "" {
+		return result, nil
+	}
+	for _, pair := range strings.Split(s, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid pair %q: expected format backend=endpoint", pair)
+		}
+		backend := strings.TrimSpace(parts[0])
+		endpoint := strings.TrimSpace(parts[1])
+		if backend == "" || endpoint == "" {
+			return nil, fmt.Errorf("invalid pair %q: backend and endpoint must not be empty", pair)
+		}
+		result[backend] = endpoint
+	}
+	return result, nil
 }
 
 // setupNetworkingControllers registers all networking controllers along with their

--- a/osac-operator/cmd/main_test.go
+++ b/osac-operator/cmd/main_test.go
@@ -223,3 +223,68 @@ var _ = Describe("startComponents", func() {
 		Eventually(mgrStopped, 5*time.Second).Should(BeClosed())
 	})
 })
+
+var _ = Describe("parseVendorControllers", func() {
+	It("returns an empty map for empty input", func() {
+		m, err := parseVendorControllers("")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(m).To(BeEmpty())
+	})
+
+	It("parses a single backend=endpoint pair", func() {
+		m, err := parseVendorControllers("vast=vast-csi-controller.osac-csi-backends.svc:50051")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(m).To(Equal(map[string]string{
+			"vast": "vast-csi-controller.osac-csi-backends.svc:50051",
+		}))
+	})
+
+	It("parses multiple comma-separated pairs", func() {
+		m, err := parseVendorControllers("vast=vast.svc:50051,netapp=netapp.svc:50052")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(m).To(Equal(map[string]string{
+			"vast":   "vast.svc:50051",
+			"netapp": "netapp.svc:50052",
+		}))
+	})
+
+	It("trims whitespace around pairs, backends, and endpoints", func() {
+		m, err := parseVendorControllers("  vast = vast.svc:50051 ,  netapp=netapp.svc:50052  ")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(m).To(Equal(map[string]string{
+			"vast":   "vast.svc:50051",
+			"netapp": "netapp.svc:50052",
+		}))
+	})
+
+	It("skips empty pairs from trailing or doubled commas", func() {
+		m, err := parseVendorControllers("vast=vast.svc:50051,,")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(m).To(Equal(map[string]string{"vast": "vast.svc:50051"}))
+	})
+
+	It("preserves ports in endpoints containing an equals sign", func() {
+		// SplitN with limit 2 keeps everything after the first '=' as the endpoint.
+		m, err := parseVendorControllers("vast=host:50051/path?a=b")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(m).To(Equal(map[string]string{"vast": "host:50051/path?a=b"}))
+	})
+
+	It("errors on a pair missing the equals separator", func() {
+		_, err := parseVendorControllers("vast")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("expected format backend=endpoint"))
+	})
+
+	It("errors on an empty backend", func() {
+		_, err := parseVendorControllers("=vast.svc:50051")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("backend and endpoint must not be empty"))
+	})
+
+	It("errors on an empty endpoint", func() {
+		_, err := parseVendorControllers("vast=")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("backend and endpoint must not be empty"))
+	})
+})

--- a/osac-operator/go.mod
+++ b/osac-operator/go.mod
@@ -5,6 +5,8 @@ go 1.26.3
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260709200747-435963d16310.1
 	github.com/coder/websocket v1.8.15
+	github.com/container-storage-interface/spec v1.12.0
+	github.com/go-logr/logr v1.4.4
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1
 	github.com/openshift/hypershift/api v0.0.0-20250331235933-616a2fae81ae
@@ -42,7 +44,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect

--- a/osac-operator/go.sum
+++ b/osac-operator/go.sum
@@ -29,6 +29,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
 github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
+github.com/container-storage-interface/spec v1.12.0 h1:zrFOEqpR5AghNaaDG4qyedwPBqU2fU0dWjLQMP/azK0=
+github.com/container-storage-interface/spec v1.12.0/go.mod h1:txsm+MA2B2WDa5kW69jNbqPnvTtfvZma7T/zsAZ9qX8=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/osac-operator/internal/controller/vast_vendor_provisioner.go
+++ b/osac-operator/internal/controller/vast_vendor_provisioner.go
@@ -1,0 +1,316 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	grpcstatus "google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/osac-project/osac/osac-operator/api/v1alpha1"
+)
+
+// bytesPerGiB converts the Volume spec's GiB size to the CSI capacity in bytes.
+const bytesPerGiB = 1024 * 1024 * 1024
+
+// Hub Secret keys (Secret "vast-tenant-config-<tenant>"), populated during VAST
+// tenant onboarding. Kept in sync with the reader in osac-aap's vast_storage
+// role (read_tenant_credentials.yaml).
+const (
+	secretKeyManagerUsername = "tenant_manager_username"
+	secretKeyManagerPassword = "tenant_manager_password"
+	secretKeyVastEndpoint    = "vast_endpoint"
+	secretKeyVipPoolName     = "vip_pool_name"
+	secretKeyVipPoolFQDN     = "vip_pool_fqdn"
+	secretKeyTenantUIDHash   = "tenant_uid_hash"
+)
+
+// vendorCSIClient is the subset of the CSI controller service the provisioner
+// uses. csi.ControllerClient (over a real gRPC connection) satisfies it, and
+// tests substitute an in-memory fake.
+type vendorCSIClient interface {
+	CreateVolume(ctx context.Context, in *csi.CreateVolumeRequest, opts ...grpc.CallOption) (*csi.CreateVolumeResponse, error)
+	DeleteVolume(ctx context.Context, in *csi.DeleteVolumeRequest, opts ...grpc.CallOption) (*csi.DeleteVolumeResponse, error)
+}
+
+// vendorDialer opens a connection to a vendor CSI controller endpoint and
+// returns a client plus a close function. It is a seam for testing: production
+// uses dialVendorController; tests inject a fake.
+type vendorDialer func(ctx context.Context, endpoint string) (vendorCSIClient, func() error, error)
+
+// VastVendorProvisioner is the production VendorProvisioner. It provisions
+// volumes by calling a vendor CSI controller (deployed per backend, e.g. the
+// VAST CSI controller) directly over gRPC, passing per-tenant credentials in
+// the CSI secrets field. The per-tenant credentials and VAST-side resource
+// references are read from the hub Secret "vast-tenant-config-<tenant>" created
+// during tenant onboarding.
+//
+// Only block volumes are implemented today. The exact CSI CreateVolume contract
+// is verified against the upstream VAST CSI driver at the tag this deployment
+// pins (docker.io/vastdataorg/csi:v2.6.5):
+//
+//	https://github.com/vast-data/vast-csi/blob/v2.6.5/vast_csi/builders/block.py
+//
+// The block builder requires the "subsystem" parameter (the VAST view, created
+// during onboarding and named "view-<tenant>-<uid_hash>-<tier>"), a VIP pool,
+// and username/password/endpoint in secrets. NFS uses a different parameter set
+// (root_export + view_policy) and is not implemented here yet.
+type VastVendorProvisioner struct {
+	// reader reads the per-tenant hub Secret. The operator already has
+	// cluster-wide secret read via its manager ClusterRole, so no extra RBAC is
+	// required.
+	reader client.Reader
+	// configNamespace is where the hub "vast-tenant-config-<tenant>" Secrets
+	// live (OSAC_STORAGE_CONFIG_NAMESPACE).
+	configNamespace string
+	// endpoints maps a StorageBackend name to its vendor CSI controller gRPC
+	// endpoint (e.g. "vast" -> "vast-csi-controller.osac-csi-backends.svc:50051").
+	endpoints map[string]string
+	dial      vendorDialer
+}
+
+// NewVastVendorProvisioner constructs a VastVendorProvisioner and fails fast on
+// invalid configuration: at least one backend->endpoint mapping is required so
+// the operator errors loudly at startup rather than running degraded and
+// leaving volumes stuck in Progressing.
+func NewVastVendorProvisioner(reader client.Reader, configNamespace string, endpoints map[string]string) (*VastVendorProvisioner, error) {
+	if reader == nil {
+		return nil, fmt.Errorf("client reader is required")
+	}
+	if configNamespace == "" {
+		return nil, fmt.Errorf("storage config namespace is required")
+	}
+	if len(endpoints) == 0 {
+		return nil, fmt.Errorf("at least one vendor controller endpoint (backend=endpoint) must be configured")
+	}
+	return &VastVendorProvisioner{
+		reader:          reader,
+		configNamespace: configNamespace,
+		endpoints:       endpoints,
+		dial:            dialVendorController,
+	}, nil
+}
+
+// tenantCreds holds the per-tenant values read from the hub Secret.
+type tenantCreds struct {
+	username     string
+	password     string
+	vastEndpoint string
+	vipPoolName  string
+	vipPoolFQDN  string
+	uidHash      string
+}
+
+// CreateVolume provisions a block volume on the vendor array. It reads the
+// per-tenant credentials/config from the hub Secret, resolves the vendor
+// controller endpoint from the backend name, and issues a CSI CreateVolume with
+// the credentials in the secrets field. CSI CreateVolume is idempotent, so a
+// retried call for an existing volume returns that volume rather than erroring.
+func (p *VastVendorProvisioner) CreateVolume(ctx context.Context, req VendorCreateVolumeRequest) (VendorCreateVolumeResponse, error) {
+	if req.Protocol != v1alpha1.VolumeProtocolBlock {
+		return VendorCreateVolumeResponse{}, fmt.Errorf(
+			"vendor provisioner supports only block volumes; protocol %q is not yet implemented", req.Protocol)
+	}
+
+	endpoint, err := p.endpointFor(req.Backend)
+	if err != nil {
+		return VendorCreateVolumeResponse{}, err
+	}
+	creds, err := p.readTenantCreds(ctx, req.Tenant)
+	if err != nil {
+		return VendorCreateVolumeResponse{}, err
+	}
+
+	cli, closeConn, err := p.dial(ctx, endpoint)
+	if err != nil {
+		return VendorCreateVolumeResponse{}, fmt.Errorf("dial vendor controller %q: %w", endpoint, err)
+	}
+	defer func() { _ = closeConn() }()
+
+	// The VAST view (NVMe subsystem) is created during onboarding and named
+	// "view-<tenant>-<uid_hash>-<tier>" (see osac-aap vast_storage
+	// ensure_storage_class). The operator references it by name; it does not
+	// create it.
+	subsystem := fmt.Sprintf("view-%s-%s-%s", req.Tenant, creds.uidHash, req.Tier)
+
+	csiReq := &csi.CreateVolumeRequest{
+		Name:               req.Name,
+		CapacityRange:      &csi.CapacityRange{RequiredBytes: req.SizeGiB * bytesPerGiB},
+		VolumeCapabilities: []*csi.VolumeCapability{blockVolumeCapability(req.AccessMode)},
+		Parameters: map[string]string{
+			"subsystem":   subsystem,
+			"tenant_name": req.Tenant,
+		},
+		Secrets: map[string]string{
+			"username": creds.username,
+			"password": creds.password,
+			"endpoint": creds.vastEndpoint,
+		},
+	}
+	creds.applyVipPool(csiReq.Parameters)
+
+	resp, err := cli.CreateVolume(ctx, csiReq)
+	if err != nil {
+		return VendorCreateVolumeResponse{}, fmt.Errorf("vendor CreateVolume for %q: %w", req.Name, err)
+	}
+	vol := resp.GetVolume()
+	if vol == nil || vol.GetVolumeId() == "" {
+		return VendorCreateVolumeResponse{}, fmt.Errorf("vendor CreateVolume for %q returned no volume id", req.Name)
+	}
+
+	return VendorCreateVolumeResponse{
+		VendorVolumeID: vol.GetVolumeId(),
+		Backend:        req.Backend,
+		Protocol:       string(v1alpha1.VolumeProtocolBlock),
+	}, nil
+}
+
+// DeleteVolume deprovisions the vendor volume. CSI DeleteVolume is idempotent:
+// a NotFound response is treated as success so a retried delete of an
+// already-removed volume does not block finalizer removal.
+func (p *VastVendorProvisioner) DeleteVolume(ctx context.Context, req VendorDeleteVolumeRequest) error {
+	endpoint, err := p.endpointFor(req.Backend)
+	if err != nil {
+		return err
+	}
+	creds, err := p.readTenantCreds(ctx, req.Tenant)
+	if err != nil {
+		return err
+	}
+
+	cli, closeConn, err := p.dial(ctx, endpoint)
+	if err != nil {
+		return fmt.Errorf("dial vendor controller %q: %w", endpoint, err)
+	}
+	defer func() { _ = closeConn() }()
+
+	_, err = cli.DeleteVolume(ctx, &csi.DeleteVolumeRequest{
+		VolumeId: req.VendorVolumeID,
+		Secrets: map[string]string{
+			"username": creds.username,
+			"password": creds.password,
+			"endpoint": creds.vastEndpoint,
+		},
+	})
+	if err != nil {
+		if grpcstatus.Code(err) == codes.NotFound {
+			return nil
+		}
+		return fmt.Errorf("vendor DeleteVolume for %q: %w", req.VendorVolumeID, err)
+	}
+	return nil
+}
+
+// endpointFor resolves the vendor controller endpoint for a backend name.
+func (p *VastVendorProvisioner) endpointFor(backend string) (string, error) {
+	if backend == "" {
+		return "", fmt.Errorf("volume has no resolved backend; cannot select a vendor controller")
+	}
+	endpoint, ok := p.endpoints[backend]
+	if !ok {
+		return "", fmt.Errorf("no vendor controller endpoint configured for backend %q", backend)
+	}
+	return endpoint, nil
+}
+
+// readTenantCreds reads and validates the per-tenant hub Secret.
+func (p *VastVendorProvisioner) readTenantCreds(ctx context.Context, tenant string) (tenantCreds, error) {
+	if tenant == "" {
+		return tenantCreds{}, fmt.Errorf("volume has no tenant annotation; cannot select vendor credentials")
+	}
+	name := fmt.Sprintf("vast-tenant-config-%s", tenant)
+	secret := &corev1.Secret{}
+	if err := p.reader.Get(ctx, client.ObjectKey{Namespace: p.configNamespace, Name: name}, secret); err != nil {
+		return tenantCreds{}, fmt.Errorf("read hub secret %s/%s: %w", p.configNamespace, name, err)
+	}
+
+	creds := tenantCreds{
+		username:     string(secret.Data[secretKeyManagerUsername]),
+		password:     string(secret.Data[secretKeyManagerPassword]),
+		vastEndpoint: string(secret.Data[secretKeyVastEndpoint]),
+		vipPoolName:  string(secret.Data[secretKeyVipPoolName]),
+		vipPoolFQDN:  string(secret.Data[secretKeyVipPoolFQDN]),
+		uidHash:      string(secret.Data[secretKeyTenantUIDHash]),
+	}
+	if creds.username == "" || creds.password == "" {
+		return tenantCreds{}, fmt.Errorf("hub secret %s/%s missing manager credentials", p.configNamespace, name)
+	}
+	if creds.vastEndpoint == "" {
+		return tenantCreds{}, fmt.Errorf("hub secret %s/%s missing %s", p.configNamespace, name, secretKeyVastEndpoint)
+	}
+	if creds.vipPoolName == "" && creds.vipPoolFQDN == "" {
+		return tenantCreds{}, fmt.Errorf("hub secret %s/%s missing a VIP pool (%s or %s)",
+			p.configNamespace, name, secretKeyVipPoolName, secretKeyVipPoolFQDN)
+	}
+	if creds.uidHash == "" {
+		return tenantCreds{}, fmt.Errorf("hub secret %s/%s missing %s", p.configNamespace, name, secretKeyTenantUIDHash)
+	}
+	return creds, nil
+}
+
+// applyVipPool sets the VIP pool CSI parameter, preferring the FQDN form when
+// present (matching the StorageClass parameters osac-aap emits today).
+func (c tenantCreds) applyVipPool(params map[string]string) {
+	if c.vipPoolFQDN != "" {
+		params["vip_pool_fqdn"] = c.vipPoolFQDN
+		return
+	}
+	params["vip_pool_name"] = c.vipPoolName
+}
+
+// blockVolumeCapability builds a block CSI volume capability from the CRD access
+// mode.
+func blockVolumeCapability(mode v1alpha1.VolumeAccessMode) *csi.VolumeCapability {
+	return &csi.VolumeCapability{
+		AccessType: &csi.VolumeCapability_Block{Block: &csi.VolumeCapability_BlockVolume{}},
+		AccessMode: &csi.VolumeCapability_AccessMode{Mode: toCSIAccessMode(mode)},
+	}
+}
+
+// toCSIAccessMode maps the CRD access mode to the CSI access mode enum.
+func toCSIAccessMode(mode v1alpha1.VolumeAccessMode) csi.VolumeCapability_AccessMode_Mode {
+	switch mode {
+	case v1alpha1.VolumeAccessModeReadWriteOnce:
+		return csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
+	case v1alpha1.VolumeAccessModeReadWriteOncePod:
+		return csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER
+	case v1alpha1.VolumeAccessModeReadOnlyMany:
+		return csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY
+	case v1alpha1.VolumeAccessModeReadWriteMany:
+		return csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER
+	default:
+		return csi.VolumeCapability_AccessMode_UNKNOWN
+	}
+}
+
+// dialVendorController is the production vendorDialer. The vendor CSI controllers
+// are reached over plaintext in-cluster gRPC (same trust model as the CSI
+// driver's node-plugin proxy).
+func dialVendorController(_ context.Context, endpoint string) (vendorCSIClient, func() error, error) {
+	conn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, nil, err
+	}
+	return csi.NewControllerClient(conn), conn.Close, nil
+}

--- a/osac-operator/internal/controller/vast_vendor_provisioner_test.go
+++ b/osac-operator/internal/controller/vast_vendor_provisioner_test.go
@@ -1,0 +1,262 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/osac-project/osac/osac-operator/api/v1alpha1"
+)
+
+// fakeCSIClient records the last request and returns canned responses/errors.
+type fakeCSIClient struct {
+	createReq  *csi.CreateVolumeRequest
+	createResp *csi.CreateVolumeResponse
+	createErr  error
+
+	deleteReq *csi.DeleteVolumeRequest
+	deleteErr error
+}
+
+func (f *fakeCSIClient) CreateVolume(_ context.Context, in *csi.CreateVolumeRequest, _ ...grpc.CallOption) (*csi.CreateVolumeResponse, error) {
+	f.createReq = in
+	return f.createResp, f.createErr
+}
+
+func (f *fakeCSIClient) DeleteVolume(_ context.Context, in *csi.DeleteVolumeRequest, _ ...grpc.CallOption) (*csi.DeleteVolumeResponse, error) {
+	f.deleteReq = in
+	if f.deleteErr != nil {
+		return nil, f.deleteErr
+	}
+	return &csi.DeleteVolumeResponse{}, nil
+}
+
+// newProvisioner builds a provisioner wired to the given fake CSI client and a
+// fake secret store containing the provided secret (if non-nil).
+func newProvisioner(t *testing.T, csiCli *fakeCSIClient, secret *corev1.Secret) (*VastVendorProvisioner, *fakeCSIClient) {
+	t.Helper()
+	builder := fake.NewClientBuilder()
+	if secret != nil {
+		builder = builder.WithObjects(secret)
+	}
+	dialed := csiCli
+	return &VastVendorProvisioner{
+		reader:          builder.Build(),
+		configNamespace: "osac-system",
+		endpoints:       map[string]string{"vast-backend": "vast-csi-controller.osac-csi-backends.svc:50051"},
+		dial: func(_ context.Context, _ string) (vendorCSIClient, func() error, error) {
+			return dialed, func() error { return nil }, nil
+		},
+	}, dialed
+}
+
+// fullSecret returns a hub Secret with all required keys populated.
+func fullSecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "vast-tenant-config-acme", Namespace: "osac-system"},
+		Data: map[string][]byte{
+			secretKeyManagerUsername: []byte("osac-acme"),
+			secretKeyManagerPassword: []byte("s3cret"),
+			secretKeyVastEndpoint:    []byte("vms.example.com"),
+			secretKeyVipPoolName:     []byte("osac-shared"),
+			secretKeyTenantUIDHash:   []byte("abc123"),
+		},
+	}
+}
+
+func blockCreateReq() VendorCreateVolumeRequest {
+	return VendorCreateVolumeRequest{
+		Name:       "pvc-1",
+		Backend:    "vast-backend",
+		Tenant:     "acme",
+		Tier:       "gold",
+		SizeGiB:    10,
+		AccessMode: v1alpha1.VolumeAccessModeReadWriteOnce,
+		Protocol:   v1alpha1.VolumeProtocolBlock,
+	}
+}
+
+func TestCreateVolumeBlockSuccess(t *testing.T) {
+	csiResp := &csi.CreateVolumeResponse{Volume: &csi.Volume{VolumeId: "vendor-vol-1"}}
+	p, cli := newProvisioner(t, &fakeCSIClient{createResp: csiResp}, fullSecret())
+
+	resp, err := p.CreateVolume(context.Background(), blockCreateReq())
+	if err != nil {
+		t.Fatalf("CreateVolume error: %v", err)
+	}
+	if resp.VendorVolumeID != "vendor-vol-1" {
+		t.Errorf("VendorVolumeID = %q, want vendor-vol-1", resp.VendorVolumeID)
+	}
+	if resp.Backend != "vast-backend" || resp.Protocol != "Block" {
+		t.Errorf("resp backend/protocol = %q/%q", resp.Backend, resp.Protocol)
+	}
+
+	req := cli.createReq
+	if got := req.GetParameters()["subsystem"]; got != "view-acme-abc123-gold" {
+		t.Errorf("subsystem = %q, want view-acme-abc123-gold", got)
+	}
+	if got := req.GetParameters()["vip_pool_name"]; got != "osac-shared" {
+		t.Errorf("vip_pool_name = %q, want osac-shared", got)
+	}
+	if got := req.GetSecrets()["username"]; got != "osac-acme" {
+		t.Errorf("secrets.username = %q, want osac-acme", got)
+	}
+	if got := req.GetSecrets()["endpoint"]; got != "vms.example.com" {
+		t.Errorf("secrets.endpoint = %q, want vms.example.com", got)
+	}
+	if got := req.GetCapacityRange().GetRequiredBytes(); got != 10*bytesPerGiB {
+		t.Errorf("required_bytes = %d, want %d", got, int64(10)*bytesPerGiB)
+	}
+	cap := req.GetVolumeCapabilities()[0]
+	if cap.GetBlock() == nil {
+		t.Errorf("expected a block volume capability")
+	}
+	if cap.GetAccessMode().GetMode() != csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER {
+		t.Errorf("access mode = %v, want SINGLE_NODE_WRITER", cap.GetAccessMode().GetMode())
+	}
+}
+
+func TestCreateVolumeVipPoolFQDNPreferred(t *testing.T) {
+	secret := fullSecret()
+	secret.Data[secretKeyVipPoolFQDN] = []byte("pool.example.com")
+	p, cli := newProvisioner(t, &fakeCSIClient{createResp: &csi.CreateVolumeResponse{Volume: &csi.Volume{VolumeId: "v"}}}, secret)
+
+	if _, err := p.CreateVolume(context.Background(), blockCreateReq()); err != nil {
+		t.Fatalf("CreateVolume error: %v", err)
+	}
+	if got := cli.createReq.GetParameters()["vip_pool_fqdn"]; got != "pool.example.com" {
+		t.Errorf("vip_pool_fqdn = %q, want pool.example.com", got)
+	}
+	if _, ok := cli.createReq.GetParameters()["vip_pool_name"]; ok {
+		t.Errorf("vip_pool_name should be omitted when fqdn is set")
+	}
+}
+
+func TestCreateVolumeRejectsNonBlock(t *testing.T) {
+	p, _ := newProvisioner(t, &fakeCSIClient{}, fullSecret())
+	req := blockCreateReq()
+	req.Protocol = v1alpha1.VolumeProtocolNFS
+	if _, err := p.CreateVolume(context.Background(), req); err == nil {
+		t.Fatalf("expected error for NFS protocol, got nil")
+	}
+}
+
+func TestCreateVolumeMissingSecret(t *testing.T) {
+	p, _ := newProvisioner(t, &fakeCSIClient{}, nil)
+	if _, err := p.CreateVolume(context.Background(), blockCreateReq()); err == nil {
+		t.Fatalf("expected error for missing secret, got nil")
+	}
+}
+
+func TestCreateVolumeMissingVipPool(t *testing.T) {
+	secret := fullSecret()
+	delete(secret.Data, secretKeyVipPoolName)
+	p, _ := newProvisioner(t, &fakeCSIClient{}, secret)
+	if _, err := p.CreateVolume(context.Background(), blockCreateReq()); err == nil {
+		t.Fatalf("expected error for missing vip pool, got nil")
+	}
+}
+
+func TestCreateVolumeUnknownBackend(t *testing.T) {
+	p, _ := newProvisioner(t, &fakeCSIClient{}, fullSecret())
+	req := blockCreateReq()
+	req.Backend = "nope"
+	if _, err := p.CreateVolume(context.Background(), req); err == nil {
+		t.Fatalf("expected error for unknown backend, got nil")
+	}
+}
+
+func TestCreateVolumeVendorError(t *testing.T) {
+	p, _ := newProvisioner(t, &fakeCSIClient{createErr: errors.New("boom")}, fullSecret())
+	if _, err := p.CreateVolume(context.Background(), blockCreateReq()); err == nil {
+		t.Fatalf("expected vendor error to propagate, got nil")
+	}
+}
+
+func TestDeleteVolumeSuccess(t *testing.T) {
+	p, cli := newProvisioner(t, &fakeCSIClient{}, fullSecret())
+	err := p.DeleteVolume(context.Background(), VendorDeleteVolumeRequest{
+		VendorVolumeID: "vendor-vol-1", Backend: "vast-backend", Tenant: "acme",
+	})
+	if err != nil {
+		t.Fatalf("DeleteVolume error: %v", err)
+	}
+	if cli.deleteReq.GetVolumeId() != "vendor-vol-1" {
+		t.Errorf("delete volume id = %q, want vendor-vol-1", cli.deleteReq.GetVolumeId())
+	}
+	if cli.deleteReq.GetSecrets()["username"] != "osac-acme" {
+		t.Errorf("delete secrets.username = %q", cli.deleteReq.GetSecrets()["username"])
+	}
+}
+
+func TestDeleteVolumeNotFoundIsSuccess(t *testing.T) {
+	p, _ := newProvisioner(t, &fakeCSIClient{deleteErr: grpcstatus.Error(codes.NotFound, "gone")}, fullSecret())
+	if err := p.DeleteVolume(context.Background(), VendorDeleteVolumeRequest{
+		VendorVolumeID: "vendor-vol-1", Backend: "vast-backend", Tenant: "acme",
+	}); err != nil {
+		t.Fatalf("NotFound should be treated as success, got %v", err)
+	}
+}
+
+func TestDeleteVolumeVendorError(t *testing.T) {
+	p, _ := newProvisioner(t, &fakeCSIClient{deleteErr: grpcstatus.Error(codes.Internal, "boom")}, fullSecret())
+	if err := p.DeleteVolume(context.Background(), VendorDeleteVolumeRequest{
+		VendorVolumeID: "vendor-vol-1", Backend: "vast-backend", Tenant: "acme",
+	}); err == nil {
+		t.Fatalf("expected vendor error to propagate, got nil")
+	}
+}
+
+func TestNewVastVendorProvisionerFailFast(t *testing.T) {
+	reader := fake.NewClientBuilder().Build()
+	if _, err := NewVastVendorProvisioner(reader, "osac-system", nil); err == nil {
+		t.Errorf("expected error for empty endpoints")
+	}
+	if _, err := NewVastVendorProvisioner(reader, "", map[string]string{"vast": "x:50051"}); err == nil {
+		t.Errorf("expected error for empty config namespace")
+	}
+	if _, err := NewVastVendorProvisioner(nil, "osac-system", map[string]string{"vast": "x:50051"}); err == nil {
+		t.Errorf("expected error for nil reader")
+	}
+	if _, err := NewVastVendorProvisioner(reader, "osac-system", map[string]string{"vast": "x:50051"}); err != nil {
+		t.Errorf("unexpected error for valid config: %v", err)
+	}
+}
+
+func TestToCSIAccessMode(t *testing.T) {
+	cases := map[v1alpha1.VolumeAccessMode]csi.VolumeCapability_AccessMode_Mode{
+		v1alpha1.VolumeAccessModeReadWriteOnce:    csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+		v1alpha1.VolumeAccessModeReadWriteOncePod: csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER,
+		v1alpha1.VolumeAccessModeReadOnlyMany:     csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY,
+		v1alpha1.VolumeAccessModeReadWriteMany:    csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+	}
+	for mode, want := range cases {
+		if got := toCSIAccessMode(mode); got != want {
+			t.Errorf("toCSIAccessMode(%q) = %v, want %v", mode, got, want)
+		}
+	}
+}

--- a/osac-operator/internal/controller/volume_controller.go
+++ b/osac-operator/internal/controller/volume_controller.go
@@ -54,14 +54,20 @@ type VendorProvisioner interface {
 }
 
 // VendorCreateVolumeRequest carries the parameters the vendor needs to
-// provision a volume. Backend is resolved by the fulfillment-service tier
-// resolution (OSAC-3277) before the Volume CR is created; the operator
-// passes it through to the vendor without re-resolving.
+// provision a volume. Backend and Protocol are resolved by the
+// fulfillment-service tier resolution (OSAC-3277) before the Volume CR is
+// created; the operator passes them through to the vendor without re-resolving.
+// Tenant and Tier let the vendor implementation select the per-tenant
+// credentials and construct the per-tenant/per-tier vendor resource references
+// (e.g. the VAST subsystem/view name) without re-deriving them.
 type VendorCreateVolumeRequest struct {
 	Name       string
 	Backend    string
+	Tenant     string
+	Tier       string
 	SizeGiB    int64
 	AccessMode v1alpha1.VolumeAccessMode
+	Protocol   v1alpha1.VolumeProtocol
 }
 
 // VendorCreateVolumeResponse carries the vendor-assigned identifiers that the
@@ -72,10 +78,13 @@ type VendorCreateVolumeResponse struct {
 	Protocol       string
 }
 
-// VendorDeleteVolumeRequest identifies the vendor volume to deprovision.
+// VendorDeleteVolumeRequest identifies the vendor volume to deprovision. Tenant
+// lets the vendor implementation select the per-tenant credentials needed to
+// authenticate the deprovision call.
 type VendorDeleteVolumeRequest struct {
 	VendorVolumeID string
 	Backend        string
+	Tenant         string
 }
 
 // VolumeReconciler reconciles Volume CRs created by the fulfillment-service
@@ -164,8 +173,6 @@ func (r *VolumeReconciler) Reconcile(ctx context.Context, req mcreconcile.Reques
 // is present, sets the initial phase to Progressing, and delegates to
 // handleProvisioning if the volume has not yet reached Ready.
 func (r *VolumeReconciler) handleUpdate(ctx context.Context, vol *v1alpha1.Volume) (ctrl.Result, error) {
-	log := ctrllog.FromContext(ctx)
-
 	if controllerutil.AddFinalizer(vol, osacVolumeFinalizer) {
 		if err := r.Update(ctx, vol); err != nil {
 			return ctrl.Result{}, err
@@ -174,14 +181,6 @@ func (r *VolumeReconciler) handleUpdate(ctx context.Context, vol *v1alpha1.Volum
 
 	if vol.Status.Phase == "" {
 		vol.Status.Phase = v1alpha1.VolumePhaseProgressing
-	}
-
-	if r.VendorProvisioner == nil {
-		// Temporary: VendorProvisioner is nil until the real vendor CSI client
-		// is wired in the CSI driver integration PR. Remove this guard once a
-		// concrete implementation is always passed to NewVolumeReconciler.
-		log.Info("no vendor provisioner configured, skipping provisioning")
-		return ctrl.Result{}, nil
 	}
 
 	// Already provisioned; nothing to do until spec changes (future: resize).
@@ -209,11 +208,26 @@ func (r *VolumeReconciler) handleUpdate(ctx context.Context, vol *v1alpha1.Volum
 func (r *VolumeReconciler) handleProvisioning(ctx context.Context, vol *v1alpha1.Volume) (ctrl.Result, error) {
 	log := ctrllog.FromContext(ctx)
 
+	// No vendor provisioner configured (OSAC_VENDOR_CONTROLLERS unset). Leave the
+	// volume in Progressing and skip provisioning instead of dereferencing a nil
+	// provisioner. Most setups (including LVMS/dev) run without a vendor storage
+	// backend configured; the Volume controller must not take the operator or
+	// other controllers down when it is unconfigured. Provisioning resumes once a
+	// vendor controller is configured.
+	if r.VendorProvisioner == nil {
+		log.Info("no vendor provisioner configured; leaving volume in Progressing (provisioning skipped)")
+		vol.Status.Phase = v1alpha1.VolumePhaseProgressing
+		return ctrl.Result{}, nil
+	}
+
 	resp, err := r.VendorProvisioner.CreateVolume(ctx, VendorCreateVolumeRequest{
 		Name:       vol.Name,
 		Backend:    vol.Status.Backend,
+		Tenant:     vol.GetAnnotations()[osacTenantKey],
+		Tier:       vol.Spec.StorageTier,
 		SizeGiB:    vol.Spec.SizeGiB,
 		AccessMode: vol.Spec.AccessMode,
+		Protocol:   vol.Status.Protocol,
 	})
 	if err != nil {
 		log.Error(err, "vendor provisioning failed")
@@ -267,6 +281,7 @@ func (r *VolumeReconciler) handleDelete(ctx context.Context, vol *v1alpha1.Volum
 		err := r.VendorProvisioner.DeleteVolume(ctx, VendorDeleteVolumeRequest{
 			VendorVolumeID: vol.Status.VendorVolumeID,
 			Backend:        vol.Status.Backend,
+			Tenant:         vol.GetAnnotations()[osacTenantKey],
 		})
 		if err != nil {
 			log.Error(err, "vendor deprovisioning failed")

--- a/osac-operator/internal/controller/volume_controller_test.go
+++ b/osac-operator/internal/controller/volume_controller_test.go
@@ -321,22 +321,81 @@ var _ = Describe("VolumeReconciler", func() {
 		Expect(still.Finalizers).To(ContainElement(osacVolumeFinalizer))
 	})
 
-	It("should return not-found gracefully when volume is already deleted", func() {
+	It("should pass tenant, tier, protocol, and backend through to the vendor create request", func() {
+		// The controller derives the vendor create request from the CR: tenant
+		// from the annotation, tier from the spec, backend/protocol from the
+		// status stamped by fulfillment-service. A regression that drops or
+		// mis-maps any of these would silently provision on the wrong
+		// backend/tenant, so assert every field the controller populates.
+		vol.Annotations = map[string]string{osacTenantKey: "acme"}
+		Expect(k8sClient.Create(testCtx, vol)).To(Succeed())
+
+		// Stamp the backend/protocol that fulfillment-service resolves before
+		// the operator provisions.
+		vol.Status.Backend = "vast-primary"
+		vol.Status.Protocol = osacv1alpha1.VolumeProtocolBlock
+		Expect(k8sClient.Status().Update(testCtx, vol)).To(Succeed())
+
 		_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{
 			Request: reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: "nonexistent", Namespace: "default"},
+				NamespacedName: types.NamespacedName{Name: vol.Name, Namespace: vol.Namespace},
 			},
 		})
 		Expect(err).ToNot(HaveOccurred())
+
+		Expect(mockProv.CreateCallCount()).To(BeNumerically(">=", 1))
+		req := mockProv.LastCreateReq
+		Expect(req.Name).To(Equal("test-vol"))
+		Expect(req.Backend).To(Equal("vast-primary"))
+		Expect(req.Tenant).To(Equal("acme"))
+		Expect(req.Tier).To(Equal("gold"))
+		Expect(req.SizeGiB).To(Equal(int64(100)))
+		Expect(req.AccessMode).To(Equal(osacv1alpha1.VolumeAccessModeReadWriteOnce))
+		Expect(req.Protocol).To(Equal(osacv1alpha1.VolumeProtocolBlock))
 	})
 
-	It("should skip provisioning when no VendorProvisioner is configured", func() {
+	It("should pass tenant, backend, and vendor volume ID through to the vendor delete request", func() {
+		vol.Annotations = map[string]string{osacTenantKey: "acme"}
+		Expect(k8sClient.Create(testCtx, vol)).To(Succeed())
+
+		// Reconcile to Ready so the volume has a VendorVolumeID and backend.
+		for range 3 {
+			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{
+				Request: reconcile.Request{
+					NamespacedName: types.NamespacedName{Name: vol.Name, Namespace: vol.Namespace},
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		provisioned := &osacv1alpha1.Volume{}
+		Expect(k8sClient.Get(testCtx, types.NamespacedName{Name: vol.Name, Namespace: vol.Namespace}, provisioned)).To(Succeed())
+		Expect(provisioned.Status.VendorVolumeID).To(HavePrefix("mock-"))
+
+		Expect(k8sClient.Delete(testCtx, vol)).To(Succeed())
+
+		_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{
+			Request: reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: vol.Name, Namespace: vol.Namespace},
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(mockProv.DeleteCallCount()).To(BeNumerically(">=", 1))
+		req := mockProv.LastDeleteReq
+		Expect(req.Tenant).To(Equal("acme"))
+		Expect(req.Backend).To(Equal(provisioned.Status.Backend))
+		Expect(req.VendorVolumeID).To(Equal(provisioned.Status.VendorVolumeID))
+	})
+
+	It("should stay in Progressing (not crash) when no VendorProvisioner is configured", func() {
+		// Most setups (LVMS/dev) run with no vendor backend configured. The
+		// controller must not dereference a nil provisioner; it leaves the volume
+		// in Progressing and does not error, so the operator stays healthy.
 		reconciler.VendorProvisioner = nil
 
 		Expect(k8sClient.Create(testCtx, vol)).To(Succeed())
 
-		// Reconcile adds finalizer + sets Progressing. The nil-provisioner path
-		// is expected to succeed without error.
 		for range 2 {
 			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{
 				Request: reconcile.Request{
@@ -351,4 +410,41 @@ var _ = Describe("VolumeReconciler", func() {
 		Expect(updated.Status.Phase).To(Equal(osacv1alpha1.VolumePhaseProgressing))
 		Expect(updated.Status.VendorVolumeID).To(BeEmpty())
 	})
+
+	It("should delete cleanly when never provisioned and no VendorProvisioner is configured", func() {
+		// A volume that never provisioned has no VendorVolumeID, so deletion must
+		// remove the finalizer without needing a provisioner — nothing leaks on
+		// the array because nothing was created.
+		reconciler.VendorProvisioner = nil
+
+		Expect(k8sClient.Create(testCtx, vol)).To(Succeed())
+		_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{
+			Request: reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: vol.Name, Namespace: vol.Namespace},
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(k8sClient.Delete(testCtx, vol)).To(Succeed())
+		_, err = reconciler.Reconcile(testCtx, mcreconcile.Request{
+			Request: reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: vol.Name, Namespace: vol.Namespace},
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		deleted := &osacv1alpha1.Volume{}
+		err = k8sClient.Get(testCtx, types.NamespacedName{Name: vol.Name, Namespace: vol.Namespace}, deleted)
+		Expect(errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("should return not-found gracefully when volume is already deleted", func() {
+		_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{
+			Request: reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: "nonexistent", Namespace: "default"},
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 })

--- a/osac-operator/internal/controller/volume_mock_provisioner_test.go
+++ b/osac-operator/internal/controller/volume_mock_provisioner_test.go
@@ -29,6 +29,12 @@ type MockVendorProvisioner struct {
 	createCount atomic.Int64
 	deleteCount atomic.Int64
 
+	// LastCreateReq and LastDeleteReq record the most recent request the
+	// controller passed in, so tests can assert the controller populates the
+	// vendor request fields (tenant, tier, protocol, backend, ...) correctly.
+	LastCreateReq VendorCreateVolumeRequest
+	LastDeleteReq VendorDeleteVolumeRequest
+
 	// CreateErr, when non-nil, is returned by CreateVolume instead of
 	// succeeding. Allows tests to simulate vendor failures.
 	CreateErr error
@@ -47,6 +53,7 @@ func NewMockVendorProvisioner() *MockVendorProvisioner {
 // "mock-" plus a monotonic counter. Backend and protocol are fixed
 // strings suitable for test assertions.
 func (m *MockVendorProvisioner) CreateVolume(_ context.Context, req VendorCreateVolumeRequest) (VendorCreateVolumeResponse, error) {
+	m.LastCreateReq = req
 	n := m.createCount.Add(1)
 	if m.CreateErr != nil {
 		return VendorCreateVolumeResponse{}, m.CreateErr
@@ -59,7 +66,8 @@ func (m *MockVendorProvisioner) CreateVolume(_ context.Context, req VendorCreate
 }
 
 // DeleteVolume records the call and returns DeleteErr (nil by default).
-func (m *MockVendorProvisioner) DeleteVolume(_ context.Context, _ VendorDeleteVolumeRequest) error {
+func (m *MockVendorProvisioner) DeleteVolume(_ context.Context, req VendorDeleteVolumeRequest) error {
+	m.LastDeleteReq = req
 	m.deleteCount.Add(1)
 	return m.DeleteErr
 }


### PR DESCRIPTION
## Summary

[OSAC-4138](https://redhat.atlassian.net/browse/OSAC-4138): replace the osac-operator Volume controller's nil `VendorProvisioner` with a real implementation that provisions **block** volumes on the vendor array by calling the vendor CSI controller directly over gRPC. This is the operator-side counterpart to [OSAC-4109](https://redhat.atlassian.net/browse/OSAC-4109) (CSI driver → fulfillment-service): CSI driver → fulfillment Volume API → Volume CR → **this** → vendor CSI controller → array.

## Why

With the provisioner nil, a volume request flowed to the operator but provisioning was skipped, so the volume stayed `Progressing`, the feedback controller never synced `AVAILABLE`, and the CSI driver's `CreateVolume` polled forever. Wiring [OSAC-4109](https://redhat.atlassian.net/browse/OSAC-4109) alone does not produce a working create-volume flow; this closes that gap.

The provisioner resolves the vendor controller endpoint from the volume's backend name, reads the per-tenant VMS Manager credentials from the hub Secret `vast-tenant-config-<tenant>` (using the operator's existing cluster-wide secret-read — no new RBAC), and issues a CSI CreateVolume/DeleteVolume with the credentials in the CSI `secrets` field. The VAST view (NVMe `subsystem`, named `view-<tenant>-<uid_hash>-<tier>`) is created out-of-band during tenant onboarding; the operator only references it by name.

Scope is **block only**. The CreateVolume contract was verified against the upstream `vast-data/vast-csi` driver source at the pinned image tag: https://github.com/vast-data/vast-csi/blob/v2.6.5/vast_csi/builders/block.py (block requires `subsystem` + a VIP pool + username/password/endpoint in secrets; NFS needs a different parameter set). NFS is tracked separately in [OSAC-4198](https://redhat.atlassian.net/browse/OSAC-4198).

This PR also: keeps a nil-provisioner guard so the Volume controller degrades safely when no vendor is configured (Volumes stay `Progressing`) instead of failing, while the delete-path safety net still refuses to drop the finalizer for an already-provisioned volume without a provisioner; enables the Volume controller by default; and, on the fulfillment-service side, stamps `status.backend`/`status.protocol` onto the Volume CR at creation so the operator has both before the first provisioning call.

## Testing

- `osac-operator`: `make fmt` (clean), `make manifests generate` (no diff — no API changes), `make build`, `make lint` (0 issues), `make test` (envtest; controller 73.1%). New unit tests cover request mapping (subsystem, vip pool, secrets, capacity, access mode), block-only enforcement, missing-secret and unknown-backend errors, delete idempotency (NotFound → success), graceful degradation when no provisioner is configured (Volumes stay `Progressing`, delete stays clean, operator starts normally), create/delete field passthrough (tenant/tier/protocol/backend), and the `OSAC_VENDOR_CONTROLLERS` parser.
- `fulfillment-service`: `gofmt -s` (clean), `buf generate` (no diff), `go build ./...`, `ginkgo run -r internal` (93 suites pass), `uv run dev.py lint` (0 issues). Added a test asserting `status.backend`/`status.protocol` are populated at creation.

E2E is out of scope here: end to end needs this PR plus [OSAC-4109](https://redhat.atlassian.net/browse/OSAC-4109), a configured vendor controller, and a cluster ([OSAC-4046](https://redhat.atlassian.net/browse/OSAC-4046)).

## Pre-merge ToDos

_None._

**Startup behavior (resolved):** the Volume controller is enabled by default (`controllers.volume: true`) and is safe with no vendor configured. When `OSAC_VENDOR_CONTROLLERS` is empty or invalid, the operator logs and runs with provisioning disabled (Volumes stay `Progressing`) rather than failing startup, so an unconfigured or misconfigured vendor backend can never take down the operator or the other controllers. Most setups (including LVMS/dev) run without a vendor backend.

## Related PRs

- Complementary: osac-project/osac#405 ([OSAC-4109](https://redhat.atlassian.net/browse/OSAC-4109)) — both are required for the end-to-end create-volume flow.
- Follow-up: [OSAC-4198](https://redhat.atlassian.net/browse/OSAC-4198) (NFS support in the vendor provisioner).

## Ticket

[OSAC-4138](https://redhat.atlassian.net/browse/OSAC-4138)

<br>

<small>Assisted-by: Claude Code &lt;noreply@anthropic.com&gt;</small>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled volume provisioning by default.
  * Added configuration for vendor CSI controller endpoints.
  * Added support for provisioning and deleting block volumes through vendor CSI controllers, including tenant, tier, protocol, and access-mode settings.
  * Volume status now reports resolved backend and storage protocol details.

* **Bug Fixes**
  * Invalid or incomplete storage configuration now disables provisioning while allowing the operator to start safely.
  * Volume deletion handles already-missing volumes successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
