### PR TITLE
OSAC-4260: VAST per-tenant VIP pool by convention with gated self-create

### DIFF
--- a/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/defaults/main.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/defaults/main.yaml
@@ -28,13 +28,28 @@ vast_storage_validate_certs: "{{ lookup('env', 'VAST_VALIDATE_CERTS') | default(
 # API timeout (seconds) passed to the vastdata.vms modules via the vms: connection dict.
 vast_storage_api_timeout: 30
 
-# Shared VIP pool configuration — one pool for all tenants.
-# Tenant isolation relies on source-based access control, not per-pool separation.
-# The pool is created idempotently during the first tenant setup.
-vast_storage_vip_pool_name: "{{ lookup('env', 'VAST_VIP_POOL_NAME') | default('osac-shared', true) }}"
+# Per-tenant VIP pool, referenced by CONVENTION: osac-<tenant>-vippool.
+# OSAC reuses the pool if it already exists (pre-created by the cloud admin or a
+# prior run). If it is missing and vast_storage_vip_pool_supernet is set, OSAC
+# self-creates a dedicated pool owned by the tenant with a carved IP slice; if
+# missing and no supernet is set, onboarding fails with pre-create instructions.
+# For block/NVMe the CSI TENANT_ADMIN resolves the pool by name, so it must exist
+# and be tenant-visible (OSAC-4260). setup.yaml sets this name per tenant; the
+# default documents the convention.
+vast_storage_vip_pool_name: "osac-{{ tenant_name }}-vippool"
+
+# Optional DNS-based VIP resolution: when set, StorageClasses use vip_pool_fqdn
+# instead of vip_pool_name.
 vast_storage_vip_pool_fqdn: "{{ lookup('env', 'VAST_VIP_POOL_FQDN') | default('', true) }}"
-vast_storage_vip_pool_ip_ranges: "{{ lookup('env', 'VAST_VIP_POOL_IP_RANGES') | default('', true) }}"
-vast_storage_vip_pool_subnet_cidr: "{{ lookup('env', 'VAST_VIP_POOL_SUBNET_CIDR') | default('', true) }}"
+
+# Supernet for self-creating dedicated per-tenant VIP pools (optional). When set,
+# tenant N (by VAST tenant_id) gets vast_storage_vip_pool_slice_size addresses at
+# offset tenant_id * slice_size within this supernet. Must be a real routable
+# range on the VAST data network. Leave empty to require pre-created pools.
+vast_storage_vip_pool_supernet: "{{ lookup('env', 'VAST_VIP_POOL_SUPERNET') | default('', true) }}"
+vast_storage_vip_pool_slice_size: "{{ lookup('env', 'VAST_VIP_POOL_SLICE_SIZE') | default('4', true) | int }}"
+
+# Optional gateway IPs applied to self-created VIP pools.
 vast_storage_vip_pool_gw_ip: "{{ lookup('env', 'VAST_VIP_POOL_GW_IP') | default('', true) }}"
 vast_storage_vip_pool_gw_ipv6: "{{ lookup('env', 'VAST_VIP_POOL_GW_IPV6') | default('', true) }}"
 

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -4,12 +4,24 @@
 # Persists tenant config + credentials to hub Secret.
 # Hub Secret write is INSIDE the block so rescue can clean up the user on failure.
 #
-# VIP pool: Uses a globally-shared pool (vast_storage_vip_pool_name) instead of
-# per-tenant pools. The pool is created idempotently on the first tenant setup
-# using VAST_VIP_POOL_IP_RANGES and VAST_VIP_POOL_SUBNET_CIDR from the IG ConfigMap.
-# Tenant isolation relies on source-based access control.
-# Limitation: All tenants share the same pool IP addresses. For dedicated
-# per-tenant IPs, future work could add IP range allocation from an IPAM source.
+# VIP pool: per-tenant pool referenced by CONVENTION — osac-<tenant>-vippool.
+#   - If the pool already exists (pre-created by the cloud admin or a prior run),
+#     OSAC reuses it — works even when the admin credentials lack VIP-pool write
+#     access.
+#   - If it is missing AND vast_storage_vip_pool_supernet is set, OSAC
+#     self-creates a dedicated pool owned by this tenant (tenant_id) with a
+#     deterministic IP slice carved from the supernet by VAST tenant_id.
+#   - If it is missing and no supernet is set, onboarding fails with pre-create
+#     instructions.
+# For block/NVMe the CSI TENANT_ADMIN resolves the pool by name via
+# GET /vippools/, so it must exist and be tenant-visible; a missing or
+# wrong-owned pool is the OSAC-4260 attach failure. The existence check runs
+# before tenant creation (fail fast); the actual create runs after, since a
+# tenant-owned pool needs the tenant's VAST id.
+# KNOWN LIMITATION (follow-up): a self-created dedicated pool is NOT deleted on
+# teardown/rollback, so the pool and its carved IP slice leak until addressed.
+# Fix by recording a vip_pool_self_created flag in the hub Secret and deleting
+# the pool by name on teardown only when self-created (never a pre-created pool).
 
 - name: Assert _provider_tiers is defined and non-empty
   ansible.builtin.assert:
