### PR TITLE
NO-ISSUE: bump graphify pin to include Vertex AI retry/backoff fix

### DIFF
--- a/.github/workflows/graphify-brain-refresh.yaml
+++ b/.github/workflows/graphify-brain-refresh.yaml
@@ -63,7 +63,14 @@ jobs:
           # (Vertex AI backend) and https://github.com/Graphify-Labs/graphify/pull/3087
           # (ci-select + fixes) are merged upstream and a new graphifyy release is published.
           # Then revert to: pip install --user "graphifyy[sql,vertex]==${GRAPHIFY_VERSION}"
-          pip install --user "graphifyy[sql,vertex] @ git+https://github.com/eliorerz/graphify@1a122e1"
+          # Bumped to 653aa4e: configures retry/backoff for the vertex backend's Vertex
+          # AI client (google-genai does not retry 429s at all unless explicitly told to),
+          # needed because osac-ci's gemini-2.5-flash/-pro quota defaults to a
+          # non-adjustable 5 requests/minute -- confirmed live in run 32885843245, where
+          # a large first-run corpus (~1100 docs) hit "Resource exhausted" on 9 of 16
+          # semantic chunks. Retry/backoff lets a run grind through that ceiling instead
+          # of hard-failing; a GCP support request for a higher quota is filed separately.
+          pip install --user "graphifyy[sql,vertex] @ git+https://github.com/eliorerz/graphify@653aa4eddc1e5ffe524a8d928b9e6d7c3c31cdf3"
           echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
 
       - name: Restore prior graphify-out/ state (fast path)


### PR DESCRIPTION
## Summary
- Run https://github.com/osac-project/osac/actions/runs/32885843245 hit `Resource exhausted` (429) on 9 of 16 semantic extraction chunks -- `osac-ci`'s `gemini-2.5-flash`/`gemini-2.5-pro` quota defaults to a **non-adjustable** 5 requests/minute (confirmed in the GCP console: this specific model pair isn't on the project's list of models with an explicit, adjustable quota, unlike e.g. `gemini-1.5-flash` at 200/min -- and those older models are themselves blocked entirely by our org's model allowlist, so switching models isn't an option).
- graphify's own shrink guard correctly refused to publish the resulting partial/smaller graph, so nothing was corrupted -- but the run still failed outright.
- `eliorerz/graphify@653aa4e` adds retry/backoff configuration to the vertex backend's Vertex AI client (`http_options.retry_options` on the `google-genai` client) -- without it, the SDK does not retry 429s at all. This lets a run grind through the 5 RPM ceiling via retries instead of hard-failing.
- A GCP support request for a higher, adjustable quota on `gemini-2.5-flash`/`gemini-2.5-pro` has been filed separately -- this fix doesn't depend on that landing.

## Test plan
- [x] Verified live against `osac-ci` that the Vertex client still constructs and calls succeed with the new retry config
- [ ] Confirm the next full-repo extraction run eventually completes (may take longer than before due to retry backoff at 5 RPM)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of automated data refreshes by adding retry and backoff handling for temporary service quota limits.
  * Updated the refresh process to use the latest stability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->