### PR TITLE
NO-ISSUE: Resolve flaky test db timeouts

### DIFF
--- a/osac-metering/metering-service/internal/database/container.go
+++ b/osac-metering/metering-service/internal/database/container.go
@@ -68,7 +68,7 @@ func (c *Container) Start(ctx context.Context) error {
 	c.configFile = configFile
 
 	c.id = fmt.Sprintf("osac-metering-db-%08x", rand.Uint32())
-	c.runCmd = exec.CommandContext(ctx,
+	c.runCmd = exec.Command(
 		c.tool,
 		"run",
 		"--name", c.id,


### PR DESCRIPTION
The metering unit test is currently flaky and results in failures like:

https://github.com/osac-project/osac/actions/runs/32372417110/job/96435834733?pr=403

It appears like the root cause is the postgres db shutting down.  Currently the metering test db is called with a parent context from the test setup with a 2 minute timeout - this modifies the caller to not use that context so the db stays up and isn't bound to the test setup timeout.  This is also how the [fulfillment-service](https://github.com/DakCrowder/osac/blob/main/fulfillment-service/internal/database/database_container.go#L190) starts its db container.