@@ -69,27 +81,15 @@
           timeout: "{{ vast_storage_api_timeout }}"
       no_log: true
 
-    - name: Validate VIP pool IP ranges are configured
-      ansible.builtin.fail:
-        msg: >-
-          VAST_VIP_POOL_IP_RANGES must be set in the storage-operations-ig ConfigMap.
-          Example: '[["10.0.100.10","10.0.100.50"]]' (JSON array of [start, end] pairs).
-      when: vast_storage_vip_pool_ip_ranges | length == 0
-
-    - name: Validate VIP pool subnet CIDR is configured
-      ansible.builtin.fail:
-        msg: >-
-          VAST_VIP_POOL_SUBNET_CIDR must be set in the storage-operations-ig ConfigMap.
-          This is the subnet prefix length (e.g., 24 for a /24 network).
-      when: vast_storage_vip_pool_subnet_cidr | string | length == 0
-
-    - name: Parse VIP pool IP ranges from JSON
+    # ── VIP pool existence check (fail fast, before creating the tenant) ──
+    # The tenant-owned create happens later (needs the VAST tenant id); here we
+    # only decide whether the conventional pool already exists and, if not,
+    # whether we are allowed to self-create it (supernet configured).
+    - name: Resolve the tenant's VIP pool name by convention
       ansible.builtin.set_fact:
-        _vast_vip_pool_ip_ranges: >-
-          {{ vast_storage_vip_pool_ip_ranges if (vast_storage_vip_pool_ip_ranges is not string)
-             else (vast_storage_vip_pool_ip_ranges | from_json) }}
+        vast_storage_vip_pool_name: "osac-{{ tenant_name }}-vippool"
 
-    - name: Look up existing VIP pools to find one matching the configured IP ranges
+    - name: Look up existing VIP pools
       ansible.builtin.uri:
         url: "https://{{ vast_endpoint }}/api/vippools/"
         method: GET
@@ -99,51 +99,30 @@
         validate_certs: "{{ vast_storage_validate_certs }}"
         timeout: "{{ vast_storage_api_timeout | int }}"
         status_code: [200]
-      register: _vast_vip_pool_lookup
+      register: _vast_vip_pool_check
       no_log: true
 
-    - name: Check if any existing pool matches the configured IP ranges
+    - name: Determine whether the conventional VIP pool already exists
       ansible.builtin.set_fact:
-        _vast_vip_pool_match: >-
-          {{ _vast_vip_pool_lookup.json
-             | selectattr('ip_ranges', 'equalto', _vast_vip_pool_ip_ranges)
-             | list | first | default({}) }}
+        _vast_vip_pool_present: >-
+          {{ (_vast_vip_pool_check.json
+              | selectattr('name', 'equalto', vast_storage_vip_pool_name)
+              | list | length) > 0 }}
 
