### PR TITLE
OSAC-2247: auto-cleanup finalizer for auto-provisioned ExternalIP on Cluster deletion

### DIFF
--- a/osac-operator/cmd/main.go
+++ b/osac-operator/cmd/main.go
@@ -348,6 +348,7 @@ func setupClusterControllers(
 				localMgr.GetClient(), localMgr.GetAPIReader(), localMgr.GetScheme(),
 				os.Getenv(envClusterOrderNamespace),
 				os.Getenv(envAgentNamespace),
+				os.Getenv(envNetworkingNamespace),
 				provider, pollInterval, maxJobHistory,
 			).SetupWithManager(mgr)
 		},

--- a/osac-operator/internal/controller/clusterorder_cleanup_test.go
+++ b/osac-operator/internal/controller/clusterorder_cleanup_test.go
@@ -1,0 +1,291 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
+	. "github.com/onsi/gomega"    //nolint:revive,staticcheck
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/osac-project/osac/osac-operator/api/v1alpha1"
+)
+
+var _ = Describe("reconcileAutoExternalIPCleanup", func() {
+	const (
+		networkingNS = "default"
+		clusterUUID  = "test-cluster-uuid"
+		pollInterval = 50 * time.Millisecond
+	)
+
+	ctx := context.Background()
+
+	newReconciler := func(networkingNamespace string) *ClusterOrderReconciler {
+		return &ClusterOrderReconciler{
+			Client:              k8sClient,
+			NetworkingNamespace: networkingNamespace,
+			StatusPollInterval:  pollInterval,
+		}
+	}
+
+	newClusterOrder := func(uuid string) *v1alpha1.ClusterOrder {
+		labels := map[string]string{}
+		if uuid != "" {
+			labels[osacClusterOrderIDLabel] = uuid
+		}
+		return &v1alpha1.ClusterOrder{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-co-",
+				Namespace:    networkingNS,
+				Labels:       labels,
+			},
+			Spec: v1alpha1.ClusterOrderSpec{TemplateID: "t"},
+		}
+	}
+
+	newAutoEIA := func(clusterID string) *v1alpha1.ExternalIPAttachment {
+		clusterIDCopy := clusterID
+		ep := v1alpha1.ExternalIPAttachmentTargetEndpointAPI
+		return &v1alpha1.ExternalIPAttachment{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-eia-",
+				Namespace:    networkingNS,
+				Labels: map[string]string{
+					osacAutoProvisionedLabel: labelValueTrue,
+				},
+			},
+			Spec: v1alpha1.ExternalIPAttachmentSpec{
+				ExternalIP:     "test-eip",
+				Cluster:        &clusterIDCopy,
+				TargetEndpoint: &ep,
+			},
+		}
+	}
+
+	newAutoEIP := func(clusterID string) *v1alpha1.ExternalIP {
+		return &v1alpha1.ExternalIP{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-eip-",
+				Namespace:    networkingNS,
+				Labels: map[string]string{
+					osacAutoProvisionedLabel:    "true",
+					osacAutoProvisionedForLabel: clusterID,
+				},
+			},
+			Spec: v1alpha1.ExternalIPSpec{
+				Pool: "test-pool",
+			},
+		}
+	}
+
+	listEIAs := func() []v1alpha1.ExternalIPAttachment {
+		list := &v1alpha1.ExternalIPAttachmentList{}
+		ExpectWithOffset(1, k8sClient.List(ctx, list, client.InNamespace(networkingNS))).To(Succeed())
+		return list.Items
+	}
+
+	listEIPs := func() []v1alpha1.ExternalIP {
+		list := &v1alpha1.ExternalIPList{}
+		ExpectWithOffset(1, k8sClient.List(ctx, list, client.InNamespace(networkingNS))).To(Succeed())
+		return list.Items
+	}
+
+	cleanupEIAs := func() {
+		list := &v1alpha1.ExternalIPAttachmentList{}
+		Expect(k8sClient.List(ctx, list, client.InNamespace(networkingNS))).To(Succeed())
+		for i := range list.Items {
+			_ = k8sClient.Delete(ctx, &list.Items[i])
+		}
+	}
+
+	cleanupEIPs := func() {
+		list := &v1alpha1.ExternalIPList{}
+		Expect(k8sClient.List(ctx, list, client.InNamespace(networkingNS))).To(Succeed())
+		for i := range list.Items {
+			_ = k8sClient.Delete(ctx, &list.Items[i])
+		}
+	}
+
+	AfterEach(func() {
+		cleanupEIAs()
+		cleanupEIPs()
+	})
+
+	Context("no-op cases", func() {
+		It("returns done=true when NetworkingNamespace is empty", func() {
+			r := newReconciler("")
+			co := newClusterOrder(clusterUUID)
+			done, result, err := r.reconcileAutoExternalIPCleanup(ctx, co)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(done).To(BeTrue())
+			Expect(result.RequeueAfter).To(BeZero())
+		})
+
+		It("returns done=true when ClusterOrder has no UUID label", func() {
+			r := newReconciler(networkingNS)
+			co := newClusterOrder("")
+			done, result, err := r.reconcileAutoExternalIPCleanup(ctx, co)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(done).To(BeTrue())
+			Expect(result.RequeueAfter).To(BeZero())
+		})
+
+		It("returns done=true when no auto-provisioned resources exist", func() {
+			r := newReconciler(networkingNS)
+			co := newClusterOrder(clusterUUID)
+			done, result, err := r.reconcileAutoExternalIPCleanup(ctx, co)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(done).To(BeTrue())
+			Expect(result.RequeueAfter).To(BeZero())
+		})
+	})
+
+	Context("ExternalIPAttachment cleanup", func() {
+		It("deletes auto-provisioned EIAs targeting this cluster and requeues", func() {
+			eia := newAutoEIA(clusterUUID)
+			Expect(k8sClient.Create(ctx, eia)).To(Succeed())
+
+			r := newReconciler(networkingNS)
+			co := newClusterOrder(clusterUUID)
+			done, result, err := r.reconcileAutoExternalIPCleanup(ctx, co)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(done).To(BeFalse())
+			Expect(result.RequeueAfter).To(Equal(pollInterval))
+
+			// EIA should have a deletion timestamp or be gone
+			remaining := listEIAs()
+			for _, e := range remaining {
+				Expect(e.DeletionTimestamp).NotTo(BeNil())
+			}
+		})
+
+		It("does not delete EIAs targeting a different cluster", func() {
+			otherEIA := newAutoEIA("different-uuid")
+			Expect(k8sClient.Create(ctx, otherEIA)).To(Succeed())
+
+			r := newReconciler(networkingNS)
+			co := newClusterOrder(clusterUUID)
+			done, result, err := r.reconcileAutoExternalIPCleanup(ctx, co)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(done).To(BeTrue())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			// Other cluster's EIA must not be deleted
+			remaining := listEIAs()
+			Expect(remaining).To(HaveLen(1))
+			Expect(remaining[0].DeletionTimestamp).To(BeNil())
+		})
+
+		It("does not delete EIAs without the auto-provisioned label", func() {
+			clusterIDCopy := clusterUUID
+			ep := v1alpha1.ExternalIPAttachmentTargetEndpointAPI
+			manualEIA := &v1alpha1.ExternalIPAttachment{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "manual-eia-",
+					Namespace:    networkingNS,
+				},
+				Spec: v1alpha1.ExternalIPAttachmentSpec{
+					ExternalIP:     "test-eip",
+					Cluster:        &clusterIDCopy,
+					TargetEndpoint: &ep,
+				},
+			}
+			Expect(k8sClient.Create(ctx, manualEIA)).To(Succeed())
+
+			r := newReconciler(networkingNS)
+			co := newClusterOrder(clusterUUID)
+			done, result, err := r.reconcileAutoExternalIPCleanup(ctx, co)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(done).To(BeTrue())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			remaining := listEIAs()
+			Expect(remaining).To(HaveLen(1))
+			Expect(remaining[0].DeletionTimestamp).To(BeNil())
+		})
+	})
+
+	Context("ExternalIP cleanup", func() {
+		It("deletes auto-provisioned EIPs for this cluster after EIAs are gone and requeues", func() {
+			eip := newAutoEIP(clusterUUID)
+			Expect(k8sClient.Create(ctx, eip)).To(Succeed())
+
+			r := newReconciler(networkingNS)
+			co := newClusterOrder(clusterUUID)
+			done, result, err := r.reconcileAutoExternalIPCleanup(ctx, co)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(done).To(BeFalse())
+			Expect(result.RequeueAfter).To(Equal(pollInterval))
+
+			remaining := listEIPs()
+			for _, e := range remaining {
+				Expect(e.DeletionTimestamp).NotTo(BeNil())
+			}
+		})
+
+		It("does not delete EIPs labeled for a different cluster", func() {
+			eip := newAutoEIP("different-uuid")
+			Expect(k8sClient.Create(ctx, eip)).To(Succeed())
+
+			r := newReconciler(networkingNS)
+			co := newClusterOrder(clusterUUID)
+			done, result, err := r.reconcileAutoExternalIPCleanup(ctx, co)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(done).To(BeTrue())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			remaining := listEIPs()
+			Expect(remaining).To(HaveLen(1))
+			Expect(remaining[0].DeletionTimestamp).To(BeNil())
+		})
+	})
+
+	Context("phased ordering", func() {
+		It("waits for EIAs to be gone before deleting EIPs", func() {
+			eia := newAutoEIA(clusterUUID)
+			Expect(k8sClient.Create(ctx, eia)).To(Succeed())
+			eip := newAutoEIP(clusterUUID)
+			Expect(k8sClient.Create(ctx, eip)).To(Succeed())
+
+			r := newReconciler(networkingNS)
+			co := newClusterOrder(clusterUUID)
+
+			// First call: EIA phase — EIA gets deleted, EIP untouched
+			done, result, err := r.reconcileAutoExternalIPCleanup(ctx, co)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(done).To(BeFalse())
+			Expect(result.RequeueAfter).To(Equal(pollInterval))
+
+			// EIP must not be deleted yet
+			eipList := listEIPs()
+			Expect(eipList).To(HaveLen(1))
+			Expect(eipList[0].DeletionTimestamp).To(BeNil())
+		})
+
+		It("returns done=true when both EIAs and EIPs are gone", func() {
+			r := newReconciler(networkingNS)
+			co := newClusterOrder(clusterUUID)
+			done, result, err := r.reconcileAutoExternalIPCleanup(ctx, co)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(done).To(BeTrue())
+			Expect(result.RequeueAfter).To(BeZero())
+		})
+	})
+})

