### PR TITLE
NO-ISSUE: pin graphify to commit with vertex backend fix

### DIFF
--- a/.github/workflows/graphify-brain-refresh.yaml
+++ b/.github/workflows/graphify-brain-refresh.yaml
@@ -63,7 +63,7 @@ jobs:
           # (Vertex AI backend) and https://github.com/Graphify-Labs/graphify/pull/3087
           # (ci-select + fixes) are merged upstream and a new graphifyy release is published.
           # Then revert to: pip install --user "graphifyy[sql,vertex]==${GRAPHIFY_VERSION}"
-          pip install --user "graphifyy[sql,vertex] @ git+https://github.com/eliorerz/graphify@e700e2b35012696e8b490c13f0ada871977f1a2f"
+          pip install --user "graphifyy[sql,vertex] @ git+https://github.com/eliorerz/graphify@1a122e1"
           echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
 
       - name: Restore prior graphify-out/ state (fast path)


### PR DESCRIPTION
Fixes graphify-brain-refresh workflow failure (run 32878010795) where vertex backend rejected GOOGLE_CLOUD_PROJECT even when set.

**Problem**: graphify cli.py's pre-flight check had no allow-no-key exemption for vertex backend (unlike ollama/bedrock/claude-cli), so it always rejected vertex regardless of GOOGLE_CLOUD_PROJECT being present.

**Fix**: Install graphify from eliorerz/graphify@1a122e1 (feat/vertex-ai-backend branch) which adds the missing vertex check. Will revert to PyPI install once the next graphify release includes this fix.

**Related**: 
- graphify fix: eliorerz/graphify#4
- Upstream PR: Graphify-Labs/graphify#3083

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the automated brain refresh process to use a pinned Graphify source revision.
  * Improved consistency and reproducibility of refresh runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->