-    - name: Use existing VIP pool when IP ranges match
-      when: _vast_vip_pool_match | length > 0
-      block:
-        - name: Override VIP pool name to match existing pool
-          ansible.builtin.set_fact:
-            vast_storage_vip_pool_name: "{{ _vast_vip_pool_match.name }}"
-
-        - name: Log existing VIP pool reuse
-          ansible.builtin.debug:
-            msg: "Found existing VIP pool '{{ vast_storage_vip_pool_name }}' (id: {{ _vast_vip_pool_match.id }}) with matching IP ranges — reusing."
-
-    - name: Create shared VIP pool when no match exists
-      when: _vast_vip_pool_match | length == 0
-      block:
-        - name: Create VIP pool with configured name and ranges
-          vastdata.vms.vippools:
-            vms:
-              host: "{{ vast_endpoint }}"
-              username: "{{ vast_username }}"
-              password: "{{ vast_password }}"
-              validate_certs: "{{ vast_storage_validate_certs }}"
-              timeout: "{{ vast_storage_api_timeout }}"
-            name: "{{ vast_storage_vip_pool_name }}"
-            ip_ranges: "{{ _vast_vip_pool_ip_ranges }}"
-            subnet_cidr: "{{ vast_storage_vip_pool_subnet_cidr | int }}"
-            gw_ip: "{{ vast_storage_vip_pool_gw_ip if (vast_storage_vip_pool_gw_ip | default('') | length > 0) else omit }}"
-            gw_ipv6: "{{ vast_storage_vip_pool_gw_ipv6 if (vast_storage_vip_pool_gw_ipv6 | default('') | length > 0) else omit }}"
-            role: PROTOCOLS
-            state: present
-          register: _vast_vip_pool_result
-          no_log: true
-
-        - name: Log VIP pool creation
-          ansible.builtin.debug:
-            msg: "Created VIP pool '{{ vast_storage_vip_pool_name }}' (id: {{ _vast_vip_pool_result.vippools.id | default('unknown') }})"
+    - name: Require a pre-created pool or a supernet for self-creation
+      ansible.builtin.fail:
+        msg: >-
+          VIP pool '{{ vast_storage_vip_pool_name }}' does not exist and no
+          VAST_VIP_POOL_SUPERNET is configured for self-creation. Either set
+          VAST_VIP_POOL_SUPERNET (e.g. '10.100.0.0/22') in the storage-operations-ig
+          ConfigMap, or ask the cloud admin to pre-create a PROTOCOLS VIP pool named
+          '{{ vast_storage_vip_pool_name }}', owned by tenant '{{ tenant_name }}'
+          (or All-Tenants), with a routable IP range on the VAST data network.
+          Block/NVMe attach (ControllerPublishVolume) cannot resolve the pool until
+          it exists and is visible to the tenant.
+      when:
+        - not (_vast_vip_pool_present | bool)
+        - vast_storage_vip_pool_supernet | length == 0
 
     - name: Ensure VAST CSI Operator is installed
       ansible.builtin.include_tasks: ensure_csi_operator.yaml
@@ -258,6 +237,68 @@
         - name: Set tenant ID for downstream tasks
           ansible.builtin.set_fact:
             _vast_tenant_id: "{{ _vast_tenant_result.tenants.id | string }}"
