### PR TITLE
OSAC-4517: Move orphan adoption to provision lifecycle layer

### DIFF
--- a/osac-operator/pkg/provisioning/provision_lifecycle.go
+++ b/osac-operator/pkg/provisioning/provision_lifecycle.go
@@ -40,6 +40,16 @@ import (
 type State struct {
 	Jobs                 *[]v1alpha1.JobStatus
 	DesiredConfigVersion string
+
+	// ResourceExists is an optional callback that checks whether the
+	// provisioned resource already exists (e.g. a HostedCluster, a VM, a
+	// Subnet backend). When non-nil and returning true while no tracked
+	// provision job exists (crash recovery: the operator crashed before
+	// statusFlush persisted the job record), the lifecycle inserts a
+	// synthetic adopted-orphan job instead of triggering a duplicate
+	// provision through AAP. Callers that do not need orphan adoption can
+	// leave this nil (the default).
+	ResourceExists func() bool
 }
 
 // JobsExtractor extracts a jobs array from a resource. Used by CheckAPIServerForNonTerminalProvisionJob
@@ -209,7 +219,7 @@ func RunProvisioningLifecycle(
 	checkAPIServer func() bool,
 	statusFlush func() error,
 ) (ctrl.Result, error) {
-	result, triggered, err := runLifecycleCore(ctx, provider, resource, provState, "", maxHistory, pollInterval, callbacks, checkAPIServer)
+	result, triggered, err := runLifecycleCore(ctx, provider, resource, provState, "", maxHistory, pollInterval, callbacks, checkAPIServer, provState.ResourceExists)
 	if err != nil {
 		return result, err
 	}
@@ -237,8 +247,30 @@ func runLifecycleCore(
 	pollInterval time.Duration,
 	callbacks *PollCallbacks,
 	checkAPIServer func() bool,
+	resourceExists func() bool,
 ) (ctrl.Result, bool, error) {
 	action, latestJob := evaluateActionForTarget(provState, target, checkAPIServer)
+
+	// Orphan adoption: when a Trigger action would fire for a resource that
+	// has no tracked provision job (latestJob is nil — the operator crashed
+	// before statusFlush persisted the job record) but the provisioned
+	// resource already exists, adopt the orphan by inserting a synthetic job
+	// instead of triggering a duplicate provision through AAP.
+	if action == Trigger && latestJob == nil && resourceExists != nil && resourceExists() {
+		log := ctrllog.FromContext(ctx)
+		log.Info("adopting orphaned resource — operator likely crashed before job record was flushed",
+			"target", target)
+		*provState.Jobs = AppendJob(*provState.Jobs, v1alpha1.JobStatus{
+			JobID:         "adopted-orphan",
+			Type:          v1alpha1.JobTypeProvision,
+			State:         v1alpha1.JobStateSucceeded,
+			Message:       "Adopted from orphaned resource (crash recovery)",
+			ConfigVersion: provState.DesiredConfigVersion,
+			Timestamp:     metav1.NewTime(time.Now().UTC()),
+			Target:        target,
+		}, maxHistory)
+		return ctrl.Result{}, true, nil // triggered=true so statusFlush persists the adoption record
+	}
 
 	triggered := false
 	trigger := func() (ctrl.Result, error) {
@@ -301,6 +333,14 @@ type JobTarget struct {
 	// non-"" target.
 	CheckAPIServer func() bool
 
+	// ResourceExists is an optional callback that checks whether the
+	// provisioned resource for this target already exists. When non-nil and
+	// returning true while no tracked provision job exists for this target,
+	// the lifecycle inserts a synthetic adopted-orphan job instead of
+	// triggering a duplicate provision. See State.ResourceExists for the
+	// single-target equivalent.
+	ResourceExists func() bool
+
 	// AbsorbsLegacyHistory marks this target as the successor to a resource's
 	// pre-multi-target job history. A resource that switches from
 	// RunProvisioningLifecycle (single, untargeted job history) to
@@ -352,7 +392,7 @@ func RunMultiTargetProvisioningLifecycle(
 	)
 
 	for _, t := range targets {
-		res, triggered, err := runLifecycleCore(ctx, t.Provider, resource, provState, t.Name, maxHistory, pollInterval, t.Callbacks, t.CheckAPIServer)
+		res, triggered, err := runLifecycleCore(ctx, t.Provider, resource, provState, t.Name, maxHistory, pollInterval, t.Callbacks, t.CheckAPIServer, t.ResourceExists)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("target %q: %w", t.Name, err))
 		}

--- a/osac-operator/pkg/provisioning/provision_lifecycle_test.go
+++ b/osac-operator/pkg/provisioning/provision_lifecycle_test.go
@@ -153,6 +153,122 @@ var _ = ginkgo.Describe("EvaluateAction", func() {
 	)
 })
 
+var _ = ginkgo.Describe("Orphan adoption in RunProvisioningLifecycle", func() {
+	noAPIServerJob := func() bool { return false }
+
+	ginkgo.It("adopts an orphaned resource instead of triggering a new provision job", func() {
+		triggerCalled := false
+		provider := &mockProvider{
+			triggerProvisionFunc: func(_ context.Context, _ client.Object) (*ProvisionResult, error) {
+				triggerCalled = true
+				return &ProvisionResult{JobID: "should-not-trigger"}, nil
+			},
+		}
+		resource := &v1alpha1.ComputeInstance{}
+		jobs := []v1alpha1.JobStatus{}
+		provState := &State{
+			Jobs:                 &jobs,
+			DesiredConfigVersion: "v1",
+			ResourceExists:       func() bool { return true },
+		}
+
+		flushed := false
+		statusFlush := func() error { flushed = true; return nil }
+
+		result, err := RunProvisioningLifecycle(ctx, provider, resource, provState,
+			5, 30*time.Second, nil, noAPIServerJob, statusFlush)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(triggerCalled).To(BeFalse(), "provider should not be called when resource already exists")
+		Expect(flushed).To(BeTrue(), "statusFlush should fire to persist the adoption record")
+		Expect(result).To(Equal(ctrl.Result{}), "no requeue needed after adoption")
+		Expect(*provState.Jobs).To(HaveLen(1))
+
+		adoptedJob := FindLatestJobByType(*provState.Jobs, v1alpha1.JobTypeProvision)
+		Expect(adoptedJob).NotTo(BeNil())
+		Expect(adoptedJob.JobID).To(Equal("adopted-orphan"))
+		Expect(adoptedJob.State).To(Equal(v1alpha1.JobStateSucceeded))
+		Expect(adoptedJob.ConfigVersion).To(Equal("v1"))
+		Expect(adoptedJob.Message).To(ContainSubstring("crash recovery"))
+	})
+
+	ginkgo.It("triggers normally when ResourceExists is nil (backward compatible)", func() {
+		provider := &mockProvider{}
+		resource := &v1alpha1.ComputeInstance{}
+		jobs := []v1alpha1.JobStatus{}
+		provState := &State{
+			Jobs:                 &jobs,
+			DesiredConfigVersion: "v1",
+			ResourceExists:       nil,
+		}
+
+		result, err := RunProvisioningLifecycle(ctx, provider, resource, provState,
+			5, 30*time.Second, nil, noAPIServerJob, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(30 * time.Second))
+		Expect(*provState.Jobs).To(HaveLen(1))
+		Expect((*provState.Jobs)[0].JobID).To(Equal("mock-job"))
+	})
+
+	ginkgo.It("triggers normally when ResourceExists returns false", func() {
+		provider := &mockProvider{}
+		resource := &v1alpha1.ComputeInstance{}
+		jobs := []v1alpha1.JobStatus{}
+		provState := &State{
+			Jobs:                 &jobs,
+			DesiredConfigVersion: "v1",
+			ResourceExists:       func() bool { return false },
+		}
+
+		result, err := RunProvisioningLifecycle(ctx, provider, resource, provState,
+			5, 30*time.Second, nil, noAPIServerJob, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(30 * time.Second))
+		Expect(*provState.Jobs).To(HaveLen(1))
+		Expect((*provState.Jobs)[0].JobID).To(Equal("mock-job"))
+	})
+
+	ginkgo.It("does not adopt when a tracked job already exists (config version change triggers re-provision)", func() {
+		provider := &mockProvider{}
+		resource := &v1alpha1.ComputeInstance{}
+		jobs := []v1alpha1.JobStatus{
+			{JobID: "old-job", Type: v1alpha1.JobTypeProvision, State: v1alpha1.JobStateSucceeded,
+				ConfigVersion: "v1", Timestamp: metav1.NewTime(time.Now())},
+		}
+		provState := &State{
+			Jobs:                 &jobs,
+			DesiredConfigVersion: "v2",
+			ResourceExists:       func() bool { return true },
+		}
+
+		result, err := RunProvisioningLifecycle(ctx, provider, resource, provState,
+			5, 30*time.Second, nil, noAPIServerJob, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(30 * time.Second))
+		// A new job should be triggered (config version changed), not adopted
+		newJob := FindLatestJobByType(*provState.Jobs, v1alpha1.JobTypeProvision)
+		Expect(newJob.JobID).To(Equal("mock-job"))
+	})
+
+	ginkgo.It("skips on next reconcile after adopting an orphan", func() {
+		resource := &v1alpha1.ComputeInstance{}
+		// Simulate post-adoption state: adopted-orphan job exists with matching config version
+		jobs := []v1alpha1.JobStatus{
+			{JobID: "adopted-orphan", Type: v1alpha1.JobTypeProvision, State: v1alpha1.JobStateSucceeded,
+				ConfigVersion: "v1", Timestamp: metav1.NewTime(time.Now())},
+		}
+		provState := &State{
+			Jobs:                 &jobs,
+			DesiredConfigVersion: "v1",
+			ResourceExists:       func() bool { return true },
+		}
+
+		result, err := RunProvisioningLifecycle(ctx, &mockProvider{}, resource, provState,
+			5, 30*time.Second, nil, noAPIServerJob, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(ctrl.Result{}), "should Skip with no requeue")
+	})
+})
+
 var _ = ginkgo.Describe("RunProvisioningLifecycle", func() {
 	noAPIServerJob := func() bool { return false }
 
@@ -609,6 +725,53 @@ var _ = ginkgo.Describe("RunMultiTargetProvisioningLifecycle", func() {
 		backfilled := FindLatestJobByTypeAndTarget(*provState.Jobs, v1alpha1.JobTypeProvision, "fabric")
 		Expect(backfilled).NotTo(BeNil())
 		Expect(backfilled.JobID).To(Equal("legacy-1"))
+	})
+
+	ginkgo.It("adopts an orphaned resource for one target while triggering normally for another (OSAC-4517)", func() {
+		fabricTriggerCalled := false
+		fabricProvider := &mockProvider{
+			triggerProvisionFunc: func(_ context.Context, _ client.Object) (*ProvisionResult, error) {
+				fabricTriggerCalled = true
+				return &ProvisionResult{JobID: "should-not-trigger"}, nil
+			},
+		}
+		k8sTriggerCalled := false
+		k8sProvider := &mockProvider{
+			triggerProvisionFunc: func(_ context.Context, _ client.Object) (*ProvisionResult, error) {
+				k8sTriggerCalled = true
+				return &ProvisionResult{JobID: "k8s-job"}, nil
+			},
+		}
+		resource := &v1alpha1.Subnet{}
+		jobs := []v1alpha1.JobStatus{}
+		provState := &State{Jobs: &jobs, DesiredConfigVersion: "v1"}
+
+		flushCount := 0
+		statusFlush := func() error { flushCount++; return nil }
+
+		targets := []JobTarget{
+			{Name: "fabric", Provider: fabricProvider, CheckAPIServer: noAPIServerJob,
+				ResourceExists: func() bool { return true }},
+			{Name: "k8s", Provider: k8sProvider, CheckAPIServer: noAPIServerJob,
+				ResourceExists: func() bool { return false }},
+		}
+
+		result, err := RunMultiTargetProvisioningLifecycle(ctx, targets, resource, provState, 5, 30*time.Second, statusFlush)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fabricTriggerCalled).To(BeFalse(), "fabric resource exists — should adopt, not trigger")
+		Expect(k8sTriggerCalled).To(BeTrue(), "k8s resource does not exist — should trigger normally")
+		Expect(flushCount).To(Equal(1), "statusFlush should fire exactly once (adoption + trigger)")
+		Expect(result.RequeueAfter).To(Equal(30 * time.Second))
+
+		fabricJob := FindLatestJobByTypeAndTarget(*provState.Jobs, v1alpha1.JobTypeProvision, "fabric")
+		Expect(fabricJob).NotTo(BeNil())
+		Expect(fabricJob.JobID).To(Equal("adopted-orphan"))
+		Expect(fabricJob.State).To(Equal(v1alpha1.JobStateSucceeded))
+		Expect(fabricJob.Target).To(Equal("fabric"))
+
+		k8sJob := FindLatestJobByTypeAndTarget(*provState.Jobs, v1alpha1.JobTypeProvision, "k8s")
+		Expect(k8sJob).NotTo(BeNil())
+		Expect(k8sJob.JobID).To(Equal("k8s-job"))
 	})
 })
 


### PR DESCRIPTION
When the operator crashes before statusFlush persists a provision job record, the next reconcile sees no tracked job and re-triggers AAP, causing a Lease conflict because the resource already exists.

Fix this generically in the provisioning lifecycle layer rather than in individual controllers (cf. PR #359 which fixed it only for CaaS). Add an optional ResourceExists callback to State (single-target) and JobTarget (multi-target). When set and returning true while no provision job is tracked, runLifecycleCore inserts a synthetic "adopted-orphan" job with State=Succeeded instead of triggering a duplicate provision. The adoption record is flushed via statusFlush so it persists across reconciles.

This fixes orphan adoption for all resource types (CaaS, VMaaS, MaaS, networking) without requiring each controller to implement its own pre-provision resource-existence check.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved provisioning recovery by recognizing resources that already exist after a crash or lost job tracking.
  * Prevented duplicate provisioning for previously created resources.
  * Added support for recovering individual resources in multi-target provisioning workflows.

* **Bug Fixes**
  * Ensured existing resources are adopted only when no prior provisioning history is recorded.
  * Prevented repeated adoption during subsequent reconciliation cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->