### PR TITLE
fix: add osac-kafka to namespace wait lists

### DIFF
--- a/osac-installer/Makefile
+++ b/osac-installer/Makefile
@@ -136,7 +136,7 @@ ifeq ($(PLATFORM),kind)
 else
 	$(eval OCP_VERSION := $(shell oc get clusterversion version -o jsonpath='{.status.desired.version}' | cut -d. -f1,2))
 	@bash -c 'source scripts/lib.sh && \
-		for ns in ansible-aap cert-manager-operator cert-manager openshift-storage metallb-system multicluster-engine openshift-cnv; do \
+		for ns in ansible-aap cert-manager-operator cert-manager openshift-storage metallb-system multicluster-engine openshift-cnv osac-kafka; do \
 			wait_for_namespace_cleanup "$$ns"; \
 		done'
 	helm upgrade --install osac-deps $(DEPS_CHART) \

--- a/osac-installer/scripts/teardown.sh
+++ b/osac-installer/scripts/teardown.sh
@@ -273,7 +273,7 @@ if [[ "${MCE_SERVICE}" == "true" ]]; then
     done
 fi
 
-NS_WAIT_LIST=("${INSTALLER_NAMESPACE}" keycloak ansible-aap cert-manager cert-manager-operator)
+NS_WAIT_LIST=("${INSTALLER_NAMESPACE}" keycloak ansible-aap cert-manager cert-manager-operator osac-kafka)
 if [[ "${MCE_SERVICE}" == "true" ]]; then
     NS_WAIT_LIST+=(multicluster-engine hive hypershift local-cluster open-cluster-management-agent open-cluster-management-agent-addon open-cluster-management-global-set open-cluster-management-hub hardware-inventory)
 fi


### PR DESCRIPTION
The osac-operators Helm chart fails when osac-kafka is stuck in Terminating state from a previous teardown. Add osac-kafka to the wait-for-operators-namespaces loop in the Makefile and to the NS_WAIT_LIST in teardown.sh so both install and teardown handle this namespace.

Fixes: [OSAC-4190](https://redhat.atlassian.net/browse/OSAC-4190)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenShift infrastructure cleanup by waiting for the `osac-kafka` namespace to be removed.
  * Added force-finalization handling when deletion of this namespace times out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->