+
+        # ── Self-create the tenant's dedicated VIP pool when it is missing ──
+        # Only runs when the pool did not already exist (checked pre-tenant). The
+        # pre-tenant gate guarantees a supernet is configured when we reach here.
+        - name: Create the tenant's dedicated VIP pool when absent
+          when: not (_vast_vip_pool_present | bool)
+          block:
+            - name: Carve a deterministic per-tenant slice from the supernet by VAST tenant_id
+              ansible.builtin.set_fact:
+                _vast_vip_slice_start: >-
+                  {{ vast_storage_vip_pool_supernet | ansible.utils.ipaddr('network')
+                     | ansible.utils.ipmath((_vast_tenant_id | int) * (vast_storage_vip_pool_slice_size | int)) }}
+
+            - name: Compute the per-tenant slice end
+              ansible.builtin.set_fact:
+                _vast_vip_slice_end: >-
+                  {{ _vast_vip_slice_start
+                     | ansible.utils.ipmath((vast_storage_vip_pool_slice_size | int) - 1) }}
+
+            - name: Fail when the carved slice overflows the supernet
+              ansible.builtin.fail:
+                msg: >-
+                  Per-tenant VIP slice [{{ _vast_vip_slice_start }}..{{ _vast_vip_slice_end }}]
+                  for VAST tenant_id {{ _vast_tenant_id }} exceeds supernet
+                  {{ vast_storage_vip_pool_supernet }}. Enlarge VAST_VIP_POOL_SUPERNET or
+                  reduce VAST_VIP_POOL_SLICE_SIZE.
+              when: >-
+                (_vast_vip_slice_end | ansible.utils.ipaddr('int'))
+                > (vast_storage_vip_pool_supernet | ansible.utils.ipaddr('last_usable') | ansible.utils.ipaddr('int'))
+
+            - name: Create the dedicated per-tenant VIP pool (falls back to pre-create on permission denial)
+              block:
+                - name: Create dedicated VIP pool owned by the tenant
+                  vastdata.vms.vippools:
+                    vms: "{{ _vast_vms_conn }}"
+                    name: "{{ vast_storage_vip_pool_name }}"
+                    tenant_id: "{{ _vast_tenant_id | int }}"
+                    ip_ranges: [["{{ _vast_vip_slice_start }}", "{{ _vast_vip_slice_end }}"]]
+                    subnet_cidr: "{{ vast_storage_vip_pool_supernet | ansible.utils.ipaddr('prefix') | int }}"
+                    gw_ip: "{{ vast_storage_vip_pool_gw_ip if (vast_storage_vip_pool_gw_ip | default('') | length > 0) else omit }}"
+                    gw_ipv6: "{{ vast_storage_vip_pool_gw_ipv6 if (vast_storage_vip_pool_gw_ipv6 | default('') | length > 0) else omit }}"
+                    role: PROTOCOLS
+                    state: present
+                  register: _vast_vip_pool_result
+                  no_log: true
+
+                - name: Log VIP pool creation
+                  ansible.builtin.debug:
+                    msg: >-
+                      Created dedicated VIP pool '{{ vast_storage_vip_pool_name }}'
+                      (tenant_id {{ _vast_tenant_id }}, range
+                      {{ _vast_vip_slice_start }}..{{ _vast_vip_slice_end }}).
+              rescue:
+                - name: Fail with pre-create instructions when VIP pool creation is not permitted
+                  ansible.builtin.fail:
+                    msg: >-
+                      Could not create VIP pool '{{ vast_storage_vip_pool_name }}'
+                      ({{ ansible_failed_result.msg | default('permission denied') }}).
+                      If the admin credentials lack VIP-pool write access, ask the cloud
+                      admin to pre-create a PROTOCOLS pool named
+                      '{{ vast_storage_vip_pool_name }}', owned by tenant '{{ tenant_name }}'
+                      (or All-Tenants), with a routable IP range on the VAST data network.
 
         - name: Configure tenant client IP ranges for shared VIP pool NFS access
           block:
@@ -465,8 +506,11 @@
         _vast_lp_create_result: {}
         _vast_client_ip_ranges: []
         _vast_node_list: {}
-        _vast_vip_pool_lookup: {}
-        _vast_vip_pool_match: {}
+        _vast_vip_pool_check: {}
+        _vast_vip_pool_present: false
+        _vast_vip_slice_start: ""
+        _vast_vip_slice_end: ""
+        _vast_vip_pool_result: {}
       no_log: true
 
 - name: Set storage_provider_tenant_config output fact

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -89,9 +89,11 @@
       ansible.builtin.set_fact:
         vast_storage_vip_pool_name: "osac-{{ tenant_name }}-vippool"
 
-    - name: Look up existing VIP pools
+    # Server-side name filter keeps this O(1) as per-tenant pools grow with
+    # tenant count (mirrors the ?name= lookups for tenants/localproviders below).
+    - name: Look up the conventional VIP pool by name
       ansible.builtin.uri:
-        url: "https://{{ vast_endpoint }}/api/vippools/"
+        url: "https://{{ vast_endpoint }}/api/vippools/?name={{ vast_storage_vip_pool_name }}"
         method: GET
         url_username: "{{ vast_username }}"
         url_password: "{{ vast_password }}"
@@ -102,12 +104,20 @@
       register: _vast_vip_pool_check
       no_log: true
 
-    - name: Determine whether the conventional VIP pool already exists
+    # Re-check the exact name client-side too: ?name= may match as a substring
+    # on some VAST versions, and the filtered list is now small either way.
+    # Capture the matched pool so its ownership can be verified after the tenant
+    # id is known (a wrong-owned pool with the conventional name is OSAC-4260).
+    - name: Capture the matched pre-existing VIP pool (if any)
       ansible.builtin.set_fact:
