### PR TITLE
OSAC-1064: Enforce project visibility in the DAO and servers

### DIFF
--- a/fulfillment-service/internal/auth/default_tenancy_logic.go
+++ b/fulfillment-service/internal/auth/default_tenancy_logic.go
@@ -94,18 +94,6 @@ func (p *DefaultTenancyLogic) DetermineDefaultTenant(ctx context.Context) (resul
 	return
 }
 
-// DetermineVisibleTenants extracts the subject from the auth context and returns the identifiers of the tenants
-// that the current user has permission to see, including the shared tenant.
-func (p *DefaultTenancyLogic) DetermineVisibleTenants(ctx context.Context) (result collections.Set[string],
-	err error) {
-	subject := SubjectFromContext(ctx)
-	result = subject.Tenants
-	if result.Finite() {
-		result = SharedTenants.Union(result)
-	}
-	return
-}
-
 // DetermineVisibility extracts the subject from the auth context and returns the set of project names that the
 // current user has permission to see for each visible tenant. The returned visibility is frozen and must not be
 // modified.

--- a/fulfillment-service/internal/auth/default_tenancy_logic_test.go
+++ b/fulfillment-service/internal/auth/default_tenancy_logic_test.go
@@ -203,51 +203,6 @@ var _ = Describe("Default tenancy logic", Ordered, func() {
 		})
 	})
 
-	Describe("Determine visible tenants", func() {
-		var logic *DefaultTenancyLogic
-
-		BeforeEach(func(ctx context.Context) {
-			var err error
-			logic, err = NewDefaultTenancyLogic().
-				SetLogger(logger).
-				Build()
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("Returns tenants and shared", func(ctx context.Context) {
-			subject := &Subject{
-				User:    "my_user",
-				Tenants: collections.NewSet("tenant-a", "tenant-b"),
-			}
-			ctx = ContextWithSubject(ctx, subject)
-			result, err := logic.DetermineVisibleTenants(ctx)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result.Equal(SharedTenants.Union(collections.NewSet("tenant-a", "tenant-b")))).To(BeTrue())
-		})
-
-		It("Returns universal set when tenants is universal", func(ctx context.Context) {
-			subject := &Subject{
-				User:    "my_user",
-				Tenants: AllTenants,
-			}
-			ctx = ContextWithSubject(ctx, subject)
-			result, err := logic.DetermineVisibleTenants(ctx)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result.Equal(AllTenants)).To(BeTrue())
-		})
-
-		It("Returns only shared when tenants is empty", func(ctx context.Context) {
-			subject := &Subject{
-				User:    "my_user",
-				Tenants: collections.NewSet[string](),
-			}
-			ctx = ContextWithSubject(ctx, subject)
-			result, err := logic.DetermineVisibleTenants(ctx)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result.Equal(SharedTenants)).To(BeTrue())
-		})
-	})
-
 	Describe("Determine visibility", func() {
 		var logic *DefaultTenancyLogic
 

--- a/fulfillment-service/internal/auth/guest_tenancy_logic.go
+++ b/fulfillment-service/internal/auth/guest_tenancy_logic.go
@@ -64,13 +64,6 @@ func (p *GuestTenancyLogic) DetermineDefaultTenant(_ context.Context) (result st
 	return
 }
 
-// DetermineVisibleTenants returns a set containing both the guest and shared tenants, allowing guest users to see
-// objects from both tenants.
-func (p *GuestTenancyLogic) DetermineVisibleTenants(_ context.Context) (result collections.Set[string], err error) {
-	result = GuestTenants.Union(SharedTenants)
-	return
-}
-
 // DetermineVisibility returns a visibility that grants access only to the shared tenant.
 func (p *GuestTenancyLogic) DetermineVisibility(_ context.Context) (result *Visibility, err error) {
 	result, err = NewVisibility().

--- a/fulfillment-service/internal/auth/guest_tenancy_logic_test.go
+++ b/fulfillment-service/internal/auth/guest_tenancy_logic_test.go
@@ -55,12 +55,4 @@ var _ = Describe("Guest tenancy logic", func() {
 			Expect(result).To(Equal("guest"))
 		})
 	})
-
-	Describe("Determine visible tenants", func() {
-		It("Should return the guest and shared tenants", func() {
-			result, err := logic.DetermineVisibleTenants(ctx)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result.Equal(GuestTenants.Union(SharedTenants))).To(BeTrue())
-		})
-	})
 })

--- a/fulfillment-service/internal/auth/tenancy_logic.go
+++ b/fulfillment-service/internal/auth/tenancy_logic.go
@@ -31,11 +31,6 @@ type TenancyLogic interface {
 	// without an explicit tenant in the request.
 	DetermineDefaultTenant(ctx context.Context) (string, error)
 
-	// DetermineVisibleTenants calculates and returns the list of tenant names that the current user has permission
-	// to see. Database queries will be filtered to only return objects where the tenants column has a non-empty
-	// intersection with the values returned by this method.
-	DetermineVisibleTenants(ctx context.Context) (collections.Set[string], error)
-
 	// DetermineVisibility calculates and returns the visibility of the current user.
 	DetermineVisibility(ctx context.Context) (*Visibility, error)
 }

--- a/fulfillment-service/internal/auth/tenancy_logic_mock.go
+++ b/fulfillment-service/internal/auth/tenancy_logic_mock.go
@@ -85,18 +85,3 @@ func (mr *MockTenancyLogicMockRecorder) DetermineVisibility(ctx any) *gomock.Cal
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetermineVisibility", reflect.TypeOf((*MockTenancyLogic)(nil).DetermineVisibility), ctx)
 }
