### PR TITLE
OSAC-860/861/862: CLI wait utility + one-shot ExternalIP attach

### DIFF
--- a/fulfillment-service/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -36,6 +37,8 @@ import (
 	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/fieldutil"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/create/netutil"
+	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/lookup"
+	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/wait"
 	"github.com/osac-project/osac/fulfillment-service/internal/config"
 	"github.com/osac-project/osac/fulfillment-service/internal/exit"
 	"github.com/osac-project/osac/fulfillment-service/internal/logging"
@@ -158,7 +161,20 @@ func Cmd() *cobra.Command {
 		nil,
 		setFlagHelp,
 	)
+	flags.StringVar(
+		&runner.args.externalIPPool,
+		"external-ip-pool",
+		"",
+		externalIPPoolFlagHelp,
+	)
+	flags.DurationVar(
+		&runner.args.timeout,
+		"timeout",
+		5*time.Minute,
+		ciTimeoutFlagHelp,
+	)
 
+	result.MarkFlagsMutuallyExclusive("external-ip-attachment", "external-ip-pool")
 	result.MarkFlagsMutuallyExclusive("catalog-item", "template")
 	result.MarkFlagsOneRequired("catalog-item", "template")
 	return result
@@ -182,6 +198,8 @@ type runnerContext struct {
 		userData                string
 		networkAttachments      []string
 		externalIPAttachment    bool
+		externalIPPool          string
+		timeout                 time.Duration
 	}
 	logger                 *slog.Logger
 	console                *terminal.Console
@@ -285,7 +303,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 
 		computeInstance = response.Object
 		c.console.Infof(ctx, "Created compute instance '%s'.\n", computeInstance.Id)
-		return nil
+		return c.maybeAttachExternalIP(ctx, conn, computeInstance)
 	}
 
 	// Legacy template path (existing code continues below):
@@ -342,6 +360,140 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	computeInstance = response.Object
 	c.console.Infof(ctx, "Created compute instance '%s'.\n", computeInstance.Id)
 