-        _vast_vip_pool_present: >-
-          {{ (_vast_vip_pool_check.json
-              | selectattr('name', 'equalto', vast_storage_vip_pool_name)
-              | list | length) > 0 }}
+        _vast_vip_pool_existing: >-
+          {{ _vast_vip_pool_check.json
+             | selectattr('name', 'equalto', vast_storage_vip_pool_name)
+             | list | first | default({}) }}
+
+    - name: Record whether the conventional VIP pool already exists
+      ansible.builtin.set_fact:
+        _vast_vip_pool_present: "{{ _vast_vip_pool_existing | length > 0 }}"
 
     - name: Require a pre-created pool or a supernet for self-creation
       ansible.builtin.fail:
@@ -237,6 +247,25 @@
         - name: Set tenant ID for downstream tasks
           ansible.builtin.set_fact:
             _vast_tenant_id: "{{ _vast_tenant_result.tenants.id | string }}"
+
+        # A pre-existing pool with the conventional name must be owned by this
+        # tenant (or All-Tenants), or a block TENANT_ADMIN still can't resolve
+        # it — the exact OSAC-4260 failure. Reject a wrong-owned pool instead of
+        # silently adopting it.
+        - name: Verify a pre-existing VIP pool is owned by this tenant (or All-Tenants)
+          ansible.builtin.fail:
+            msg: >-
+              VIP pool '{{ vast_storage_vip_pool_name }}' already exists but is owned by
+              VAST tenant_id {{ _vast_vip_pool_existing.tenant_id | default('unknown') }},
+              which is neither this tenant ({{ _vast_tenant_id }}) nor All-Tenants. A
+              block/NVMe TENANT_ADMIN cannot resolve a pool owned by another tenant
+              (the OSAC-4260 failure mode). Re-create it owned by tenant
+              '{{ tenant_name }}' or as All-Tenants.
+          when:
+            - _vast_vip_pool_present | bool
+            - _vast_vip_pool_existing.tenant_id is defined
+            - _vast_vip_pool_existing.tenant_id is not none
+            - (_vast_vip_pool_existing.tenant_id | int) != (_vast_tenant_id | int)
 
         # ── Self-create the tenant's dedicated VIP pool when it is missing ──
         # Only runs when the pool did not already exist (checked pre-tenant). The
@@ -507,6 +536,7 @@
         _vast_client_ip_ranges: []
         _vast_node_list: {}
         _vast_vip_pool_check: {}
+        _vast_vip_pool_existing: {}
         _vast_vip_pool_present: false
         _vast_vip_slice_start: ""
         _vast_vip_slice_end: ""

--- a/osac-aap/config/base/configmap-storage-operations-ig-example.yaml
+++ b/osac-aap/config/base/configmap-storage-operations-ig-example.yaml
@@ -16,7 +16,15 @@ data:
   # Set to "false" for self-signed certificates in dev/test environments.
   # VAST_VALIDATE_CERTS: "true"
 
-  # Gateway IP for cross-subnet VIP routing (optional).
+  # Per-tenant VIP pool (osac-<tenant>-vippool). OSAC reuses the pool if it already
+  # exists (pre-created by the cloud admin). To let OSAC self-create a dedicated pool
+  # per tenant when missing, set a routable supernet on the VAST data network; each
+  # tenant gets a slice of VAST_VIP_POOL_SLICE_SIZE addresses (default 4) at offset
+  # tenant_id * slice_size. Leave the supernet empty to require pre-created pools.
+  # VAST_VIP_POOL_SUPERNET: "10.100.0.0/22"
+  # VAST_VIP_POOL_SLICE_SIZE: "4"
+
+  # Gateway IP applied to self-created VIP pools (optional).
   # VAST_VIP_POOL_GW_IP: ""
   # VAST_VIP_POOL_GW_IPV6: ""
 

--- a/osac-aap/tests/integration/integration_config.yml.template
+++ b/osac-aap/tests/integration/integration_config.yml.template
@@ -39,10 +39,8 @@ vast_tenant_prefix: "osac-test-"
 # TLS validation — set to false for mock server or self-signed cert testing
 vast_validate_certs: ${VAST_VALIDATE_CERTS}
 
-# Shared VIP pool configuration
-vast_vip_pool_name: "${VAST_VIP_POOL_NAME}"
-vast_vip_pool_ip_ranges: '${VAST_VIP_POOL_IP_RANGES}'
-vast_vip_pool_subnet_cidr: ${VAST_VIP_POOL_SUBNET_CIDR}
+# Per-tenant VIP pool configuration (supernet for self-created dedicated pools)
+vast_vip_pool_supernet: "${VAST_VIP_POOL_SUPERNET}"
 
 # Storage tier definitions — JSON array with per-tier provider selection and backend_id,
 # matching the storage_provider_tiers/osac_job_vars.storage_tier_definitions shape.

