### PR TITLE
OSAC-4271: add NetworkClass creation mechanism for k8s-only networking

### DIFF
--- a/osac-installer/charts/osac/templates/hooks/create-network-class.yaml
+++ b/osac-installer/charts/osac/templates/hooks/create-network-class.yaml
@@ -1,0 +1,102 @@
+{{- if .Values.networkClass.enabled }}
+{{- $egressRules := list -}}
+{{- range .Values.networkClass.defaults.egressRules }}
+{{- $rule := dict "protocol" .protocol -}}
+{{- if .ipv4Cidr }}{{ $_ := set $rule "ipv4_cidr" .ipv4Cidr }}{{ end -}}
+{{- if .ipv6Cidr }}{{ $_ := set $rule "ipv6_cidr" .ipv6Cidr }}{{ end -}}
+{{- if .portFrom }}{{ $_ := set $rule "port_from" .portFrom }}{{ end -}}
+{{- if .portTo }}{{ $_ := set $rule "port_to" .portTo }}{{ end -}}
+{{- $egressRules = append $egressRules $rule -}}
+{{- end }}
+{{- $body := dict
+      "title" (required "networkClass.title is required when networkClass.enabled is true" .Values.networkClass.title)
+      "is_default" .Values.networkClass.isDefault
+      "spec" (dict "defaults" (dict
+        "virtual_network_ipv4_cidr" .Values.networkClass.defaults.virtualNetworkIPv4CIDR
+        "subnet_ipv4_cidr" .Values.networkClass.defaults.subnetIPv4CIDR
+        "enable_nat_gateway" .Values.networkClass.defaults.enableNatGateway
+        "egress_rules" $egressRules
+      ))
+    -}}
+{{- if .Values.networkClass.description }}{{ $_ := set $body "description" .Values.networkClass.description }}{{ end -}}
+{{- if .Values.networkClass.k8sManager }}{{ $_ := set $body "k8s_manager" .Values.networkClass.k8sManager }}{{ end -}}
+{{- if .Values.networkClass.fabricManager }}{{ $_ := set $body "fabric_manager" .Values.networkClass.fabricManager }}{{ end -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-network-class
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "25"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 5
+  activeDeadlineSeconds: 900
+  template:
+    metadata:
+      labels:
+        {{- include "osac.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: admin
+      initContainers:
+      {{- include "osac.waitForFulfillment" . | nindent 6 }}
+      containers:
+      - name: create-network-class
+        image: {{ .Values.cliImage }}
+        command:
+          - /bin/bash
+          - -euo
+          - pipefail
+          - -c
+          - |
+            AUTH_TOKEN=$(< /var/run/secrets/kubernetes.io/serviceaccount/token)
+            API="https://fulfillment-internal-api:8001/api/private/v1/network_classes"
+            RESPONSE=/tmp/nc-response.json
+
+            CODE=$(curl -skS \
+              --connect-timeout 5 --max-time 30 \
+              -o "${RESPONSE}" -w '%{http_code}' \
+              -X POST "${API}" \
+              -H "Authorization: Bearer ${AUTH_TOKEN}" \
+              -H "Content-Type: application/json" \
+              --data-binary {{ $body | toJson | quote }})
+
+            case "${CODE}" in
+              2??)
+                echo "NetworkClass created."
+                ;;
+              409)
+                echo "NetworkClass already exists, skipping."
+                ;;
+              *)
+                echo "ERROR: Failed to create NetworkClass (HTTP ${CODE})" >&2
+                cat "${RESPONSE}" >&2
+                exit 1
+                ;;
+            esac
+        env:
+        - name: HOME
+          value: /tmp
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      restartPolicy: OnFailure
+{{- end }}

--- a/osac-installer/charts/osac/values.schema.json
+++ b/osac-installer/charts/osac/values.schema.json
@@ -1517,6 +1517,99 @@
           "default": false
         }
       }
