### PR TITLE
NO-ISSUE: give the Vertex AI POC workflow persistent, resumable state

### DIFF
--- a/.github/workflows/graphify-brain-refresh-vertex-poc.yaml
+++ b/.github/workflows/graphify-brain-refresh-vertex-poc.yaml
@@ -108,18 +108,35 @@ jobs:
           # GOOGLE_CLOUD_PROJECT env var triggers auto-detection, no explicit
           # --backend flag needed. Removed --code-only to allow semantic pass
           # on docs/images/etc. Update still defaults to code-only incremental.
-          # Force one full rebuild after semantic extraction is enabled by checking
-          # for a marker in metadata.json. Pre-semantic bundles lack this marker,
-          # so the first run will do a full extraction with --force to ensure a
-          # clean rebuild (not an incremental merge).
+          #
+          # --force must NOT be used for a fresh-or-resuming run: graphify
+          # itself prints "--force: full re-scan, semantic cache reads
+          # skipped" (confirmed live) -- unconditionally, regardless of
+          # whether graph.json exists. Since this workflow's whole point is
+          # resuming into the persistent directory after a partial failure
+          # (see "Link graphify-out/..." above), passing --force here would
+          # throw away exactly the per-file cache that lets a resumed run
+          # skip re-extracting chunks that already succeeded.
+          #
+          # --force is still correct for exactly one case: a legacy graph.json
+          # that exists but predates semantic extraction (no semantic_extraction
+          # marker) -- there's no semantic cache to lose there (semantic
+          # extraction never ran against it), and forcing avoids an ill-defined
+          # incremental merge between old code-only content and new semantic
+          # content. That's a one-time migration case, not the normal path for
+          # this POC's own persistent directory (which starts empty and only
+          # ever holds semantic graphs), but the branch is kept for correctness.
           if [[ -f graphify-out/graph.json && -f graphify-out/manifest.json && \
                 -f graphify-out/metadata.json ]] && \
              jq -e '.semantic_extraction == true' graphify-out/metadata.json >/dev/null 2>&1; then
             echo "Prior semantic graph found -- running incremental update."
             graphify update .
-          else
-            echo "No usable semantic graph -- running full extraction."
+          elif [[ -f graphify-out/graph.json ]]; then
+            echo "Existing non-semantic (legacy) graph found -- running a clean, forced rebuild."
             graphify extract . --force
+          else
+            echo "No usable graph yet -- running extraction (cache-aware, resumes any partial progress)."
+            graphify extract .
           fi
           # extract doesn't write GRAPH_REPORT.md itself; update sometimes
           # does. Always (re)generate it explicitly.

--- a/.github/workflows/graphify-brain-refresh-vertex-poc.yaml
+++ b/.github/workflows/graphify-brain-refresh-vertex-poc.yaml
@@ -2,10 +2,9 @@ name: Graphify Brain Refresh (Vertex AI POC)
 
 # Temporary, on-demand-only sibling of graphify-brain-refresh.yaml, used to
 # validate the Vertex AI semantic-extraction backend in isolation while
-# eliorerz/graphify's upstream PRs (#3083, #3087) are still pending and
-# osac-ci's gemini-2.5-flash/-pro quota is still the non-adjustable 5 req/min
-# default. graphify-brain-refresh.yaml itself was reverted back to plain
-# code-only extraction so the real hourly job stays reliable in the meantime.
+# eliorerz/graphify's upstream PRs (#3083, #3087) are still pending. graphify-
+# brain-refresh.yaml itself was reverted back to plain code-only extraction
+# so the real hourly job stays reliable in the meantime.
 #
 # Isolation from the production job:
 #   - workflow_dispatch only, no schedule -- never runs unattended.
@@ -15,6 +14,19 @@ name: Graphify Brain Refresh (Vertex AI POC)
 #     consume.
 #   - No alert-on-repeated-failure job -- failures here are expected while
 #     validating, not something to page anyone over.
+#
+# Runs on osac-ci-1 (self-hosted, llm-labeled runners) instead of an
+# ephemeral GH-hosted runner, with graphify-out/ symlinked to a dedicated
+# persistent directory on that machine (see "Link graphify-out/..." below).
+# This is the ONLY workflow that should ever touch that directory. Rationale:
+# a failed run (e.g. one bad chunk out of many) previously lost ALL progress,
+# since GH Actions' own cache only saves on success and the GH Release
+# re-pull only reflects the last fully-successful run. graphify's semantic
+# extraction cache is file-level (keyed by content hash + prompt hash), so a
+# persistent directory that survives failures lets a resumed run skip
+# straight to re-extracting only what's actually missing, confirmed live:
+# run 32983459202 got 15/16 chunks done before one transient "Server
+# disconnected" error killed the whole run's progress under the old scheme.
 #
 # Delete this file once the Vertex AI backend is proven reliable (upstream
 # PRs merged + a real quota in place), and fold its config back into
@@ -35,8 +47,8 @@ env:
 jobs:
   refresh:
     name: Refresh and publish graph (Vertex AI POC)
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    runs-on: [self-hosted, llm]
+    timeout-minutes: 120
     permissions:
       contents: write  # gh release create/upload against this same repo
       id-token: write  # WIF auth to osac-ci GCP project for Vertex AI
@@ -70,54 +82,24 @@ jobs:
           pip install --user "graphifyy[sql,vertex] @ git+https://github.com/eliorerz/graphify@653aa4eddc1e5ffe524a8d928b9e6d7c3c31cdf3"
           echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Restore prior graphify-out/ state (fast path)
