### PR TITLE
OSAC-1506: sync VIP endpoints from ClusterOrder status to Cluster proto

### DIFF
--- a/osac-operator/internal/controller/clusterorder_feedback_controller_test.go
+++ b/osac-operator/internal/controller/clusterorder_feedback_controller_test.go
@@ -606,6 +606,29 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 			Expect(mockClient.lastUpdate.GetStatus().GetState()).To(Equal(privatev1.ClusterState_CLUSTER_STATE_FAILED))
 		})
 
+		It("should sync VIP endpoints to Cluster proto when set in status", func() {
+			co := &osacv1alpha1.ClusterOrder{}
+			Expect(k8sClient.Get(testCtx, typeNamespacedName, co)).To(Succeed())
+			co.Status.ApiEndpoint = "10.0.0.1"
+			co.Status.IngressEndpoint = "10.0.0.2"
+			Expect(k8sClient.Status().Update(testCtx, co)).To(Succeed())
+
+			request := reconcile.Request{NamespacedName: typeNamespacedName}
+			_, err := reconciler.Reconcile(testCtx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockClient.updateCalled).To(BeTrue())
+			Expect(mockClient.lastUpdate.GetStatus().GetApiEndpoint()).To(Equal("10.0.0.1"))
+			Expect(mockClient.lastUpdate.GetStatus().GetIngressEndpoint()).To(Equal("10.0.0.2"))
+		})
+
+		It("should not sync VIP endpoints when status fields are empty", func() {
+			request := reconcile.Request{NamespacedName: typeNamespacedName}
+			_, err := reconciler.Reconcile(testCtx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockClient.lastUpdate.GetStatus().GetApiEndpoint()).To(BeEmpty())
+			Expect(mockClient.lastUpdate.GetStatus().GetIngressEndpoint()).To(BeEmpty())
+		})
+
 		It("should not call update when reconciled twice with same data", func() {
 			co := &osacv1alpha1.ClusterOrder{}
 			Expect(k8sClient.Get(testCtx, typeNamespacedName, co)).To(Succeed())

--- a/osac-operator/internal/controller/feedback_controller.go
+++ b/osac-operator/internal/controller/feedback_controller.go
@@ -120,7 +120,20 @@ func newClusterOrderSyncUpdate(hubClient clnt.Client) func(context.Context, *ckv
 			return err
 		}
 		syncClusterOrderNodeRequests(ctx, obj, remote)
+		syncClusterOrderVIPEndpoints(obj, remote)
 		return nil
+	}
+}
+
+// syncClusterOrderVIPEndpoints copies MetalLB VIP addresses from ClusterOrder status
+// to the Cluster proto. The VIPs are written by the CaaS template and consumed by the
+// ExternalIPAttachment controller and the fulfillment-service API surface.
+func syncClusterOrderVIPEndpoints(obj *ckv1alpha1.ClusterOrder, remote *privatev1.Cluster) {
+	if obj.Status.ApiEndpoint != "" {
+		remote.GetStatus().SetApiEndpoint(obj.Status.ApiEndpoint)
+	}
+	if obj.Status.IngressEndpoint != "" {
+		remote.GetStatus().SetIngressEndpoint(obj.Status.IngressEndpoint)
 	}
 }
 


### PR DESCRIPTION
The CaaS template writes MetalLB VIP addresses as annotations on the ClusterOrder CR ([OSAC-2077](https://redhat.atlassian.net/browse/OSAC-2077)); reconcileVIPEndpoints already copies them to status.ApiEndpoint/IngressEndpoint. This change adds syncClusterOrderVIPEndpoints to the feedback controller, forwarding those status fields to ClusterStatus.api_endpoint/ingress_endpoint in the fulfillment-service proto on every update reconcile.

Syncing happens unconditionally whenever the fields are non-empty, so the VIPs appear in the API as soon as the template writes them — before the cluster reaches Ready phase.

Assisted-by: Claude Code <noreply@anthropic.com>