+    },
+    "networkClass": {
+      "type": "object",
+      "description": "Create a NetworkClass in the fulfillment service after install. At least one of k8sManager/fabricManager must be set when enabled.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Run the create-network-class hook job",
+          "default": false
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-friendly short title for the NetworkClass. Required when enabled — the fulfillment service rejects NetworkClass creation without one.",
+          "default": ""
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-friendly long description for the NetworkClass (Markdown)",
+          "default": ""
+        },
+        "k8sManager": {
+          "type": "string",
+          "description": "k8sManager name to set on the NetworkClass (must match a manager already registered via operator.networkManagers.k8sManagers)",
+          "default": ""
+        },
+        "fabricManager": {
+          "type": "string",
+          "description": "fabricManager name to set on the NetworkClass (must match a manager already registered via operator.networkManagers.fabricManagers)",
+          "default": ""
+        },
+        "isDefault": {
+          "type": "boolean",
+          "description": "Mark this as the default NetworkClass used when a VirtualNetwork doesn't specify one",
+          "default": true
+        },
+        "defaults": {
+          "type": "object",
+          "description": "Tenant-onboarding defaults. Required for this NetworkClass to auto-create a default VirtualNetwork/Subnet/SecurityGroup for new tenants.",
+          "properties": {
+            "virtualNetworkIPv4CIDR": {
+              "type": "string",
+              "description": "IPv4 CIDR for the auto-created tenant VirtualNetwork (e.g. 10.200.0.0/16)"
+            },
+            "subnetIPv4CIDR": {
+              "type": "string",
+              "description": "IPv4 CIDR for the auto-created tenant Subnet (e.g. 10.200.0.0/20)"
+            },
+            "enableNatGateway": {
+              "type": "boolean",
+              "description": "Auto-create a NATGateway for the tenant's default VirtualNetwork",
+              "default": false
+            },
+            "egressRules": {
+              "type": "array",
+              "description": "Default egress rules for the auto-created tenant SecurityGroup",
+              "items": {
+                "type": "object",
+                "required": [
+                  "protocol"
+                ],
+                "properties": {
+                  "protocol": {
+                    "type": "string",
+                    "description": "Rule protocol",
+                    "enum": [
+                      "PROTOCOL_TCP",
+                      "PROTOCOL_UDP",
+                      "PROTOCOL_ICMP",
+                      "PROTOCOL_ALL"
+                    ]
+                  },
+                  "ipv4Cidr": {
+                    "type": "string",
+                    "description": "IPv4 CIDR for this rule (e.g. 0.0.0.0/0)"
+                  },
+                  "ipv6Cidr": {
+                    "type": "string",
+                    "description": "IPv6 CIDR for this rule"
+                  },
+                  "portFrom": {
+                    "type": "integer",
+                    "description": "Starting port (tcp/udp only)"
+                  },
+                  "portTo": {
+                    "type": "integer",
+                    "description": "Ending port (tcp/udp only)"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "required": []

--- a/osac-installer/charts/osac/values.yaml
+++ b/osac-installer/charts/osac/values.yaml
@@ -340,3 +340,30 @@ lvms:
   # after install. For CI/development environments only — production deployments
   # should use their own storage operators (Ceph, Pure, VAST, etc.).
   enabled: false
+
+networkClass:
+  # Create a NetworkClass in the fulfillment service after install. At least one of
+  # k8sManager/fabricManager must be set when enabled — the corresponding manager
+  # must already be registered via operator.networkManagers (see that chart's values).
+  enabled: false
+  # [REQUIRED when enabled] Human-friendly short title — the fulfillment service
+  # rejects NetworkClass creation without one (NC-VAL-02).
+  title: ""
+  description: ""
+  k8sManager: ""
+  fabricManager: ""
+  isDefault: true
+  defaults:
+    # Tenant-onboarding defaults: without these, this being the default NetworkClass
+    # does not auto-create a VirtualNetwork/Subnet/SecurityGroup for new tenants, and
+    # ComputeInstance creation without explicit network_attachments will fail.
+    virtualNetworkIPv4CIDR: "10.200.0.0/16"
+    subnetIPv4CIDR: "10.200.0.0/20"
+    enableNatGateway: false
+    egressRules:
+    - protocol: PROTOCOL_ALL
+      ipv4Cidr: "0.0.0.0/0"
+  # Example (k8s-only profile):
+  # enabled: true
+  # title: "K8s-only networking"
+  # k8sManager: "k8s_only"

--- a/osac-operator/charts/operator/values.yaml
+++ b/osac-operator/charts/operator/values.yaml
@@ -101,4 +101,12 @@ networkManagers:
         VirtualNetwork/Subnet provisioning with no separate physical fabric to
         bridge into — used as the platform default NetworkClass.
       capabilities: "ipv4,ipv6,dualStack"
-  k8sManagers: {}
+  k8sManagers:
+    k8s_only:
+      enabled: false
+      description: >-
+        Composite k8s-native networking (CUDN, Kubernetes NetworkPolicy, MetalLB
+        L2) with no separate physical fabric. Delegates each resource type to an
+        existing k8s-native implementation — see osac-aap's osac.templates.k8s_only
+        role.
+      capabilities: "ipv4,ipv6"


### PR DESCRIPTION
Registers a k8s_only k8sManager catalog entry in osac-operator's chart (disabled by default) for composite k8s-native networking (CUDN, NetworkPolicy, MetalLB L2) with no separate physical fabric, delegating to osac-aap's osac.templates.k8s_only role.

Adds a networkClass values section to osac-installer's chart (disabled by default) and a post-install/post-upgrade hook Job that creates a NetworkClass via the fulfillment-service private REST API, idempotent on
409. Includes tenant-onboarding spec.defaults (CIDRs, egress rules) — without these, DefaultNetworkingProvisioner.Provision() skips default networking entirely, so a fresh install enabling this would never get a working default subnet for ComputeInstance creation.

No profile enables either mechanism yet; disabled-state rendering is byte-identical across all profiles.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional automatic NetworkClass registration during chart installation or upgrade.
  - Added configuration for NetworkClass metadata, manager references, defaults, tenant networking, NAT, and egress rules.
  - Added request validation and handling for successful or already-existing NetworkClasses.

- **Configuration**
  - Added a predefined, disabled Kubernetes-only network manager with IPv4 and IPv6 capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->