-        id: cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
-        with:
-          path: graphify-out/
-          # Cache keys are immutable in GH Actions -- a static key would make
-          # every save after the first a silent no-op. Save under a per-run
-          # key and restore via restore-keys prefix match so the fast path
-          # always finds the most recent entry.
-          key: graphify-brain-vertex-poc-cache-${{ github.run_id }}
-          restore-keys: |
-            graphify-brain-vertex-poc-cache-
-
-      - name: Re-pull last published bundle (authoritative)
-        id: repull
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Link graphify-out/ to persistent state directory
         run: |
           set -euo pipefail
-          rm -rf /tmp/graphify-repull && mkdir -p /tmp/graphify-repull
-          if gh release download "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" \
-               --pattern 'graphify-bundle.tar.gz' --dir /tmp/graphify-repull; then
-            rm -rf graphify-out
-            mkdir -p graphify-out
-            tar xzf /tmp/graphify-repull/graphify-bundle.tar.gz -C graphify-out
-            echo "ok=true" >> "$GITHUB_OUTPUT"
+          # Dedicated to this workflow only -- nothing else on osac-ci-1
+          # should read or write here. A symlink (not a copy-in/copy-out
+          # pair) means graphify's writes -- including partial progress from
+          # a run that later fails -- land directly in durable storage, with
+          # no separate "save" step needed and no way to lose progress on
+          # a mid-run failure.
+          PERSIST_DIR="/home/github-runner/graphify-vertex-poc-out"
+          mkdir -p "${PERSIST_DIR}"
+          rm -rf graphify-out
+          ln -s "${PERSIST_DIR}" graphify-out
+          if [[ -f graphify-out/graph.json ]]; then
+            echo "::notice::Resuming from persistent state at ${PERSIST_DIR} ($(du -sh "${PERSIST_DIR}" | cut -f1))"
           else
-            echo "No published bundle to re-pull yet (first run, or release missing)."
-            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No persistent state found at ${PERSIST_DIR} -- starting fresh"
           fi
-
-      - name: Determine restore path taken
-        id: restore-path
-        run: |
-          # cache-hit is only true on an exact primary-key match, which never
-          # happens now that the save key is per-run (see restore step above)
-          # -- cache-matched-key is set on both exact and restore-keys/prefix
-          # matches, so it's the correct signal for "did the fast path find
-          # anything at all".
-          if [[ "${{ steps.repull.outputs.ok }}" == "true" ]]; then
-            path="artifact-repull"
-          elif [[ -n "${{ steps.cache.outputs.cache-matched-key }}" ]]; then
-            path="cache-hit"
-          else
-            path="full-rebuild"
-          fi
-          echo "path=${path}" >> "$GITHUB_OUTPUT"
-          echo "::notice::graphify-brain-refresh-vertex-poc restore path: ${path}"
 
       - name: Extract or update graph
         run: |
@@ -211,9 +193,7 @@ jobs:
               --notes "Auto-published by graphify-brain-refresh-vertex-poc.yaml. Experimental -- not consumed by the fetch hook or any real workflow; validates the Vertex AI backend in isolation from graph-latest."
           fi
 
-      - name: Save graphify-out/ for next run's fast path
-        if: success()
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
-        with:
-          path: graphify-out/
-          key: graphify-brain-vertex-poc-cache-${{ github.run_id }}
+      # No separate "save" step needed -- graphify-out/ is a symlink into
+      # persistent storage (see "Link graphify-out/..." above), so every
+      # write already landed there directly, including partial progress
+      # from a run that fails after this point.


### PR DESCRIPTION
## Summary
- Run https://github.com/osac-project/osac/actions/runs/32983459202 got 15 of 16 semantic extraction chunks done cleanly (zero rate-limit errors, using the real `osac-ci` service account via WIF), then hit a single transient `Server disconnected without sending a response` on chunk 14 -- but the whole run's progress was lost anyway, since GH Actions' own cache only saves `if: success()` and the GH Release re-pull only reflects the last fully-successful run.
- graphify's own semantic extraction cache is file-level (content hash + prompt hash), so it doesn't need an all-or-nothing run to be useful -- it just needs somewhere durable to persist across a failed run.
- Moves this workflow onto `osac-ci-1` (self-hosted, `llm`-labeled runners) and symlinks `graphify-out/` to a dedicated persistent directory there (`/home/github-runner/graphify-vertex-poc-out`) that **only this workflow** touches. Every write -- including partial progress from a run that later fails -- lands directly in durable storage, so a resumed run only re-extracts what's actually missing instead of starting over.
- Removes the now-redundant GH Actions cache restore/save and GH Release re-pull steps (the persistent directory supersedes them for this workflow).

## Test plan
- [x] YAML validates
- [x] Confirmed `gh`, `jq`, `python3` all present on the target self-hosted runners
- [ ] Re-dispatch the workflow and confirm it resumes from the 15/16-chunk progress rather than starting over

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Vertex AI proof-of-concept workflow to run in a persistent environment.
  * Extended the workflow timeout to support longer-running operations.
  * Improved recovery and efficiency by preserving progress and reusing available cached data.
  * Enabled incremental updates for semantic graph extraction, with full rebuilds for legacy graphs.
  * Clarified documentation regarding pending upstream changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->