### PR TITLE
OSAC-3327: Add CODEOWNERS protection for fullsend config files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,22 @@
+# CODEOWNERS
+#
+# This file defines code ownership for automated review assignment.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Patterns are evaluated top-to-bottom (last matching pattern takes precedence).
+
+# CODEOWNERS Self-Protection
+# Protects this file from unauthorized modification
+/CODEOWNERS @osac-project/wg-infra
+
+# fullsend Configuration Protection
+# Prevents pull_request_target misconfiguration and unauthorized workflow changes
+# per ADR-0033 security requirements.
+#
+# These files control CI/CD execution with access to repository secrets.
+# Changes require review from infrastructure team to prevent:
+# - Credential exfiltration via pull_request_target
+# - Unauthorized workflow modifications
+# - Accidental security regressions
+.github/workflows/fullsend.yaml @osac-project/wg-infra
+.fullsend/ @osac-project/wg-infra


### PR DESCRIPTION
Protects .github/workflows/fullsend.yaml and .fullsend/ directory from
unauthorized modification to prevent pull_request_target misconfiguration
    
Files protected:
 - /CODEOWNERS - Prevents removal of ownership rules
 - .github/workflows/fullsend.yaml - Workflow with pull_request_target and access to repository secrets
 - .fullsend/ - fullsend configuration and guidance documents
    
Owner: @osac-project/wg-infra
    
Security rationale:
 - pull_request_target workflows run with full repository access
 - Malicious modifications could exfiltrate credentials or secrets
 - Changes require infrastructure team review before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added documented ownership and review requirements for project automation and configuration.
  * Clarified security-focused review responsibilities for changes affecting continuous integration and delivery.
  * Established consistent approval expectations to help maintain the reliability and security of project workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->