### PR TITLE
OSAC-3885: Allow public ingress certs in Keycloak

### DIFF
--- a/fulfillment-service/docs/INSTALL.md
+++ b/fulfillment-service/docs/INSTALL.md
@@ -732,6 +732,12 @@ spec:
 .
 ```
 
+**Note**: For clusters with publicly-trusted ingress certificates (e.g., production clusters with
+Let's Encrypt), you can use `reencrypt` termination instead of `passthrough`. This presents the
+cluster's public ingress certificate to browsers while re-encrypting traffic to Keycloak's internal
+TLS endpoint. See `osac-installer/docs/helm-deployment-guide.md` for the Helm-based configuration
+using `keycloak.route.publicIngress: true`.
+
 ## Configure the Keycloak realm
 
 The service expects a Keycloak realm named `osac` with specific clients and roles. The full realm

--- a/osac-installer/charts/osac-infra/files/hooks/patch-keycloak-route.sh
+++ b/osac-installer/charts/osac-infra/files/hooks/patch-keycloak-route.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reconciliation loop: watch for changes to default-ca Secret and update Route destinationCACertificate
+LAST_CA_CERT=""
+
+reconcile() {
+  # Check if Secret exists
+  if ! oc get secret default-ca -n cert-manager &>/dev/null; then
+    echo "default-ca secret not found, waiting..."
+    return 1
+  fi
+
+  # Read current CA cert from Secret
+  CA_CERT=$(oc get secret default-ca -n cert-manager -o jsonpath='{.data.ca\.crt}' | base64 -d)
+
+  # Skip if cert hasn't changed
+  if [[ "$CA_CERT" == "$LAST_CA_CERT" ]]; then
+    return 0
+  fi
+
+  echo "CA certificate changed, patching keycloak Route..."
+
+  # Check if Route exists
+  if ! oc get route keycloak -n keycloak &>/dev/null; then
+    echo "keycloak Route not found, waiting..."
+    return 1
+  fi
+
+  # Read current Route TLS termination mode
+  TERMINATION=$(oc get route keycloak -n keycloak -o jsonpath='{.spec.tls.termination}')
+
+  # Only patch if termination is reencrypt (publicIngress mode)
+  if [[ "$TERMINATION" != "reencrypt" ]]; then
+    echo "Route termination is $TERMINATION (not reencrypt), skipping patch"
+    return 0
+  fi
+
+  # Patch Route with new CA cert (use python3 for JSON escaping, available in all hook images)
+  CA_CERT_JSON=$(python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))" <<< "$CA_CERT")
+  if oc patch route keycloak -n keycloak --type=json -p "[{
+    \"op\": \"replace\",
+    \"path\": \"/spec/tls/destinationCACertificate\",
+    \"value\": $CA_CERT_JSON
+  }]" 2>/dev/null; then
+    echo "Successfully patched keycloak Route with updated destinationCACertificate"
+    LAST_CA_CERT="$CA_CERT"
+  else
+    # If replace fails, try add (first time)
+    if oc patch route keycloak -n keycloak --type=json -p "[{
+      \"op\": \"add\",
+      \"path\": \"/spec/tls/destinationCACertificate\",
+      \"value\": $CA_CERT_JSON
+    }]"; then
+      echo "Added destinationCACertificate to keycloak Route"
+      LAST_CA_CERT="$CA_CERT"
+    else
+      echo "ERROR: Failed to patch keycloak Route"
+      return 1
+    fi
+  fi
+}
+
+# Initial reconciliation with retries
+echo "Starting Route patch reconciliation..."
+for i in $(seq 1 60); do
+  if reconcile; then
+    echo "Route patch reconciliation complete"
+    exit 0
+  fi
+  [[ $i -eq 60 ]] && { echo "ERROR: Route patch reconciliation failed after 300s"; exit 1; }
+  sleep 5
+done

--- a/osac-installer/charts/osac-infra/templates/ca-issuer.yaml
+++ b/osac-installer/charts/osac-infra/templates/ca-issuer.yaml
@@ -49,6 +49,9 @@ spec:
   - secret:
       name: "default-ca"
       key: "ca.crt"
+  {{- if .Values.keycloak.route.publicIngress }}
+  - useDefaultCAs: true
+  {{- end }}
   target:
     configMap:
       key: bundle.pem

--- a/osac-installer/charts/osac-infra/templates/hooks/patch-keycloak-route.yaml
+++ b/osac-installer/charts/osac-infra/templates/hooks/patch-keycloak-route.yaml
@@ -1,0 +1,149 @@
+{{- if and .Values.keycloak.enabled .Values.keycloak.route.publicIngress .Values.caIssuer.enabled }}
+# This hook patches the Keycloak Route to set destinationCACertificate for reencrypt TLS mode.
+# Uses pre-upgrade (not post-upgrade) to apply the CA cert before the Route is accessed during
+# upgrade, ensuring the reencrypt termination is properly configured when Keycloak starts.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: osac-infra-patch-keycloak-route
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac-infra.hookLabels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "15"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: osac-infra-patch-keycloak-route-cert-manager
+  namespace: cert-manager
+  labels:
+    {{- include "osac-infra.hookLabels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "15"
+rules:
+- apiGroups: [""]
+  resources: [secrets]
+  resourceNames: [default-ca]
+  verbs: [get, watch, list]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: osac-infra-patch-keycloak-route-keycloak
+  namespace: keycloak
+  labels:
+    {{- include "osac-infra.hookLabels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "15"
+rules:
+- apiGroups: [route.openshift.io]
+  resources: [routes]
+  resourceNames: [keycloak]
+  verbs: [get, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: osac-infra-patch-keycloak-route-cert-manager
+  namespace: cert-manager
+  labels:
+    {{- include "osac-infra.hookLabels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "15"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: osac-infra-patch-keycloak-route-cert-manager
+subjects:
+- kind: ServiceAccount
+  name: osac-infra-patch-keycloak-route
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: osac-infra-patch-keycloak-route-keycloak
+  namespace: keycloak
+  labels:
+    {{- include "osac-infra.hookLabels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "15"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: osac-infra-patch-keycloak-route-keycloak
+subjects:
+- kind: ServiceAccount
+  name: osac-infra-patch-keycloak-route
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: osac-infra-patch-keycloak-route
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac-infra.hookLabels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "15"
+spec:
+  backoffLimit: 5
+  activeDeadlineSeconds: 600
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        {{- include "osac-infra.hookLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: osac-infra-patch-keycloak-route
+      restartPolicy: OnFailure
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: scripts
+        configMap:
+          name: osac-infra-hook-scripts
+          defaultMode: 0755
+      containers:
+      - name: patch-route
+        image: {{ .Values.cliImage }}
+        env:
+        - name: HOME
+          value: /tmp
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: scripts
+          mountPath: /scripts
+          readOnly: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - "ALL"
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        command:
+        - /bin/bash
+        - /scripts/patch-keycloak-route.sh
+{{- end }}

--- a/osac-installer/charts/osac-infra/templates/keycloak/resources.yaml
+++ b/osac-installer/charts/osac-infra/templates/keycloak/resources.yaml
@@ -502,7 +502,12 @@ spec:
   port:
     targetPort: https
   tls:
-    termination: passthrough
+    {{- if .Values.keycloak.route.publicIngress }}
+    # reencrypt mode presents the cluster's public ingress cert to browsers while re-encrypting
+    # traffic to Keycloak's internal TLS endpoint. The destinationCACertificate (required for
+    # reencrypt) is set by the osac-infra-patch-keycloak-route hook Job at install/upgrade time.
+    {{- end }}
+    termination: {{ if .Values.keycloak.route.publicIngress }}reencrypt{{ else }}passthrough{{ end }}
 {{- end }}
 {{- if .Values.keycloak.devFixtures.enabled }}
 ---

--- a/osac-installer/charts/osac-infra/values.yaml
+++ b/osac-installer/charts/osac-infra/values.yaml
@@ -25,6 +25,7 @@ keycloak:
   defaultUserPassword: foobar
   route:
     hostname: ""
+    publicIngress: false
   # devFixtures seeds known, non-random passwords for the realm's built-in
   # tenant/test users (admin, user, tenant1_admin, ...). Must stay disabled
   # outside Kind/CI -- this chart is also used for real installs.

--- a/osac-installer/docs/helm-deployment-guide.md
+++ b/osac-installer/docs/helm-deployment-guide.md
@@ -116,6 +116,32 @@ These are top-level values, disabled by default. Enable only in CI/dev:
 | `hubAccess.enabled` | Creates hub-access SA/RBAC and registers local cluster as a hub. Only for environments where fulfillment-service and hub are the same cluster. |
 | `bundledPostgres.enabled` | Deploys a single-pod ephemeral PostgreSQL. Uses `fsync=off` and `emptyDir` — data lost on restart. Not for production. |
 
+## Infrastructure Configuration
+
+### Keycloak Route with Public Ingress Certificates
+
+For clusters with publicly-trusted wildcard ingress certificates (e.g., production OpenShift clusters with Let's Encrypt), you can configure Keycloak's Route to use `reencrypt` termination instead of `passthrough`:
+
+```yaml
+# values/<profile>/infra.yaml
+keycloak:
+  route:
+    publicIngress: true  # Switches Route from passthrough to reencrypt
+    hostname: keycloak.apps.example.com  # Optional: custom hostname
+```
+
+**How it works:**
+- `passthrough` (default): Browser connects directly to Keycloak's internal TLS cert (self-signed CA)
+- `reencrypt`: Router presents the cluster's public ingress cert to browsers, then re-encrypts traffic to Keycloak's internal TLS endpoint using the CA cert
+
+**Requirements:**
+- `caIssuer.enabled: true` (default) — The hook depends on cert-manager's CA bundle
+- The `osac-infra-patch-keycloak-route` hook Job automatically sets `destinationCACertificate` at install/upgrade time
+
+**When to use:**
+- Production clusters where browser cert warnings are unacceptable
+- Environments with corporate CA or Let's Encrypt ingress certs
+
 ## Makefile Targets
 
 All targets require `PLATFORM=kind|openshift PROFILE=dev|vmaas-ci|... NS=<namespace>`.

--- a/osac-installer/prerequisites/keycloak/service/route.yaml
+++ b/osac-installer/prerequisites/keycloak/service/route.yaml
@@ -22,4 +22,9 @@ spec:
   port:
     targetPort: https
   tls:
+    # NOTE: For clusters with publicly-trusted *.apps ingress certs, switch to:
+    #   termination: reencrypt
+    #   destinationCACertificate: |
+    #     <PEM-encoded CA cert from keycloak-tls-cert secret>
+    # See osac-installer charts/osac-infra/values.yaml: keycloak.route.publicIngress
     termination: passthrough


### PR DESCRIPTION
Public ingresses were not previously possible to use since Keycloak's tls route defaulted to passthrough and the CA bundle was defaulted to the one generated by the installer.

This updates Keycloak's route to allow reencrypt and adds the public ingress CA to the default CA bundle so that in-cluster clients can call Keycloak.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional public ingress support for Keycloak using re-encrypted TLS connections.
  - Automatically configures and maintains the required destination CA certificate.
  - Added configuration for custom public hostnames.

- **Documentation**
  - Added setup guidance, prerequisites, supported environments, and certificate configuration details.
  - Documented how to enable public ingress and switch route termination modes.

- **Configuration**
  - Public ingress is disabled by default and can be enabled through deployment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->