### PR TITLE
OSAC-4236: [DEV] BCM Inventory Backend — GetHostNICs Implementation

### DIFF
--- a/bare-metal-fulfillment-operator/internal/baremetalhost/manager.go
+++ b/bare-metal-fulfillment-operator/internal/baremetalhost/manager.go
@@ -159,6 +159,9 @@ func (m *Manager) GetHardwareNICs(ctx context.Context, name string) ([]string, e
 	}
 	macs := make([]string, 0, len(bmh.Status.HardwareDetails.NIC))
 	for _, nic := range bmh.Status.HardwareDetails.NIC {
+		if nic.MAC == "" {
+			continue
+		}
 		macs = append(macs, strings.ToLower(nic.MAC))
 	}
 	return macs, nil

--- a/bare-metal-fulfillment-operator/internal/baremetalhost/manager.go
+++ b/bare-metal-fulfillment-operator/internal/baremetalhost/manager.go
@@ -23,6 +23,7 @@ package baremetalhost
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -143,6 +144,24 @@ func (m *Manager) DeleteBMH(ctx context.Context, name string) error {
 
 	log.Info("Deleted BareMetalHost", "name", name, "namespace", m.namespace)
 	return nil
+}
+
+// GetHardwareNICs returns the lowercased MAC addresses from the BareMetalHost
+// status.hardware.nics (Metal3 hardware inspection data). Returns nil when
+// the BMH has no hardware details or no NICs recorded.
+func (m *Manager) GetHardwareNICs(ctx context.Context, name string) ([]string, error) {
+	bmh := &metal3api.BareMetalHost{}
+	if err := m.client.Get(ctx, client.ObjectKey{Namespace: m.namespace, Name: name}, bmh); err != nil {
+		return nil, fmt.Errorf("failed to get BareMetalHost %s/%s: %w", m.namespace, name, err)
+	}
+	if bmh.Status.HardwareDetails == nil || len(bmh.Status.HardwareDetails.NIC) == 0 {
+		return nil, nil
+	}
+	macs := make([]string, 0, len(bmh.Status.HardwareDetails.NIC))
+	for _, nic := range bmh.Status.HardwareDetails.NIC {
+		macs = append(macs, strings.ToLower(nic.MAC))
+	}
+	return macs, nil
 }
 
 // IsBMHReady checks whether the BMH has completed Metal3 registration and is

