### PR TITLE
OSAC-4204: [DEV] osac describe baremetalinstance — Network Interfaces Section

### DIFF
--- a/fulfillment-service/internal/cmd/cli/describe/baremetalinstance/describe_baremetalinstance_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/describe/baremetalinstance/describe_baremetalinstance_cmd.go
@@ -94,6 +94,15 @@ func renderBareMetalInstance(w io.Writer, bmi *publicv1.BareMetalInstance) {
 	fmt.Fprintf(writer, "Catalog Item:\t%s\n", catalogItem)
 	fmt.Fprintf(writer, "State:\t%s\n", state)
 	writer.Flush()
+
+	fmt.Fprintf(w, "\nNetwork Interfaces:\n")
+	if !bmi.GetStatus().HasHardware() || len(bmi.GetStatus().GetHardware().GetNics()) == 0 {
+		fmt.Fprintf(w, "  N/A\n")
+	} else {
+		for _, nic := range bmi.GetStatus().GetHardware().GetNics() {
+			fmt.Fprintf(w, "  %s\n", nic.GetMac())
+		}
+	}
 }
 
 const shortHelp = `Describe a bare metal instance`

--- a/fulfillment-service/internal/cmd/cli/describe/baremetalinstance/describe_baremetalinstance_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/describe/baremetalinstance/describe_baremetalinstance_cmd.go
@@ -97,7 +97,7 @@ func renderBareMetalInstance(w io.Writer, bmi *publicv1.BareMetalInstance) {
 
 	fmt.Fprintf(w, "\nNetwork Interfaces:\n")
 	if !bmi.GetStatus().HasHardware() || len(bmi.GetStatus().GetHardware().GetNics()) == 0 {
-		fmt.Fprintf(w, "  N/A\n")
+		fmt.Fprintf(w, "  (none)\n")
 	} else {
 		for _, nic := range bmi.GetStatus().GetHardware().GetNics() {
 			fmt.Fprintf(w, "  %s\n", nic.GetMac())

--- a/fulfillment-service/internal/cmd/cli/describe/baremetalinstance/describe_baremetalinstance_suite_test.go
+++ b/fulfillment-service/internal/cmd/cli/describe/baremetalinstance/describe_baremetalinstance_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package baremetalinstance
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDescribeBareMetalInstance(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Describe bare metal instance command")
+}

--- a/fulfillment-service/internal/cmd/cli/describe/baremetalinstance/describe_baremetalinstance_test.go
+++ b/fulfillment-service/internal/cmd/cli/describe/baremetalinstance/describe_baremetalinstance_test.go
@@ -43,23 +43,21 @@ var _ = Describe("Describe Bare Metal Instance", func() {
 				}.Build(),
 			}
 			output := formatBareMetalInstance(bmi)
-			Expect(output).To(ContainSubstring("Network Interfaces:"))
-			Expect(output).To(ContainSubstring("aa:bb:cc:dd:ee:01"))
-			Expect(output).To(ContainSubstring("ff:00:11:22:33:44"))
-			Expect(output).NotTo(ContainSubstring("N/A"))
+			Expect(output).To(ContainSubstring("Network Interfaces:\n  aa:bb:cc:dd:ee:01\n"))
+			Expect(output).To(ContainSubstring("  ff:00:11:22:33:44\n"))
+			Expect(output).NotTo(ContainSubstring("(none)"))
 		})
 
-		It("should show N/A when Status.Hardware is nil", func() {
+		It("should show (none) when Status.Hardware is nil", func() {
 			bmi := &publicv1.BareMetalInstance{
 				Id:     "bmi-002",
 				Status: publicv1.BareMetalInstanceStatus_builder{}.Build(),
 			}
 			output := formatBareMetalInstance(bmi)
-			Expect(output).To(ContainSubstring("Network Interfaces:"))
-			Expect(output).To(ContainSubstring("N/A"))
+			Expect(output).To(ContainSubstring("Network Interfaces:\n  (none)\n"))
 		})
 
-		It("should show N/A when Status.Hardware.Nics is empty", func() {
+		It("should show (none) when Status.Hardware.Nics is empty", func() {
 			bmi := &publicv1.BareMetalInstance{
 				Id: "bmi-003",
 				Status: publicv1.BareMetalInstanceStatus_builder{
@@ -69,18 +67,16 @@ var _ = Describe("Describe Bare Metal Instance", func() {
 				}.Build(),
 			}
 			output := formatBareMetalInstance(bmi)
-			Expect(output).To(ContainSubstring("Network Interfaces:"))
-			Expect(output).To(ContainSubstring("N/A"))
+			Expect(output).To(ContainSubstring("Network Interfaces:\n  (none)\n"))
 		})
 
-		It("should show N/A when Status is nil", func() {
+		It("should show (none) when Status is nil", func() {
 			bmi := &publicv1.BareMetalInstance{
 				Id:     "bmi-004",
 				Status: nil,
 			}
 			output := formatBareMetalInstance(bmi)
-			Expect(output).To(ContainSubstring("Network Interfaces:"))
-			Expect(output).To(ContainSubstring("N/A"))
+			Expect(output).To(ContainSubstring("Network Interfaces:\n  (none)\n"))
 		})
 	})
 })

--- a/fulfillment-service/internal/cmd/cli/describe/baremetalinstance/describe_baremetalinstance_test.go
+++ b/fulfillment-service/internal/cmd/cli/describe/baremetalinstance/describe_baremetalinstance_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package baremetalinstance
+
+import (
+	"bytes"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+
+	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
+)
+
+func formatBareMetalInstance(bmi *publicv1.BareMetalInstance) string {
+	var buf bytes.Buffer
+	renderBareMetalInstance(&buf, bmi)
+	return buf.String()
+}
+
+var _ = Describe("Describe Bare Metal Instance", func() {
+	Describe("Network Interfaces section", func() {
+		It("should show MACs when hardware is present", func() {
+			bmi := &publicv1.BareMetalInstance{
+				Id: "bmi-001",
+				Status: publicv1.BareMetalInstanceStatus_builder{
+					Hardware: publicv1.BareMetalHardware_builder{
+						Nics: []*publicv1.BareMetalNICStatus{
+							publicv1.BareMetalNICStatus_builder{Mac: "aa:bb:cc:dd:ee:01"}.Build(),
+							publicv1.BareMetalNICStatus_builder{Mac: "ff:00:11:22:33:44"}.Build(),
+						},
+					}.Build(),
+				}.Build(),
+			}
+			output := formatBareMetalInstance(bmi)
+			Expect(output).To(ContainSubstring("Network Interfaces:"))
+			Expect(output).To(ContainSubstring("aa:bb:cc:dd:ee:01"))
+			Expect(output).To(ContainSubstring("ff:00:11:22:33:44"))
+			Expect(output).NotTo(ContainSubstring("N/A"))
+		})
+
+		It("should show N/A when Status.Hardware is nil", func() {
+			bmi := &publicv1.BareMetalInstance{
+				Id:     "bmi-002",
+				Status: publicv1.BareMetalInstanceStatus_builder{}.Build(),
+			}
+			output := formatBareMetalInstance(bmi)
+			Expect(output).To(ContainSubstring("Network Interfaces:"))
+			Expect(output).To(ContainSubstring("N/A"))
+		})
+
+		It("should show N/A when Status.Hardware.Nics is empty", func() {
+			bmi := &publicv1.BareMetalInstance{
+				Id: "bmi-003",
+				Status: publicv1.BareMetalInstanceStatus_builder{
+					Hardware: publicv1.BareMetalHardware_builder{
+						Nics: []*publicv1.BareMetalNICStatus{},
+					}.Build(),
+				}.Build(),
+			}
+			output := formatBareMetalInstance(bmi)
+			Expect(output).To(ContainSubstring("Network Interfaces:"))
+			Expect(output).To(ContainSubstring("N/A"))
+		})
+
+		It("should show N/A when Status is nil", func() {
+			bmi := &publicv1.BareMetalInstance{
+				Id:     "bmi-004",
+				Status: nil,
+			}
+			output := formatBareMetalInstance(bmi)
+			Expect(output).To(ContainSubstring("Network Interfaces:"))
+			Expect(output).To(ContainSubstring("N/A"))
+		})
+	})
+})


### PR DESCRIPTION
## [OSAC-4204](https://redhat.atlassian.net/browse/OSAC-4204): [DEV] osac describe baremetalinstance — Network Interfaces Section

**Jira:** https://redhat.atlassian.net/browse/OSAC-4204
**Story type:** [DEV]
**Epic:** [OSAC-4200](https://redhat.atlassian.net/browse/OSAC-4200) — Expose NIC MAC Addresses in BareMetalInstance
**Depends on:** #424 ([OSAC-4203](https://redhat.atlassian.net/browse/OSAC-4203) — proto extensions + syncStatus propagation)

### Summary

Adds a "Network Interfaces:" section to `osac describe baremetalinstance` output. When `status.hardware.nics` is populated, renders one MAC address per line; when hardware is nil, empty, or status is nil, renders "N/A".

### Changes

**`internal/cmd/cli/describe/baremetalinstance/describe_baremetalinstance_cmd.go`:**
- In `renderBareMetalInstance`, after the tabwriter section (flushed), append "Network Interfaces:" section directly to the writer
- Uses nil-safe proto accessor chain: `GetStatus().HasHardware()`, `GetHardware().GetNics()`, `GetMac()`

**New test files (package had no tests before):**
- `describe_baremetalinstance_suite_test.go` — Ginkgo suite bootstrap
- `describe_baremetalinstance_test.go` — 4 unit specs via `renderBareMetalInstance`

### Testing

4 specs (TDD — all failed before implementation, all pass after):
1. Hardware present → section shows each MAC
2. Status.Hardware nil → (none)
3. Status.Hardware.Nics empty → (none)
4. Status nil → (none)

0 lint issues.

### CLI output example

```
ID:           bmi-abc123
Catalog Item: gpu-node
State:        RUNNING

Network Interfaces:
  aa:bb:cc:dd:ee:01
  aa:bb:cc:dd:ee:02
```

### Acceptance Criteria

- [x] Running instance with NIC data shows Network Interfaces section with one row per MAC
- [x] Nil/empty hardware shows (none)
- [x] MACs in lowercase colon-separated format
- [x] Unit tests cover both cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bare-metal instance details now include a **Network Interfaces** section.
  * MAC addresses are displayed for available network interfaces.
  * Displays `(none)` when network or hardware information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->