### PR TITLE
NO-ISSUE: Bump protc-gen-cleanapi to v0.0.12

### DIFF
--- a/fulfillment-service/AGENTS.md
+++ b/fulfillment-service/AGENTS.md
@@ -127,7 +127,10 @@ Generated code lands in `internal/api/` (never edit manually).
 **Proto Workflow**:
 - **Private protos** (`proto/private/`): Full API with internal implementation details. Some resources have `[(cleanapi.field).private = true]` annotations to filter sensitive fields from the public API.
 - **Public protos** (`proto/public/`): Generated from private protos using protoc-gen-cleanapi. Private fields/messages are removed. This is the API published to buf.build.
-- **cleanapi**: The proto file defining annotations is exported from `buf.build/cleanapi/cleanapi:v0.0.8` to `.buf/deps/cleanapi` when running `uv run dev.py build protos`. This directory is gitignored and not committed.
+- **cleanapi**: The proto file defining annotations is exported to `.buf/deps/cleanapi` when running `uv run dev.py build protos`. This directory is gitignored and not committed.
+
+**Updating protoc-gen-cleanapi version**:
+The cleanapi version is defined once in `dev/tools.py` (`PROTOC_GEN_CLEANAPI.version`). When you update it there, run `uv run dev.py build sync-cleanapi-version` to propagate the version to `buf.yaml` and `buf.gen.yaml`, and automatically sync `buf.lock` via `buf dep update` (which runs unconditionally to handle fresh checkouts and failed prior updates). The proto build command (`uv run dev.py build protos`) does this automatically.
 
 Buf and protoc are installed separately - see the [buf installation guide](https://buf.build/docs/installation) and install protoc with `brew install protobuf` on macOS.
 

--- a/fulfillment-service/buf.gen.yaml
+++ b/fulfillment-service/buf.gen.yaml
@@ -45,7 +45,7 @@ inputs:
 - directory: proto/public
 - directory: proto/private
 - directory: proto/tests
-- module: buf.build/cleanapi/cleanapi:v0.0.8
+- module: buf.build/cleanapi/cleanapi:v0.0.12
 
 plugins:
 

--- a/fulfillment-service/buf.lock
+++ b/fulfillment-service/buf.lock
@@ -2,10 +2,10 @@
 version: v2
 deps:
   - name: buf.build/bufbuild/protovalidate
-    commit: 435963d1631043e694e56e6bcc3c79c3
-    digest: b5:f4ea07ad2dd94bd7243562f9908b9fb104feef8076040c89d9f7c1dedc074de4d4ce2b997686ef4400f3eccb765a7cfc20ed4acdd70b9a3699351245c61dba97
+    commit: 511051f7f4374c3ca873b53ae68a9288
+    digest: b5:a4a2d4d808a25984cced60769c822c5d496ef0b740f56ac0c9e6b97aaa25b86a9332a00ffd74e0cd202be29e91bd3edfb0bf2ba4dacfe48ff2d8217f9986e3c8
   - name: buf.build/cleanapi/cleanapi
-    commit: 3151c9df215b494a93ccc0d9551923bf
+    commit: 057b15fdc07e4561932abdb4875b86cd
     digest: b5:331e4329d80612b4d3dcd50891738337fb14a240a71693a9e0132c5dda6e05499edc619532f0e78208cb30b27a5d3d1fb9916fb4fcf96a629a5885d1e89fdce4
   - name: buf.build/googleapis/googleapis
     commit: c17df5b2beca46928cc87d5656bd5343

--- a/fulfillment-service/buf.yaml
+++ b/fulfillment-service/buf.yaml
@@ -45,4 +45,4 @@ deps:
 - buf.build/googleapis/googleapis
 - buf.build/grpc-ecosystem/grpc-gateway
 - buf.build/bufbuild/protovalidate
-- buf.build/cleanapi/cleanapi:v0.0.8
+- buf.build/cleanapi/cleanapi:v0.0.12

--- a/fulfillment-service/dev/build.py
+++ b/fulfillment-service/dev/build.py
@@ -17,6 +17,7 @@ import glob
 import logging
 import os
 import pathlib
+import re
 import shutil
 import sys
 
@@ -25,6 +26,7 @@ import click
 from . import commands
 from . import dirs
 from . import setup
+from . import tools
 
 
 @click.group(invoke_without_command=True)
@@ -85,6 +87,52 @@ def images() -> None:
         sys.exit(1)
 
 
+def _sync_cleanapi_version() -> None:
+    """
+    Updates buf.yaml and buf.gen.yaml to use the cleanapi version from tools.PROTOC_GEN_CLEANAPI.
+    This ensures the version is only maintained in one place (dev/tools.py).
+    Always runs `buf dep update` to sync buf.lock, regardless of whether YAML files changed.
+    """
+    cleanapi_version = f"v{tools.PROTOC_GEN_CLEANAPI.version}"
+    project_dir = dirs.project()
+
+    files_to_update = [
+        project_dir / "buf.yaml",
+        project_dir / "buf.gen.yaml",
+    ]
+
+    # Pattern to match cleanapi version in YAML files
+    pattern = re.compile(r'(buf\.build/cleanapi/cleanapi):v[\d.]+')
+    replacement = rf'\1:{cleanapi_version}'
+
+    for file_path in files_to_update:
+        if not file_path.exists():
+            logging.warning(f"File not found: {file_path}")
+            continue
+
+        content = file_path.read_text()
+        updated_content = pattern.sub(replacement, content)
+
+        if content != updated_content:
+            file_path.write_text(updated_content)
+            logging.info(f"Updated cleanapi version to {cleanapi_version} in {file_path.name}")
+
+    # Always run buf dep update to ensure buf.lock is in sync
+    # This handles fresh checkouts and failed prior updates
+    commands.run(args=["buf", "dep", "update"], cwd=project_dir, check=True)
+
+
+@build.command()
+def sync_cleanapi_version() -> None:
+    """
+    Syncs the cleanapi version from dev/tools.py to buf.yaml and buf.gen.yaml.
+
+    This command is automatically run during proto builds, but can be run manually
+    to update the YAML files without generating code.
+    """
+    _sync_cleanapi_version()
+
+
 @build.command()
 def protos() -> None:
     """
@@ -95,6 +143,9 @@ def protos() -> None:
     """
     # Ensure dependencies are installed
     setup.install_protoc_gen_cleanapi()
+
+    # Sync cleanapi version from tools.py to buf.yaml and buf.gen.yaml
+    _sync_cleanapi_version()
 
     # Check if required tools are available
     if not shutil.which("protoc"):
@@ -121,10 +172,12 @@ def protos() -> None:
     deps_dir.mkdir(parents=True, exist_ok=True)
 
     # Export each dependency
+    # cleanapi version comes from tools.PROTOC_GEN_CLEANAPI
+    cleanapi_version = f"v{tools.PROTOC_GEN_CLEANAPI.version}"
     for dep in ["buf.build/bufbuild/protovalidate",
         "buf.build/googleapis/googleapis",
         "buf.build/grpc-ecosystem/grpc-gateway",
-        "buf.build/cleanapi/cleanapi:v0.0.8"]:
+        f"buf.build/cleanapi/cleanapi:{cleanapi_version}"]:
         dep_name = dep.split("/")[-1].split(":")[0]
         dep_path = deps_dir / dep_name
         if not dep_path.exists():

