### PR TITLE
OSAC-3735: Fall back to file secret store when no keychain exists on macOS

### DIFF
--- a/.github/workflows/darwin-keychain-tests.yml
+++ b/.github/workflows/darwin-keychain-tests.yml
@@ -1,0 +1,52 @@
+#
+# Copyright (c) 2026 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+# The rest of this repo's CI runs on ubuntu-latest only (see unit-tests.yml,
+# integration-tests.yml), so config_secret_store_darwin.go's //go:build darwin path never
+# compiles or runs there -- keychainAvailable always resolves to the
+# config_secret_store_other.go no-op stub in CI. This workflow closes that gap on a
+# macos-latest runner, instead of moving the whole unit-tests.yml suite to macOS.
+name: Darwin Keychain Tests
+
+on:
+  pull_request:
+    branches:
+    - main
+    paths:
+    - '.github/workflows/darwin-keychain-tests.yml'
+    - 'fulfillment-service/internal/config/config_secret_store.go'
+    - 'fulfillment-service/internal/config/config_secret_store_darwin.go'
+    - 'fulfillment-service/internal/config/config_secret_store_darwin_test.go'
+    - 'fulfillment-service/internal/config/config_secret_store_other.go'
+    - 'fulfillment-service/internal/config/config_settings.go'
+    - 'fulfillment-service/internal/config/config_settings_test.go'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  run-darwin-keychain-tests:
+    name: Run darwin keychain tests
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      with:
+        persist-credentials: false
+    - uses: ./.github/actions/setup-go
+      with:
+        working-directory: fulfillment-service
+    - working-directory: fulfillment-service
+      run: |
+        go test -run 'TestKeychainAvailable|TestSettingsSave_FallsBackToFileWithNoKeychain' -v ./internal/config/...

--- a/fulfillment-service/AGENTS.md
+++ b/fulfillment-service/AGENTS.md
@@ -302,6 +302,7 @@ As with any proto change, run `uv run dev.py lint proto && buf generate` afterwa
 - `SERVICE_SUFFIX` lint rule is intentionally excluded in `buf.yaml`
 - Unit tests: run `ginkgo run -r internal` (not `ginkgo run -r`) to avoid triggering integration tests
 - CI timeout: 1 hour for unit and integration test runs
+- Platform-gated tests (`//go:build darwin`, e.g. `internal/config/config_secret_store_darwin_test.go`) are skipped by `ginkgo run -r internal` on non-macOS machines and in the default Linux CI; they run separately in `.github/workflows/darwin-keychain-tests.yml` on a `macos-latest` runner
 
 See [Linting and Code Generation](#linting-and-code-generation) for the required `uv run dev.py lint proto && buf generate` step, and [Files Requiring Extra Caution](#files-requiring-extra-caution) for generated paths that must never be hand-edited.
 

--- a/fulfillment-service/internal/cmd/cli/login/login_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/login/login_cmd.go
@@ -447,6 +447,9 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to save configuration: %w", err)
 	}
+	if cfg.UsingFileSecretStore() {
+		c.console.Render(ctx, "file_secret_store_fallback.txt", nil)
+	}
 
 	return nil
 }

--- a/fulfillment-service/internal/cmd/cli/login/login_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/login/login_cmd.go
@@ -447,11 +447,17 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to save configuration: %w", err)
 	}
+	c.warnIfUsingFileSecretStore(ctx, cfg)
+
+	return nil
+}
+
+// warnIfUsingFileSecretStore renders a warning when the just-completed save wrote secrets to the file fallback
+// instead of the OS keyring.
+func (c *runnerContext) warnIfUsingFileSecretStore(ctx context.Context, cfg *config.Settings) {
 	if cfg.UsingFileSecretStore() {
 		c.console.Render(ctx, "file_secret_store_fallback.txt", nil)
 	}
-
-	return nil
 }
 
 // parseAddress parses the address and returns the address and whether accoding to that address the connection should

--- a/fulfillment-service/internal/cmd/cli/login/templates/file_secret_store_fallback.txt
+++ b/fulfillment-service/internal/cmd/cli/login/templates/file_secret_store_fallback.txt
@@ -1,0 +1,2 @@
+Warning: no usable operating system keyring was found, so your access and refresh tokens were saved
+unencrypted in your configuration directory instead of the system keyring.

--- a/fulfillment-service/internal/config/config_secret_store.go
+++ b/fulfillment-service/internal/config/config_secret_store.go
@@ -35,6 +35,10 @@ type SecretStore interface {
 
 	// Save serializes the given object and writes it to the store. Passing nil clears all data from the store.
 	Save(ctx context.Context, object any) error
+
+	// Backend reports which backend this store is using ("keyring" or "file"), so callers can tell the user
+	// when their secrets are not going into the OS keyring.
+	Backend() string
 }
 
 // SecretStoreBuilder contains the data and logic needed to build a secret store that automatically selects the best