--- a/osac-aap/tests/integration/setup_test_env.sh
+++ b/osac-aap/tests/integration/setup_test_env.sh
@@ -173,9 +173,7 @@ CSIEOF
   # so the playbook_dir-based default doesn't resolve correctly.
   REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
   cat > "${SCRIPT_DIR}/.storage_env" <<ENVEOF
-export VAST_VIP_POOL_NAME="osac-test-pool"
-export VAST_VIP_POOL_IP_RANGES='[["10.0.0.10","10.0.0.50"]]'
-export VAST_VIP_POOL_SUBNET_CIDR="24"
+export VAST_VIP_POOL_SUPERNET="10.0.0.0/24"
 export VAST_VALIDATE_CERTS="false"
 export OSAC_CSI_BACKENDS_CHART_REF="${REPO_ROOT}/../osac-csi-driver/charts/csi-backends"
 ENVEOF

--- a/osac-aap/tests/integration/targets/storage_provider_onboarding/tasks/main.yml
+++ b/osac-aap/tests/integration/targets/storage_provider_onboarding/tasks/main.yml
@@ -52,9 +52,7 @@
   gather_facts: false
 
   environment:
-    VAST_VIP_POOL_NAME: "osac-test-pool"
-    VAST_VIP_POOL_IP_RANGES: '[["10.0.0.10","10.0.0.50"]]'
-    VAST_VIP_POOL_SUBNET_CIDR: "24"
+    VAST_VIP_POOL_SUPERNET: "10.0.0.0/24"
     OSAC_STORAGE_CONFIG_NAMESPACE: "osac-system"
 
   vars:
@@ -135,7 +133,7 @@
     - name: Assert StorageClass parameters
       ansible.builtin.assert:
         that:
-          - _sc_result.resources[0].parameters.vip_pool_name == "osac-test-pool"
+          - _sc_result.resources[0].parameters.vip_pool_name == "osac-test-onboard-vippool"
           - _sc_result.resources[0].parameters.root_export == "/osac-test-onboard-d0f7f176/default"
           - "_sc_result.resources[0].parameters['csi.storage.k8s.io/provisioner-secret-name'] == 'vast-csi-test-onboard'"
           - "_sc_result.resources[0].parameters['csi.storage.k8s.io/provisioner-secret-namespace'] == 'osac-system'"

--- a/osac-aap/tests/integration/targets/storage_provider_setup/tasks/main.yml
+++ b/osac-aap/tests/integration/targets/storage_provider_setup/tasks/main.yml
@@ -9,9 +9,7 @@
   gather_facts: false
 
   environment:
-    VAST_VIP_POOL_NAME: "osac-test-pool"
-    VAST_VIP_POOL_IP_RANGES: '[["10.0.0.10","10.0.0.50"]]'
-    VAST_VIP_POOL_SUBNET_CIDR: "24"
+    VAST_VIP_POOL_SUPERNET: "10.0.0.0/24"
     OSAC_STORAGE_CONFIG_NAMESPACE: "osac-system"
 
   vars:
@@ -135,8 +133,8 @@
     - name: Assert hub Secret has VIP pool name
       ansible.builtin.assert:
         that:
-          - _secret_data.vip_pool_name == "osac-test-pool"
-        fail_msg: "Expected vip_pool_name 'osac-test-pool', got '{{ _secret_data.vip_pool_name }}'"
+          - _secret_data.vip_pool_name == "osac-test-setup-vippool"
+        fail_msg: "Expected vip_pool_name 'osac-test-setup-vippool', got '{{ _secret_data.vip_pool_name }}'"
         success_msg: "vip_pool_name correct"
 
     - name: Assert hub Secret has endpoint
@@ -175,7 +173,7 @@
           - storage_provider_tenant_configs is mapping
           - "'vast' in storage_provider_tenant_configs"
           - storage_provider_tenant_configs.vast.vast_tenant_id is defined
