### PR TITLE
OSAC-2978: Regenerate public ClusterTemplateSpecDefaults generated code from proto

### DIFF
--- a/fulfillment-service/internal/api/osac/public/v1/cluster_template_type.pb.go
+++ b/fulfillment-service/internal/api/osac/public/v1/cluster_template_type.pb.go
@@ -541,8 +541,8 @@ type ClusterTemplateSpecDefaults struct {
 	Version *ClusterVersionReference `protobuf:"bytes,5,opt,name=version,proto3" json:"version,omitempty"`
 	// Default Secret reference for pull secret credentials.
 	//
-	// When set, clusters created from this template will use this secret reference unless the user provides an
-	// explicit pull_secret or pull_secret_secret.
+	// Mutually exclusive with `pull_secret`. When set, clusters created from this template will use this secret
+	// reference unless the user provides an explicit pull_secret or pull_secret_secret.
 	PullSecretSecret *SecretLocalReference `protobuf:"bytes,6,opt,name=pull_secret_secret,json=pullSecretSecret,proto3" json:"pull_secret_secret,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
@@ -675,8 +675,8 @@ type ClusterTemplateSpecDefaults_builder struct {
 	Version *ClusterVersionReference
 	// Default Secret reference for pull secret credentials.
 	//
-	// When set, clusters created from this template will use this secret reference unless the user provides an
-	// explicit pull_secret or pull_secret_secret.
+	// Mutually exclusive with `pull_secret`. When set, clusters created from this template will use this secret
+	// reference unless the user provides an explicit pull_secret or pull_secret_secret.
 	PullSecretSecret *SecretLocalReference
 }
 

--- a/fulfillment-service/internal/api/osac/public/v1/cluster_template_type_protoopaque.pb.go
+++ b/fulfillment-service/internal/api/osac/public/v1/cluster_template_type_protoopaque.pb.go
@@ -625,8 +625,8 @@ type ClusterTemplateSpecDefaults_builder struct {
 	Version *ClusterVersionReference
 	// Default Secret reference for pull secret credentials.
 	//
-	// When set, clusters created from this template will use this secret reference unless the user provides an
-	// explicit pull_secret or pull_secret_secret.
+	// Mutually exclusive with `pull_secret`. When set, clusters created from this template will use this secret
+	// reference unless the user provides an explicit pull_secret or pull_secret_secret.
 	PullSecretSecret *SecretLocalReference
 }
 


### PR DESCRIPTION
## What

  Regenerates the public `ClusterTemplateSpecDefaults` generated Go code so it matches the proto source.

  ## Why
  
  Follow-up to #385. The pull_secret_secret comment in the public cluster_template_type.proto was updated, but `buf generate` was not re-run before merge. This left the generated code out of sync with the proto, which the "Check generated code" CI job flagged.
  
  ## Change
  
  Ran `buf generate`; only doc comments changed:
  - `internal/api/osac/public/v1/cluster_template_type.pb.go`
  - `internal/api/osac/public/v1/cluster_template_type_protoopaque.pb.go`
  
  ## Verification
  
  - `uv run dev.py lint proto` → passes
  - `buf generate` + `git diff --exit-code -- internal/api` → clean
  - `go build ./internal/api/osac/public/v1/` → compiles