@@ -64,13 +68,30 @@ func (b *SecretStoreBuilder) SetDir(value string) *SecretStoreBuilder {
 	return b
 }
 
-// Build uses the data stored in the builder to create and configure a new secret store. It probes the operating system
-// keyring by attempting to read the secrets key: if the call succeeds or returns ErrNotFound the keyring is usable;
-// any other error indicates the backend is not available and a file-based store is returned instead.
+// keychainAvailableFunc indirects to keychainAvailable (platform-specific; see config_secret_store_darwin.go /
+// config_secret_store_other.go) so tests can pin its result instead of depending on the real host machine's
+// keychain state.
+var keychainAvailableFunc = keychainAvailable
+
+// Build uses the data stored in the builder to create and configure a new secret store. On platforms where the
+// keyring backend can be entirely absent without keyring.Get's probe being able to tell (currently just macOS --
+// see keychainAvailable), it checks that first and returns a file-based store immediately if no backend is
+// present. Otherwise it probes the operating system keyring by attempting to read the secrets key: if the call
+// succeeds or returns ErrNotFound the keyring is usable; any other error indicates the backend is not available
+// and a file-based store is returned instead.
 func (b *SecretStoreBuilder) Build() (result SecretStore, err error) {
 	// Check parameters:
 	if b.logger == nil {
 		err = errors.New("logger is mandatory")
+		return
+	}
+
+	// Skip the probe entirely if there's no keyring backend to probe:
+	if !keychainAvailableFunc() {
+		result, err = NewFileSecretStore().
+			SetLogger(b.logger).
+			SetDir(b.dir).
+			Build()
 		return
 	}
 
@@ -146,6 +167,8 @@ type keyringSecretStore struct {
 	logger *slog.Logger
 	key    string
 }
+
+func (s *keyringSecretStore) Backend() string { return "keyring" }
 
 func (s *keyringSecretStore) Load(ctx context.Context, object any) error {
 	data, err := keyring.Get(keyringService, s.key)
@@ -262,6 +285,8 @@ type fileSecretStore struct {
 	logger *slog.Logger
 	file   string
 }
+
+func (s *fileSecretStore) Backend() string { return "file" }
 
 func (s *fileSecretStore) Load(ctx context.Context, object any) error {
 	data, err := os.ReadFile(s.file)

--- a/fulfillment-service/internal/config/config_secret_store_darwin.go
+++ b/fulfillment-service/internal/config/config_secret_store_darwin.go
@@ -1,0 +1,53 @@
+//go:build darwin
+
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// securityBinPath is the path to the macOS security(1) CLI. Mutable so tests can stub it.
+var securityBinPath = "/usr/bin/security" // SIP-protected, stable across macOS versions
+
+// keychainProbeTimeout bounds the default-keychain and lock-state checks; real invocations complete in well
+// under a second.
+const keychainProbeTimeout = 5 * time.Second
+
+// keychainAvailable reports whether a default keychain is configured and unlocked. See the fix commit for why
+// this check exists: keyring.Get's own probe can't make either distinction on macOS.
+func keychainAvailable() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), keychainProbeTimeout)
+	defer cancel()
+
+	//nolint:gosec // G204: securityBinPath is a hardcoded, test-stubbable literal, not externally controlled
+	out, err := exec.CommandContext(ctx, securityBinPath, "default-keychain").Output()
+	if err != nil {
+		return false
+	}
+	path := strings.Trim(strings.TrimSpace(string(out)), `"`)
+
+	// A configured default keychain isn't enough -- if it's locked, keyring.Get/Set risk hanging on an
+	// interactive unlock dialog instead of failing cleanly (see the fix commit for the full mechanism).
+	// show-keychain-info requires the target keychain to be unlocked to read its settings and fails fast
+	// (exit 152, no dialog) when it isn't -- empirically verified against a real locked/unlocked test
+	// keychain. A bare `security show-keychain-info` with no argument does NOT resolve to the default
+	// keychain (it returns a null placeholder), so the path from the first call is passed explicitly.
+	//nolint:gosec // G204: securityBinPath is a hardcoded, test-stubbable literal, not externally controlled
+	return exec.CommandContext(ctx, securityBinPath, "show-keychain-info", path).Run() == nil
+}