-          - storage_provider_tenant_configs.vast.vip_pool_name == "osac-test-pool"
+          - storage_provider_tenant_configs.vast.vip_pool_name == "osac-test-setup-vippool"
         fail_msg: "storage_provider_tenant_configs output not set correctly: {{ storage_provider_tenant_configs | default('undefined') }}"
         success_msg: "storage_provider_tenant_configs output correct"
 

--- a/osac-aap/tests/integration/targets/storage_provider_setup_rollback/tasks/main.yml
+++ b/osac-aap/tests/integration/targets/storage_provider_setup_rollback/tasks/main.yml
@@ -39,9 +39,7 @@
   gather_facts: false
 
   environment:
-    VAST_VIP_POOL_NAME: "osac-test-pool"
-    VAST_VIP_POOL_IP_RANGES: '[["10.0.0.10","10.0.0.50"]]'
-    VAST_VIP_POOL_SUBNET_CIDR: "24"
+    VAST_VIP_POOL_SUPERNET: "10.0.0.0/24"
     OSAC_STORAGE_CONFIG_NAMESPACE: "osac-system"
 
   vars:


### PR DESCRIPTION
## Summary
- Block/NVMe `ControllerPublishVolume` failed with `No 'vippool' found for params {name: osac-shared}` for non-default tenants: the shared `osac-shared` pool was owned by the default tenant (`tenant_id=1`), so a per-tenant `TENANT_ADMIN` couldn't resolve it by name via `GET /vippools/`. (NFS works because it resolves the tenant by client source IP; block resolves the pool by tenant ownership.)
- Replaces the single shared pool with a **per-tenant pool referenced by convention** — `osac-<tenant>-vippool` — in the `vast_storage` onboarding role:
  - **Exists** → reuse it (works even when admin creds lack VIP-pool write access), after verifying it's owned by this tenant (or All-Tenants).
  - **Missing + `VAST_VIP_POOL_SUPERNET` set** → self-create a dedicated tenant-owned pool, carving a deterministic IP slice from the supernet by VAST `tenant_id`; a permission failure falls back to pre-create instructions.
  - **Missing + no supernet** → fail fast with pre-create instructions for the cloud admin.
- `defaults`: drop `vip_pool_ip_ranges`/`subnet_cidr`; add `vip_pool_supernet` + `vip_pool_slice_size`; `vip_pool_name` is now the convention. Documented the new knobs in the `storage-operations-ig` ConfigMap example.

## Design notes
- **Convention over configuration** so onboarding still works when admin credentials lose write access to VIP pools / tenant resources — OSAC references a pre-created pool by name, and only self-creates when a supernet is configured.
- The existence check runs *before* tenant creation (fail fast); the actual create runs *after*, since a tenant-owned pool needs the tenant's VAST id.
- **Known limitation (follow-up, noted in `setup.yaml`):** a self-created pool is not yet deleted on teardown/rollback, so the pool and its carved IP slice leak. To be addressed via a `vip_pool_self_created` flag in the hub Secret + name-based deletion on teardown (never deleting a pre-created pool).

## Jira
https://redhat.atlassian.net/browse/OSAC-4260

## Test plan
- [x] `ansible-lint` on the `vast_storage` role passes at the `production` profile
- [x] YAML parses; pre-commit (yamllint, secret scan) passes
- [x] Pre-flight review gate (performance + security) PASS
- [ ] CI `integration-tests` (`STORAGE_TESTS_ENABLED=true`) — storage_provider setup/onboarding/rollback targets updated to the supernet + conventional pool names (self-create path against the mock VMS server)
- [ ] Real-VAST validation: onboarded tenant resolves `osac-<tenant>-vippool`; `ControllerPublishVolume` succeeds; block PVC attaches (requires a routable range on the VAST data network)

---

_This PR description was drafted with AI assistance ([create-pr](https://github.com/osac-project/osac-workspace/tree/main/skills/create-pr) v0.1.3). Review for accuracy_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic per-tenant VAST VIP pool naming using the `osac-<tenant>-vippool` convention.
  - Added optional self-provisioning from a configured address supernet, including configurable per-tenant address slices and gateway settings.
  - Existing VIP pools can still be used when self-provisioning is not configured.

- **Documentation**
  - Clarified VIP pool self-provisioning and gateway configuration in example settings.

- **Tests**
  - Updated integration coverage for per-tenant VIP pool names and supernet-based configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->