### PR TITLE
OSAC-3752: document Kind install in osac-installer AGENTS.md

### DIFF
--- a/osac-installer/AGENTS.md
+++ b/osac-installer/AGENTS.md
@@ -41,10 +41,25 @@ make install-osac  PLATFORM=openshift PROFILE=<profile> NS=<namespace>
 
 # Uninstall
 make uninstall PLATFORM=openshift PROFILE=<profile> NS=<namespace>
-
-# Integration tests (Kind)
-make test PLATFORM=kind PROFILE=dev NS=osac SUITE=fulfillment
 ```
+
+## Kind (local dev)
+
+`PLATFORM`, `PROFILE`, and `NS` are required on every deploy/test target (no defaults). Kind only supports `PROFILE=dev`. Cluster name: `osac-dev`.
+
+```bash
+# From osac-installer/
+make install       PLATFORM=kind PROFILE=dev NS=osac   # cluster + infra + OSAC
+make install-infra PLATFORM=kind PROFILE=dev NS=osac   # cluster + infra only
+make test          PLATFORM=kind PROFILE=dev NS=osac SUITE=fulfillment  # SUITE=all|fulfillment|operator|bmf
+make uninstall     PLATFORM=kind PROFILE=dev NS=osac   # deletes the Kind cluster
+```
+
+Requires `/etc/hosts` entries:
+
+- `127.0.0.1 keycloak.keycloak.svc.cluster.local`
+- `127.0.0.1 fulfillment-api.osac.svc.cluster.local`
+- `127.0.0.1 fulfillment-internal-api.osac.svc.cluster.local`
 
 ## Critical Rules
 


### PR DESCRIPTION
## Summary
- Add a Kind (local dev) section to `osac-installer/AGENTS.md` covering `install` / `install-infra` / `test` / `uninstall` and `/etc/hosts`.
- Gives workspace docs a real place to defer to after `kind-dev/` was removed.

Companion: https://github.com/osac-project/osac-workspace/pull/222

## Jira
https://issues.redhat.com/browse/OSAC-3752

## Test plan
- [x] Commands match `osac-installer/Makefile` (`PLATFORM=kind` only with `PROFILE=dev`, cluster `osac-dev`)
- [ ] Unit tests pass — N/A (docs only)

---

_This PR description was drafted with AI assistance ([create-pr](https://github.com/osac-project/osac-workspace/tree/main/skills/create-pr) v0.2.0). Review for accuracy_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added local development guidance, including required deployment settings, supported profile, cluster naming, and installation, testing, and removal commands.
  * Documented required `/etc/hosts` entries.
  * Consolidated the integration test instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->