--- a/fulfillment-service/internal/config/config_secret_store_darwin.go
+++ b/fulfillment-service/internal/config/config_secret_store_darwin.go
@@ -25,7 +25,10 @@ import (
 // securityBinPath is the path to the macOS security(1) CLI. Mutable so tests can stub it.
 var securityBinPath = "/usr/bin/security" // SIP-protected, stable across macOS versions
 
-// keychainProbePassword is the unlock-keychain probe's password; empty in production (mutable for tests -- see fix commit).
+// keychainProbePassword is the unlock-keychain probe's password; empty in production (mutable for tests -- see fix
+// commit). Known limitation: the empty-password no-op-when-unlocked behavior was verified on a standard,
+// non-MDM-managed Mac; MDM-enforced keychain policies are untested and could cause a false "unavailable" (safe --
+// just an unnecessary file-store fallback, not a dialog).
 var keychainProbePassword = ""
 
 // keychainProbeTimeout bounds the default-keychain and lock-state checks; real invocations finish in well under a second.

--- a/fulfillment-service/internal/config/config_secret_store_darwin.go
+++ b/fulfillment-service/internal/config/config_secret_store_darwin.go
@@ -39,7 +39,6 @@ func keychainAvailable() bool {
 	ctx, cancel := context.WithTimeout(context.Background(), keychainProbeTimeout)
 	defer cancel()
 
-	//nolint:gosec // G204: securityBinPath is a hardcoded, test-stubbable literal, not externally controlled
 	cmd := exec.CommandContext(ctx, securityBinPath, "default-keychain")
 	cmd.WaitDelay = time.Second
 	out, err := cmd.Output()

--- a/fulfillment-service/internal/config/config_secret_store_darwin.go
+++ b/fulfillment-service/internal/config/config_secret_store_darwin.go
@@ -25,17 +25,13 @@ import (
 // securityBinPath is the path to the macOS security(1) CLI. Mutable so tests can stub it.
 var securityBinPath = "/usr/bin/security" // SIP-protected, stable across macOS versions
 
-// keychainProbePassword is the password used for the unlock-keychain probe. Empty in production, relying on
-// securityd's already-unlocked no-op shortcut; mutable because that shortcut doesn't survive a sandboxed HOME
-// override, so tests against a real unlocked keychain must supply its actual password (see the fix commit).
+// keychainProbePassword is the unlock-keychain probe's password; empty in production (mutable for tests -- see fix commit).
 var keychainProbePassword = ""
 
-// keychainProbeTimeout bounds the default-keychain and lock-state checks; real invocations complete in well
-// under a second.
+// keychainProbeTimeout bounds the default-keychain and lock-state checks; real invocations finish in well under a second.
 const keychainProbeTimeout = 5 * time.Second
 
-// keychainAvailable reports whether a default keychain is configured and unlocked. See the fix commit for why
-// this check exists: keyring.Get's own probe can't make either distinction on macOS.
+// keychainAvailable reports whether a default keychain is configured and unlocked (see fix commit for why keyring.Get alone can't tell).
 func keychainAvailable() bool {
 	ctx, cancel := context.WithTimeout(context.Background(), keychainProbeTimeout)
 	defer cancel()
@@ -49,10 +45,7 @@ func keychainAvailable() bool {
 	}
 	path := strings.Trim(strings.TrimSpace(string(out)), `"`)
 
-	// A locked default keychain must also count as unavailable: unlock-keychain -p is a no-op on an
-	// already-unlocked keychain (exit 0) but fails fast with zero dialog on a locked one (exit 51) -- unlike
-	// show-keychain-info, which has to consult SecurityAgent and pop a real dialog once run on an interactive
-	// session, and was rejected for that reason (see the fix commit for the full empirical trail).
+	// A locked default keychain must count as unavailable too -- unlock-keychain -p fails fast with no dialog on one, unlike show-keychain-info (see fix commit).
 	//nolint:gosec // G204: securityBinPath, keychainProbePassword, and path are hardcoded/test-stubbable/system-derived, not externally controlled
 	cmd = exec.CommandContext(ctx, securityBinPath, "unlock-keychain", "-p", keychainProbePassword, path)
 	cmd.WaitDelay = time.Second

--- a/fulfillment-service/internal/config/config_secret_store_darwin.go
+++ b/fulfillment-service/internal/config/config_secret_store_darwin.go
@@ -25,6 +25,11 @@ import (
 // securityBinPath is the path to the macOS security(1) CLI. Mutable so tests can stub it.
 var securityBinPath = "/usr/bin/security" // SIP-protected, stable across macOS versions
 
+// keychainProbePassword is the password used for the unlock-keychain probe. Empty in production, relying on
+// securityd's already-unlocked no-op shortcut; mutable because that shortcut doesn't survive a sandboxed HOME
+// override, so tests against a real unlocked keychain must supply its actual password (see the fix commit).
+var keychainProbePassword = ""
+
 // keychainProbeTimeout bounds the default-keychain and lock-state checks; real invocations complete in well
 // under a second.
 const keychainProbeTimeout = 5 * time.Second
@@ -36,18 +41,20 @@ func keychainAvailable() bool {
 	defer cancel()
 
 	//nolint:gosec // G204: securityBinPath is a hardcoded, test-stubbable literal, not externally controlled
-	out, err := exec.CommandContext(ctx, securityBinPath, "default-keychain").Output()
+	cmd := exec.CommandContext(ctx, securityBinPath, "default-keychain")
+	cmd.WaitDelay = time.Second
+	out, err := cmd.Output()
 	if err != nil {
 		return false
 	}
 	path := strings.Trim(strings.TrimSpace(string(out)), `"`)
 
-	// A configured default keychain isn't enough -- if it's locked, keyring.Get/Set risk hanging on an
-	// interactive unlock dialog instead of failing cleanly (see the fix commit for the full mechanism).
-	// show-keychain-info requires the target keychain to be unlocked to read its settings and fails fast
-	// (exit 152, no dialog) when it isn't -- empirically verified against a real locked/unlocked test
-	// keychain. A bare `security show-keychain-info` with no argument does NOT resolve to the default
-	// keychain (it returns a null placeholder), so the path from the first call is passed explicitly.
-	//nolint:gosec // G204: securityBinPath is a hardcoded, test-stubbable literal, not externally controlled
-	return exec.CommandContext(ctx, securityBinPath, "show-keychain-info", path).Run() == nil
+	// A locked default keychain must also count as unavailable: unlock-keychain -p is a no-op on an
+	// already-unlocked keychain (exit 0) but fails fast with zero dialog on a locked one (exit 51) -- unlike
+	// show-keychain-info, which has to consult SecurityAgent and pop a real dialog once run on an interactive
+	// session, and was rejected for that reason (see the fix commit for the full empirical trail).
+	//nolint:gosec // G204: securityBinPath, keychainProbePassword, and path are hardcoded/test-stubbable/system-derived, not externally controlled
+	cmd = exec.CommandContext(ctx, securityBinPath, "unlock-keychain", "-p", keychainProbePassword, path)
+	cmd.WaitDelay = time.Second
+	return cmd.Run() == nil
 }

--- a/fulfillment-service/internal/config/config_secret_store_darwin_test.go
+++ b/fulfillment-service/internal/config/config_secret_store_darwin_test.go
@@ -1,0 +1,169 @@
+//go:build darwin
+
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+// WARNING: This file contains plain (non-Ginkgo) Go tests, matching it_keychain_darwin_test.go's precedent. Do not
+// add t.Parallel() to these tests while they rely on mutating the package-level securityBinPath var.
+
+package config
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestKeychainAvailable_NoDefaultKeychain(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if keychainAvailable() {
+		t.Error("keychainAvailable() = true, want false with no default keychain configured")
+	}
+}
+
+func TestKeychainAvailable_RealKeychainPresent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	keychainDir := filepath.Join(dir, "Library", "Keychains")
+	if err := os.MkdirAll(keychainDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	keychainPath := filepath.Join(keychainDir, "login.keychain-db")
+	if out, err := exec.Command(securityBinPath, "create-keychain", "-p", "test-only-password", keychainPath).CombinedOutput(); err != nil {
+		t.Fatalf("create-keychain: %v: %s", err, out)
+	}
+	if out, err := exec.Command(securityBinPath, "default-keychain", "-s", keychainPath).CombinedOutput(); err != nil {
+		t.Fatalf("default-keychain -s: %v: %s", err, out)
+	}
+
+	// This verifies the full keychainAvailable() plumbing (stage-1 default-keychain detection under sandboxed
+	// HOME, stage-2 unlock-keychain subprocess execution and exit-code interpretation) using the keychain's real
+	// password, since securityd's session-trust no-op shortcut doesn't transfer through HOME overrides in
+	// sandboxed test keychains. The production empty-string probe's no-op behavior is verified manually in Task 4
+	// against a real, unsandboxed login session.
+	originalKeychainProbePassword := keychainProbePassword
+	keychainProbePassword = "test-only-password"
+	t.Cleanup(func() { keychainProbePassword = originalKeychainProbePassword })
+
+	if !keychainAvailable() {
+		t.Error("keychainAvailable() = false, want true with a default keychain configured")
+	}
+}
+
+func TestKeychainAvailable_SecurityBinaryFails(t *testing.T) {
+	stubDir := t.TempDir()
+	stubPath := filepath.Join(stubDir, "security")
+	if err := os.WriteFile(stubPath, []byte("#!/bin/sh\nexit 1\n"), 0755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	original := securityBinPath
+	securityBinPath = stubPath
+	t.Cleanup(func() { securityBinPath = original })
+
+	if keychainAvailable() {
+		t.Error("keychainAvailable() = true, want false when the security binary fails")
+	}
+}
+
+func TestKeychainAvailable_SecurityBinaryHangs(t *testing.T) {
+	stubDir := t.TempDir()
+	stubPath := filepath.Join(stubDir, "security")
+	if err := os.WriteFile(stubPath, []byte("#!/bin/sh\nexec sleep 10\n"), 0755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	original := securityBinPath
+	securityBinPath = stubPath
+	t.Cleanup(func() { securityBinPath = original })
+
+	start := time.Now()
+	available := keychainAvailable()
+	elapsed := time.Since(start)
+
+	if available {
+		t.Error("keychainAvailable() = true, want false when the security binary hangs")
+	}
+	if elapsed >= 7*time.Second {
+		t.Errorf("keychainAvailable() took %s, want well under the 10s sleep -- keychainProbeTimeout doesn't seem to be cancelling the subprocess", elapsed)
+	}
+}
+
+func TestKeychainAvailable_DefaultKeychainLocked(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	keychainDir := filepath.Join(dir, "Library", "Keychains")
+	if err := os.MkdirAll(keychainDir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	keychainPath := filepath.Join(keychainDir, "login.keychain-db")
+	if out, err := exec.Command(securityBinPath, "create-keychain", "-p", "test-only-password", keychainPath).CombinedOutput(); err != nil {
+		t.Fatalf("create-keychain: %v: %s", err, out)
+	}
+	if out, err := exec.Command(securityBinPath, "default-keychain", "-s", keychainPath).CombinedOutput(); err != nil {
+		t.Fatalf("default-keychain -s: %v: %s", err, out)
+	}
+	// Locking doesn't require the keychain's password -- only unlocking does.
+	if out, err := exec.Command(securityBinPath, "lock-keychain", keychainPath).CombinedOutput(); err != nil {
+		t.Fatalf("lock-keychain: %v: %s", err, out)
+	}
+
+	if keychainAvailable() {
+		t.Error("keychainAvailable() = true, want false with a locked default keychain")
+	}
+}
+
+// TestSettingsSave_FallsBackToFileWithNoKeychain exercises the exact code path the original bug lives in -- a
+// real credential save, as login_cmd.go performs post-auth -- without needing a live server or the full IT
+// harness. Uses a throwaway discard logger rather than the Ginkgo suite's package-level logger fixture, since
+// that fixture only initializes inside TestConfig's BeforeSuite, which this file's own -run-filtered invocations
+// never trigger.
+func TestSettingsSave_FallsBackToFileWithNoKeychain(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	dir := t.TempDir()
+	logger := slog.New(slog.DiscardHandler)
+
+	settings, err := NewSettings().
+		SetLogger(logger).
+		SetDir(dir).
+		Build()
+	if err != nil {
+		t.Fatalf("NewSettings().Build(): %v", err)
+	}
+	settings.SetAccessToken("test-access-token")
+	settings.SetRefreshToken("test-refresh-token")
+
+	ctx := context.Background()
+	done := make(chan error, 1)
+	go func() { done <- settings.Save(ctx) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Settings.Save(): %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Settings.Save() did not return within 10s -- likely blocked on an interactive keychain prompt")
+	}
+
+	secretsFile := filepath.Join(dir, "secrets.json")
+	if _, err := os.Stat(secretsFile); err != nil {
+		t.Fatalf("expected secrets.json to exist via file fallback: %v", err)
+	}
+}

--- a/fulfillment-service/internal/config/config_secret_store_darwin_test.go
+++ b/fulfillment-service/internal/config/config_secret_store_darwin_test.go
@@ -28,14 +28,9 @@ import (
 	"time"
 )
 
-func TestKeychainAvailable_NoDefaultKeychain(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	if keychainAvailable() {
-		t.Error("keychainAvailable() = true, want false with no default keychain configured")
-	}
-}
-
-func TestKeychainAvailable_RealKeychainPresent(t *testing.T) {
+// setupDefaultKeychain creates a throwaway keychain under a sandboxed HOME and makes it the default, returning its path.
+func setupDefaultKeychain(t *testing.T, password string) string {
+	t.Helper()
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 
@@ -44,12 +39,38 @@ func TestKeychainAvailable_RealKeychainPresent(t *testing.T) {
 		t.Fatalf("MkdirAll: %v", err)
 	}
 	keychainPath := filepath.Join(keychainDir, "login.keychain-db")
-	if out, err := exec.Command(securityBinPath, "create-keychain", "-p", "test-only-password", keychainPath).CombinedOutput(); err != nil {
+	if out, err := exec.Command(securityBinPath, "create-keychain", "-p", password, keychainPath).CombinedOutput(); err != nil {
 		t.Fatalf("create-keychain: %v: %s", err, out)
 	}
 	if out, err := exec.Command(securityBinPath, "default-keychain", "-s", keychainPath).CombinedOutput(); err != nil {
 		t.Fatalf("default-keychain -s: %v: %s", err, out)
 	}
+	return keychainPath
+}
+
+// stubSecurityBinary points securityBinPath at a throwaway shell script for the duration of the test.
+func stubSecurityBinary(t *testing.T, script string) {
+	t.Helper()
+	stubDir := t.TempDir()
+	stubPath := filepath.Join(stubDir, "security")
+	if err := os.WriteFile(stubPath, []byte(script), 0755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	original := securityBinPath
+	securityBinPath = stubPath
+	t.Cleanup(func() { securityBinPath = original })
+}
+
+func TestKeychainAvailable_NoDefaultKeychain(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if keychainAvailable() {
+		t.Error("keychainAvailable() = true, want false with no default keychain configured")
+	}
+}
+
+func TestKeychainAvailable_RealKeychainPresent(t *testing.T) {
+	setupDefaultKeychain(t, "test-only-password")
 
 	// This verifies the full keychainAvailable() plumbing (stage-1 default-keychain detection under sandboxed
 	// HOME, stage-2 unlock-keychain subprocess execution and exit-code interpretation) using the keychain's real
@@ -66,15 +87,7 @@ func TestKeychainAvailable_RealKeychainPresent(t *testing.T) {
 }
 
 func TestKeychainAvailable_SecurityBinaryFails(t *testing.T) {
-	stubDir := t.TempDir()
-	stubPath := filepath.Join(stubDir, "security")
-	if err := os.WriteFile(stubPath, []byte("#!/bin/sh\nexit 1\n"), 0755); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	original := securityBinPath
-	securityBinPath = stubPath
-	t.Cleanup(func() { securityBinPath = original })
+	stubSecurityBinary(t, "#!/bin/sh\nexit 1\n")
 
 	if keychainAvailable() {
 		t.Error("keychainAvailable() = true, want false when the security binary fails")
@@ -82,15 +95,7 @@ func TestKeychainAvailable_SecurityBinaryFails(t *testing.T) {
 }
 
 func TestKeychainAvailable_SecurityBinaryHangs(t *testing.T) {
-	stubDir := t.TempDir()
-	stubPath := filepath.Join(stubDir, "security")
-	if err := os.WriteFile(stubPath, []byte("#!/bin/sh\nexec sleep 10\n"), 0755); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	original := securityBinPath
-	securityBinPath = stubPath
-	t.Cleanup(func() { securityBinPath = original })
+	stubSecurityBinary(t, "#!/bin/sh\nexec sleep 10\n")
 
 	start := time.Now()
 	available := keychainAvailable()
@@ -105,20 +110,7 @@ func TestKeychainAvailable_SecurityBinaryHangs(t *testing.T) {
 }
 
 func TestKeychainAvailable_DefaultKeychainLocked(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
-
-	keychainDir := filepath.Join(dir, "Library", "Keychains")
-	if err := os.MkdirAll(keychainDir, 0700); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
-	}
-	keychainPath := filepath.Join(keychainDir, "login.keychain-db")
-	if out, err := exec.Command(securityBinPath, "create-keychain", "-p", "test-only-password", keychainPath).CombinedOutput(); err != nil {
-		t.Fatalf("create-keychain: %v: %s", err, out)
-	}
-	if out, err := exec.Command(securityBinPath, "default-keychain", "-s", keychainPath).CombinedOutput(); err != nil {
-		t.Fatalf("default-keychain -s: %v: %s", err, out)
-	}
+	keychainPath := setupDefaultKeychain(t, "test-only-password")
 	// Locking doesn't require the keychain's password -- only unlocking does.
 	if out, err := exec.Command(securityBinPath, "lock-keychain", keychainPath).CombinedOutput(); err != nil {
 		t.Fatalf("lock-keychain: %v: %s", err, out)

--- a/fulfillment-service/internal/config/config_secret_store_darwin_test.go
+++ b/fulfillment-service/internal/config/config_secret_store_darwin_test.go
@@ -13,8 +13,9 @@ Unless required by applicable law or agreed to in writing, software distributed 
 language governing permissions and limitations under the License.
 */
 
-// WARNING: This file contains plain (non-Ginkgo) Go tests, matching it_keychain_darwin_test.go's precedent. Do not
-// add t.Parallel() to these tests while they rely on mutating the package-level securityBinPath var.
+// WARNING: This file contains plain (non-Ginkgo) Go tests, since it must be //go:build darwin-gated and the
+// existing Ginkgo suite in this package is unconditional. Do not add t.Parallel() to these tests while they rely
+// on mutating the package-level securityBinPath var.
 
 package config
 

--- a/fulfillment-service/internal/config/config_secret_store_other.go
+++ b/fulfillment-service/internal/config/config_secret_store_other.go
@@ -1,0 +1,22 @@
+//go:build !darwin
+
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package config
+
+// keychainAvailable always reports true on non-darwin platforms: the existing keyring.Get probe in Build() already
+// distinguishes "backend unavailable" from "item not found" correctly here.
+func keychainAvailable() bool {
+	return true
+}

--- a/fulfillment-service/internal/config/config_secret_store_test.go
+++ b/fulfillment-service/internal/config/config_secret_store_test.go
@@ -41,6 +41,17 @@ var _ = Describe("Secret store", func() {
 	})
 
 	Describe("Store selection", func() {
+		var originalKeychainAvailableFunc func() bool
+
+		BeforeEach(func() {
+			originalKeychainAvailableFunc = keychainAvailableFunc
+			keychainAvailableFunc = func() bool { return true }
+		})
+
+		AfterEach(func() {
+			keychainAvailableFunc = originalKeychainAvailableFunc
+		})
+
 		It("Selects the keyring store when the keyring is available", func() {
 			keyring.MockInit()
 			store, err := NewSecretStore().

--- a/fulfillment-service/internal/config/config_secret_store_test.go
+++ b/fulfillment-service/internal/config/config_secret_store_test.go
@@ -26,6 +26,13 @@ import (
 	"github.com/osac-project/osac/fulfillment-service/internal/logging"
 )
 
+// pinKeychainAvailable overrides keychainAvailableFunc for the current spec and restores it afterward.
+func pinKeychainAvailable(available bool) {
+	original := keychainAvailableFunc
+	keychainAvailableFunc = func() bool { return available }
+	DeferCleanup(func() { keychainAvailableFunc = original })
+}
+
 var _ = Describe("Secret store", func() {
 	var ctx context.Context
 
@@ -41,15 +48,8 @@ var _ = Describe("Secret store", func() {
 	})
 
 	Describe("Store selection", func() {
-		var originalKeychainAvailableFunc func() bool
-
 		BeforeEach(func() {
-			originalKeychainAvailableFunc = keychainAvailableFunc
-			keychainAvailableFunc = func() bool { return true }
-		})
-
-		AfterEach(func() {
-			keychainAvailableFunc = originalKeychainAvailableFunc
+			pinKeychainAvailable(true)
 		})
 
 		It("Selects the keyring store when the keyring is available", func() {

--- a/fulfillment-service/internal/config/config_settings.go
+++ b/fulfillment-service/internal/config/config_settings.go
@@ -143,6 +143,7 @@ func (s *Settings) Reset() {
 	s.general = generalSettings{}
 	s.secret = secretSettings{}
 	s.caPool = nil
+	s.secretStoreBackend = ""
 }
 
 // Address returns the server address.

--- a/fulfillment-service/internal/config/config_settings.go
+++ b/fulfillment-service/internal/config/config_settings.go
@@ -45,12 +45,13 @@ type SettingsBuilder struct {
 // Settings is the type used to store the configuration of the client. General settings are persisted to a JSON file,
 // while secret data (tokens, credentials) is stored in the operating system keyring.
 type Settings struct {
-	logger  *slog.Logger
-	lock    *sync.RWMutex
-	dir     string
-	general generalSettings
-	secret  secretSettings
-	caPool  *x509.CertPool
+	logger             *slog.Logger
+	lock               *sync.RWMutex
+	dir                string
+	general            generalSettings
+	secret             secretSettings
+	caPool             *x509.CertPool
+	secretStoreBackend string
 }
 
 // NewSettings creates a builder that can then be used to configure and create a Settings object.
@@ -129,6 +130,12 @@ type CaFile struct {
 // false if the receiver is nil.
 func (s *Settings) Armed() bool {
 	return s != nil && s.general.Address != ""
+}
+
+// UsingFileSecretStore reports whether the most recent Save wrote secrets to the file-based fallback store
+// instead of the operating system keyring.
+func (s *Settings) UsingFileSecretStore() bool {
+	return s.secretStoreBackend == "file"
 }
 
 // Reset resets all settings to their zero values.
@@ -397,6 +404,7 @@ func (s *Settings) saveSecret(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create secret store: %w", err)
 	}
+	s.secretStoreBackend = store.Backend()
 	var object any
 	if s.secret != (secretSettings{}) {
 		object = &s.secret

--- a/fulfillment-service/internal/config/config_settings_test.go
+++ b/fulfillment-service/internal/config/config_settings_test.go
@@ -184,19 +184,9 @@ var _ = Describe("Settings", func() {
 	})
 
 	When("Keyring available", func() {
-		var originalKeychainAvailableFunc func() bool
-
 		BeforeEach(func() {
 			keyring.MockInit()
-		})
-
-		BeforeEach(func() {
-			originalKeychainAvailableFunc = keychainAvailableFunc
-			keychainAvailableFunc = func() bool { return true }
-		})
-
-		AfterEach(func() {
-			keychainAvailableFunc = originalKeychainAvailableFunc
+			pinKeychainAvailable(true)
 		})
 
 		It("Saves secrets in the keyring, not in the config file", func(ctx context.Context) {
@@ -267,21 +257,10 @@ var _ = Describe("Settings", func() {
 	})
 
 	When("Keyring is not available", func() {
-		var originalKeychainAvailableFunc func() bool
-
 		BeforeEach(func() {
 			keyring.MockInitWithError(fmt.Errorf("keyring backend not available"))
-		})
-
-		// Pin the gate to "available" so these assertions exercise the mocked keyring-probe fallback path they're
-		// actually testing, not an accidental gate short-circuit on a darwin machine with no default keychain.
-		BeforeEach(func() {
-			originalKeychainAvailableFunc = keychainAvailableFunc
-			keychainAvailableFunc = func() bool { return true }
-		})
-
-		AfterEach(func() {
-			keychainAvailableFunc = originalKeychainAvailableFunc
+			// Pinned to "available" so this exercises the mocked keyring-probe fallback, not a darwin gate short-circuit.
+			pinKeychainAvailable(true)
 		})
 
 		It("Saves secrets in the secrets file, not in the keyring", func(ctx context.Context) {

--- a/fulfillment-service/internal/config/config_settings_test.go
+++ b/fulfillment-service/internal/config/config_settings_test.go
@@ -267,8 +267,21 @@ var _ = Describe("Settings", func() {
 	})
 
 	When("Keyring is not available", func() {
+		var originalKeychainAvailableFunc func() bool
+
 		BeforeEach(func() {
 			keyring.MockInitWithError(fmt.Errorf("keyring backend not available"))
+		})
+
+		// Pin the gate to "available" so these assertions exercise the mocked keyring-probe fallback path they're
+		// actually testing, not an accidental gate short-circuit on a darwin machine with no default keychain.
+		BeforeEach(func() {
+			originalKeychainAvailableFunc = keychainAvailableFunc
+			keychainAvailableFunc = func() bool { return true }
+		})
+
+		AfterEach(func() {
+			keychainAvailableFunc = originalKeychainAvailableFunc
 		})
 
 		It("Saves secrets in the secrets file, not in the keyring", func(ctx context.Context) {

--- a/fulfillment-service/internal/config/config_settings_test.go
+++ b/fulfillment-service/internal/config/config_settings_test.go
@@ -184,8 +184,19 @@ var _ = Describe("Settings", func() {
 	})
 
 	When("Keyring available", func() {
+		var originalKeychainAvailableFunc func() bool
+
 		BeforeEach(func() {
 			keyring.MockInit()
+		})
+
+		BeforeEach(func() {
+			originalKeychainAvailableFunc = keychainAvailableFunc
+			keychainAvailableFunc = func() bool { return true }
+		})
+
+		AfterEach(func() {
+			keychainAvailableFunc = originalKeychainAvailableFunc
 		})
 
 		It("Saves secrets in the keyring, not in the config file", func(ctx context.Context) {


### PR DESCRIPTION
## Summary
- Adds a `keychainAvailable()` gate to `SecretStoreBuilder.Build()` on macOS that detects an absent or locked default keychain and falls back to the existing file-based secret store, instead of risking a hang or an unexpected interactive password dialog (`keyring.Get` alone can't distinguish "no keychain backend" from "item not found" on macOS)
- Uses `security default-keychain` + `security unlock-keychain -p` for detection (non-interactive by design -- credentials supplied inline, so SecurityAgent is never consulted), adds darwin-only tests and a macOS CI job, and surfaces a CLI warning when secrets land in the file fallback
- Resolves [OSAC-3735](https://redhat.atlassian.net/browse/OSAC-3735) at the root cause (`SecretStoreBuilder.Build()`'s probe) rather than the workarounds in #207 and #407, both left untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved secret storage selection by detecting unavailable macOS keychains and falling back to file-based storage.
  * Login now clearly warns when credentials are stored unencrypted in the configuration directory.
* **Bug Fixes**
  * Added safeguards for missing, locked, failing, or unresponsive macOS keychains.
* **Tests**
  * Added comprehensive macOS keychain and fallback coverage.
  * Added automated testing on macOS for keychain-related scenarios.
* **Documentation**
  * Documented platform-specific keychain test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->