### PR TITLE
NO-ISSUE: run PR CI suites on merge_group

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
     - main
+  merge_group:
   workflow_dispatch:
   # 2x/day (every 12h). Offset 47 minutes past the hour, not on the hour --
   # GitHub Actions' shared cron scheduler queues everyone's on-the-hour
@@ -26,12 +27,23 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
-      should-run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+      # Same ignore list for pull_request and merge_group. schedule /
+      # workflow_dispatch always run. Job-level `if:` skip reports success
+      # so docs-only PRs (and merge groups) are not blocked.
+      should-run: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || steps.filter.outputs.code == 'true' }}
     steps:
+      # dorny/paths-filter uses git diff on merge_group (not the PR Files API),
+      # so the repo must be checked out with enough history for base..head.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        if: github.event_name == 'merge_group'
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         id: filter
         with:
           predicate-quantifier: 'every'

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -2,6 +2,7 @@ name: pre-commit
 
 on:
   pull_request:
+  merge_group:
 
 jobs:
   pre-commit:
@@ -38,7 +39,7 @@ jobs:
       id: gitleaks-config
       if: always()
       env:
-        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
       run: |
         set -euo pipefail
         git show "${BASE_SHA}:.gitleaks.toml" > /tmp/gitleaks-base.toml
@@ -52,8 +53,8 @@ jobs:
       id: gitleaks
       if: always() && steps.gitleaks-config.outcome == 'success'
       env:
-        BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
       run: |
         set -euo pipefail
         docker run --rm \
@@ -76,7 +77,7 @@ jobs:
   # comment may fail there — accepted gap; the scan job still blocks the PR.
   gitleaks-rotation-comment:
     needs: pre-commit
-    if: always() && needs.pre-commit.outputs.gitleaks-failed == 'true'
+    if: always() && needs.pre-commit.outputs.gitleaks-failed == 'true' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,6 +18,7 @@ on:
   pull_request:
     branches:
     - main
+  merge_group:
   workflow_dispatch:
   # 2x/day (every 12h). Offset 13 minutes past the hour, not on the hour --
   # GitHub Actions' shared cron scheduler queues everyone's on-the-hour
@@ -36,12 +37,23 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
-      should-run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+      # Same ignore list for pull_request and merge_group. schedule /
+      # workflow_dispatch always run. Job-level `if:` skip reports success
+      # so docs-only PRs (and merge groups) are not blocked.
+      should-run: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || steps.filter.outputs.code == 'true' }}
     steps:
+      # dorny/paths-filter uses git diff on merge_group (not the PR Files API),
+      # so the repo must be checked out with enough history for base..head.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        if: github.event_name == 'merge_group'
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         id: filter
         with:
           predicate-quantifier: 'every'


### PR DESCRIPTION
## Summary
- Trigger `pre-commit`, unit tests, and integration tests on `merge_group` so merge queue gets real pass/fail on the speculative SHA (fixes the `checks_timed_out` kick from github-config#191 / osac#375).
- Apply the same docs-only path filter on merge_group as on pull_request (checkout + git diff, because `dorny/paths-filter` has no PR Files API there).
- Point gitleaks at `merge_group.base_sha` / `head_sha`; keep the rotation comment PR-only (no issue number on merge_group).

## Test plan
- [ ] PR event still runs real pre-commit / unit / integration on this PR
- [ ] After enqueue, merge-group SHA shows those jobs running (not missing); failure must block merge
- [ ] Docs-only change still skips unit/integration (success); pre-commit still runs
- [ ] Do **not** re-apply github-config required checks until this is on `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated integration and unit test workflows to support merge queue validation.
  - Improved change detection for pull requests and merge-group builds, ensuring relevant checks run consistently.
  - Updated pre-commit checks and secret scanning to work with merge-group revisions.
  - Limited rotation reminder comments to pull requests, reducing unnecessary notifications in other workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->