--- a/osac-operator/internal/controller/clusterorder_controller.go
+++ b/osac-operator/internal/controller/clusterorder_controller.go
@@ -73,6 +73,7 @@ type ClusterOrderReconciler struct {
 	Scheme                *runtime.Scheme
 	ClusterOrderNamespace string
 	AgentNamespace        string
+	NetworkingNamespace   string
 	ProvisioningProvider  provisioning.ProvisioningProvider
 	StatusPollInterval    time.Duration
 	MaxJobHistory         int
@@ -84,6 +85,7 @@ func NewClusterOrderReconciler(
 	scheme *runtime.Scheme,
 	clusterOrderNamespace string,
 	agentNamespace string,
+	networkingNamespace string,
 	provisioningProvider provisioning.ProvisioningProvider,
 	statusPollInterval time.Duration,
 	maxJobHistory int,
@@ -111,6 +113,7 @@ func NewClusterOrderReconciler(
 		Scheme:                scheme,
 		ClusterOrderNamespace: clusterOrderNamespace,
 		AgentNamespace:        agentNamespace,
+		NetworkingNamespace:   networkingNamespace,
 		ProvisioningProvider:  provisioningProvider,
 		StatusPollInterval:    statusPollInterval,
 		MaxJobHistory:         maxJobHistory,
@@ -126,6 +129,8 @@ func NewClusterOrderReconciler(
 // +kubebuilder:rbac:groups=hypershift.openshift.io,resources=hostedclusters;nodepools,verbs=get;list;watch
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=subnets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=networkclasses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=externalipattachments,verbs=get;list;watch;delete
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=externalips,verbs=get;list;watch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -537,6 +542,12 @@ func (r *ClusterOrderReconciler) handleDelete(ctx context.Context, _ reconcile.R
 
 	instance.Status.Phase = v1alpha1.ClusterOrderPhaseDeleting
 
+	// Delete auto-provisioned ExternalIPAttachments then ExternalIPs before deprovisioning.
+	done, cleanupResult, err := r.reconcileAutoExternalIPCleanup(ctx, instance)
+	if err != nil || !done {
+		return cleanupResult, err
+	}
+
 	// Release agents allocated to this cluster
 	if err := r.reconcileAgentCleanup(ctx, instance); err != nil {
 		return ctrl.Result{}, err
@@ -586,6 +597,76 @@ func (r *ClusterOrderReconciler) handleDelete(ctx context.Context, _ reconcile.R
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// reconcileAutoExternalIPCleanup deletes auto-provisioned ExternalIPAttachments and
+// ExternalIPs for this ClusterOrder in phase order: EIAs first, then EIPs. Returns
+// (done=true) when cleanup is complete or not applicable, (done=false) with a requeue
+// result when resources still exist.
+func (r *ClusterOrderReconciler) reconcileAutoExternalIPCleanup(ctx context.Context, instance *v1alpha1.ClusterOrder) (bool, ctrl.Result, error) {
+	if r.NetworkingNamespace == "" {
+		return true, ctrl.Result{}, nil
+	}
+	clusterUUID, exists := instance.GetLabels()[osacClusterOrderIDLabel]
+	if !exists || clusterUUID == "" {
+		return true, ctrl.Result{}, nil
+	}
+
+	log := ctrllog.FromContext(ctx)
+
+	// Phase 1: ExternalIPAttachments targeting this cluster, labeled auto-provisioned.
+	eiaList := &v1alpha1.ExternalIPAttachmentList{}
+	if err := r.List(ctx, eiaList,
+		client.InNamespace(r.NetworkingNamespace),
+		client.MatchingLabels{osacAutoProvisionedLabel: labelValueTrue},
+	); err != nil {
+		return false, ctrl.Result{}, err
+	}
+	var pendingEIAs int
+	for i := range eiaList.Items {
+		eia := &eiaList.Items[i]
+		if eia.Spec.Cluster == nil || *eia.Spec.Cluster != clusterUUID {
+			continue
+		}
+		pendingEIAs++
+		if eia.DeletionTimestamp.IsZero() {
+			log.Info("deleting auto-provisioned ExternalIPAttachment", "name", eia.Name)
+			if err := client.IgnoreNotFound(r.Delete(ctx, eia)); err != nil {
+				return false, ctrl.Result{}, err
+			}
+		}
+	}
+	if pendingEIAs > 0 {
+		return false, ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
+	}
+
+	// Phase 2: ExternalIPs labeled auto-provisioned-for this cluster.
+	eipList := &v1alpha1.ExternalIPList{}
+	if err := r.List(ctx, eipList,
+		client.InNamespace(r.NetworkingNamespace),
+		client.MatchingLabels{
+			osacAutoProvisionedLabel:    labelValueTrue,
+			osacAutoProvisionedForLabel: clusterUUID,
+		},
+	); err != nil {
+		return false, ctrl.Result{}, err
+	}
+	var pendingEIPs int
+	for i := range eipList.Items {
+		eip := &eipList.Items[i]
+		pendingEIPs++
+		if eip.DeletionTimestamp.IsZero() {
+			log.Info("deleting auto-provisioned ExternalIP", "name", eip.Name)
+			if err := client.IgnoreNotFound(r.Delete(ctx, eip)); err != nil {
+				return false, ctrl.Result{}, err
+			}
+		}
+	}
+	if pendingEIPs > 0 {
+		return false, ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
+	}
+
+	return true, ctrl.Result{}, nil
 }
 
 func (r *ClusterOrderReconciler) provisionState(instance *v1alpha1.ClusterOrder) *provisioning.State {

--- a/osac-operator/internal/controller/clusterorder_integration_test.go
+++ b/osac-operator/internal/controller/clusterorder_integration_test.go
@@ -46,7 +46,7 @@ var _ = Describe("ClusterOrder Integration Tests", func() {
 		provider = newControllableProvider()
 		reconciler = NewClusterOrderReconciler(
 			k8sClient, k8sClient, k8sClient.Scheme(),
-			clusterOrderTestNamespace, "",
+			clusterOrderTestNamespace, "", "",
 			provider, statusPollInterval, provisioning.DefaultMaxJobHistory,
 		)
 	})

--- a/osac-operator/internal/controller/clusterorder_names.go
+++ b/osac-operator/internal/controller/clusterorder_names.go
@@ -28,6 +28,8 @@ var (
 	osacFinalizer                     string = fmt.Sprintf("%s/finalizer", osacPrefix)
 	osacManagementStateAnnotation     string = fmt.Sprintf("%s/management-state", osacPrefix)
 	osacClusterOrderFeedbackFinalizer string = fmt.Sprintf("%s/clusterorder-feedback", osacPrefix)
+	osacAutoProvisionedLabel          string = fmt.Sprintf("%s/auto-provisioned", osacPrefix)
+	osacAutoProvisionedForLabel       string = fmt.Sprintf("%s/auto-provisioned-for", osacPrefix)
 )
 
 func generateNamespaceName(instance *v1alpha1.ClusterOrder) string {

--- a/osac-operator/internal/controller/constants_common.go
+++ b/osac-operator/internal/controller/constants_common.go
@@ -59,4 +59,6 @@ const (
 
 	conditionReasonConfigurationApplied  = "ConfigurationApplied"
 	conditionMessageConfigurationApplied = "Controller has processed the current spec"
+
+	labelValueTrue = "true"
 )


### PR DESCRIPTION

On ClusterOrder deletion, reconcileAutoExternalIPCleanup deletes auto-provisioned ExternalIPAttachments (by spec.cluster + auto-provisioned label) and then ExternalIPs (by auto-provisioned-for label) in phase order before deprovisioning proceeds. Requeues until each phase is complete. NATGateway and manually-created resources are not touched.

Adds NetworkingNamespace field to ClusterOrderReconciler and passes OSAC_NETWORKING_NAMESPACE from main.go. Adds osacAutoProvisionedLabel and osacAutoProvisionedForLabel constants.

Assisted-by: Claude Code <noreply@anthropic.com>