-
-// DetermineVisibleTenants mocks base method.
-func (m *MockTenancyLogic) DetermineVisibleTenants(ctx context.Context) (collections.Set[string], error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DetermineVisibleTenants", ctx)
-	ret0, _ := ret[0].(collections.Set[string])
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DetermineVisibleTenants indicates an expected call of DetermineVisibleTenants.
-func (mr *MockTenancyLogicMockRecorder) DetermineVisibleTenants(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetermineVisibleTenants", reflect.TypeOf((*MockTenancyLogic)(nil).DetermineVisibleTenants), ctx)
-}

--- a/fulfillment-service/internal/cmd/service/start/grpcserver/register_servers_test.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/register_servers_test.go
@@ -93,8 +93,8 @@ var _ = BeforeSuite(func() {
 	tenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).
 		Return(auth.SystemTenant, nil).
 		AnyTimes()
-	tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-		Return(auth.AllTenants, nil).
+	tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+		Return(auth.TotalVisibility(), nil).
 		AnyTimes()
 
 	// Start the containerized database:

--- a/fulfillment-service/internal/database/dao/generic_dao_create.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_create.go
@@ -43,10 +43,6 @@ func (r *CreateRequest[O]) SetObject(value O) *CreateRequest[O] {
 
 // Do executes the create operation and returns the response.
 func (r *CreateRequest[O]) Do(ctx context.Context) (response *CreateResponse[O], err error) {
-	err = r.init(ctx)
-	if err != nil {
-		return
-	}
 	r.tx, err = database.TxFromContext(ctx)
 	if err != nil {
 		return

--- a/fulfillment-service/internal/database/dao/generic_dao_delete.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_delete.go
@@ -44,10 +44,6 @@ func (r *DeleteRequest[O]) SetId(value string) *DeleteRequest[O] {
 
 // Do executes the delete operation and returns the response.
 func (r *DeleteRequest[O]) Do(ctx context.Context) (response *DeleteResponse, err error) {
-	err = r.init(ctx)
-	if err != nil {
-		return
-	}
 	r.tx, err = database.TxFromContext(ctx)
 	if err != nil {
 		return
@@ -58,17 +54,27 @@ func (r *DeleteRequest[O]) Do(ctx context.Context) (response *DeleteResponse, er
 }
 
 func (r *DeleteRequest[O]) do(ctx context.Context) (response *DeleteResponse, err error) {
-	// Add the tenancy filter:
-	err = r.addTenancyFilter(ctx)
-	if err != nil {
-		return
-	}
-
-	// Add the id parameter:
+	// Check parameters:
 	if r.args.id == "" {
 		err = errors.New("object identifier is mandatory")
 		return
 	}
+
+	// Check visibility:
+	ok, err := r.addVisibilityFilter(ctx)
+	if err != nil {
+		return
+	}
+	if !ok {
+		err = &ErrNotFound{
+			IDs: []string{
+				r.args.id,
+			},
+		}
+		return
+	}
+
+	// Add the id parameter:
 	if r.sql.filter.Len() > 0 {
 		r.sql.filter.WriteString(` and`)
 	}

--- a/fulfillment-service/internal/database/dao/generic_dao_events_test.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_events_test.go
@@ -63,9 +63,10 @@ var _ = Describe("Generic DAO events", func() {
 
 		// Create a tenancy logic without restrictions:
 		tenancy = auth.NewMockTenancyLogic(ctrl)
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(auth.AllTenants, nil).
+		tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+			Return(auth.TotalVisibility(), nil).
 			AnyTimes()
+
 		// Create the tenant used in the tests:
 		tenantsDao, err := NewGenericDAO[*privatev1.Tenant]().
 			SetLogger(logger).

--- a/fulfillment-service/internal/database/dao/generic_dao_exists.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_exists.go
@@ -37,10 +37,6 @@ func (r *ExistsRequest[O]) SetId(value string) *ExistsRequest[O] {
 
 // Do executes the exists operation and returns the response.
 func (r *ExistsRequest[O]) Do(ctx context.Context) (response *ExistsResponse, err error) {
-	err = r.init(ctx)
-	if err != nil {
-		return
-	}
 	r.tx, err = database.TxFromContext(ctx)
 	if err != nil {
 		return
@@ -51,17 +47,25 @@ func (r *ExistsRequest[O]) Do(ctx context.Context) (response *ExistsResponse, er
 }
 
 func (r *ExistsRequest[O]) do(ctx context.Context) (response *ExistsResponse, err error) {
-	// Add the tenancy filter:
-	err = r.addTenancyFilter(ctx)
-	if err != nil {
-		return
-	}
-
-	// Add the id parameter:
+	// Check parameters:
 	if r.id == "" {
 		err = errors.New("object identifier is mandatory")
 		return
 	}
+
+	// Check visibility:
+	ok, err := r.addVisibilityFilter(ctx)
+	if err != nil {
+		return
+	}
+	if !ok {
+		response = &ExistsResponse{
+			exists: false,
+		}
+		return
+	}
+
+	// Add the id parameter:
 	r.sql.params = append(r.sql.params, r.id)
 	if r.sql.filter.Len() > 0 {
 		r.sql.filter.WriteString(` and`)

--- a/fulfillment-service/internal/database/dao/generic_dao_get.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_get.go
@@ -48,10 +48,6 @@ func (r *GetRequest[O]) SetLock(value bool) *GetRequest[O] {
 
 // Do executes the get operation and returns the response.
 func (r *GetRequest[O]) Do(ctx context.Context) (response *GetResponse[O], err error) {
-	err = r.init(ctx)
-	if err != nil {
-		return
-	}
 	r.tx, err = database.TxFromContext(ctx)
 	if err != nil {
 		return
@@ -62,17 +58,27 @@ func (r *GetRequest[O]) Do(ctx context.Context) (response *GetResponse[O], err e
 }
 
 func (r *GetRequest[O]) do(ctx context.Context) (response *GetResponse[O], err error) {
-	// Add the where clause to filter by tenant:
-	err = r.addTenancyFilter(ctx)
-	if err != nil {
-		return
-	}
-
-	// Add the where clause to filter by identifier:
+	// Check parameters:
 	if r.id == "" {
 		err = errors.New("object identifier is mandatory")
 		return
 	}
+
+	// Check visibility:
+	ok, err := r.addVisibilityFilter(ctx)
+	if err != nil {
+		return
+	}
+	if !ok {
+		err = &ErrNotFound{
+			IDs: []string{
+				r.id,
+			},
+		}
+		return
+	}
+
+	// Add the where clause to filter by identifier:
 	r.sql.params = append(r.sql.params, r.id)
 	if r.sql.filter.Len() > 0 {
 		r.sql.filter.WriteString(` and`)

--- a/fulfillment-service/internal/database/dao/generic_dao_immutability_test.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_immutability_test.go
@@ -71,8 +71,8 @@ var _ = Describe("Immutable fields", func() {
 
 		// Create a tenancy logic without restrictions:
 		tenancy = auth.NewMockTenancyLogic(ctrl)
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(auth.AllTenants, nil).
+		tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+			Return(auth.TotalVisibility(), nil).
 			AnyTimes()
 
 		// Create the DAO:

--- a/fulfillment-service/internal/database/dao/generic_dao_integrity_test.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_integrity_test.go
@@ -71,8 +71,8 @@ var _ = Describe("Referential integrity", func() {
 
 		// Create a tenancy logic without restrictions:
 		tenancy = auth.NewMockTenancyLogic(ctrl)
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(auth.AllTenants, nil).
+		tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+			Return(auth.TotalVisibility(), nil).
 			AnyTimes()
 
 		// Create the DAO:

--- a/fulfillment-service/internal/database/dao/generic_dao_list.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_list.go
@@ -53,10 +53,6 @@ func (r *ListRequest[O]) SetOffset(value int32) *ListRequest[O] {
 
 // Do executes the list operation and returns the response.
 func (r *ListRequest[O]) Do(ctx context.Context) (response *ListResponse[O], err error) {
-	err = r.init(ctx)
-	if err != nil {
-		return
-	}
 	r.tx, err = database.TxFromContext(ctx)
 	if err != nil {
 		return
@@ -75,9 +71,13 @@ func (r *ListRequest[O]) do(ctx context.Context) (response *ListResponse[O], err
 		return
 	}
 
-	// Add tenant visibility filter:
-	err = r.addTenancyFilter(ctx)
+	// Check visibility:
+	ok, err := r.addVisibilityFilter(ctx)
 	if err != nil {
+		return
+	}
+	if !ok {
+		response = &ListResponse[O]{}
 		return
 	}
 

--- a/fulfillment-service/internal/database/dao/generic_dao_lock.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_lock.go
@@ -53,10 +53,6 @@ func (r *LockRequest[O]) AddIds(values ...string) *LockRequest[O] {
 
 // Do executes the lock operation and returns the response.
 func (r *LockRequest[O]) Do(ctx context.Context) (response *LockResponse[O], err error) {
-	err = r.init(ctx)
-	if err != nil {
-		return
-	}
 	r.tx, err = database.TxFromContext(ctx)
 	if err != nil {
 		return
@@ -67,9 +63,15 @@ func (r *LockRequest[O]) Do(ctx context.Context) (response *LockResponse[O], err
 }
 
 func (r *LockRequest[O]) do(ctx context.Context) (response *LockResponse[O], err error) {
-	// Add tenant visibility filter:
-	err = r.addTenancyFilter(ctx)
+	// Check visibility:
+	ok, err := r.addVisibilityFilter(ctx)
 	if err != nil {
+		return
+	}
+	if !ok {
+		err = &ErrNotFound{
+			IDs: r.ids,
+		}
 		return
 	}
 

--- a/fulfillment-service/internal/database/dao/generic_dao_lock_test.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_lock_test.go
@@ -25,7 +25,6 @@ import (
 
 	testsv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/tests/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/auth"
-	"github.com/osac-project/osac/fulfillment-service/internal/collections"
 	"github.com/osac-project/osac/fulfillment-service/internal/database"
 )
 
@@ -65,8 +64,8 @@ var _ = Describe("Lock", func() {
 
 		// Create a tenancy logic without restrictions:
 		tenancy := auth.NewMockTenancyLogic(ctrl)
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewUniversalSet[string](), nil).
+		tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+			Return(auth.TotalVisibility(), nil).
 			AnyTimes()
 		DeferCleanup(ctrl.Finish)
 

--- a/fulfillment-service/internal/database/dao/generic_dao_metrics_test.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_metrics_test.go
@@ -76,8 +76,8 @@ var _ = Describe("Metrics", func() {
 
 		// Create a tenancy logic without restrictions:
 		tenancy = auth.NewMockTenancyLogic(ctrl)
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(auth.AllTenants, nil).
+		tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+			Return(auth.TotalVisibility(), nil).
 			AnyTimes()
 
 		// Create the tenant used in the tests:

--- a/fulfillment-service/internal/database/dao/generic_dao_name_uniqueness_test.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_name_uniqueness_test.go
@@ -27,7 +27,6 @@ import (
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
 	testsv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/tests/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/auth"
-	"github.com/osac-project/osac/fulfillment-service/internal/collections"
 	"github.com/osac-project/osac/fulfillment-service/internal/database"
 )
 
@@ -90,8 +89,8 @@ var _ = Describe("Name uniqueness", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		tenancy = auth.NewMockTenancyLogic(ctrl)
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewUniversalSet[string](), nil).
+		tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+			Return(auth.TotalVisibility(), nil).
 			AnyTimes()
 
 		tenantsDao, err = NewGenericDAO[*privatev1.Tenant]().

--- a/fulfillment-service/internal/database/dao/generic_dao_request.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_request.go
@@ -32,16 +32,16 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/osac-project/osac/fulfillment-service/internal/collections"
+	"github.com/osac-project/osac/fulfillment-service/internal/auth"
 	"github.com/osac-project/osac/fulfillment-service/internal/database"
 )
 
 // request is a common base for all DAO request types, containing shared fields.
 type request[O Object] struct {
-	dao     *GenericDAO[O]
-	tx      database.Tx
-	tenants collections.Set[string]
-	sql     struct {
+	dao        *GenericDAO[O]
+	tx         database.Tx
+	visibility *auth.Visibility
+	sql        struct {
 		filter strings.Builder
 		params []any
 	}
@@ -59,18 +59,6 @@ type archiveArgs struct {
 	annotationsData []byte
 	version         int32
 	data            []byte
-}
-
-// init initializes the request, in particular it calculates the set of visible tenants.
-func (r *request[O]) init(ctx context.Context) error {
-	// Determine the set of visible tenants:
-	tenants, err := r.dao.tenancyLogic.DetermineVisibleTenants(ctx)
-	if err != nil {
-		return err
-	}
-	r.tenants = tenants
-
-	return nil
 }
 
 // archive moves a deleted object to the archived table and removes it from the main table.
@@ -179,57 +167,94 @@ func (r *request[O]) translateArchiveError(ctx context.Context, tenant string, e
 	}
 }
 
-// addTenancyFilter adds a clause to restrict results to only those objects that belong to tenants the current user
-// has permission to see.
-func (r *request[O]) addTenancyFilter(ctx context.Context) error {
-	// If the visible tenants set is universal, it means that the user has permission to see all tenants, so we don't
-	// need to apply any filtering:
-	if r.tenants.Universal() {
-		return nil
+// addVisibilityFilter adds a where clause to restrict results to only those objects that belong to tenants and projects
+// that the current user has permission to see.
+//
+// Returns a boolean flag indicating if the user has permissions to see any objects. When this is false it means that
+// the user doesn't have permission to see any objects, so the caller can skip building and executing the query and
+// return an error or an empty result instead.
+func (r *request[O]) addVisibilityFilter(ctx context.Context) (result bool, err error) {
+	// This method should always be called before any other filter or parameter is added:
+	if r.sql.filter.Len() > 0 {
+		err = fmt.Errorf(
+			"visibility filter must be the first filter added, but it already contains '%s'",
+			r.sql.filter.String(),
+		)
+		return
+	}
+	if len(r.sql.params) > 0 {
+		err = fmt.Errorf(
+			"visibility filter must be the first filter added, but it already contains %d parameters",
+			len(r.sql.params),
+		)
+		return
 	}
 
-	// If the visible tenants set is empty, it means that the user has no permission to see any tenants, so we can
-	// discard any previous filter and return instead a filter that matches nothing. Note that if parameters have
-	// been already added to the query, for example in the form of '$1', we need to preserve the existing filter
-	// to avoid potential binding errors.
-	if r.tenants.Empty() {
-		if len(r.sql.params) == 0 {
-			r.sql.filter.WriteString("false")
-		} else {
-			previous := r.sql.filter.String()
-			r.sql.filter.Reset()
-			r.sql.filter.WriteString("false and (")
-			r.sql.filter.WriteString(previous)
-			r.sql.filter.WriteString(")")
+	// Determine the set of visible projects for each visible tenant on first use:
+	if r.visibility == nil {
+		r.visibility, err = r.dao.tenancyLogic.DetermineVisibility(ctx)
+		if err != nil {
+			return
 		}
-		return nil
 	}
 
-	// If the tenant set is finite, then we can add a filter that matches the tenant in the set.
-	if r.tenants.Finite() {
-		ids := r.tenants.Inclusions()
-		sort.Strings(ids)
-		r.sql.params = append(r.sql.params, ids)
-		filter := fmt.Sprintf("tenant = any($%d)", len(r.sql.params))
-		if r.sql.filter.Len() == 0 {
-			r.sql.filter.WriteString(filter)
-		} else {
-			previous := r.sql.filter.String()
-			r.sql.filter.Reset()
-			fmt.Fprintf(&r.sql.filter, "(%s) and %s", previous, filter)
+	// If the visibility is unrestricted, it means that the user has permission to see all tenants and projects,
+	// so we don't need to apply any filtering:
+	if r.visibility.IsTotal() {
+		result = true
+		return
+	}
+
+	// Add a filter that matches each visible tenant. The default project (empty string) is always visible for a
+	// tenant the user can see, and is matched with equality. Named projects use the ltree '@>' operator so that
+	// granting a project also grants its descendants: the bound array is on the left and must contain an ancestor of
+	// the row project. The default project is never passed to '@>': the empty ltree is the root of the tree, so
+	// `array['']::ltree[] @> project` would match every project in the tenant.
+	//
+	// For example, if the user can see projects 'a1' and 'a2' in tenant 'a', and only the default project in tenant
+	// 'b', the filter will be like this:
+	//
+	//	tenant = 'a' and (project = '' or array['a1', 'a2']::ltree[] @> project) or tenant = 'b' and project = ''
+	//
+	// Tenants that are not visible are omitted. If the user can see tenant 'b' but not tenant 'a', the filter will
+	// not mention tenant 'a'.
+	tenants := r.visibility.VisibleTenants()
+	filters := 0
+	fmt.Fprintf(&r.sql.filter, "(")
+	for _, tenant := range tenants {
+		projects := r.visibility.VisibleProjects(tenant)
+		named := make([]string, 0, len(projects))
+		for _, project := range projects {
+			if project != "" {
+				named = append(named, project)
+			}
 		}
-		return nil
+		if filters > 0 {
+			fmt.Fprintf(&r.sql.filter, " or ")
+		}
+		index := len(r.sql.params) + 1
+		r.sql.params = append(r.sql.params, tenant)
+		if len(named) == 0 {
+			fmt.Fprintf(&r.sql.filter, "tenant = $%d and project = ''", index)
+		} else {
+			r.sql.params = append(r.sql.params, named)
+			fmt.Fprintf(
+				&r.sql.filter,
+				"tenant = $%d and (project = '' or $%d::ltree[] @> project)",
+				index, index+1,
+			)
+		}
+		filters++
 	}
+	fmt.Fprintf(&r.sql.filter, ")")
 
-	// If we are here then the tenant set is infinite, and we don't know how to apply filtering for that at the
-	// moment, so return an error.
-	r.dao.logger.Warn(
-		"Operation not permitted because visible tenant set is infinite",
-		slog.Any("exclusions", r.tenants.Exclusions()),
-	)
-	return &ErrDenied{
-		Reason: "operation not permitted",
+	// Due to the way we construct the filters above, if no filters were added it means that the user doesn't have
+	// permission to see any objects. We also clean the filter buffer, which at that point will contain '()'.
+	result = filters > 0
+	if !result {
+		r.sql.filter.Reset()
 	}
+	return
 }
 
 type makeMetadataArgs struct {
@@ -256,23 +281,12 @@ func (r *request[O]) makeMetadata(args makeMetadataArgs) metadataIface {
 	}
 	result.SetFinalizers(args.finalizers)
 	result.SetCreator(args.creator)
-	result.SetTenant(r.filterTenant(args.tenant))
+	result.SetTenant(args.tenant)
 	result.SetProject(args.project)
 	result.SetLabels(args.labels)
 	result.SetAnnotations(args.annotations)
 	result.SetVersion(args.version)
 	return result
-}
-
-// filterTenant returns the object's tenant if it is visible to the user, or an empty string otherwise.
-func (r *request[O]) filterTenant(tenant string) string {
-	if r.tenants.Universal() {
-		return tenant
-	}
-	if r.tenants.Contains(tenant) {
-		return tenant
-	}
-	return ""
 }
 
 func (r *request[O]) getMetadata(object O) metadataIface {

--- a/fulfillment-service/internal/database/dao/generic_dao_tenant_visibility_test.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_tenant_visibility_test.go
@@ -17,21 +17,22 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 
 	testsv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/tests/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/auth"
-	"github.com/osac-project/osac/fulfillment-service/internal/collections"
 	"github.com/osac-project/osac/fulfillment-service/internal/database"
 )
 
-var _ = Describe("Tenant visibility", func() {
+var _ = Describe("Generic DAO visibility", func() {
 	var (
 		ctx  context.Context
 		tx   database.Tx
 		ctrl *gomock.Controller
+		pool *pgxpool.Pool
 	)
 
 	BeforeEach(func() {
@@ -44,7 +45,7 @@ var _ = Describe("Tenant visibility", func() {
 		db, err := server.NewInstance().Build()
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(db.Close)
-		pool, err := db.Pool(ctx)
+		pool, err = db.Pool(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(pool.Close)
 
@@ -96,364 +97,571 @@ var _ = Describe("Tenant visibility", func() {
 		DeferCleanup(ctrl.Finish)
 	})
 
-	It("Filters field based on user visibility", func() {
-		// Create a tenancy logic that makes certain tenants visible to the user:
-		tenancy := auth.NewMockTenancyLogic(ctrl)
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewSet("tenant-a", "tenant-c"), nil).
-			AnyTimes()
+	Describe("Tenant visibility", func() {
+		It("Filters based on user visibility", func() {
+			// Create a tenancy logic that makes certain tenants visible to the user:
+			visibility, err := auth.NewVisibility().
+				AddVisibleTenants("tenant-a", "tenant-c").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			tenancy := auth.NewMockTenancyLogic(ctrl)
+			tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+				Return(visibility, nil).
+				AnyTimes()
 
-		// Create the DAO:
-		dao, err := NewGenericDAO[*testsv1.Object]().
-			SetLogger(logger).
-			SetTenancyLogic(tenancy).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
+			// Create the DAO:
+			dao, err := NewGenericDAO[*testsv1.Object]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
 
-		// Create an object with a visible tenant, verify the response shows it:
-		createResponse, err := dao.Create().
-			SetObject(testsv1.Object_builder{
-				Metadata: testsv1.Metadata_builder{
-					Tenant: "tenant-a",
-				}.Build(),
-			}.Build()).
-			Do(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		object := createResponse.GetObject()
-		Expect(object.GetMetadata().GetTenant()).To(Equal("tenant-a"))
+			// Create an object with a visible tenant, verify the response shows it:
+			createResponse, err := dao.Create().
+				SetObject(testsv1.Object_builder{
+					Metadata: testsv1.Metadata_builder{
+						Tenant: "tenant-a",
+					}.Build(),
+				}.Build()).
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+			Expect(object.GetMetadata().GetTenant()).To(Equal("tenant-a"))
 
-		// Retrieve the object by identifier and verify it still shows the tenant:
-		getResponse, err := dao.Get().
-			SetId(object.GetId()).
-			Do(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		object = getResponse.GetObject()
-		Expect(object.GetMetadata().GetTenant()).To(Equal("tenant-a"))
+			// Retrieve the object by identifier and verify it still shows the tenant:
+			getResponse, err := dao.Get().
+				SetId(object.GetId()).
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			object = getResponse.GetObject()
+			Expect(object.GetMetadata().GetTenant()).To(Equal("tenant-a"))
 
-		// Retrieve the object as part of a list and verify it still shows the tenant:
-		listResponse, err := dao.List().
-			SetFilter(fmt.Sprintf("this.id == %q", object.GetId())).
-			SetLimit(1).
-			Do(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(listResponse.GetItems()).To(HaveLen(1))
-		Expect(listResponse.GetItems()[0].GetMetadata().GetTenant()).To(Equal("tenant-a"))
+			// Retrieve the object as part of a list and verify it still shows the tenant:
+			listResponse, err := dao.List().
+				SetFilter(fmt.Sprintf("this.id == %q", object.GetId())).
+				SetLimit(1).
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(listResponse.GetItems()).To(HaveLen(1))
+			Expect(listResponse.GetItems()[0].GetMetadata().GetTenant()).To(Equal("tenant-a"))
 
-		// Update the object and verify the response still shows the tenant:
-		object.SetMyString("hello")
-		object.GetMetadata().SetTenant("tenant-a")
-		updateResponse, err := dao.Update().
-			SetObject(object).
-			Do(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		object = updateResponse.GetObject()
-		Expect(object.GetMetadata().GetTenant()).To(Equal("tenant-a"))
+			// Update the object and verify the response still shows the tenant:
+			object.SetMyString("hello")
+			object.GetMetadata().SetTenant("tenant-a")
+			updateResponse, err := dao.Update().
+				SetObject(object).
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			object = updateResponse.GetObject()
+			Expect(object.GetMetadata().GetTenant()).To(Equal("tenant-a"))
 
-		// Verify the actual database contains the tenant:
-		var tenant string
-		row := tx.QueryRow(ctx, "select tenant from objects where id = $1", object.GetId())
-		err = row.Scan(&tenant)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(tenant).To(Equal("tenant-a"))
+			// Verify the actual database contains the tenant:
+			var tenant string
+			row := tx.QueryRow(ctx, "select tenant from objects where id = $1", object.GetId())
+			err = row.Scan(&tenant)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(tenant).To(Equal("tenant-a"))
+		})
+
+		It("Shows all tenants when user has no tenant restrictions", func() {
+			// Create a tenancy logic that makes all tenants visible to the user:
+			visibility, err := auth.NewVisibility().
+				SetTotal(true).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			tenancy := auth.NewMockTenancyLogic(ctrl)
+			tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+				Return(visibility, nil).
+				AnyTimes()
+
+			// Create the DAO:
+			dao, err := NewGenericDAO[*testsv1.Object]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create an object and verify that it shows the tenant:
+			createResponse, err := dao.Create().
+				SetObject(testsv1.Object_builder{
+					Metadata: testsv1.Metadata_builder{
+						Tenant: "tenant-a",
+					}.Build(),
+				}.Build()).
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+			Expect(object.GetMetadata().GetTenant()).To(Equal("tenant-a"))
+		})
+
+		It("Shows no tenants when user has no visible tenants that intersect with object tenants", func() {
+			// Create a tenancy logic that makes only one tenant visible to the user:
+			visibility, err := auth.NewVisibility().
+				AddVisibleTenants("tenant-x").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			tenancy := auth.NewMockTenancyLogic(ctrl)
+			tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+				Return(visibility, nil).
+				AnyTimes()
+
+			// Create the DAO:
+			dao, err := NewGenericDAO[*testsv1.Object]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create an object with a tenant that doesn't overlap with visible tenants:
+			createResponse, err := dao.Create().
+				SetObject(testsv1.Object_builder{
+					Metadata: testsv1.Metadata_builder{
+						Tenant: "tenant-y",
+					}.Build(),
+				}.Build()).
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+
+			// Verify the object is not found via Get because the SQL tenant filter excludes it:
+			_, err = dao.Get().
+				SetId(object.GetId()).
+				Do(ctx)
+			var notFoundErr *ErrNotFound
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(BeAssignableToTypeOf(notFoundErr))
+
+			// Verify the object is not returned via List either:
+			listResponse, err := dao.List().
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(listResponse.GetItems()).To(BeEmpty())
+		})
+
+		It("Allows a tenant to delete an object it created", func() {
+			// Create a DAO with visibility of all projects for tenant A:
+			visibility, err := auth.NewVisibility().
+				AddVisibleTenants("tenant-a").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			tenancy := auth.NewMockTenancyLogic(ctrl)
+			tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+				Return(visibility, nil).
+				AnyTimes()
+			dao, err := NewGenericDAO[*testsv1.Object]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create the object:
+			createResponse, err := dao.Create().
+				SetObject(testsv1.Object_builder{
+					Metadata: testsv1.Metadata_builder{
+						Tenant: "tenant-a",
+					}.Build(),
+				}.Build()).
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+
+			// Verify that the object can be deleted:
+			_, err = dao.Delete().
+				SetId(object.GetId()).
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify that the object is no longer retrievable:
+			_, err = dao.Get().
+				SetId(object.GetId()).
+				Do(ctx)
+			var notFoundErr *ErrNotFound
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(BeAssignableToTypeOf(notFoundErr))
+		})
+
+		It("Rejects deletion of an object belonging to an invisible tenant as not found", func() {
+			// Create the DAO with visibility for all projects for tenant A and insert the object:
+			visibilityA, err := auth.NewVisibility().
+				AddVisibleTenants("tenant-a").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			tenancyA := auth.NewMockTenancyLogic(ctrl)
+			tenancyA.EXPECT().DetermineVisibility(gomock.Any()).
+				Return(visibilityA, nil).
+				AnyTimes()
+			daoA, err := NewGenericDAO[*testsv1.Object]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancyA).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create the object with tenant A:
+			createResponse, err := daoA.Create().
+				SetObject(testsv1.Object_builder{
+					Metadata: testsv1.Metadata_builder{
+						Tenant: "tenant-a",
+					}.Build(),
+				}.Build()).
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+
+			// Create a DAO with visibility for tenant B and verify that it can't delete the object of
+			// tenant A:
+			visibilityB, err := auth.NewVisibility().
+				AddVisibleTenants("tenant-b").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			tenancyB := auth.NewMockTenancyLogic(ctrl)
+			tenancyB.EXPECT().DetermineVisibility(gomock.Any()).
+				Return(visibilityB, nil).
+				AnyTimes()
+			daoB, err := NewGenericDAO[*testsv1.Object]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancyB).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			_, err = daoB.Delete().
+				SetId(object.GetId()).
+				Do(ctx)
+			var notFoundErr *ErrNotFound
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(BeAssignableToTypeOf(notFoundErr))
+
+			// Verify that the object still exists using the DAO for tenant A:
+			getResponse, err := daoA.Get().
+				SetId(object.GetId()).
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetId()).To(Equal(object.GetId()))
+		})
+
+		It("Allows a tenant to update an object it created", func() {
+			// Create a DAO with visibility for tenant A:
+			visibility, err := auth.NewVisibility().
+				AddVisibleTenants("tenant-a").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			tenancy := auth.NewMockTenancyLogic(ctrl)
+			tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+				Return(visibility, nil).
+				AnyTimes()
+			dao, err := NewGenericDAO[*testsv1.Object]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create the object:
+			createResponse, err := dao.Create().
+				SetObject(testsv1.Object_builder{
+					Metadata: testsv1.Metadata_builder{
+						Tenant: "tenant-a",
+					}.Build(),
+				}.Build()).
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+
+			// Verify that the object can be updated:
+			object.SetMyString("updated")
+			updateResponse, err := dao.Update().
+				SetObject(object).
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updateResponse.GetObject().GetMyString()).To(Equal("updated"))
+
+			// Retrieve the object and verify the update persisted:
+			getResponse, err := dao.Get().
+				SetId(object.GetId()).
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetMyString()).To(Equal("updated"))
+		})
+
+		It("Isolates tenant rows when filter has a top-level OR", func() {
+			// Create an unrestricted tenancy to seed objects in different tenants:
+			tenancyAll := auth.NewMockTenancyLogic(ctrl)
+			tenancyAll.EXPECT().DetermineVisibility(gomock.Any()).
+				Return(auth.TotalVisibility(), nil).
+				AnyTimes()
+			daoAll, err := NewGenericDAO[*testsv1.Object]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancyAll).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create an object in tenant-a (will be visible):
+			_, err = daoAll.Create().
+				SetObject(testsv1.Object_builder{
+					Metadata: testsv1.Metadata_builder{
+						Tenant: "tenant-a",
+						Name:   "shared-name",
+					}.Build(),
+				}.Build()).
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create an object in tenant-b with the same name (should be invisible to tenant-a):
+			_, err = daoAll.Create().
+				SetObject(testsv1.Object_builder{
+					Metadata: testsv1.Metadata_builder{
+						Tenant: "tenant-b",
+						Name:   "shared-name",
+					}.Build(),
+				}.Build()).
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Create a restricted DAO that can only see tenant-a:
+			visibilityRestricted, err := auth.NewVisibility().
+				AddVisibleTenants("tenant-a").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			tenancyRestricted := auth.NewMockTenancyLogic(ctrl)
+			tenancyRestricted.EXPECT().DetermineVisibility(gomock.Any()).
+				Return(visibilityRestricted, nil).
+				AnyTimes()
+			daoRestricted, err := NewGenericDAO[*testsv1.Object]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancyRestricted).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// List with a top-level OR filter (id-or-name pattern). The tenancy clause
+			// must apply to the entire filter, not just the first branch:
+			listResponse, err := daoRestricted.List().
+				SetFilter(`this.id == "nonexistent" || this.metadata.name == "shared-name"`).
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(listResponse.GetTotal()).To(Equal(int32(1)))
+			Expect(listResponse.GetItems()).To(HaveLen(1))
+			Expect(listResponse.GetItems()[0].GetMetadata().GetTenant()).To(Equal("tenant-a"))
+		})
+
+		It("Rejects update of an object belonging to an invisible tenant as not found", func() {
+			// Create a tenancy logic that makes all tenants visible, used to create the object:
+			visibilityA, err := auth.NewVisibility().
+				AddVisibleTenants("tenant-a").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			tenancyA := auth.NewMockTenancyLogic(ctrl)
+			tenancyA.EXPECT().DetermineVisibility(gomock.Any()).
+				Return(visibilityA, nil).
+				AnyTimes()
+
+			// Create the DAO for tenant A and insert the object:
+			daoA, err := NewGenericDAO[*testsv1.Object]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancyA).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			createResponse, err := daoA.Create().
+				SetObject(testsv1.Object_builder{
+					Metadata: testsv1.Metadata_builder{
+						Tenant: "tenant-a",
+					}.Build(),
+				}.Build()).
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			object := createResponse.GetObject()
+
+			// Create a tenancy logic that only sees tenant B and verify that it can't update the object of
+			// tenant A:
+			visibilityB, err := auth.NewVisibility().
+				AddVisibleTenants("tenant-b").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			tenancyB := auth.NewMockTenancyLogic(ctrl)
+			tenancyB.EXPECT().DetermineVisibility(gomock.Any()).
+				Return(visibilityB, nil).
+				AnyTimes()
+			daoB, err := NewGenericDAO[*testsv1.Object]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancyB).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			object.SetMyString("updated")
+			_, err = daoB.Update().
+				SetObject(object).
+				Do(ctx)
+			var notFoundErr *ErrNotFound
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(BeAssignableToTypeOf(notFoundErr))
+
+			// Verify the object was not modified using the DAO for tenant A:
+			getResponse, err := daoA.Get().
+				SetId(object.GetId()).
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetMyString()).To(BeEmpty())
+		})
 	})
 
-	It("Shows all tenants when user has no tenant restrictions", func() {
-		// Create a tenancy logic that makes all tenants visible to the user:
-		tenancy := auth.NewMockTenancyLogic(ctrl)
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(auth.AllTenants, nil).
-			AnyTimes()
+	Describe("Project visibility", func() {
+		BeforeEach(func() {
+			createProject := func(tenant, parent, name string) {
+				_, err := pool.Exec(ctx,
+					`
+					insert into projects (
+						id,
+						tenant,
+						project,
+						name,
+						data
+					)
+					values (
+						$1,
+						$2,
+						$3,
+						$4,
+						'{}'
+					)
+					`,
+					fmt.Sprintf("%s-%s", tenant, name), tenant, parent, name,
+				)
+				Expect(err).ToNot(HaveOccurred())
+			}
+			createProject("tenant-a", "", "p1")
+			createProject("tenant-a", "", "p2")
+			createProject("tenant-a", "p1", "p1.child")
+			createProject("tenant-a", "p1.child", "p1.child.grandchild")
+		})
 
-		// Create the DAO:
-		dao, err := NewGenericDAO[*testsv1.Object]().
-			SetLogger(logger).
-			SetTenancyLogic(tenancy).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
+		unrestrictedDAO := func() *GenericDAO[*testsv1.Object] {
+			tenancy := auth.NewMockTenancyLogic(ctrl)
+			tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+				Return(auth.TotalVisibility(), nil).
+				AnyTimes()
+			dao, err := NewGenericDAO[*testsv1.Object]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			return dao
+		}
 
-		// Create an object and verify that it shows the tenant:
-		createResponse, err := dao.Create().
-			SetObject(testsv1.Object_builder{
-				Metadata: testsv1.Metadata_builder{
-					Tenant: "tenant-a",
-				}.Build(),
-			}.Build()).
-			Do(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		object := createResponse.GetObject()
-		Expect(object.GetMetadata().GetTenant()).To(Equal("tenant-a"))
-	})
+		daoWithVisibility := func(visibility *auth.Visibility) *GenericDAO[*testsv1.Object] {
+			tenancy := auth.NewMockTenancyLogic(ctrl)
+			tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+				Return(visibility, nil).
+				AnyTimes()
+			dao, err := NewGenericDAO[*testsv1.Object]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			return dao
+		}
 
-	It("Shows no tenants when user has no visible tenants that intersect with object tenants", func() {
-		// Create a tenancy logic that makes only one tenant visible to the user:
-		tenancy := auth.NewMockTenancyLogic(ctrl)
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewSet("tenant-x"), nil).
-			AnyTimes()
+		createObject := func(dao *GenericDAO[*testsv1.Object], project, name string) string {
+			response, err := dao.Create().
+				SetObject(testsv1.Object_builder{
+					Metadata: testsv1.Metadata_builder{
+						Tenant:  "tenant-a",
+						Project: project,
+						Name:    name,
+					}.Build(),
+				}.Build()).
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			return response.GetObject().GetId()
+		}
 
-		// Create the DAO:
-		dao, err := NewGenericDAO[*testsv1.Object]().
-			SetLogger(logger).
-			SetTenancyLogic(tenancy).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
+		listedNames := func(dao *GenericDAO[*testsv1.Object]) []string {
+			response, err := dao.List().Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			names := make([]string, 0, len(response.GetItems()))
+			for _, item := range response.GetItems() {
+				names = append(names, item.GetMetadata().GetName())
+			}
+			return names
+		}
 
-		// Create an object with a tenant that doesn't overlap with visible tenants:
-		createResponse, err := dao.Create().
-			SetObject(testsv1.Object_builder{
-				Metadata: testsv1.Metadata_builder{
-					Tenant: "tenant-y",
-				}.Build(),
-			}.Build()).
-			Do(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		object := createResponse.GetObject()
-		Expect(object.GetMetadata().GetTenant()).To(BeEmpty())
+		It("Includes the default project and excludes ungranted named projects", func() {
+			seed := unrestrictedDAO()
+			defaultID := createObject(seed, "", "default-obj")
+			namedID := createObject(seed, "p1", "p1-obj")
 
-		// Verify the object is not found via Get because the SQL tenant filter excludes it:
-		_, err = dao.Get().
-			SetId(object.GetId()).
-			Do(ctx)
-		var notFoundErr *ErrNotFound
-		Expect(err).To(HaveOccurred())
-		Expect(err).To(BeAssignableToTypeOf(notFoundErr))
+			visibility, err := auth.NewVisibility().
+				AddVisibleTenants("tenant-a").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			dao := daoWithVisibility(visibility)
 
-		// Verify the object is not returned via List either:
-		listResponse, err := dao.List().
-			Do(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(listResponse.GetItems()).To(BeEmpty())
-	})
+			Expect(listedNames(dao)).To(ConsistOf("default-obj"))
 
-	It("Allows a tenant to delete an object it created", func() {
-		// Create a DAO with visibility for tenant A:
-		tenancy := auth.NewMockTenancyLogic(ctrl)
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewSet("tenant-a"), nil).
-			AnyTimes()
-		dao, err := NewGenericDAO[*testsv1.Object]().
-			SetLogger(logger).
-			SetTenancyLogic(tenancy).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
+			_, err = dao.Get().SetId(defaultID).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
 
-		// Create the object:
-		createResponse, err := dao.Create().
-			SetObject(testsv1.Object_builder{
-				Metadata: testsv1.Metadata_builder{
-					Tenant: "tenant-a",
-				}.Build(),
-			}.Build()).
-			Do(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		object := createResponse.GetObject()
+			_, err = dao.Get().SetId(namedID).Do(ctx)
+			var notFoundErr *ErrNotFound
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(BeAssignableToTypeOf(notFoundErr))
 
-		// Verify that the object can be deleted:
-		_, err = dao.Delete().
-			SetId(object.GetId()).
-			Do(ctx)
-		Expect(err).ToNot(HaveOccurred())
+			existsResponse, err := dao.Exists().SetId(namedID).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(existsResponse.GetExists()).To(BeFalse())
+		})
 
-		// Verify that the object is no longer retrievable:
-		_, err = dao.Get().
-			SetId(object.GetId()).
-			Do(ctx)
-		var notFoundErr *ErrNotFound
-		Expect(err).To(HaveOccurred())
-		Expect(err).To(BeAssignableToTypeOf(notFoundErr))
-	})
+		It("Includes granted named projects and their descendants", func() {
+			seed := unrestrictedDAO()
+			createObject(seed, "", "default-obj")
+			p1ID := createObject(seed, "p1", "p1-obj")
+			childID := createObject(seed, "p1.child", "p1-child-obj")
+			grandchildID := createObject(seed, "p1.child.grandchild", "p1-grandchild-obj")
+			p2ID := createObject(seed, "p2", "p2-obj")
 
-	It("Rejects deletion of an object belonging to an invisible tenant as not found", func() {
-		// Create the DAO with visibility for tenant A and insert the object:
-		tenancyA := auth.NewMockTenancyLogic(ctrl)
-		tenancyA.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewSet("tenant-a"), nil).
-			AnyTimes()
-		daoA, err := NewGenericDAO[*testsv1.Object]().
-			SetLogger(logger).
-			SetTenancyLogic(tenancyA).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
+			visibility, err := auth.NewVisibility().
+				AddVisibleProject("tenant-a", "p1").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			dao := daoWithVisibility(visibility)
 
-		// Create the object with tenant A:
-		createResponse, err := daoA.Create().
-			SetObject(testsv1.Object_builder{
-				Metadata: testsv1.Metadata_builder{
-					Tenant: "tenant-a",
-				}.Build(),
-			}.Build()).
-			Do(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		object := createResponse.GetObject()
+			Expect(listedNames(dao)).To(ConsistOf("default-obj", "p1-obj", "p1-child-obj", "p1-grandchild-obj"))
 
-		// Create a DAO with visibility for tenant B and verify that it can't delete the object of
-		// tenant A:
-		tenancyB := auth.NewMockTenancyLogic(ctrl)
-		tenancyB.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewSet("tenant-b"), nil).
-			AnyTimes()
-		daoB, err := NewGenericDAO[*testsv1.Object]().
-			SetLogger(logger).
-			SetTenancyLogic(tenancyB).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-		_, err = daoB.Delete().
-			SetId(object.GetId()).
-			Do(ctx)
-		var notFoundErr *ErrNotFound
-		Expect(err).To(HaveOccurred())
-		Expect(err).To(BeAssignableToTypeOf(notFoundErr))
+			_, err = dao.Get().SetId(p1ID).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
 
-		// Verify that the object still exists using the DAO for tenant A:
-		getResponse, err := daoA.Get().
-			SetId(object.GetId()).
-			Do(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(getResponse.GetObject().GetId()).To(Equal(object.GetId()))
-	})
+			_, err = dao.Get().SetId(childID).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
 
-	It("Allows a tenant to update an object it created", func() {
-		// Create a DAO with visibility for tenant A:
-		tenancy := auth.NewMockTenancyLogic(ctrl)
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewSet("tenant-a"), nil).
-			AnyTimes()
-		dao, err := NewGenericDAO[*testsv1.Object]().
-			SetLogger(logger).
-			SetTenancyLogic(tenancy).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
+			_, err = dao.Get().SetId(grandchildID).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
 
-		// Create the object:
-		createResponse, err := dao.Create().
-			SetObject(testsv1.Object_builder{
-				Metadata: testsv1.Metadata_builder{
-					Tenant: "tenant-a",
-				}.Build(),
-			}.Build()).
-			Do(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		object := createResponse.GetObject()
+			_, err = dao.Get().SetId(p2ID).Do(ctx)
+			var notFoundErr *ErrNotFound
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(BeAssignableToTypeOf(notFoundErr))
 
-		// Verify that the object can be updated:
-		object.SetMyString("updated")
-		updateResponse, err := dao.Update().
-			SetObject(object).
-			Do(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(updateResponse.GetObject().GetMyString()).To(Equal("updated"))
+			existsResponse, err := dao.Exists().SetId(p1ID).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(existsResponse.GetExists()).To(BeTrue())
 
-		// Retrieve the object and verify the update persisted:
-		getResponse, err := dao.Get().
-			SetId(object.GetId()).
-			Do(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(getResponse.GetObject().GetMyString()).To(Equal("updated"))
-	})
+			existsResponse, err = dao.Exists().SetId(grandchildID).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(existsResponse.GetExists()).To(BeTrue())
 
-	It("Isolates tenant rows when filter has a top-level OR", func() {
-		// Create an unrestricted tenancy to seed objects in different tenants:
-		tenancyAll := auth.NewMockTenancyLogic(ctrl)
-		tenancyAll.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewUniversalSet[string](), nil).
-			AnyTimes()
-		daoAll, err := NewGenericDAO[*testsv1.Object]().
-			SetLogger(logger).
-			SetTenancyLogic(tenancyAll).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
+			existsResponse, err = dao.Exists().SetId(p2ID).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(existsResponse.GetExists()).To(BeFalse())
+		})
 
-		// Create an object in tenant-a (will be visible):
-		_, err = daoAll.Create().
-			SetObject(testsv1.Object_builder{
-				Metadata: testsv1.Metadata_builder{
-					Tenant: "tenant-a",
-					Name:   "shared-name",
-				}.Build(),
-			}.Build()).
-			Do(ctx)
-		Expect(err).ToNot(HaveOccurred())
+		It("Does not include ancestor projects of a granted descendant", func() {
+			seed := unrestrictedDAO()
+			createObject(seed, "", "default-obj")
+			createObject(seed, "p1", "p1-obj")
+			createObject(seed, "p1.child", "p1-child-obj")
+			createObject(seed, "p2", "p2-obj")
 
-		// Create an object in tenant-b with the same name (should be invisible to tenant-a):
-		_, err = daoAll.Create().
-			SetObject(testsv1.Object_builder{
-				Metadata: testsv1.Metadata_builder{
-					Tenant: "tenant-b",
-					Name:   "shared-name",
-				}.Build(),
-			}.Build()).
-			Do(ctx)
-		Expect(err).ToNot(HaveOccurred())
+			visibility, err := auth.NewVisibility().
+				AddVisibleProject("tenant-a", "p1.child").
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+			dao := daoWithVisibility(visibility)
 
-		// Create a restricted DAO that can only see tenant-a:
-		tenancyRestricted := auth.NewMockTenancyLogic(ctrl)
-		tenancyRestricted.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewSet("tenant-a"), nil).
-			AnyTimes()
-		daoRestricted, err := NewGenericDAO[*testsv1.Object]().
-			SetLogger(logger).
-			SetTenancyLogic(tenancyRestricted).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-
-		// List with a top-level OR filter (id-or-name pattern). The tenancy clause
-		// must apply to the entire filter, not just the first branch:
-		listResponse, err := daoRestricted.List().
-			SetFilter(`this.id == "nonexistent" || this.metadata.name == "shared-name"`).
-			Do(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(listResponse.GetTotal()).To(Equal(int32(1)))
-		Expect(listResponse.GetItems()).To(HaveLen(1))
-		Expect(listResponse.GetItems()[0].GetMetadata().GetTenant()).To(Equal("tenant-a"))
-	})
-
-	It("Rejects update of an object belonging to an invisible tenant as not found", func() {
-		// Create a tenancy logic that makes all tenants visible, used to create the object:
-		tenancyA := auth.NewMockTenancyLogic(ctrl)
-		tenancyA.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewSet("tenant-a"), nil).
-			AnyTimes()
-
-		// Create the DAO for tenant A and insert the object:
-		daoA, err := NewGenericDAO[*testsv1.Object]().
-			SetLogger(logger).
-			SetTenancyLogic(tenancyA).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-		createResponse, err := daoA.Create().
-			SetObject(testsv1.Object_builder{
-				Metadata: testsv1.Metadata_builder{
-					Tenant: "tenant-a",
-				}.Build(),
-			}.Build()).
-			Do(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		object := createResponse.GetObject()
-
-		// Create a tenancy logic that only sees tenant B and verify that it can't update the object of
-		// tenant A:
-		tenancyB := auth.NewMockTenancyLogic(ctrl)
-		tenancyB.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewSet("tenant-b"), nil).
-			AnyTimes()
-		daoB, err := NewGenericDAO[*testsv1.Object]().
-			SetLogger(logger).
-			SetTenancyLogic(tenancyB).
-			Build()
-		Expect(err).ToNot(HaveOccurred())
-		object.SetMyString("updated")
-		_, err = daoB.Update().
-			SetObject(object).
-			Do(ctx)
-		var notFoundErr *ErrNotFound
-		Expect(err).To(HaveOccurred())
-		Expect(err).To(BeAssignableToTypeOf(notFoundErr))
-
-		// Verify the object was not modified using the DAO for tenant A:
-		getResponse, err := daoA.Get().
-			SetId(object.GetId()).
-			Do(ctx)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(getResponse.GetObject().GetMyString()).To(BeEmpty())
+			Expect(listedNames(dao)).To(ConsistOf("default-obj", "p1-child-obj"))
+		})
 	})
 })

--- a/fulfillment-service/internal/database/dao/generic_dao_test.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_test.go
@@ -30,7 +30,6 @@ import (
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
 	testsv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/tests/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/auth"
-	"github.com/osac-project/osac/fulfillment-service/internal/collections"
 	"github.com/osac-project/osac/fulfillment-service/internal/database"
 	"github.com/osac-project/osac/fulfillment-service/internal/uuid"
 )
@@ -120,8 +119,8 @@ var _ = Describe("Generic DAO", func() {
 
 		// Create a tenancy logic without restrictions:
 		tenancy = auth.NewMockTenancyLogic(ctrl)
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewUniversalSet[string](), nil).
+		tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+			Return(auth.TotalVisibility(), nil).
 			AnyTimes()
 
 		// Create the DAOs for tenants and projects:

--- a/fulfillment-service/internal/database/dao/generic_dao_update.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_update.go
@@ -43,10 +43,6 @@ func (r *UpdateRequest[O]) SetObject(value O) *UpdateRequest[O] {
 
 // Do executes the update operation and returns the response.
 func (r *UpdateRequest[O]) Do(ctx context.Context) (response *UpdateResponse[O], err error) {
-	err = r.init(ctx)
-	if err != nil {
-		return
-	}
 	r.tx, err = database.TxFromContext(ctx)
 	if err != nil {
 		return
@@ -57,18 +53,28 @@ func (r *UpdateRequest[O]) Do(ctx context.Context) (response *UpdateResponse[O],
 }
 
 func (r *UpdateRequest[O]) do(ctx context.Context) (response *UpdateResponse[O], err error) {
-	// Add the where clause to filter by tenant:
-	err = r.addTenancyFilter(ctx)
-	if err != nil {
-		return
-	}
-
-	// Add the where clause to filter by identifier:
+	// Check parameters:
 	id := r.object.GetId()
 	if id == "" {
 		err = errors.New("object identifier is mandatory")
 		return
 	}
+
+	// Check visibility:
+	ok, err := r.addVisibilityFilter(ctx)
+	if err != nil {
+		return
+	}
+	if !ok {
+		err = &ErrNotFound{
+			IDs: []string{
+				id,
+			},
+		}
+		return
+	}
+
+	// Add the where clause to filter by identifier:
 	r.sql.params = append(r.sql.params, id)
 	if r.sql.filter.Len() > 0 {
 		r.sql.filter.WriteString(` and`)

--- a/fulfillment-service/internal/database/dao/generic_dao_version_test.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_version_test.go
@@ -23,7 +23,6 @@ import (
 
 	testsv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/tests/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/auth"
-	"github.com/osac-project/osac/fulfillment-service/internal/collections"
 	"github.com/osac-project/osac/fulfillment-service/internal/database"
 )
 
@@ -72,8 +71,8 @@ var _ = Describe("Version", func() {
 
 		// Create a tenancy logic without restrictions:
 		tenancy = auth.NewMockTenancyLogic(ctrl)
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(collections.NewUniversalSet[string](), nil).
+		tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+			Return(auth.TotalVisibility(), nil).
 			AnyTimes()
 
 		// Create the tenants used in the tests:

--- a/fulfillment-service/internal/servers/events_server.go
+++ b/fulfillment-service/internal/servers/events_server.go
@@ -33,7 +33,6 @@ import (
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/auth"
-	"github.com/osac-project/osac/fulfillment-service/internal/collections"
 	"github.com/osac-project/osac/fulfillment-service/internal/events"
 	"github.com/osac-project/osac/fulfillment-service/internal/packages"
 	"github.com/osac-project/osac/fulfillment-service/internal/util"
@@ -64,7 +63,7 @@ type EventsServer struct {
 
 type eventsServerSubInfo struct {
 	stream     grpc.ServerStreamingServer[publicv1.EventsWatchResponse]
-	tenants    collections.Set[string]
+	visibility *auth.Visibility
 	filterSrc  string
 	filterPrg  cel.Program
 	eventsChan chan *publicv1.Event
@@ -217,15 +216,15 @@ func (s *EventsServer) Watch(request *publicv1.EventsWatchRequest,
 	// Get the context:
 	ctx := stream.Context()
 
-	// Determine the visible tenants:
-	tenants, err := s.tenancyLogic.DetermineVisibleTenants(ctx)
+	// Determine the visibility:
+	visibility, err := s.tenancyLogic.DetermineVisibility(ctx)
 	if err != nil {
 		s.logger.ErrorContext(
 			ctx,
-			"Failed to determine visible tenants",
+			"Failed to determine visibility",
 			slog.Any("error", err),
 		)
-		return grpcstatus.Errorf(grpccodes.Internal, "failed to determine visible tenants")
+		return grpcstatus.Errorf(grpccodes.Internal, "failed to determine visibility")
 	}
 
 	// Compile the filter expression:
@@ -260,7 +259,7 @@ func (s *EventsServer) Watch(request *publicv1.EventsWatchRequest,
 	)
 	subInfo := eventsServerSubInfo{
 		stream:     stream,
-		tenants:    tenants,
+		visibility: visibility,
 		filterSrc:  filterSrc,
 		filterPrg:  filterPrg,
 		eventsChan: make(chan *publicv1.Event),
@@ -417,8 +416,8 @@ func (s *EventsServer) processEvent(ctx context.Context, public *publicv1.Event,
 			continue
 		}
 		tenant := metadata.GetTenant()
-		visible := sub.tenants.Contains(tenant)
-		if !visible {
+		project := metadata.GetProject()
+		if !sub.visibility.IsProjectVisible(tenant, project) {
 			continue
 		}
 

--- a/fulfillment-service/internal/servers/events_server_test.go
+++ b/fulfillment-service/internal/servers/events_server_test.go
@@ -33,7 +33,6 @@ import (
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/auth"
-	"github.com/osac-project/osac/fulfillment-service/internal/collections"
 	"github.com/osac-project/osac/fulfillment-service/internal/events"
 	"github.com/osac-project/osac/fulfillment-service/internal/uuid"
 )
@@ -143,10 +142,31 @@ var _ = Describe("Events server visibility", func() {
 	}
 
 	// makeTenancy creates a mock tenancy logic returning the given visible tenants:
-	makeTenancy := func(tenants collections.Set[string]) *auth.MockTenancyLogic {
+	makeTenancy := func(tenants ...string) *auth.MockTenancyLogic {
+		builder := auth.NewVisibility()
+		builder.AddVisibleTenants(auth.SharedTenant)
+		for _, tenant := range tenants {
+			builder.AddVisibleTenants(tenant)
+		}
+		visibility, err := builder.Build()
+		Expect(err).ToNot(HaveOccurred())
 		mock := auth.NewMockTenancyLogic(ctrl)
-		mock.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(tenants, nil).
+		mock.EXPECT().DetermineVisibility(gomock.Any()).
+			Return(visibility, nil).
+			AnyTimes()
+		return mock
+	}
+
+	// makeTenancyWithProject creates a mock tenancy logic returning visibility of the given tenant and named project:
+	makeTenancyWithProject := func(tenant, project string) *auth.MockTenancyLogic {
+		builder := auth.NewVisibility()
+		builder.AddVisibleTenants(auth.SharedTenant)
+		builder.AddVisibleProject(tenant, project)
+		visibility, err := builder.Build()
+		Expect(err).ToNot(HaveOccurred())
+		mock := auth.NewMockTenancyLogic(ctrl)
+		mock.EXPECT().DetermineVisibility(gomock.Any()).
+			Return(visibility, nil).
 			AnyTimes()
 		return mock
 	}
@@ -177,9 +197,7 @@ var _ = Describe("Events server visibility", func() {
 
 	It("Delivers events when tenant is visible", func() {
 		// Send an event for a visible tenant:
-		server, client := startServer(makeTenancy(
-			collections.NewSet("tenant-a"),
-		))
+		server, client := startServer(makeTenancy("tenant-a"))
 		collector, cancel := startWatch(server, client)
 		defer cancel()
 		sendEvent(
@@ -203,9 +221,7 @@ var _ = Describe("Events server visibility", func() {
 	})
 
 	It("Filters out events when tenant is not visible", func() {
-		server, client := startServer(makeTenancy(
-			collections.NewSet("tenant-b"),
-		))
+		server, client := startServer(makeTenancy("tenant-b"))
 		collector, cancel := startWatch(server, client)
 		defer cancel()
 		sendEvent(
@@ -225,9 +241,7 @@ var _ = Describe("Events server visibility", func() {
 
 	It("Delivers only visible events when multiple are sent", func() {
 		// Send two events, one for a visible tenant and one for a non-visible tenant:
-		server, client := startServer(makeTenancy(
-			collections.NewSet("tenant-a"),
-		))
+		server, client := startServer(makeTenancy("tenant-a"))
 		collector, cancel := startWatch(server, client)
 		defer cancel()
 		sendEvent(
@@ -263,11 +277,55 @@ var _ = Describe("Events server visibility", func() {
 		Consistently(collector.Events, time.Second).Should(HaveLen(1))
 	})
 
+	It("Delivers events when project is visible", func() {
+		// Send an event for a visible project:
+		server, client := startServer(makeTenancyWithProject("tenant-a", "project-x"))
+		collector, cancel := startWatch(server, client)
+		defer cancel()
+		sendEvent(
+			privatev1.Event_builder{
+				Id:   uuid.New(),
+				Type: privatev1.EventType_EVENT_TYPE_OBJECT_CREATED,
+				Cluster: privatev1.Cluster_builder{
+					Id: uuid.New(),
+					Metadata: privatev1.Metadata_builder{
+						Tenant:  "tenant-a",
+						Project: "project-x",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		)
+
+		// Wait till there is one event in the collector:
+		Eventually(collector.Events, time.Second).Should(HaveLen(1))
+
+		// Verify that the event is for the visible project:
+		Expect(collector.Events()[0].GetCluster().GetMetadata().GetProject()).To(Equal("project-x"))
+	})
+
+	It("Filters out events when project is not visible", func() {
+		server, client := startServer(makeTenancyWithProject("tenant-a", "project-y"))
+		collector, cancel := startWatch(server, client)
+		defer cancel()
+		sendEvent(
+			privatev1.Event_builder{
+				Id:   uuid.New(),
+				Type: privatev1.EventType_EVENT_TYPE_OBJECT_CREATED,
+				Cluster: privatev1.Cluster_builder{
+					Id: uuid.New(),
+					Metadata: privatev1.Metadata_builder{
+						Tenant:  "tenant-a",
+						Project: "project-x",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		)
+		Consistently(collector.Events, time.Second).Should(BeEmpty())
+	})
+
 	It("Delivers event with cluster payload", func() {
 		// Send an event with cluster payload:
-		server, client := startServer(makeTenancy(
-			collections.NewSet("tenant-a"),
-		))
+		server, client := startServer(makeTenancy("tenant-a"))
 		collector, cancel := startWatch(server, client)
 		defer cancel()
 		sendEvent(
@@ -292,9 +350,7 @@ var _ = Describe("Events server visibility", func() {
 
 	It("Delivers event with compute instance payload", func() {
 		// Send an event with compute instance payload:
-		server, client := startServer(makeTenancy(
-			collections.NewSet("tenant-a"),
-		))
+		server, client := startServer(makeTenancy("tenant-a"))
 		collector, cancel := startWatch(server, client)
 		defer cancel()
 		sendEvent(
@@ -319,9 +375,7 @@ var _ = Describe("Events server visibility", func() {
 
 	It("Delivers event with bare metal instance payload", func() {
 		// Send an event with bare metal instance payload:
-		server, client := startServer(makeTenancy(
-			collections.NewSet("tenant-a"),
-		))
+		server, client := startServer(makeTenancy("tenant-a"))
 		collector, cancel := startWatch(server, client)
 		defer cancel()
 		sendEvent(
@@ -348,9 +402,7 @@ var _ = Describe("Events server visibility", func() {
 	// separate from FilterTranslator/GenericServer/GenericDAO's public-filter-oracle fix. This is the only
 	// regression coverage confirming that environment stays scoped to the public Event message.
 	It("Rejects a filter referencing the private-only hub field", func() {
-		_, client := startServer(makeTenancy(
-			collections.NewSet("tenant-a"),
-		))
+		_, client := startServer(makeTenancy("tenant-a"))
 
 		// The server-streaming call returns immediately, before the server handler has run (see startWatch above),
 		// so the filter-compile failure surfaces on the first Recv, not on Watch itself:

--- a/fulfillment-service/internal/servers/generic_server.go
+++ b/fulfillment-service/internal/servers/generic_server.go
@@ -1294,19 +1294,15 @@ func (s *GenericServer[O]) setCreator(ctx context.Context, object O, creator str
 // being created or updated. In case of error it returns a gRPC error that can be directly returned to the client.
 func (s *GenericServer[O]) determineAssignedTenant(ctx context.Context,
 	requestObject, currentObject O) (result string, err error) {
-	// Check that there are visible tenants:
-	visibleTenants, err := s.tenancyLogic.DetermineVisibleTenants(ctx)
+	// Determine the visibility:
+	visibility, err := s.tenancyLogic.DetermineVisibility(ctx)
 	if err != nil {
 		s.logger.ErrorContext(
 			ctx,
-			"Failed to determine visible tenants",
+			"Failed to determine visibility",
 			slog.Any("error", err),
 		)
-		err = grpcstatus.Errorf(grpccodes.Internal, "failed to determine visible tenants")
-		return
-	}
-	if visibleTenants.Empty() {
-		err = grpcstatus.Errorf(grpccodes.PermissionDenied, "there are no visible tenants")
+		err = grpcstatus.Errorf(grpccodes.Internal, "failed to determine visibility")
 		return
 	}
 
@@ -1348,7 +1344,7 @@ func (s *GenericServer[O]) determineAssignedTenant(ctx context.Context,
 
 	// If the request specifies a tenant, check that it is visible and assignable:
 	if requestTenant != "" {
-		if !visibleTenants.Contains(requestTenant) {
+		if !visibility.IsTenantVisible(requestTenant) {
 			s.logger.WarnContext(
 				ctx,
 				"User is trying to assign a tenant that is invisible to them",

--- a/fulfillment-service/internal/servers/private_compute_instance_catalog_items_server_test.go
+++ b/fulfillment-service/internal/servers/private_compute_instance_catalog_items_server_test.go
@@ -1254,9 +1254,12 @@ var _ = Describe("Private compute instance catalog items server", func() {
 				// DAO's tenancy filter hides the "other-tenant" disk image (collapsing to
 				// zero rows -> NotFound, without leaking cross-tenant existence).
 				restrictedTenancy := auth.NewMockTenancyLogic(ctrl)
-				visible := auth.SharedTenants.Union(collections.NewSet("my-tenant"))
-				restrictedTenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-					Return(visible, nil).AnyTimes()
+				restrictedVisibility, err := auth.NewVisibility().
+					AddVisibleTenants(auth.SharedTenant, "my-tenant").
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+				restrictedTenancy.EXPECT().DetermineVisibility(gomock.Any()).
+					Return(restrictedVisibility, nil).AnyTimes()
 				restrictedTenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
 					Return(collections.NewSet("my-tenant"), nil).AnyTimes()
 				restrictedTenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).
@@ -1302,10 +1305,14 @@ var _ = Describe("Private compute instance catalog items server", func() {
 				// buildCatalogServer wires a catalog server whose caller has the given default tenant
 				// and can see the shared tenant plus the listed extra tenants.
 				buildCatalogServer := func(defaultTenant string, extraVisible ...string) *PrivateComputeInstanceCatalogItemsServer {
-					visible := auth.SharedTenants.Union(collections.NewSet(extraVisible...))
+					visibility, err := auth.NewVisibility().
+						AddVisibleTenant(auth.SharedTenant).
+						AddVisibleTenants(extraVisible...).
+						Build()
+					Expect(err).ToNot(HaveOccurred())
 					mockTenancy := auth.NewMockTenancyLogic(ctrl)
-					mockTenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-						Return(visible, nil).AnyTimes()
+					mockTenancy.EXPECT().DetermineVisibility(gomock.Any()).
+						Return(visibility, nil).AnyTimes()
 					mockTenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
 						Return(collections.NewSet(defaultTenant), nil).AnyTimes()
 					mockTenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).

--- a/fulfillment-service/internal/servers/private_identity_providers_server_test.go
+++ b/fulfillment-service/internal/servers/private_identity_providers_server_test.go
@@ -440,8 +440,8 @@ var _ = Describe("Private identity providers server", func() {
 				localTenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).
 					Return(auth.SystemTenant, nil).
 					AnyTimes()
-				localTenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-					Return(auth.AllTenants, nil).
+				localTenancy.EXPECT().DetermineVisibility(gomock.Any()).
+					Return(auth.TotalVisibility(), nil).
 					AnyTimes()
 				localServer, err := NewPrivateIdentityProvidersServer().
 					SetLogger(logger).

--- a/fulfillment-service/internal/servers/private_projects_server_test.go
+++ b/fulfillment-service/internal/servers/private_projects_server_test.go
@@ -447,8 +447,8 @@ var _ = Describe("Private projects server", func() {
 			localTenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).
 				Return(auth.SystemTenant, nil).
 				AnyTimes()
-			localTenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-				Return(auth.AllTenants, nil).
+			localTenancy.EXPECT().DetermineVisibility(gomock.Any()).
+				Return(auth.TotalVisibility(), nil).
 				AnyTimes()
 			localServer, err := NewPrivateProjectsServer().
 				SetLogger(logger).

--- a/fulfillment-service/internal/servers/servers_suite_test.go
+++ b/fulfillment-service/internal/servers/servers_suite_test.go
@@ -76,8 +76,8 @@ var _ = BeforeSuite(func() {
 	tenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).
 		Return(testTenant, nil).
 		AnyTimes()
-	tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-		Return(auth.AllTenants, nil).
+	tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+		Return(auth.TotalVisibility(), nil).
 		AnyTimes()
 
 	// Create the database server:

--- a/fulfillment-service/internal/servers/servers_tenancy_test.go
+++ b/fulfillment-service/internal/servers/servers_tenancy_test.go
@@ -73,6 +73,10 @@ var _ = Describe("Tenancy logic", func() {
 
 	It("Returns tenant in metadata when object is created", func() {
 		// Create a mock tenancy logic that returns a specific tenant:
+		visibility, err := auth.NewVisibility().
+			AddVisibleTenants(auth.SharedTenant, "my-tenant").
+			Build()
+		Expect(err).ToNot(HaveOccurred())
 		assignable := collections.NewSet("my-tenant")
 		tenancy := auth.NewMockTenancyLogic(ctrl)
 		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
@@ -81,8 +85,8 @@ var _ = Describe("Tenancy logic", func() {
 		tenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).
 			Return("my-tenant", nil).
 			AnyTimes()
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(auth.SharedTenants.Union(assignable), nil).
+		tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+			Return(visibility, nil).
 			AnyTimes()
 
 		// Create the template using the DAO directly (this is setup for the test):
@@ -163,6 +167,10 @@ var _ = Describe("Tenancy logic", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create a tenancy logic that doesn't return assignable tenants:
+		visibility, err := auth.NewVisibility().
+			AddVisibleTenants(auth.SharedTenant, "my-tenant").
+			Build()
+		Expect(err).ToNot(HaveOccurred())
 		tenancy := auth.NewMockTenancyLogic(ctrl)
 		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
 			Return(collections.NewSet[string](), nil).
@@ -170,8 +178,8 @@ var _ = Describe("Tenancy logic", func() {
 		tenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).
 			Return("my-tenant", nil).
 			AnyTimes()
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(auth.SharedTenants.Union(collections.NewSet("my-tenant")), nil).
+		tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+			Return(visibility, nil).
 			AnyTimes()
 
 		// Create the clusters server with the empty tenancy logic:
@@ -204,6 +212,10 @@ var _ = Describe("Tenancy logic", func() {
 
 	It("Uses default tenant when tenant is explicitly empty", func() {
 		// Create a tenancy logic that returns a valid tenant:
+		visibility, err := auth.NewVisibility().
+			AddVisibleTenants(auth.SharedTenant, "my-tenant").
+			Build()
+		Expect(err).ToNot(HaveOccurred())
 		assignable := collections.NewSet("my-tenant")
 		tenancy := auth.NewMockTenancyLogic(ctrl)
 		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
@@ -212,8 +224,8 @@ var _ = Describe("Tenancy logic", func() {
 		tenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).
 			Return("my-tenant", nil).
 			AnyTimes()
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(auth.SharedTenants.Union(assignable), nil).
+		tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+			Return(visibility, nil).
 			AnyTimes()
 
 		// Create the template using the DAO:
@@ -269,6 +281,10 @@ var _ = Describe("Tenancy logic", func() {
 
 	It("Respects explicitly specified tenant over default", func() {
 		// Create a tenancy logic where the default tenant differs from the one the user will specify:
+		visibility, err := auth.NewVisibility().
+			AddVisibleTenants(auth.SharedTenant, "my-tenant", "your-tenant").
+			Build()
+		Expect(err).ToNot(HaveOccurred())
 		assignable := collections.NewSet("my-tenant", "your-tenant")
 		tenancy := auth.NewMockTenancyLogic(ctrl)
 		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
@@ -277,8 +293,8 @@ var _ = Describe("Tenancy logic", func() {
 		tenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).
 			Return("your-tenant", nil).
 			AnyTimes()
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(auth.SharedTenants.Union(assignable), nil).
+		tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+			Return(visibility, nil).
 			AnyTimes()
 
 		// Create the template using the DAO:
@@ -331,6 +347,10 @@ var _ = Describe("Tenancy logic", func() {
 	})
 
 	It("Rejects changing tenant on update", func() {
+		visibility, err := auth.NewVisibility().
+			AddVisibleTenants(auth.SharedTenant, "my-tenant", "your-tenant").
+			Build()
+		Expect(err).ToNot(HaveOccurred())
 		assignable := collections.NewSet("my-tenant", "your-tenant")
 		tenancy := auth.NewMockTenancyLogic(ctrl)
 		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
@@ -339,8 +359,8 @@ var _ = Describe("Tenancy logic", func() {
 		tenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).
 			Return("my-tenant", nil).
 			AnyTimes()
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(auth.SharedTenants.Union(assignable), nil).
+		tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+			Return(visibility, nil).
 			AnyTimes()
 
 		templatesDao, err := dao.NewGenericDAO[*privatev1.ClusterTemplate]().
@@ -399,6 +419,10 @@ var _ = Describe("Tenancy logic", func() {
 	})
 
 	It("Preserves tenant when update does not specify it", func() {
+		visibility, err := auth.NewVisibility().
+			AddVisibleTenants(auth.SharedTenant, "my-tenant").
+			Build()
+		Expect(err).ToNot(HaveOccurred())
 		assignable := collections.NewSet("my-tenant")
 		tenancy := auth.NewMockTenancyLogic(ctrl)
 		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
@@ -407,8 +431,8 @@ var _ = Describe("Tenancy logic", func() {
 		tenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).
 			Return("my-tenant", nil).
 			AnyTimes()
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(auth.SharedTenants.Union(assignable), nil).
+		tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+			Return(visibility, nil).
 			AnyTimes()
 
 		templatesDao, err := dao.NewGenericDAO[*privatev1.ClusterTemplate]().
@@ -470,6 +494,10 @@ var _ = Describe("Tenancy logic", func() {
 
 	It("Rejects object creation when assigned tenant is invisible to the user", func() {
 		// Create a tenancy logic that returns visible tenants:
+		visibility, err := auth.NewVisibility().
+			AddVisibleTenants(auth.SharedTenant, "my-tenant").
+			Build()
+		Expect(err).ToNot(HaveOccurred())
 		assignable := collections.NewSet("my-tenant")
 		tenancy := auth.NewMockTenancyLogic(ctrl)
 		tenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
@@ -478,8 +506,8 @@ var _ = Describe("Tenancy logic", func() {
 		tenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).
 			Return("my-tenant", nil).
 			AnyTimes()
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(auth.SharedTenants.Union(assignable), nil).
+		tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+			Return(visibility, nil).
 			AnyTimes()
 
 		// Create the template:
@@ -537,8 +565,8 @@ var _ = Describe("Tenancy logic", func() {
 		tenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).
 			Return(auth.SharedTenant, nil).
 			AnyTimes()
-		tenancy.EXPECT().DetermineVisibleTenants(gomock.Any()).
-			Return(auth.AllTenants, nil).
+		tenancy.EXPECT().DetermineVisibility(gomock.Any()).
+			Return(auth.TotalVisibility(), nil).
 			AnyTimes()
 
 		// Create the server:


### PR DESCRIPTION
## Summary

This is the next step after #333: the `Visibility` object is now used to filter reads and writes, instead of tenant-only sets.

Queries in the generic DAO, tenant assignment in the generic server, and the events watch stream all call `DetermineVisibility`. The SQL filter grants the default project with equality and uses ltree `<@` only for named projects, so an empty project is not treated as the root of the tree (which would match every project in the tenant). Watch events are delivered only when both the event's tenant and project are visible.

`DetermineVisibleTenants` is removed from `TenancyLogic` and its implementations, since nothing called it after this switch.

Related: https://redhat.atlassian.net/browse/OSAC-1064

## Test plan

- [x] `ginkgo run --focus="Generic DAO visibility" internal/database/dao`
- [x] `ginkgo run internal/auth`
- [ ] `ginkgo run -r internal`
- [ ] Review that a tenant grant without named projects lists only default-project objects
- [ ] Review that granting project `p1` includes `p1` and `p1.child`, but not sibling `p2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Access Control**
  * Unified tenant and project visibility rules across resource and event access.
  * Project visibility supports default projects and granted descendants while excluding unauthorized projects.
  * Guest access is limited to the shared tenant.

* **Bug Fixes**
  * Resource operations consistently return empty results or not-found errors for inaccessible resources.
  * Event delivery now respects project visibility and blocks unauthorized project events.
  * Unauthorized resources are filtered before database queries run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->