--- a/fulfillment-service/dev/tools.py
+++ b/fulfillment-service/dev/tools.py
@@ -134,13 +134,13 @@ GOLANGCI_LINT = Tool(
 
 PROTOC_GEN_CLEANAPI = Tool(
     name="protoc-gen-cleanapi",
-    version="0.0.8",
+    version="0.0.12",
     github_repo="jhernand/protoc-gen-cleanapi",
     version_command=["protoc-gen-cleanapi", "--version"],
     version_pattern=r"^(?P<version>\S+)",
     checksums={
         "protoc-gen-cleanapi_{version}_checksums.txt":
-        "22ee7ea769c14fe48fafa2a1f60cc4f21a5bb91cc6ca60c1415b204e9dedf40b",
+        "eaf158c71951b1238d20a1e48cbf5fd4af536dff4f2e75d2296fbb31d1157094",
     },
     # Override defaults - this tool uses underscores and no version in artifact name
     checksums_artifact="protoc-gen-cleanapi_{version}_checksums.txt",


### PR DESCRIPTION
The new version:
- allows removing unused imports and tracks
imports in options
- handling renamed imports and comments containing import names

Includes updates to automatically sync the version of
protoc-gen-cleanapi across the repo using
`uv run dev.py build sync-cleanapi-version`

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated API generation tooling and annotation dependencies to the latest supported release.
  * Automatically synchronizes related API generation settings before generating service interfaces.
  * Added a command for manually refreshing API generation configuration.
  * Improved build consistency by keeping generation tools and configuration aligned.

* **Documentation**
  * Updated protocol workflow guidance for exporting annotations, updating generation tools, and refreshing configuration.

* **Style**
  * Cleaned up minor formatting in a protocol definition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->