### PR TITLE
OSAC-4262: run VAST vendor controller with block plugin in controller mode

### DIFF
--- a/osac-csi-driver/charts/csi-backends/README.md
+++ b/osac-csi-driver/charts/csi-backends/README.md
@@ -62,10 +62,20 @@ Values:
 vast:
   enabled: true
   config:
+    plugin: block          # block (raw-block) | csi (NFS/filesystem)
+    mode: controller       # controller (controller-only) | controller_and_node
     vmsHost: "<vms-management-ip>"
     vipPoolName: "<vip-pool>"
     credentialsSecret: vast-credentials
 ```
+
+The VAST driver serves a **single plugin per process**, so this controller
+handles one protocol at a time. It defaults to `block` (the current priority).
+NFS/filesystem needs its own separate deployment — and object storage likewise
+when it lands — rather than reconfiguring this one; those follow OSAC-4262. Use
+`mode: controller` for the vendor path: the operator issues only controller
+RPCs, so node-side NVMe probes (which require the host FS at `/host`) are
+skipped, avoiding the block plugin's CrashLoopBackOff under `controller_and_node`.
 
 ### Pure Storage
 

--- a/osac-csi-driver/charts/csi-backends/templates/vast-controller.yaml
+++ b/osac-csi-driver/charts/csi-backends/templates/vast-controller.yaml
@@ -35,8 +35,10 @@ spec:
       containers:
         - name: vast-csi
           image: "{{ .Values.vast.image.repository }}:{{ .Values.vast.image.tag }}"
-          args: ["serve"]
+          args: ["serve", "--plugin", {{ .Values.vast.config.plugin | quote }}]
           env:
+            - name: X_CSI_MODE
+              value: {{ .Values.vast.config.mode | quote }}
             - name: CSI_ENDPOINT
               value: "tcp://0.0.0.0:{{ .Values.vast.service.port }}"
             - name: X_CSI_VMS_HOST

--- a/osac-csi-driver/charts/csi-backends/values.yaml
+++ b/osac-csi-driver/charts/csi-backends/values.yaml
@@ -20,6 +20,19 @@ vast:
   service:
     port: 50051
   config:
+    # Vendor plugin this controller serves. VAST selects one plugin per process:
+    #   "block" -> raw-block (support_block=True)
+    #   "csi"   -> NFS/filesystem (support_block=False)
+    # Block is the priority; file/NFS (and object storage, later) need their own
+    # separate deployment rather than sharing this one. See OSAC-4262.
+    plugin: block
+    # X_CSI_MODE for the vendor controller:
+    #   "controller"           -> controller-only; the operator issues only
+    #                             controller RPCs, so node-side NVMe probes
+    #                             (which need the host FS at /host) are skipped.
+    #   "controller_and_node"  -> vendor default; crashes for the block plugin
+    #                             where /host is unavailable.
+    mode: controller
     vmsHost: ""
     vipPoolName: ""
     nfsExport: /k8s


### PR DESCRIPTION
## What

Make the `csi-backends` VAST vendor controller's **served plugin** and **`X_CSI_MODE`** Helm values, defaulting to the current priority — `plugin: block`, `mode: controller`.

Rendered result when `vast.enabled=true`:

```yaml
args: ["serve", "--plugin", "block"]
env:
  - name: X_CSI_MODE
    value: "controller"
```

## Why

The controller ran `serve`, which defaults to `--plugin csi` (filesystem, `support_block=False`) and rejects raw-block capabilities:

```
CreateVolume ... INVALID_ARGUMENT ... "block access type is not supported"
```

It also defaulted to `X_CSI_MODE=controller_and_node`, whose block-plugin startup runs node-side `try_nvme_probes()` needing the host FS at `/host` → CrashLoopBackOff. Controller-only mode is correct for the operator vendor path (it issues only controller RPCs), and avoids the `/host` requirement.

## Design note — one plugin per process

VAST serves a single plugin per process, so block and NFS/filesystem cannot share this controller. Block is the priority now; **NFS/filesystem — and object storage later — each get their own separate deployment** rather than reconfiguring this one. This PR makes the plugin/mode configurable so those follow-ups slot in cleanly (per-protocol controller + `--vendor-controllers` entry + tier resolution).

## Acceptance criteria ([OSAC-4262](https://redhat.atlassian.net/browse/OSAC-4262))

- [x] vast-csi vendor controller runs the block plugin in controller mode (no crash; accepts block volume capability)
- [x] operator vendor CreateVolume path no longer hits `"block access type is not supported"` (filesystem-plugin rejection removed)

## Testing

- `helm lint` passes
- `helm template --set vast.enabled=true` renders the expected `args`/`X_CSI_MODE`

Parent chart-ownership decision tracked in OSAC-4252.