### PR TITLE
OSAC-4263: create k8s_only composite Ansible role

### DIFF
--- a/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/README.md
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/README.md
@@ -1,0 +1,55 @@
+# k8s_only
+
+Composite dispatch role for a k8s-only NetworkClass — one that has a `k8sManager`
+but no `fabricManager` (no separate physical fabric to bridge into).
+
+## Why this role exists
+
+The osac-operator dispatcher resolves every networking resource kind (VirtualNetwork,
+Subnet, SecurityGroup, ExternalIPPool, ExternalIP, ExternalIPAttachment) to a single
+manager name per NetworkClass, then triggers the matching AAP job template, which in
+turn calls `osac.templates.{{ implementation_strategy }}` for that one role. This means
+whichever role a k8sManager resolves to must expose an entrypoint for every resource
+kind it needs to handle — even when the actual implementation already exists elsewhere.
+
+`cudn_net` already does this for its own SecurityGroup entrypoints, delegating to the
+standalone `network_policy` role rather than re-implementing NetworkPolicy handling
+itself. `k8s_only` generalizes that same idea across every resource kind, so a
+k8s-only deployment doesn't need its own from-scratch implementation of anything —
+it composes the existing, independently-tested k8s-native roles:
+
+- **VirtualNetwork / Subnet** → `cudn_net` (ClusterUserDefinedNetwork)
+- **SecurityGroup** → `network_policy` (Kubernetes NetworkPolicy)
+- **ExternalIPPool / ExternalIP / ExternalIPAttachment** → `metallb_l2` (MetalLB L2 advertisement)
+
+## Task Files
+
+Every task file is a single `ansible.builtin.include_role` delegation — no logic of
+its own. Vars set by the calling playbook (`virtual_network`, `subnet`,
+`security_group`, `external_ip_pool`, `external_ip`, `external_ip_attachment`, and
+their `*_name` companions) flow through automatically since `include_role` inherits
+the calling scope.
+
+| Task file | Delegates to |
+|---|---|
+| `create_virtual_network.yaml` / `delete_virtual_network.yaml` | `osac.templates.cudn_net` |
+| `create_subnet.yaml` / `delete_subnet.yaml` | `osac.templates.cudn_net` |
+| `create_security_group.yaml` / `delete_security_group.yaml` | `osac.templates.network_policy` |
+| `create_external_ip_pool.yaml` / `delete_external_ip_pool.yaml` | `osac.templates.metallb_l2` |
+| `create_external_ip.yaml` / `delete_external_ip.yaml` | `osac.templates.metallb_l2` |
+| `attach_external_ip.yaml` / `detach_external_ip.yaml` | `osac.templates.metallb_l2` |
+
+## Not yet implemented
+
+**NATGateway** (`create_nat_gateway`/`delete_nat_gateway`) is not implemented by this
+role yet — it will be added by a follow-up ticket (OSAC-4265) once NATGateway support
+via an OVN EgressIP CR is validated.
+
+## Registration
+
+This role deliberately has no `meta/osac.yaml` — it is not independently selectable
+or auto-published as its own NetworkClass the way `cudn_net`/`network_policy`/
+`metallb_l2` are. Registering it as the `k8s-only` k8sManager (creating the
+NetworkClass and the labeled ConfigMap the osac-operator dispatcher reads to resolve
+`implementation_strategy: k8s_only`) happens outside this role — in E2E test
+environments and in production installs.

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/attach_external_ip.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/attach_external_ip.yaml
@@ -1,0 +1,8 @@
+---
+# k8s_only delegates ExternalIPAttachment creation to metallb_l2 (MetalLB
+# LoadBalancer Service binding). See README.md for the rationale.
+
+- name: Delegate ExternalIP attach to metallb_l2 role
+  ansible.builtin.include_role:
+    name: osac.templates.metallb_l2
+    tasks_from: attach_external_ip

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/create_external_ip.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/create_external_ip.yaml
@@ -1,0 +1,8 @@
+---
+# k8s_only delegates ExternalIP provisioning to metallb_l2 (MetalLB LoadBalancer
+# Service). See README.md for the rationale.
+
+- name: Delegate ExternalIP creation to metallb_l2 role
+  ansible.builtin.include_role:
+    name: osac.templates.metallb_l2
+    tasks_from: create_external_ip

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/create_external_ip_pool.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/create_external_ip_pool.yaml
@@ -1,0 +1,8 @@
+---
+# k8s_only delegates ExternalIPPool provisioning to metallb_l2 (MetalLB IPAddressPool
+# + L2Advertisement). See README.md for the rationale.
+
+- name: Delegate ExternalIPPool creation to metallb_l2 role
+  ansible.builtin.include_role:
+    name: osac.templates.metallb_l2
+    tasks_from: create_external_ip_pool

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/create_security_group.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/create_security_group.yaml
@@ -1,0 +1,9 @@
+---
+# k8s_only delegates SecurityGroup enforcement to the standalone network_policy
+# role (NetworkPolicy-based), which is reusable across any K8s-based NetworkClass.
+# See README.md for the rationale.
+
+- name: Delegate SecurityGroup creation to network_policy role
+  ansible.builtin.include_role:
+    name: osac.templates.network_policy
+    tasks_from: create_security_group

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/create_subnet.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/create_subnet.yaml
@@ -1,0 +1,8 @@
+---
+# k8s_only delegates Subnet provisioning to cudn_net (Namespace + ClusterUserDefinedNetwork).
+# See README.md for the rationale.
+
+- name: Delegate Subnet creation to cudn_net role
+  ansible.builtin.include_role:
+    name: osac.templates.cudn_net
+    tasks_from: create_subnet

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/create_virtual_network.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/create_virtual_network.yaml
@@ -1,0 +1,8 @@
+---
+# k8s_only delegates VirtualNetwork provisioning to cudn_net (ClusterUserDefinedNetwork).
+# See README.md for the rationale.
+
+- name: Delegate VirtualNetwork creation to cudn_net role
+  ansible.builtin.include_role:
+    name: osac.templates.cudn_net
+    tasks_from: create_virtual_network

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/delete_external_ip.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/delete_external_ip.yaml
@@ -1,0 +1,8 @@
+---
+# k8s_only delegates ExternalIP deletion to metallb_l2 (MetalLB LoadBalancer
+# Service). See README.md for the rationale.
+
+- name: Delegate ExternalIP deletion to metallb_l2 role
+  ansible.builtin.include_role:
+    name: osac.templates.metallb_l2
+    tasks_from: delete_external_ip

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/delete_external_ip_pool.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/delete_external_ip_pool.yaml
@@ -1,0 +1,8 @@
+---
+# k8s_only delegates ExternalIPPool deletion to metallb_l2 (MetalLB IPAddressPool
+# + L2Advertisement). See README.md for the rationale.
+
+- name: Delegate ExternalIPPool deletion to metallb_l2 role
+  ansible.builtin.include_role:
+    name: osac.templates.metallb_l2
+    tasks_from: delete_external_ip_pool

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/delete_security_group.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/delete_security_group.yaml
@@ -1,0 +1,9 @@
+---
+# k8s_only delegates SecurityGroup enforcement to the standalone network_policy
+# role (NetworkPolicy-based), which is reusable across any K8s-based NetworkClass.
+# See README.md for the rationale.
+
+- name: Delegate SecurityGroup deletion to network_policy role
+  ansible.builtin.include_role:
+    name: osac.templates.network_policy
+    tasks_from: delete_security_group

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/delete_subnet.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/delete_subnet.yaml
@@ -1,0 +1,8 @@
+---
+# k8s_only delegates Subnet deletion to cudn_net (Namespace + ClusterUserDefinedNetwork).
+# See README.md for the rationale.
+
+- name: Delegate Subnet deletion to cudn_net role
+  ansible.builtin.include_role:
+    name: osac.templates.cudn_net
+    tasks_from: delete_subnet

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/delete_virtual_network.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/delete_virtual_network.yaml
@@ -1,0 +1,8 @@
+---
+# k8s_only delegates VirtualNetwork deletion to cudn_net (ClusterUserDefinedNetwork).
+# See README.md for the rationale.
+
+- name: Delegate VirtualNetwork deletion to cudn_net role
+  ansible.builtin.include_role:
+    name: osac.templates.cudn_net
+    tasks_from: delete_virtual_network

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/detach_external_ip.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/tasks/detach_external_ip.yaml
@@ -1,0 +1,8 @@
+---
+# k8s_only delegates ExternalIPAttachment deletion to metallb_l2 (MetalLB
+# LoadBalancer Service binding). See README.md for the rationale.
+
+- name: Delegate ExternalIP detach to metallb_l2 role
+  ansible.builtin.include_role:
+    name: osac.templates.metallb_l2
+    tasks_from: detach_external_ip


### PR DESCRIPTION
Adds a new osac.templates.k8s_only role that acts as a single dispatch target for a k8s-only NetworkClass (a k8sManager with no fabricManager). Each entrypoint delegates to an existing specialized role rather than reimplementing anything: VirtualNetwork/Subnet to cudn_net, SecurityGroup to network_policy (directly, matching cudn_net's own existing delegation precedent), and the ExternalIP family (ExternalIPPool/ExternalIP/ExternalIPAttachment) to metallb_l2.

NATGateway support is intentionally not included here — it depends on validating OVN EgressIP CR compatibility first and is tracked separately as OSAC-4265, which will add those two task files into this same role directory.

The role has no meta/osac.yaml, meta/argument_specs.yaml, or defaults/main.yaml: it isn't independently selectable or auto- published as its own NetworkClass the way cudn_net/network_policy/ metallb_l2 are, matching the existing bm_host_private_network precedent for delegation-only roles. Registering the "k8s-only" k8sManager (NetworkClass + labeled ConfigMap) happens outside this role.

Assisted-by: Claude Code <noreply@anthropic.com>