--- a/bare-metal-fulfillment-operator/internal/inventory/bcm.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/bcm.go
@@ -228,11 +228,10 @@ func (c *BCMClient) UnassignHost(_ context.Context, _ string, _ []string) error 
 // Reading from the BMH CR avoids a costly GetDevices round-trip to the BCM API.
 // Returns nil, nil when the BMH has no hardware inspection data (caller treats this as "NIC data unavailable").
 func (c *BCMClient) GetHostNICs(ctx context.Context, inventoryHostID string) ([]HostNIC, error) {
-	parts := strings.SplitN(inventoryHostID, "/", 2)
-	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid inventoryHostID %q: expected namespace/hostname format", inventoryHostID)
+	_, bmhName, err := ParseHostID(inventoryHostID)
+	if err != nil {
+		return nil, err
 	}
-	bmhName := parts[1]
 
 	macs, err := c.bmhManager.GetHardwareNICs(ctx, bmhName)
 	if err != nil {

--- a/bare-metal-fulfillment-operator/internal/inventory/bcm.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/bcm.go
@@ -223,9 +223,27 @@ func (c *BCMClient) UnassignHost(_ context.Context, _ string, _ []string) error 
 	return fmt.Errorf("bcm UnassignHost not implemented")
 }
 
-// GetHostNICs returns nil for BCM hosts. NIC metadata discovery is not yet
-// supported for this backend; returning nil allows the controller to proceed
-// to Ready without blocking on an unimplemented inventory call.
-func (c *BCMClient) GetHostNICs(_ context.Context, _ string) ([]HostNIC, error) {
-	return nil, nil
+// GetHostNICs reads all NIC MAC addresses from the BareMetalHost CR hardware inspection data.
+// inventoryHostID must be in namespace/hostname format where hostname is the BMH name.
+// Reading from the BMH CR avoids a costly GetDevices round-trip to the BCM API.
+// Returns nil, nil when the BMH has no hardware inspection data (caller treats this as "NIC data unavailable").
+func (c *BCMClient) GetHostNICs(ctx context.Context, inventoryHostID string) ([]HostNIC, error) {
+	parts := strings.SplitN(inventoryHostID, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid inventoryHostID %q: expected namespace/hostname format", inventoryHostID)
+	}
+	bmhName := parts[1]
+
+	macs, err := c.bmhManager.GetHardwareNICs(ctx, bmhName)
+	if err != nil {
+		return nil, fmt.Errorf("GetHostNICs: failed to get BMH %s: %w", bmhName, err)
+	}
+	if len(macs) == 0 {
+		return nil, nil
+	}
+	nics := make([]HostNIC, 0, len(macs))
+	for _, mac := range macs {
+		nics = append(nics, HostNIC{MAC: mac})
+	}
+	return nics, nil
 }

--- a/bare-metal-fulfillment-operator/internal/inventory/bcm_test.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/bcm_test.go
@@ -27,7 +27,10 @@ import (
 	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
 	. "github.com/onsi/gomega"    //nolint:revive,staticcheck
 
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/baremetalhost"
 	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/bcmclient"
@@ -372,6 +375,85 @@ var _ = Describe("BCM Inventory Adapter", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(host).NotTo(BeNil())
 			Expect(host.ManagedBy).To(Equal("baremetal"))
+		})
+	})
+
+	Describe("GetHostNICs", func() {
+		const bmhNamespace = "osac-baremetal"
+
+		var ctx context.Context
+
+		newClientWithNICs := func(bmhName string, macs ...string) *BCMClient {
+			scheme := newTestScheme()
+			nics := make([]metal3api.NIC, 0, len(macs))
+			for _, mac := range macs {
+				nics = append(nics, metal3api.NIC{MAC: mac})
+			}
+			bmh := &metal3api.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{Name: bmhName, Namespace: bmhNamespace},
+			}
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(bmh).
+				WithStatusSubresource(&metal3api.BareMetalHost{}).
+				Build()
+			// Set status via status subresource
+			bmh.Status.HardwareDetails = &metal3api.HardwareDetails{NIC: nics}
+			Expect(k8sClient.Status().Update(context.Background(), bmh)).To(Succeed())
+			mgr := baremetalhost.NewManager(k8sClient, bmhNamespace)
+			return NewBCMClient(&mockBCMAPI{}, mgr, "bcm")
+		}
+
+		newClientNoBMH := func() *BCMClient {
+			scheme := newTestScheme()
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			mgr := baremetalhost.NewManager(k8sClient, bmhNamespace)
+			return NewBCMClient(&mockBCMAPI{}, mgr, "bcm")
+		}
+
+		BeforeEach(func() {
+			ctx = context.Background()
+		})
+
+		It("returns lowercased MACs from BMH status.hardware.nics", func() {
+			client := newClientWithNICs("node001", "AA:BB:CC:DD:EE:01", "FF:00:11:22:33:44")
+			nics, err := client.GetHostNICs(ctx, "osac-baremetal/node001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nics).To(HaveLen(2))
+			Expect(nics[0].MAC).To(Equal("aa:bb:cc:dd:ee:01"))
+			Expect(nics[1].MAC).To(Equal("ff:00:11:22:33:44"))
+		})
+
+		It("returns error when BMH does not exist", func() {
+			client := newClientNoBMH()
+			_, err := client.GetHostNICs(ctx, "osac-baremetal/nonexistent")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns nil,nil when BMH has no hardware details", func() {
+			scheme := newTestScheme()
+			bmh := &metal3api.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{Name: "node001", Namespace: bmhNamespace},
+			}
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(bmh).Build()
+			mgr := baremetalhost.NewManager(k8sClient, bmhNamespace)
+			client := NewBCMClient(&mockBCMAPI{}, mgr, "bcm")
+			nics, err := client.GetHostNICs(ctx, "osac-baremetal/node001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nics).To(BeNil())
+		})
+
+		It("returns nil,nil when BMH hardware.nics is empty", func() {
+			client := newClientWithNICs("node001") // no MACs
+			nics, err := client.GetHostNICs(ctx, "osac-baremetal/node001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nics).To(BeNil())
+		})
+
+		It("returns error for invalid inventoryHostID format", func() {
+			client := newClientNoBMH()
+			_, err := client.GetHostNICs(ctx, "no-slash")
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
## [OSAC-4236](https://redhat.atlassian.net/browse/OSAC-4236): [DEV] BCM Inventory Backend — GetHostNICs Implementation

**Jira:** https://redhat.atlassian.net/browse/OSAC-4236
**Story type:** [DEV]
**Epic:** [OSAC-4200](https://redhat.atlassian.net/browse/OSAC-4200) — Expose NIC MAC Addresses in BareMetalInstance
**Depends on:** #410 (OSAC-4201, merged)

### Summary

Implements `GetHostNICs` for the BCM inventory backend. Rather than making a costly `GetDevices` call (no pagination, fetches all devices), reads all NIC MAC addresses directly from the `BareMetalHost` CR's `status.hardware.nics` field via a new `baremetalhost.Manager.GetHardwareNICs` method. Returns the full list of physical interfaces — consistent with the Metal3 backend which also reads from `Status.HardwareDetails.NIC[]`.

### Changes

**`internal/baremetalhost/manager.go`:** Added `GetHardwareNICs(ctx, name) []string` — reads `status.hardware.nics[*].mac` via jsonpath, lowercases all MACs

**`internal/inventory/bcm.go`:** `GetHostNICs` parses `namespace/hostname` from `inventoryHostID`, calls `GetHardwareNICs`, converts to `[]HostNIC`; returns `nil, nil` when no NICs present (no BCM REST API call)

**`internal/inventory/bcm_test.go`:** Updated tests to use fake k8s client with BMH fixture containing hardware NIC data

### Design note

BCM `FindFreeHost` already validates `macPattern` on each candidate device. BCM hosts also go through BareMetalHost-level hardware inspection, so `status.hardware.nics` is populated by the time `GetHostNICs` is called. This avoids an extra BCM REST API call and aligns the data source with Metal3.

### Acceptance Criteria

- [x] `BCMClient` implements `GetHostNICs` using BMH hardware details (no extra BCM API call)
- [x] Returns full NIC list (all MACs), consistent with Metal3 backend
- [x] Returns `nil, nil` when no NICs present
- [x] Unit tests covering populated NICs, empty NICs, and missing BMH