### PR TITLE
OSAC-4257: pass tenant in vendor CSI secrets for VAST TENANT_ADMIN auth

### DIFF
--- a/osac-operator/internal/controller/vast_vendor_provisioner.go
+++ b/osac-operator/internal/controller/vast_vendor_provisioner.go
@@ -166,6 +166,11 @@ func (p *VastVendorProvisioner) CreateVolume(ctx context.Context, req VendorCrea
 			"username": creds.username,
 			"password": creds.password,
 			"endpoint": creds.vastEndpoint,
+			// tenant scopes auth to the tenant's VMS view: the VAST CSI driver
+			// sends it as the X-Tenant-Name header, which VMS requires to
+			// authenticate a TENANT_ADMIN manager on /api/token/ (a per-tenant
+			// manager cannot authenticate without it — VMS returns 401).
+			"tenant": req.Tenant,
 		},
 	}
 	creds.applyVipPool(csiReq.Parameters)
@@ -211,6 +216,11 @@ func (p *VastVendorProvisioner) DeleteVolume(ctx context.Context, req VendorDele
 			"username": creds.username,
 			"password": creds.password,
 			"endpoint": creds.vastEndpoint,
+			// tenant scopes auth to the tenant's VMS view: the VAST CSI driver
+			// sends it as the X-Tenant-Name header, which VMS requires to
+			// authenticate a TENANT_ADMIN manager on /api/token/ (a per-tenant
+			// manager cannot authenticate without it — VMS returns 401).
+			"tenant": req.Tenant,
 		},
 	})
 	if err != nil {

--- a/osac-operator/internal/controller/vast_vendor_provisioner_test.go
+++ b/osac-operator/internal/controller/vast_vendor_provisioner_test.go
@@ -128,6 +128,12 @@ func TestCreateVolumeBlockSuccess(t *testing.T) {
 	if got := req.GetSecrets()["endpoint"]; got != "vms.example.com" {
 		t.Errorf("secrets.endpoint = %q, want vms.example.com", got)
 	}
+	// The tenant secret is required: the VAST CSI driver maps it to the
+	// X-Tenant-Name header, without which a per-tenant TENANT_ADMIN manager
+	// cannot authenticate to VMS (401).
+	if got := req.GetSecrets()["tenant"]; got != "acme" {
+		t.Errorf("secrets.tenant = %q, want acme", got)
+	}
 	if got := req.GetCapacityRange().GetRequiredBytes(); got != 10*bytesPerGiB {
 		t.Errorf("required_bytes = %d, want %d", got, int64(10)*bytesPerGiB)
 	}
@@ -210,6 +216,9 @@ func TestDeleteVolumeSuccess(t *testing.T) {
 	}
 	if cli.deleteReq.GetSecrets()["username"] != "osac-acme" {
 		t.Errorf("delete secrets.username = %q", cli.deleteReq.GetSecrets()["username"])
+	}
+	if got := cli.deleteReq.GetSecrets()["tenant"]; got != "acme" {
+		t.Errorf("delete secrets.tenant = %q, want acme", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

**[OSAC-4257](https://redhat.atlassian.net/browse/OSAC-4257):** The osac-operator's `VastVendorProvisioner` omitted the `tenant` key in the CSI `secrets` it sends to the VAST CSI controller, so per-tenant `TENANT_ADMIN` authentication to VMS failed with `401` and block volume provisioning never worked against a real VAST tenant. This adds `"tenant": req.Tenant` to the `Secrets` map in both `CreateVolume` and `DeleteVolume`.

## Why

The VAST CSI driver maps `secrets["tenant"]` to the `X-Tenant-Name` header on the VMS `/api/token/` request, which VMS **requires** to authenticate a per-tenant `TENANT_ADMIN` manager. Without it, every provision failed:

```
vendor CreateVolume ... /api/v1/token/ {"detail":"Authentication failure, user: osac-tenant-<tenant>"} <Unauthorized(401)>
```

This blocked the OSAC Storage Control Plane ([OSAC-2872](https://redhat.atlassian.net/browse/OSAC-2872)) end to end. The `tenant` key mirrors what the StorageClass-path CSI secret (created during onboarding) already carries.

## Testing

- `make fmt` clean, `make lint` → 0 issues, `make test` passes (controller package incl. new assertions).
- Added regression tests asserting the `tenant` secret is present on both the CreateVolume and DeleteVolume vendor requests.
- Validated end to end on real VAST (se-lab caas-sean1): block volume **create + delete** via both the private Volume API and the OSAC CSI PVC path — VAST volume created and removed — succeeded once this fix was deployed (previously 401).

## Related (found during [OSAC-2872](https://redhat.atlassian.net/browse/OSAC-2872) e2e, not in this PR)

Deployment/design gaps filed separately: [OSAC-4258](https://redhat.atlassian.net/browse/OSAC-4258) (hub-access RBAC on volumes/status), [OSAC-4259](https://redhat.atlassian.net/browse/OSAC-4259) (Volume provisioning race), [OSAC-4260](https://redhat.atlassian.net/browse/OSAC-4260) (block VIP pool tenant-scoping), [OSAC-4261](https://redhat.atlassian.net/browse/OSAC-4261) (CSI driver fulfillment wiring + Keycloak client), [OSAC-4262](https://redhat.atlassian.net/browse/OSAC-4262) (vast-csi vendor controller plugin/mode).

## Ticket

[OSAC-4257](https://redhat.atlassian.net/browse/OSAC-4257) (part of [OSAC-2872](https://redhat.atlassian.net/browse/OSAC-2872) — OSAC Storage Control Plane)

<br>
<small>Assisted-by: Claude Code <noreply@anthropic.com></small>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant-specific volume provisioning and deletion by including the appropriate tenant context in storage requests.
  * Ensures authentication is correctly scoped when working with tenant volumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->