### PR TITLE
OSAC-4202: [DEV] OpenStack/Ironic Backend — FindFreeHost Port Filter and GetHostNICs

### DIFF
--- a/bare-metal-fulfillment-operator/internal/inventory/openstack.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/openstack.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gophercloud/gophercloud/v2"
 	"github.com/gophercloud/gophercloud/v2/openstack"
 	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/nodes"
+	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/ports"
 	"github.com/gophercloud/gophercloud/v2/pagination"
 	"github.com/gophercloud/utils/v2/openstack/clientconfig"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -184,6 +185,7 @@ func (c *OpenStackClient) findFreeHost(ctx context.Context, matchExpressions map
 
 	var foundHost *Host
 	err := nodes.List(c.client, listOpts).EachPage(ctx, func(ctx context.Context, page pagination.Page) (bool, error) {
+		log := ctrllog.FromContext(ctx)
 		nodeList, err := nodes.ExtractNodes(page)
 		if err != nil {
 			return false, err
@@ -216,6 +218,25 @@ func (c *OpenStackClient) findFreeHost(ctx context.Context, matchExpressions map
 				matchManagedBy = shared.OsacDefaultManagedByValue
 			}
 			if managedBy != matchManagedBy {
+				continue
+			}
+
+			// Skip nodes without registered Ironic ports
+			portPages, portErr := ports.ListDetail(c.client, ports.ListOpts{NodeUUID: node.UUID}).AllPages(ctx)
+			if portErr != nil {
+				if isAuthError(portErr) {
+					return false, portErr
+				}
+				log.V(1).Info("Skipping node: port lookup failed", "node", node.UUID, "error", portErr)
+				continue
+			}
+			portList, portErr := ports.ExtractPorts(portPages)
+			if portErr != nil || len(portList) == 0 {
+				if portErr != nil {
+					log.Error(portErr, "Skipping node: failed to extract ports", "node", node.UUID)
+				} else {
+					log.Error(nil, "Skipping node: no registered ports", "node", node.UUID)
+				}
 				continue
 			}
 
@@ -413,9 +434,37 @@ func getNestedLabel(node *nodes.Node, labelKey string) (string, bool) {
 	return "", false
 }
 
-// GetHostNICs returns nil for OpenStack hosts. NIC metadata discovery via
-// Ironic ports is implemented in OSAC-4202; returning nil allows the controller
-// to proceed to Ready without blocking on the unimplemented call.
-func (c *OpenStackClient) GetHostNICs(_ context.Context, _ string) ([]HostNIC, error) {
-	return nil, nil
+func (c *OpenStackClient) GetHostNICs(ctx context.Context, inventoryHostID string) ([]HostNIC, error) {
+	nics, err := c.getHostNICs(ctx, inventoryHostID)
+	if err != nil && isAuthError(err) {
+		log := ctrllog.FromContext(ctx)
+		log.Info("auth error on GetHostNICs, attempting reconnect", "inventoryHostID", inventoryHostID, "error", err)
+		if reconnErr := c.reconnect(ctx); reconnErr != nil {
+			return nil, fmt.Errorf("get host NICs %s: reconnect failed: %w", inventoryHostID, reconnErr)
+		}
+		nics, err = c.getHostNICs(ctx, inventoryHostID)
+		if err != nil {
+			return nil, fmt.Errorf("get host NICs %s after reconnect: %w", inventoryHostID, err)
+		}
+	}
+	return nics, err
+}
+
+func (c *OpenStackClient) getHostNICs(ctx context.Context, inventoryHostID string) ([]HostNIC, error) {
+	portPages, err := ports.ListDetail(c.client, ports.ListOpts{NodeUUID: inventoryHostID}).AllPages(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing ports for node %s: %w", inventoryHostID, err)
+	}
+	portList, err := ports.ExtractPorts(portPages)
+	if err != nil {
+		return nil, fmt.Errorf("extracting ports for node %s: %w", inventoryHostID, err)
+	}
+	if len(portList) == 0 {
+		return nil, fmt.Errorf("node %s has no NIC inventory despite being allocated", inventoryHostID)
+	}
+	nics := make([]HostNIC, 0, len(portList))
+	for _, p := range portList {
+		nics = append(nics, HostNIC{MAC: strings.ToLower(p.Address)})
+	}
+	return nics, nil
 }

--- a/bare-metal-fulfillment-operator/internal/inventory/openstack.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/openstack.go
@@ -222,7 +222,7 @@ func (c *OpenStackClient) findFreeHost(ctx context.Context, matchExpressions map
 			}
 
 			// Skip nodes without registered Ironic ports
-			portPages, portErr := ports.ListDetail(c.client, ports.ListOpts{NodeUUID: node.UUID}).AllPages(ctx)
+			portList, portErr := c.listNodePorts(ctx, node.UUID)
 			if portErr != nil {
 				if isAuthError(portErr) {
 					return false, portErr
@@ -230,13 +230,8 @@ func (c *OpenStackClient) findFreeHost(ctx context.Context, matchExpressions map
 				log.V(1).Info("Skipping node: port lookup failed", "node", node.UUID, "error", portErr)
 				continue
 			}
-			portList, portErr := ports.ExtractPorts(portPages)
-			if portErr != nil || len(portList) == 0 {
-				if portErr != nil {
-					log.Error(portErr, "Skipping node: failed to extract ports", "node", node.UUID)
-				} else {
-					log.Error(nil, "Skipping node: no registered ports", "node", node.UUID)
-				}
+			if len(portList) == 0 {
+				log.Error(nil, "Skipping node: no registered ports", "node", node.UUID)
 				continue
 			}
 
@@ -450,14 +445,24 @@ func (c *OpenStackClient) GetHostNICs(ctx context.Context, inventoryHostID strin
 	return nics, err
 }
 
-func (c *OpenStackClient) getHostNICs(ctx context.Context, inventoryHostID string) ([]HostNIC, error) {
-	portPages, err := ports.ListDetail(c.client, ports.ListOpts{NodeUUID: inventoryHostID}).AllPages(ctx)
+// listNodePorts fetches and extracts the Ironic ports for the given node UUID.
+// Returns an empty slice (not an error) when the node has no registered ports.
+func (c *OpenStackClient) listNodePorts(ctx context.Context, nodeUUID string) ([]ports.Port, error) {
+	portPages, err := ports.ListDetail(c.client, ports.ListOpts{NodeUUID: nodeUUID}).AllPages(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("listing ports for node %s: %w", inventoryHostID, err)
+		return nil, fmt.Errorf("listing ports for node %s: %w", nodeUUID, err)
 	}
 	portList, err := ports.ExtractPorts(portPages)
 	if err != nil {
-		return nil, fmt.Errorf("extracting ports for node %s: %w", inventoryHostID, err)
+		return nil, fmt.Errorf("extracting ports for node %s: %w", nodeUUID, err)
+	}
+	return portList, nil
+}
+
+func (c *OpenStackClient) getHostNICs(ctx context.Context, inventoryHostID string) ([]HostNIC, error) {
+	portList, err := c.listNodePorts(ctx, inventoryHostID)
+	if err != nil {
+		return nil, err
 	}
 	if len(portList) == 0 {
 		return nil, fmt.Errorf("node %s has no NIC inventory despite being allocated", inventoryHostID)

--- a/bare-metal-fulfillment-operator/internal/inventory/openstack_internal_test.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/openstack_internal_test.go
@@ -23,6 +23,9 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/v2"
+	"github.com/gophercloud/gophercloud/v2/openstack/baremetal/v1/ports"
+	th "github.com/gophercloud/gophercloud/v2/testhelper"
+	fakeclient "github.com/gophercloud/gophercloud/v2/testhelper/client"
 )
 
 func TestIsAuthError(t *testing.T) {
@@ -121,6 +124,225 @@ func TestIsAuthError(t *testing.T) {
 		})
 	}
 }
+
+func TestGetHostNICs_OpenStack(t *testing.T) {
+	t.Run("returns lowercased MACs from port records", func(t *testing.T) {
+		fakeServer := th.SetupHTTP()
+		defer fakeServer.Teardown()
+
+		fakeServer.Mux.HandleFunc("/ports/detail", func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("node_uuid") != "test-node-uuid" {
+				t.Errorf("unexpected node_uuid: %s", r.URL.Query().Get("node_uuid"))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `{"ports": [{"address": "AA:BB:CC:DD:EE:01"}, {"address": "ff:00:11:22:33:44"}]}`)
+		})
+
+		sc := fakeclient.ServiceClient(fakeServer)
+		c := &OpenStackClient{
+			client: sc,
+			newServiceClient: func(context.Context) (*gophercloud.ServiceClient, error) {
+				return nil, fmt.Errorf("should not reconnect")
+			},
+		}
+
+		nics, err := c.GetHostNICs(context.Background(), "test-node-uuid")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(nics) != 2 {
+			t.Fatalf("expected 2 NICs, got %d", len(nics))
+		}
+		if nics[0].MAC != "aa:bb:cc:dd:ee:01" {
+			t.Errorf("expected lowercased MAC, got %q", nics[0].MAC)
+		}
+		if nics[1].MAC != "ff:00:11:22:33:44" {
+			t.Errorf("expected lowercased MAC, got %q", nics[1].MAC)
+		}
+	})
+
+	t.Run("returns error when port list is empty", func(t *testing.T) {
+		fakeServer := th.SetupHTTP()
+		defer fakeServer.Teardown()
+
+		fakeServer.Mux.HandleFunc("/ports/detail", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `{"ports": []}`)
+		})
+
+		sc := fakeclient.ServiceClient(fakeServer)
+		c := &OpenStackClient{
+			client: sc,
+			newServiceClient: func(context.Context) (*gophercloud.ServiceClient, error) {
+				return nil, fmt.Errorf("should not reconnect")
+			},
+		}
+
+		_, err := c.GetHostNICs(context.Background(), "test-node-uuid")
+		if err == nil {
+			t.Fatal("expected error for empty port list, got nil")
+		}
+	})
+
+	t.Run("retries on auth error and returns NICs on success", func(t *testing.T) {
+		fakeServer := th.SetupHTTP()
+		defer fakeServer.Teardown()
+
+		callCount := 0
+		fakeServer.Mux.HandleFunc("/ports/detail", func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			if callCount == 1 {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `{"ports": [{"address": "aa:bb:cc:dd:ee:01"}]}`)
+		})
+
+		sc := fakeclient.ServiceClient(fakeServer)
+		c := &OpenStackClient{
+			client:           sc,
+			newServiceClient: func(context.Context) (*gophercloud.ServiceClient, error) { return sc, nil },
+		}
+
+		nics, err := c.GetHostNICs(context.Background(), "test-node-uuid")
+		if err != nil {
+			t.Fatalf("unexpected error after reconnect: %v", err)
+		}
+		if len(nics) != 1 || nics[0].MAC != "aa:bb:cc:dd:ee:01" {
+			t.Errorf("expected 1 NIC with correct MAC, got %v", nics)
+		}
+		if callCount != 2 {
+			t.Errorf("expected 2 calls (auth retry), got %d", callCount)
+		}
+	})
+
+	t.Run("returns error on non-auth API failure", func(t *testing.T) {
+		fakeServer := th.SetupHTTP()
+		defer fakeServer.Teardown()
+
+		fakeServer.Mux.HandleFunc("/ports/detail", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+
+		sc := fakeclient.ServiceClient(fakeServer)
+		c := &OpenStackClient{
+			client: sc,
+			newServiceClient: func(context.Context) (*gophercloud.ServiceClient, error) {
+				return nil, fmt.Errorf("should not reconnect")
+			},
+		}
+
+		_, err := c.GetHostNICs(context.Background(), "test-node-uuid")
+		if err == nil {
+			t.Fatal("expected error for 500, got nil")
+		}
+	})
+}
+
+func TestFindFreeHost_PortFilter(t *testing.T) {
+	const nodeListResponse = `{"nodes": [{"uuid": "node-1", "name": "host-1", "resource_class": "gpu-node", "provision_state": "available", "extra": {}}]}`
+
+	t.Run("selects node with ports", func(t *testing.T) {
+		fakeServer := th.SetupHTTP()
+		defer fakeServer.Teardown()
+
+		fakeServer.Mux.HandleFunc("/nodes", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, nodeListResponse)
+		})
+		fakeServer.Mux.HandleFunc("/ports/detail", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `{"ports": [{"address": "aa:bb:cc:dd:ee:01"}]}`)
+		})
+
+		sc := fakeclient.ServiceClient(fakeServer)
+		c := &OpenStackClient{
+			client:           sc,
+			newServiceClient: func(context.Context) (*gophercloud.ServiceClient, error) { return sc, nil },
+			HostClass:        "openstack",
+		}
+
+		host, err := c.FindFreeHost(context.Background(), map[string]string{"hostType": "gpu-node"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if host == nil {
+			t.Fatal("expected a host, got nil")
+		}
+		if host.InventoryHostID != "node-1" {
+			t.Errorf("expected node-1, got %q", host.InventoryHostID)
+		}
+	})
+
+	t.Run("skips node with no registered ports", func(t *testing.T) {
+		fakeServer := th.SetupHTTP()
+		defer fakeServer.Teardown()
+
+		fakeServer.Mux.HandleFunc("/nodes", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, nodeListResponse)
+		})
+		fakeServer.Mux.HandleFunc("/ports/detail", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `{"ports": []}`)
+		})
+
+		sc := fakeclient.ServiceClient(fakeServer)
+		c := &OpenStackClient{
+			client:           sc,
+			newServiceClient: func(context.Context) (*gophercloud.ServiceClient, error) { return sc, nil },
+			HostClass:        "openstack",
+		}
+
+		host, err := c.FindFreeHost(context.Background(), map[string]string{"hostType": "gpu-node"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if host != nil {
+			t.Errorf("expected nil (portless node skipped), got %+v", host)
+		}
+	})
+
+	t.Run("skips node when port API returns error", func(t *testing.T) {
+		fakeServer := th.SetupHTTP()
+		defer fakeServer.Teardown()
+
+		fakeServer.Mux.HandleFunc("/nodes", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, nodeListResponse)
+		})
+		fakeServer.Mux.HandleFunc("/ports/detail", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		})
+
+		sc := fakeclient.ServiceClient(fakeServer)
+		c := &OpenStackClient{
+			client:           sc,
+			newServiceClient: func(context.Context) (*gophercloud.ServiceClient, error) { return sc, nil },
+			HostClass:        "openstack",
+		}
+
+		host, err := c.FindFreeHost(context.Background(), map[string]string{"hostType": "gpu-node"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if host != nil {
+			t.Errorf("expected nil (port API error → skip), got %+v", host)
+		}
+	})
+}
+
+// compile-time check that ports package is used
+var _ = ports.ListOpts{}
 
 func TestReconnect(t *testing.T) {
 	const (


### PR DESCRIPTION
## [OSAC-4202](https://redhat.atlassian.net/browse/OSAC-4202): [DEV] OpenStack/Ironic Backend — FindFreeHost Port Filter and GetHostNICs

**Jira:** https://redhat.atlassian.net/browse/OSAC-4202
**Story type:** [DEV]
**Epic:** [OSAC-4200](https://redhat.atlassian.net/browse/OSAC-4200) — Expose NIC MAC Addresses in BareMetalInstance
**Depends on:** #410 (OSAC-4201, merged)

### Summary

Implements `GetHostNICs` for the OpenStack/Ironic inventory backend and extends `FindFreeHost` to skip nodes with no registered Ironic ports. NIC MAC addresses are fetched from Ironic port records via `ports.ListDetail`, lowercased, and returned as `HostNIC` entries. The existing `isAuthError` → reconnect → retry pattern is applied to all port API calls.

### Changes

**`internal/inventory/openstack.go`:**
- `FindFreeHost`: added port filter — calls `ports.ListDetail` per candidate node; skips node on empty result or API error (auth errors propagated for reconnect)
- `GetHostNICs`: fetches all Ironic ports for a node via `ports.ListDetail`, lowercases `Port.Address`, returns `[]HostNIC`; returns error on nil/empty (node guaranteed to have ports after `FindFreeHost` filter)
- Auth/reconnect pattern applied consistently to all port calls

**`internal/inventory/openstack_internal_test.go`:** 7 new test cases using gophercloud fake HTTP server

### Acceptance Criteria

- [x] `FindFreeHost` skips nodes with no registered Ironic ports
- [x] Port API error during `FindFreeHost` treats node as ineligible (skip, not fail)
- [x] `GetHostNICs` calls `ports.ListDetail` and returns lowercased MACs
- [x] Auth/reconnect retry applied to port calls in both methods
- [x] Unit tests for all paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved bare-metal host discovery by recognizing only hosts with registered network ports.
  * Added support for retrieving host network interfaces from OpenStack.
  * MAC addresses are now returned in a consistent lowercase format.

* **Bug Fixes**
  * Improved recovery when OpenStack authentication expires during port lookups.
  * Added clearer handling for hosts with no available ports and other port retrieval failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->