### PR TITLE
NO-ISSUE: write metadata.json before cluster-only, not after

### DIFF
--- a/.github/workflows/graphify-brain-refresh-vertex-poc.yaml
+++ b/.github/workflows/graphify-brain-refresh-vertex-poc.yaml
@@ -138,13 +138,24 @@ jobs:
             echo "No usable graph yet -- running extraction (cache-aware, resumes any partial progress)."
             graphify extract .
           fi
-          # extract doesn't write GRAPH_REPORT.md itself; update sometimes
-          # does. Always (re)generate it explicitly.
-          graphify cluster-only .
 
       - name: Write metadata.json
         run: |
           set -euo pipefail
+          # Deliberately runs right after extract/update, BEFORE cluster-only
+          # below -- graphify extract/update already wrote a complete,
+          # correct graph.json by this point; cluster-only only adds
+          # GRAPH_REPORT.md/labels on top of it and can fail independently
+          # (confirmed live: a 1-node discrepancy between extract's write and
+          # cluster-only's re-clustering tripped the shrink guard on
+          # cluster-only's own write, even though extract's graph.json was
+          # already complete and correct). Writing metadata.json here means
+          # the semantic_extraction marker is set as soon as a genuinely good
+          # graph.json exists, so a NEXT run correctly takes the cheap
+          # `update .` path instead of misreading a cluster-only failure as
+          # "no valid semantic graph yet" and wastefully re-running a full,
+          # cache-skipping --force extraction.
+          #
           # Extract just the bare numeric version (graphify --version prints
           # non-numeric text too, e.g. "graphify 0.9.41") so this matches
           # exactly what the fetch script's own version check expects to
@@ -157,6 +168,15 @@ jobs:
             --arg generated_at "${generated_at}" \
             '{source_sha: $source_sha, graphify_version: $graphify_version, generated_at: $generated_at, semantic_extraction: true}' \
             > graphify-out/metadata.json
+
+      - name: Generate cluster report (GRAPH_REPORT.md, community labels)
+        run: |
+          set -euo pipefail
+          # Separate step, after metadata.json is already durably marked
+          # semantic -- see the comment above. extract doesn't write
+          # GRAPH_REPORT.md itself; update sometimes does. Always
+          # (re)generate it explicitly.
+          graphify cluster-only .
 
       - name: Export Obsidian vault (best-effort, independent asset)
         id: obsidian


### PR DESCRIPTION
## Summary
Run https://github.com/osac-project/osac/actions/runs/32986908660 was a real milestone: full semantic extraction succeeded end-to-end via the Vertex AI backend on `osac-ci-1` -- 16/16 chunks, zero rate-limit or network errors, a complete `graph.json` (75,195 nodes, 135,476 edges) written successfully.

The job still failed overall, though: the subsequent `graphify cluster-only .` step (GRAPH_REPORT.md + community labels) re-clustered to 75,194 nodes (net -1, likely fuzzy-dedup non-determinism) and the shrink guard correctly refused that second write. Since `"Write metadata.json"` ran *after* `cluster-only` in the same step, the job died before ever setting the `semantic_extraction` marker -- meaning a follow-up run would misread the already-good `graph.json` as "no valid semantic graph yet" and take the legacy-migration branch, wastefully running a full `--force` extraction (skipping cache) on a graph that was already complete and correct.

## Fix
Moves `metadata.json` writing to run immediately after `extract`/`update` succeeds, before `cluster-only`, and splits `cluster-only` into its own step. A `cluster-only` failure still fails the job (still visible, still investigable), but no longer erases the fact that a genuinely good `graph.json` already exists -- the next run correctly takes the cheap `update .` path.

## Test plan
- [x] YAML validates
- [ ] Confirm the next run takes the `update .` path given the existing graph.json + now-present metadata.json in the persistent directory
- [ ] Investigate the `cluster-only` 1-node discrepancy separately (not blocking -- the underlying graph data is unaffected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved semantic graph processing reliability by recording metadata as soon as graph updates complete.
  * Isolated cluster report generation so cluster-related failures no longer prevent completed graph metadata from being recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->