### PR TITLE
OSAC-2988: Add pull secret ref to cluster create cli cmd

### DIFF
--- a/fulfillment-service/internal/cmd/cli/create/cluster/create_cluster_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/cluster/create_cluster_cmd.go
@@ -154,6 +154,7 @@ func Cmd() *cobra.Command {
 	)
 	result.MarkFlagsMutuallyExclusive("catalog-item", "template")
 	result.MarkFlagsOneRequired("catalog-item", "template")
+	result.MarkFlagsMutuallyExclusive("pull-secret", "pull-secret-file")
 	return result
 }
 
@@ -316,7 +317,6 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 
 // resolveCredentials reads pull secret and SSH public key from file flags when specified.
 func (c *runnerContext) resolveCredentials() (pullSecret, sshPublicKey string, err error) {
-	pullSecret = c.args.pullSecret
 	if c.args.pullSecretFile != "" {
 		data, readErr := os.ReadFile(c.args.pullSecretFile)
 		if readErr != nil {
@@ -344,6 +344,11 @@ func (c *runnerContext) applyOptionalSpecFields(
 ) {
 	if pullSecret != "" {
 		specBuilder.PullSecret = &pullSecret
+	}
+	if c.args.pullSecret != "" {
+		specBuilder.PullSecretSecret = publicv1.SecretLocalReference_builder{
+			Name: c.args.pullSecret,
+		}.Build()
 	}
 	if sshPublicKey != "" {
 		specBuilder.SshPublicKey = &sshPublicKey
@@ -962,12 +967,14 @@ times.
 `
 
 const pullSecretFlagHelp = `
-_SECRET_ - Pull secret for authenticating to image repositories, provided as
-an inline value. See also {{ bt }}--pull-secret-file{{ bt }}.
+_NAME_ - Name of a Secret resource containing pull secret credentials.
+Mutually exclusive with {{ bt }}--pull-secret-file{{ bt }}. The secret must
+exist in the same tenant. See also {{ bt }}osac create secret{{ bt }}.
 `
 
 const pullSecretFileFlagHelp = `
-_FILE_ - Path to a file containing the pull secret.
+_FILE_ - Path to a file containing the pull secret, provided as inline
+credentials. Mutually exclusive with {{ bt }}--pull-secret{{ bt }}.
 `
 
 const sshPublicKeyFlagHelp = `

--- a/fulfillment-service/internal/cmd/cli/create/cluster/create_cluster_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/create/cluster/create_cluster_cmd_test.go
@@ -248,6 +248,37 @@ var _ = Describe("findVersion", func() {
 	})
 })
 
+var _ = Describe("Create cluster pull secret flags", func() {
+	It("should register --pull-secret flag", func() {
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		flag := cmd.Flags().Lookup("pull-secret")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.DefValue).To(Equal(""))
+	})
+
+	It("should register --pull-secret-file flag", func() {
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		flag := cmd.Flags().Lookup("pull-secret-file")
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.DefValue).To(Equal(""))
+	})
+
+	It("should reject both --pull-secret and --pull-secret-file", func() {
+		cmd := Cmd()
+		cmd.SetOut(GinkgoWriter)
+		cmd.SetErr(GinkgoWriter)
+		cmd.SetArgs([]string{"--catalog-item", "cat-001", "--name", "test", "--pull-secret", "my-secret", "--pull-secret-file", "/tmp/secret"})
+		err := cmd.Execute()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("if any flags in the group"))
+		Expect(err.Error()).To(ContainSubstring("pull-secret"))
+	})
+})
+
 var _ = Describe("Create cluster networking flags", func() {
 	It("should register --network-attachment flag", func() {
 		cmd := Cmd()


### PR DESCRIPTION
Modifies the --pull-secret arg to take an identifier for a secret ref.  This is a breaking change to existing cli behavior where this flag is for inline secret values.

Note: there is an existing --pull-secret-file that is also supported for passing files as part of the cluster create cmd.  However, the e2e tests currently reference this field.  We will need to merge this, update e2e, then circle back and clean up the file arg.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying pull secrets either by secret resource or by file.
  * Added validation to prevent using both pull-secret options at the same time.
  * Updated command help text to clarify the differences between the two options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->