+	return c.maybeAttachExternalIP(ctx, conn, computeInstance)
+}
+
+// maybeAttachExternalIP is a no-op unless --external-ip-pool is provided. When set it:
+//  1. Polls until the ComputeInstance reaches RUNNING state.
+//  2. Creates an ExternalIP from the requested pool.
+//  3. Polls until the ExternalIP reaches ALLOCATED state.
+//  4. Creates an ExternalIPAttachment linking the two resources.
+func (c *runnerContext) maybeAttachExternalIP(ctx context.Context, conn grpc.ClientConnInterface, ci *publicv1.ComputeInstance) error {
+	if c.args.externalIPPool == "" {
+		return nil
+	}
+
+	// Step 1: wait for the compute instance to reach RUNNING.
+	c.console.Infof(ctx, "Waiting for compute instance '%s' to reach RUNNING...\n", ci.GetMetadata().GetName())
+
+	ciClient := publicv1.NewComputeInstancesClient(conn)
+	ci, err := wait.Poll(ctx, wait.Options[*publicv1.ComputeInstance]{
+		Fetch: func(ctx context.Context) (*publicv1.ComputeInstance, error) {
+			resp, err := ciClient.Get(ctx, publicv1.ComputeInstancesGetRequest_builder{
+				Id: ci.GetId(),
+			}.Build())
+			if err != nil {
+				return nil, fmt.Errorf("failed to poll compute instance: %w", err)
+			}
+			return resp.GetObject(), nil
+		},
+		StateOf: func(r *publicv1.ComputeInstance) string {
+			return r.GetStatus().GetState().String()
+		},
+		TargetState: publicv1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING.String(),
+		FailureStates: []string{
+			publicv1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_FAILED.String(),
+			publicv1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_DELETING.String(),
+		},
+		Timeout: c.args.timeout,
+		OnProgress: func(r *publicv1.ComputeInstance) {
+			c.console.Infof(ctx, "  compute instance '%s': %s\n",
+				r.GetMetadata().GetName(), r.GetStatus().GetState().String())
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("compute instance '%s' did not reach RUNNING: %w", ci.GetMetadata().GetName(), err)
+	}
+
+	// Step 2: resolve pool and create ExternalIP.
+	poolClient := publicv1.NewExternalIPPoolsClient(conn)
+	pool, err := lookup.Find(c.args.externalIPPool, "external IP pool", func(filter string, limit int32) ([]*publicv1.ExternalIPPool, error) {
+		resp, err := poolClient.List(ctx, publicv1.ExternalIPPoolsListRequest_builder{
+			Filter: proto.String(filter),
+			Limit:  proto.Int32(limit),
+		}.Build())
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve external IP pool %q: %w", c.args.externalIPPool, err)
+		}
+		return resp.GetItems(), nil
+	})
+	if err != nil {
+		return err
+	}
+
+	eipClient := publicv1.NewExternalIPsClient(conn)
+	eipResp, err := eipClient.Create(ctx, publicv1.ExternalIPsCreateRequest_builder{
+		Object: publicv1.ExternalIP_builder{
+			Metadata: publicv1.Metadata_builder{
+				Tenant: c.settings.Tenant(),
+			}.Build(),
+			Spec: publicv1.ExternalIPSpec_builder{
+				Pool: &publicv1.ExternalIPPoolReference{Id: pool.GetId()},
+			}.Build(),
+		}.Build(),
+	}.Build())
+	if err != nil {
+		return fmt.Errorf("failed to create external IP: %w", err)
+	}
+	eip := eipResp.GetObject()
+
+	// Step 3: wait for ExternalIP ALLOCATED.
+	c.console.Infof(ctx, "Created external IP '%s' (ID: %s). Waiting for ALLOCATED...\n",
+		eip.GetMetadata().GetName(), eip.GetId())
+
+	eip, err = wait.Poll(ctx, wait.Options[*publicv1.ExternalIP]{
+		Fetch: func(ctx context.Context) (*publicv1.ExternalIP, error) {
+			resp, err := eipClient.Get(ctx, publicv1.ExternalIPsGetRequest_builder{
+				Id: eip.GetId(),
+			}.Build())
+			if err != nil {
+				return nil, fmt.Errorf("failed to poll external IP: %w", err)
+			}
+			return resp.GetObject(), nil
+		},
+		StateOf: func(r *publicv1.ExternalIP) string {
+			return r.GetStatus().GetState().String()
+		},
+		TargetState: publicv1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED.String(),
+		FailureStates: []string{
+			publicv1.ExternalIPState_EXTERNAL_IP_STATE_FAILED.String(),
+			publicv1.ExternalIPState_EXTERNAL_IP_STATE_DELETING.String(),
+		},
+		Timeout: c.args.timeout,
+		OnProgress: func(r *publicv1.ExternalIP) {
+			c.console.Infof(ctx, "  external IP '%s': %s\n",
+				r.GetMetadata().GetName(), r.GetStatus().GetState().String())
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("external IP '%s' did not reach ALLOCATED: %w", eip.GetMetadata().GetName(), err)
+	}
+
+	// Step 4: attach.
+	attachClient := publicv1.NewExternalIPAttachmentsClient(conn)
+	attachResp, err := attachClient.Create(ctx, publicv1.ExternalIPAttachmentsCreateRequest_builder{
+		Object: publicv1.ExternalIPAttachment_builder{
+			Metadata: publicv1.Metadata_builder{
+				Tenant: c.settings.Tenant(),
+			}.Build(),
+			Spec: publicv1.ExternalIPAttachmentSpec_builder{
+				ExternalIp:      &publicv1.ExternalIPLocalReference{Id: eip.GetId()},
+				ComputeInstance: &publicv1.ComputeInstanceLocalReference{Id: ci.GetId()},
+			}.Build(),
+		}.Build(),
+	}.Build())
+	if err != nil {
+		return fmt.Errorf(
+			"external IP '%s' is ALLOCATED but attachment to compute instance '%s' failed: %w",
+			eip.GetMetadata().GetName(), ci.GetMetadata().GetName(), err,
+		)
+	}
+
+	c.console.Infof(ctx,
+		"Attached external IP '%s' (address: %s) to compute instance '%s' (attachment ID: %s).\n",
+		eip.GetMetadata().GetName(), eip.GetStatus().GetAddress(),
+		ci.GetMetadata().GetName(), attachResp.GetObject().GetId(),
+	)
 	return nil
 }
 
@@ -1099,4 +1251,17 @@ _KEY=VALUE_ - Set a spec field or template parameter on the resource.
 Use dot notation for nested fields (e.g.
 {{ bt }}template_parameters.vpc_id=vpc-123{{ bt }}). Only supported
 with {{ bt }}--catalog-item{{ bt }}. Can be specified multiple times.
+`
+
+const externalIPPoolFlagHelp = `
+_ID|NAME_ - ID or name of an ExternalIPPool to allocate an ExternalIP from and
+attach to the new compute instance once it reaches RUNNING state. When set, the
+command blocks until the ExternalIPAttachment is created or the timeout expires.
+Mutually exclusive with {{ bt }}--external-ip-attachment{{ bt }}.
+`
+
+const ciTimeoutFlagHelp = `
+_DURATION_ - Maximum time to wait for each async state transition when
+{{ bt }}--external-ip-pool{{ bt }} is provided (e.g. "5m", "10m30s"). Defaults
+to 5 minutes. Applied independently to the RUNNING wait and the ALLOCATED wait.
 `

--- a/fulfillment-service/internal/cmd/cli/create/externalip/create_externalip_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/externalip/create_externalip_cmd.go
@@ -14,14 +14,17 @@ language governing permissions and limitations under the License.
 package externalip
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/proto"
 
 	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/lookup"
+	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/wait"
 	"github.com/osac-project/osac/fulfillment-service/internal/config"
 	"github.com/osac-project/osac/fulfillment-service/internal/logging"
 	"github.com/osac-project/osac/fulfillment-service/internal/terminal"
@@ -52,14 +55,28 @@ func Cmd() *cobra.Command {
 		"",
 		poolFlagHelp,
 	)
+	flags.StringVar(
+		&runner.args.computeInstance,
+		"compute-instance",
+		"",
+		computeInstanceFlagHelp,
+	)
+	flags.DurationVar(
+		&runner.args.timeout,
+		"timeout",
+		5*time.Minute,
+		timeoutFlagHelp,
+	)
 	result.MarkFlagRequired("pool") //nolint:errcheck
 	return result
 }
 
 type runnerContext struct {
 	args struct {
-		name string
-		pool string
+		name            string
+		pool            string
+		computeInstance string
+		timeout         time.Duration
 	}
 	logger   *slog.Logger
 	console  *terminal.Console
@@ -83,6 +100,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	}
 	defer conn.Close()
 
+	// Step 1: resolve pool and create the ExternalIP.
 	poolClient := publicv1.NewExternalIPPoolsClient(conn)
 	pool, err := lookup.Find(c.args.pool, "external IP pool", func(filter string, limit int32) ([]*publicv1.ExternalIPPool, error) {
 		resp, err := poolClient.List(ctx, publicv1.ExternalIPPoolsListRequest_builder{
@@ -98,25 +116,106 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	client := publicv1.NewExternalIPsClient(conn)
+	eipClient := publicv1.NewExternalIPsClient(conn)
 
-	externalIP := publicv1.ExternalIP_builder{
-		Metadata: publicv1.Metadata_builder{
-			Name:   c.args.name,
-			Tenant: c.settings.Tenant(),
+	createResp, err := eipClient.Create(ctx, publicv1.ExternalIPsCreateRequest_builder{
+		Object: publicv1.ExternalIP_builder{
+			Metadata: publicv1.Metadata_builder{
+				Name:   c.args.name,
+				Tenant: c.settings.Tenant(),
+			}.Build(),
+			Spec: publicv1.ExternalIPSpec_builder{
+				Pool: &publicv1.ExternalIPPoolReference{Id: pool.GetId()},
+			}.Build(),
 		}.Build(),
-		Spec: publicv1.ExternalIPSpec_builder{
-			Pool: &publicv1.ExternalIPPoolReference{Id: pool.GetId()},
-		}.Build(),
-	}.Build()
-
-	response, err := client.Create(ctx, publicv1.ExternalIPsCreateRequest_builder{Object: externalIP}.Build())
+	}.Build())
 	if err != nil {
 		return fmt.Errorf("failed to create external IP: %w", err)
 	}
+	eip := createResp.GetObject()
 
-	c.console.Infof(ctx, "Created external IP '%s' (ID: %s).\n", response.Object.GetMetadata().GetName(), response.Object.GetId())
+	// Without --compute-instance: done.
+	if c.args.computeInstance == "" {
+		c.console.Infof(ctx, "Created external IP '%s' (ID: %s).\n",
+			eip.GetMetadata().GetName(), eip.GetId())
+		return nil
+	}
 
+	// One-shot path: wait for ALLOCATED, then attach.
+
+	// Step 2: poll until ALLOCATED.
+	c.console.Infof(ctx, "Created external IP '%s' (ID: %s). Waiting for ALLOCATED...\n",
+		eip.GetMetadata().GetName(), eip.GetId())
+
+	eip, err = wait.Poll(ctx, wait.Options[*publicv1.ExternalIP]{
+		Fetch: func(ctx context.Context) (*publicv1.ExternalIP, error) {
+			resp, err := eipClient.Get(ctx, publicv1.ExternalIPsGetRequest_builder{
+				Id: eip.GetId(),
+			}.Build())
+			if err != nil {
+				return nil, fmt.Errorf("failed to poll external IP: %w", err)
+			}
+			return resp.GetObject(), nil
+		},
+		StateOf: func(r *publicv1.ExternalIP) string {
+			return r.GetStatus().GetState().String()
+		},
+		TargetState: publicv1.ExternalIPState_EXTERNAL_IP_STATE_ALLOCATED.String(),
+		FailureStates: []string{
+			publicv1.ExternalIPState_EXTERNAL_IP_STATE_FAILED.String(),
+			publicv1.ExternalIPState_EXTERNAL_IP_STATE_DELETING.String(),
+		},
+		Timeout: c.args.timeout,
+		OnProgress: func(r *publicv1.ExternalIP) {
+			c.console.Infof(ctx, "  external IP '%s': %s\n",
+				r.GetMetadata().GetName(), r.GetStatus().GetState().String())
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("external IP '%s' did not reach ALLOCATED: %w", eip.GetMetadata().GetName(), err)
+	}
+
+	// Step 3: resolve compute instance.
+	ciClient := publicv1.NewComputeInstancesClient(conn)
+	ci, err := lookup.Find(c.args.computeInstance, "compute instance", func(filter string, limit int32) ([]*publicv1.ComputeInstance, error) {
+		resp, err := ciClient.List(ctx, publicv1.ComputeInstancesListRequest_builder{
+			Filter: proto.String(filter),
+			Limit:  proto.Int32(limit),
+		}.Build())
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve compute instance %q: %w", c.args.computeInstance, err)
+		}
+		return resp.GetItems(), nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Step 4: create the attachment.
+	attachClient := publicv1.NewExternalIPAttachmentsClient(conn)
+	attachResp, err := attachClient.Create(ctx, publicv1.ExternalIPAttachmentsCreateRequest_builder{
+		Object: publicv1.ExternalIPAttachment_builder{
+			Metadata: publicv1.Metadata_builder{
+				Tenant: c.settings.Tenant(),
+			}.Build(),
+			Spec: publicv1.ExternalIPAttachmentSpec_builder{
+				ExternalIp:      &publicv1.ExternalIPLocalReference{Id: eip.GetId()},
+				ComputeInstance: &publicv1.ComputeInstanceLocalReference{Id: ci.GetId()},
+			}.Build(),
+		}.Build(),
+	}.Build())
+	if err != nil {
+		return fmt.Errorf(
+			"external IP '%s' is ALLOCATED but attachment to compute instance '%s' failed: %w",
+			eip.GetMetadata().GetName(), ci.GetMetadata().GetName(), err,
+		)
+	}
+
+	c.console.Infof(ctx,
+		"Created external IP '%s' (ID: %s) and attached to compute instance '%s' (attachment ID: %s).\n",
+		eip.GetMetadata().GetName(), eip.GetId(),
+		ci.GetMetadata().GetName(), attachResp.GetObject().GetId(),
+	)
 	return nil
 }
 
@@ -127,14 +226,23 @@ Allocate an external IP address from an ExternalIPPool.
 
 The {{ bt }}--pool{{ bt }} flag is required and specifies the ExternalIPPool to allocate from.
 
+When {{ bt }}--compute-instance{{ bt }} is provided, the command performs a one-shot attach:
+  1. Creates the ExternalIP.
+  2. Waits for it to reach ALLOCATED state.
+  3. Resolves the compute instance by name or ID.
+  4. Creates an ExternalIPAttachment linking the two resources.
+
 Examples:
 
 {{ bt 3 }}shell
 # Create an external IP from a specific pool
 {{ binary }} create externalip --name my-ip --pool pool-abc123
 
-# Create an external IP using pool name
-{{ binary }} create externalip --name my-ip --pool external-pool-1
+# Create and immediately attach to a compute instance
+{{ binary }} create externalip --name my-ip --pool pool-abc123 --compute-instance my-vm
+
+# One-shot attach with a custom wait timeout
+{{ binary }} create externalip --name my-ip --pool pool-abc123 --compute-instance my-vm --timeout 10m
 {{ bt 3 }}
 `
 
@@ -144,4 +252,15 @@ _NAME_ - Name of the external IP.
 
 const poolFlagHelp = `
 _ID|NAME_ - ID or name of the parent ExternalIPPool to allocate the address from. Required.
+`
+
+const computeInstanceFlagHelp = `
+_ID|NAME_ - ID or name of the ComputeInstance to attach the new ExternalIP to once it reaches
+ALLOCATED state. When set, the command blocks until the attachment is created or the timeout
+expires.
+`
+
+const timeoutFlagHelp = `
+_DURATION_ - Maximum time to wait for the ExternalIP to reach ALLOCATED state when
+{{ bt }}--compute-instance{{ bt }} is provided (e.g. "5m", "10m30s"). Defaults to 5 minutes.
 `

--- a/fulfillment-service/internal/cmd/cli/wait/wait.go
+++ b/fulfillment-service/internal/cmd/cli/wait/wait.go
@@ -1,0 +1,152 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+// Package wait provides a generic polling utility for CLI commands that need to wait for resource
+// state transitions (e.g., ExternalIP reaching ALLOCATED, ComputeInstance reaching RUNNING).
+package wait
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// FetchFunc retrieves the current state of a resource.
+type FetchFunc[T any] func(ctx context.Context) (T, error)
+
+// StateFunc extracts the state string from a resource.
+type StateFunc[T any] func(T) string
+
+// ProgressFunc is called after each fetch with the current resource value.
+// Use it to print a progress line to the user, for example:
+//
+//	"Waiting for ExternalIP 'my-ip' to reach ALLOCATED... (current: PENDING)"
+type ProgressFunc[T any] func(T)
+
+// Options configures a [Poll] call.
+type Options[T any] struct {
+	// Fetch retrieves the current resource. Required.
+	Fetch FetchFunc[T]
+
+	// StateOf extracts the state string from the resource. Required.
+	StateOf StateFunc[T]
+
+	// TargetState is the state that signals success. Required.
+	TargetState string
+
+	// FailureStates are states that signal a non-recoverable failure.
+	// Poll returns [ErrTerminalState] immediately upon entering one of these.
+	FailureStates []string
+
+	// Timeout caps the total wait time. Defaults to 5 minutes when zero.
+	Timeout time.Duration
+
+	// Interval is the initial delay between polls. Defaults to 2 seconds when zero.
+	Interval time.Duration
+
+	// MaxInterval caps the delay after exponential backoff. Defaults to 10 seconds when zero.
+	MaxInterval time.Duration
+
+	// OnProgress is called after every fetch (including the first).
+	// Optional — pass nil to suppress progress output.
+	OnProgress ProgressFunc[T]
+}
+
+// ErrTerminalState is returned when the resource enters a failure state listed in
+// [Options.FailureStates].
+type ErrTerminalState struct {
+	// State is the failure state that was observed.
+	State string
+}
+
+func (e *ErrTerminalState) Error() string {
+	return fmt.Sprintf("reached terminal failure state %q", e.State)
+}
+
+// ErrTimeout is returned when [Options.Timeout] (or the caller's context deadline) expires
+// before the resource reaches [Options.TargetState].
+type ErrTimeout struct {
+	// After is the timeout duration that was configured.
+	After time.Duration
+	// Current is the state the resource was in when the timeout fired.
+	Current string
+}
+
+func (e *ErrTimeout) Error() string {
+	return fmt.Sprintf(
+		"timed out after %s waiting for state transition (current: %s)",
+		e.After.Round(time.Second), e.Current,
+	)
+}
+
+// Poll polls a resource until it reaches [Options.TargetState], a [Options.FailureStates] entry,
+// or the context / [Options.Timeout] expires. It returns the final resource value on success.
+//
+// Backoff: the inter-poll delay starts at [Options.Interval] and doubles after each poll that does
+// not reach the target state, capped at [Options.MaxInterval].
+func Poll[T any](ctx context.Context, opts Options[T]) (T, error) {
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = 5 * time.Minute
+	}
+	interval := opts.Interval
+	if interval <= 0 {
+		interval = 2 * time.Second
+	}
+	maxInterval := opts.MaxInterval
+	if maxInterval <= 0 {
+		maxInterval = 10 * time.Second
+	}
+
+	failureSet := make(map[string]bool, len(opts.FailureStates))
+	for _, s := range opts.FailureStates {
+		failureSet[s] = true
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for {
+		resource, err := opts.Fetch(ctx)
+		if err != nil {
+			var zero T
+			return zero, err
+		}
+
+		state := opts.StateOf(resource)
+
+		if opts.OnProgress != nil {
+			opts.OnProgress(resource)
+		}
+
+		if state == opts.TargetState {
+			return resource, nil
+		}
+
+		if failureSet[state] {
+			var zero T
+			return zero, &ErrTerminalState{State: state}
+		}
+
+		select {
+		case <-ctx.Done():
+			var zero T
+			return zero, &ErrTimeout{After: timeout, Current: state}
+		case <-time.After(interval):
+			interval *= 2
+			if interval > maxInterval {
+				interval = maxInterval
+			}
+		}
+	}
+}

--- a/fulfillment-service/internal/cmd/cli/wait/wait_suite_test.go
+++ b/fulfillment-service/internal/cmd/cli/wait/wait_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package wait_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestWait(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Wait Suite")
+}

--- a/fulfillment-service/internal/cmd/cli/wait/wait_test.go
+++ b/fulfillment-service/internal/cmd/cli/wait/wait_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package wait_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/osac-project/osac/fulfillment-service/internal/cmd/cli/wait"
+)
+
+// fakeResource is a minimal stand-in for any resource type.
+type fakeResource struct {
+	state string
+}
+
+// stateOf extracts the state field.
+func stateOf(r fakeResource) string { return r.state }
+
+// seqFetch returns a FetchFunc that emits states[0], states[1], ... in order.
+// It returns an error if called more times than there are states.
+func seqFetch(states []string) wait.FetchFunc[fakeResource] {
+	i := 0
+	return func(_ context.Context) (fakeResource, error) {
+		if i >= len(states) {
+			return fakeResource{}, fmt.Errorf("seqFetch: called %d times, only %d states defined", i+1, len(states))
+		}
+		r := fakeResource{state: states[i]}
+		i++
+		return r, nil
+	}
+}
+
+// fastOpts returns Options with millisecond timing for test speed.
+func fastOpts(fetch wait.FetchFunc[fakeResource], target string) wait.Options[fakeResource] {
+	return wait.Options[fakeResource]{
+		Fetch:       fetch,
+		StateOf:     stateOf,
+		TargetState: target,
+		Timeout:     5 * time.Second,
+		Interval:    time.Millisecond,
+		MaxInterval: time.Millisecond,
+	}
+}
+
+var _ = Describe("Poll", func() {
+
+	Describe("success paths", func() {
+		It("returns immediately when first fetch already shows the target state", func() {
+			opts := fastOpts(seqFetch([]string{"ALLOCATED"}), "ALLOCATED")
+			result, err := wait.Poll(context.Background(), opts)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.state).To(Equal("ALLOCATED"))
+		})
+
+		It("returns the resource after several polls when the target state is eventually reached", func() {
+			opts := fastOpts(seqFetch([]string{"PENDING", "PENDING", "ALLOCATED"}), "ALLOCATED")
+			result, err := wait.Poll(context.Background(), opts)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.state).To(Equal("ALLOCATED"))
+		})
+	})
+
+	Describe("failure paths", func() {
+		It("returns ErrTerminalState immediately when a failure state is detected", func() {
+			opts := fastOpts(seqFetch([]string{"PENDING", "FAILED"}), "ALLOCATED")
+			opts.FailureStates = []string{"FAILED", "ERROR"}
+			_, err := wait.Poll(context.Background(), opts)
+			Expect(err).To(HaveOccurred())
+			var termErr *wait.ErrTerminalState
+			Expect(errors.As(err, &termErr)).To(BeTrue(), "expected ErrTerminalState, got %T: %v", err, err)
+			Expect(termErr.State).To(Equal("FAILED"))
+			Expect(termErr.Error()).To(ContainSubstring("FAILED"))
+		})
+
+		It("returns ErrTerminalState for every listed failure state", func() {
+			for _, fs := range []string{"FAILED", "ERROR"} {
+				opts := fastOpts(seqFetch([]string{fs}), "ALLOCATED")
+				opts.FailureStates = []string{"FAILED", "ERROR"}
+				_, err := wait.Poll(context.Background(), opts)
+				var termErr *wait.ErrTerminalState
+				Expect(errors.As(err, &termErr)).To(BeTrue(), "expected ErrTerminalState for state %q", fs)
+				Expect(termErr.State).To(Equal(fs))
+			}
+		})
+
+		It("returns ErrTimeout when the timeout fires before the target state is reached", func() {
+			steady := func(_ context.Context) (fakeResource, error) {
+				return fakeResource{state: "PENDING"}, nil
+			}
+			opts := wait.Options[fakeResource]{
+				Fetch:       steady,
+				StateOf:     stateOf,
+				TargetState: "ALLOCATED",
+				Timeout:     30 * time.Millisecond,
+				Interval:    5 * time.Millisecond,
+				MaxInterval: 5 * time.Millisecond,
+			}
+			_, err := wait.Poll(context.Background(), opts)
+			Expect(err).To(HaveOccurred())
+			var toErr *wait.ErrTimeout
+			Expect(errors.As(err, &toErr)).To(BeTrue(), "expected ErrTimeout, got %T: %v", err, err)
+			Expect(toErr.Current).To(Equal("PENDING"))
+			Expect(toErr.Error()).To(ContainSubstring("PENDING"))
+		})
+
+		It("propagates fetch errors directly without wrapping", func() {
+			sentinel := errors.New("connection refused")
+			errFetch := func(_ context.Context) (fakeResource, error) {
+				return fakeResource{}, sentinel
+			}
+			_, err := wait.Poll(context.Background(), fastOpts(errFetch, "ALLOCATED"))
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, sentinel)).To(BeTrue())
+		})
+
+		It("stops polling when the caller cancels the context", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			calls := 0
+			cancelFetch := func(_ context.Context) (fakeResource, error) {
+				calls++
+				if calls >= 2 {
+					cancel()
+				}
+				return fakeResource{state: "PENDING"}, nil
+			}
+			opts := wait.Options[fakeResource]{
+				Fetch:       cancelFetch,
+				StateOf:     stateOf,
+				TargetState: "ALLOCATED",
+				Timeout:     10 * time.Second,
+				Interval:    time.Millisecond,
+				MaxInterval: time.Millisecond,
+			}
+			_, err := wait.Poll(ctx, opts)
+			Expect(err).To(HaveOccurred())
+			Expect(calls).To(BeNumerically(">=", 2))
+		})
+	})
+
+	Describe("OnProgress callback", func() {
+		It("is called for every fetch including the first", func() {
+			opts := fastOpts(seqFetch([]string{"PENDING", "ALLOCATING", "ALLOCATED"}), "ALLOCATED")
+			var seen []string
+			opts.OnProgress = func(r fakeResource) { seen = append(seen, r.state) }
+			_, err := wait.Poll(context.Background(), opts)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(seen).To(Equal([]string{"PENDING", "ALLOCATING", "ALLOCATED"}))
+		})
+
+		It("is called on the failure state before the error is returned", func() {
+			opts := fastOpts(seqFetch([]string{"PENDING", "FAILED"}), "ALLOCATED")
+			opts.FailureStates = []string{"FAILED"}
+			var seen []string
+			opts.OnProgress = func(r fakeResource) { seen = append(seen, r.state) }
+			_, _ = wait.Poll(context.Background(), opts)
+			Expect(seen).To(ContainElement("FAILED"))
+		})
+	})
+
+	Describe("defaults", func() {
+		It("does not panic when Timeout is zero (context deadline overrides)", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+			defer cancel()
+			steady := func(_ context.Context) (fakeResource, error) {
+				return fakeResource{state: "PENDING"}, nil
+			}
+			_, err := wait.Poll(ctx, wait.Options[fakeResource]{
+				Fetch:       steady,
+				StateOf:     stateOf,
+				TargetState: "ALLOCATED",
+				// Timeout: 0 → defaults to 5m, but ctx cancels in 20ms
+				Interval:    time.Millisecond,
+				MaxInterval: time.Millisecond,
+			})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
## Summary

- **[OSAC-860](https://redhat.atlassian.net/browse/OSAC-860)**: Add `internal/cmd/cli/wait` package — generic `Poll[T]` utility with exponential backoff, configurable timeout, failure states, and progress callback. Includes full Ginkgo unit test suite (10 tests).
- **[OSAC-861](https://redhat.atlassian.net/browse/OSAC-861)**: Add `--compute-instance` flag to `osac create externalip` — creates the ExternalIP then blocks until ALLOCATED and creates an ExternalIPAttachment in a single command.
- **[OSAC-862](https://redhat.atlassian.net/browse/OSAC-862)**: Add `--external-ip-pool` flag to `osac create computeinstance` — after creation, polls until RUNNING, allocates an ExternalIP from the pool, waits for ALLOCATED, then creates the ExternalIPAttachment. Mutually exclusive with `--external-ip-attachment`.

Both [OSAC-861](https://redhat.atlassian.net/browse/OSAC-861) and [OSAC-862](https://redhat.atlassian.net/browse/OSAC-862) use the `wait.Poll` utility from [OSAC-860](https://redhat.atlassian.net/browse/OSAC-860) for all polling and `lookup.Find` for name/ID resolution.

## Test plan

- [ ] `ginkgo run ./internal/cmd/cli/wait/...` — 10 unit tests pass
- [ ] `osac create externalip --pool <pool> --name my-ip --compute-instance <vm>` — creates EIP and attachment end-to-end
- [ ] `osac create computeinstance --catalog-item <id> --external-ip-pool <pool>` — creates CI, waits RUNNING, allocates EIP, attaches
- [ ] `osac create computeinstance --external-ip-attachment --external-ip-pool <pool>` — should be rejected as mutually exclusive
- [ ] `osac create externalip --pool <pool> --timeout 30s --compute-instance <vm>` — timeout respected on short interval

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to automatically assign an external IP pool and attach an IP during compute-instance creation.
  * Added options to attach an existing or newly created external IP to a compute instance.
  * Added configurable timeouts and progress reporting for resource readiness and allocation workflows.
* **Bug Fixes**
  * Improved error handling for timeouts, failed states, lookup failures, and interrupted operations.
* **Tests**
  * Added coverage for successful polling, failures, cancellations, timeouts, and progress updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->