### PR TITLE
OSAC-4236: Implement BCM GetHostNICs via BareMetalHost hardware details

### DIFF
--- a/bare-metal-fulfillment-operator/internal/baremetalhost/manager.go
+++ b/bare-metal-fulfillment-operator/internal/baremetalhost/manager.go
@@ -150,11 +150,15 @@ func (m *Manager) DeleteBMH(ctx context.Context, name string) error {
 // status.hardware.nics (Metal3 hardware inspection data). Returns nil when
 // the BMH has no hardware details or no NICs recorded.
 func (m *Manager) GetHardwareNICs(ctx context.Context, name string) ([]string, error) {
+	log := ctrllog.FromContext(ctx)
+
 	bmh := &metal3api.BareMetalHost{}
 	if err := m.client.Get(ctx, client.ObjectKey{Namespace: m.namespace, Name: name}, bmh); err != nil {
 		return nil, fmt.Errorf("failed to get BareMetalHost %s/%s: %w", m.namespace, name, err)
 	}
 	if bmh.Status.HardwareDetails == nil || len(bmh.Status.HardwareDetails.NIC) == 0 {
+		log.V(1).Info("BareMetalHost has no hardware NIC data",
+			"name", name, "namespace", m.namespace)
 		return nil, nil
 	}
 	macs := make([]string, 0, len(bmh.Status.HardwareDetails.NIC))
@@ -164,6 +168,9 @@ func (m *Manager) GetHardwareNICs(ctx context.Context, name string) ([]string, e
 		}
 		macs = append(macs, strings.ToLower(nic.MAC))
 	}
+
+	log.V(1).Info("Retrieved hardware NICs from BareMetalHost",
+		"name", name, "namespace", m.namespace, "count", len(macs))
 	return macs, nil
 }
 

--- a/bare-metal-fulfillment-operator/internal/inventory/bcm_test.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/bcm_test.go
@@ -700,6 +700,15 @@ var _ = Describe("BCM Inventory Adapter", func() {
 			Expect(nics).To(BeNil())
 		})
 
+		It("filters out NICs with empty MAC addresses", func() {
+			client := newClientWithNICs("node001", "AA:BB:CC:DD:EE:01", "", "FF:00:11:22:33:44")
+			nics, err := client.GetHostNICs(ctx, "osac-baremetal/node001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nics).To(HaveLen(2))
+			Expect(nics[0].MAC).To(Equal("aa:bb:cc:dd:ee:01"))
+			Expect(nics[1].MAC).To(Equal("ff:00:11:22:33:44"))
+		})
+
 		It("returns error for invalid inventoryHostID format", func() {
 			client := newClientNoBMH()
 			_, err := client.GetHostNICs(ctx, "no-slash")


### PR DESCRIPTION
## Summary

Implements `GetHostNICs` for the BCM inventory backend, completing NIC MAC address discovery for BCM-managed hosts (part of [OSAC-3254](https://redhat.atlassian.net/browse/OSAC-3254) / [OSAC-4200](https://redhat.atlassian.net/browse/OSAC-4200)).

- Reads NIC MAC addresses from the `BareMetalHost` CR hardware inspection data via `baremetalhost.Manager.GetHardwareNICs`, avoiding a costly BCM `GetDevices` round-trip
- Parses `inventoryHostID` using shared `ParseHostID` (consistent with all other callers)
- Filters empty MACs, lowercases all addresses
- Adds V(1) structured logging to `GetHardwareNICs` for consistency with other Manager methods
- Returns `nil, nil` when no NICs present (per `Client` interface contract for unsupported backends)

Supersedes #432 (Adrien's draft PR — he asked me to take over while he's on PTO until Sep 14).

**Depends on:** #410 (OSAC-4201, merged), #424 (OSAC-4203, merged), #428 (OSAC-4204, merged)

## Changes from #432

- Added V(1) structured logging to `GetHardwareNICs` (consistency with `CreateBMH`, `DeleteBMH`, `IsBMHReady`)
- Added test for empty-MAC filtering behavior

## Test plan

- [x] Unit tests pass (31/31 specs in BCM Inventory Adapter suite)
- [x] Integration tested `FindFreeHost` against real BCM 11.0 API (3 LiteNodes discovered)
- [x] Verified host ID format from real BCM is compatible with `ParseHostID` → `GetHostNICs` pipeline
- [ ] Full e2e with BCM backend on OpenShift (blocked on BCM dev environment setup on cluster)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hardware inventory results by excluding empty network interface MAC addresses and consistently returning valid MAC addresses in lowercase.
- **Reliability**
  - Added diagnostic logging for hardware network interface discovery, including cases where no interface data is available and the number of addresses retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->