### PR TITLE
OSAC-4267: wire ExternalIP family controllers to NetworkClass dispatcher

### DIFF
--- a/osac-installer/values/vmaas-ci/instance.yaml
+++ b/osac-installer/values/vmaas-ci/instance.yaml
@@ -31,6 +31,15 @@ operator:
   tenants:
   - name: shared
   - name: osac-e2e-ci
+  # VMaaS has no physical fabric. Register k8s_only so the dispatcher can
+  # stamp ExternalIP/VN/SG onto the composite role (CUDN + NetworkPolicy +
+  # MetalLB L2) instead of fabricManager cudn_net, which cannot provision
+  # ExternalIP pools.
+  networkManagers:
+    k8sManagers:
+      k8s_only:
+        enabled: true
+        capabilities: "ipv4,ipv6,dualStack"
 
 # --- Fulfillment Service ---
 service:
@@ -205,3 +214,16 @@ metering:
 # --- LVMS StorageBackend registration ---
 lvms:
   enabled: true
+
+# Default NetworkClass for VMaaS-without-fabric. Created after AAP
+# publish-templates (hook weight 25 vs 20). AAP still publishes a cudn_net
+# class; this Create becomes the default (fabric_manager is immutable once
+# set, so the published class cannot be retargeted).
+networkClass:
+  enabled: true
+  title: "K8s-only networking"
+  description: >-
+    VMaaS overlay without a physical fabric. VirtualNetwork/Subnet use CUDN,
+    SecurityGroup uses NetworkPolicy, ExternalIP uses MetalLB L2.
+  k8sManager: "k8s_only"
+  isDefault: true

--- a/osac-installer/values/vmaas-ci/instance.yaml
+++ b/osac-installer/values/vmaas-ci/instance.yaml
@@ -215,15 +215,15 @@ metering:
 lvms:
   enabled: true
 
-# Default NetworkClass for VMaaS-without-fabric. Created after AAP
-# publish-templates (hook weight 25 vs 20). AAP still publishes a cudn_net
-# class; this Create becomes the default (fabric_manager is immutable once
-# set, so the published class cannot be retargeted).
+# Default NetworkClass for VMaaS-without-fabric (create-network-class hook).
+# Must clear fabricManager — chart defaults leave cudn_net, and Helm merge
+# would stamp both managers
 networkClass:
   enabled: true
   title: "K8s-only networking"
   description: >-
     VMaaS overlay without a physical fabric. VirtualNetwork/Subnet use CUDN,
     SecurityGroup uses NetworkPolicy, ExternalIP uses MetalLB L2.
+  fabricManager: ""
   k8sManager: "k8s_only"
   isDefault: true

--- a/osac-operator/charts/operator/values.yaml
+++ b/osac-operator/charts/operator/values.yaml
@@ -98,9 +98,10 @@ networkManagers:
     cudn_net:
       enabled: true
       description: >-
-        CUDN-based isolated networking (ClusterUserDefinedNetwork). Self-contained
-        VirtualNetwork/Subnet provisioning with no separate physical fabric to
-        bridge into — used as the platform default NetworkClass.
+        CUDN-based isolated networking (ClusterUserDefinedNetwork). Leaf overlay
+        role for VirtualNetwork/Subnet — not a physical fabric manager. VMaaS
+        without a fabric uses k8sManagers.k8s_only as the NetworkClass manager,
+        which delegates overlay work here.
       capabilities: "ipv4,ipv6,dualStack"
   k8sManagers:
     k8s_only:

--- a/osac-operator/cmd/main.go
+++ b/osac-operator/cmd/main.go
@@ -675,8 +675,8 @@ func setupNetworkingControllers(
 	}
 
 	// Build a shared dispatcher Resolver for controllers that support the two-manager
-	// model (VirtualNetwork, Subnet, SecurityGroup). Only available when a
-	// fulfillment-service connection and networking namespace are both configured;
+	// model (VirtualNetwork, Subnet, SecurityGroup, ExternalIP family). Only available
+	// when a fulfillment-service connection and networking namespace are both configured;
 	// nil otherwise, in which case those controllers always use the legacy
 	// implementation-strategy path.
 	var resolver *dispatcher.Resolver
@@ -723,23 +723,23 @@ func setupNetworkingControllers(
 	}
 	if err := setupExternalIPPoolControllers(
 		mgr, localMgr, grpcConn, networkingNamespace,
-		networkingProvider, statusPollInterval, maxJobHistory, targetCluster,
-		networkProvisioningEnabled,
+		networkingProvider, statusPollInterval, maxJobHistory, targetCluster, resolver,
+		networkClassesClient, networkProvisioningEnabled,
 	); err != nil {
 		return err
 	}
 	if err := setupExternalIPControllers(
 		mgr, localMgr, grpcConn, networkingNamespace,
-		networkingProvider, statusPollInterval, maxJobHistory, targetCluster,
-		networkProvisioningEnabled,
+		networkingProvider, statusPollInterval, maxJobHistory, targetCluster, resolver,
+		networkClassesClient, networkProvisioningEnabled,
 	); err != nil {
 		return err
 	}
 	if err := setupExternalIPAttachmentControllers(
 		mgr, localMgr, grpcConn,
 		networkingNamespace, computeInstanceNamespace, clusterOrderNamespace, bareMetalInstanceNamespace,
-		externalIPAttachmentProvider, statusPollInterval, maxJobHistory, targetCluster,
-		networkProvisioningEnabled,
+		externalIPAttachmentProvider, statusPollInterval, maxJobHistory, targetCluster, resolver,
+		networkClassesClient, networkProvisioningEnabled,
 	); err != nil {
 		return err
 	}
@@ -857,6 +857,7 @@ func setupExternalIPPoolControllers(
 	mgr mcmanager.Manager, localMgr ctrl.Manager, grpcConn *grpc.ClientConn,
 	networkingNamespace string, provider provisioning.ProvisioningProvider,
 	statusPollInterval time.Duration, maxJobHistory int, targetCluster multicluster.ClusterName,
+	resolver *dispatcher.Resolver, networkClassesClient privatev1.NetworkClassesClient,
 	networkProvisioningEnabled bool,
 ) error {
 	if grpcConn != nil {
@@ -868,6 +869,7 @@ func setupExternalIPPoolControllers(
 	}
 	reconciler := controller.NewExternalIPPoolReconciler(
 		mgr, networkingNamespace, provider, statusPollInterval, maxJobHistory, targetCluster,
+		resolver, networkClassesClient,
 	)
 	reconciler.NetworkProvisioningEnabled = networkProvisioningEnabled
 	if err := reconciler.SetupWithManager(mgr); err != nil {
@@ -880,10 +882,12 @@ func setupExternalIPControllers(
 	mgr mcmanager.Manager, localMgr ctrl.Manager, grpcConn *grpc.ClientConn,
 	networkingNamespace string, provider provisioning.ProvisioningProvider,
 	statusPollInterval time.Duration, maxJobHistory int, targetCluster multicluster.ClusterName,
+	resolver *dispatcher.Resolver, networkClassesClient privatev1.NetworkClassesClient,
 	networkProvisioningEnabled bool,
 ) error {
 	reconciler := controller.NewExternalIPReconciler(
 		mgr, networkingNamespace, provider, statusPollInterval, maxJobHistory, targetCluster,
+		resolver, networkClassesClient,
 	)
 	reconciler.NetworkProvisioningEnabled = networkProvisioningEnabled
 	if err := reconciler.SetupWithManager(mgr); err != nil {
@@ -904,12 +908,14 @@ func setupExternalIPAttachmentControllers(
 	networkingNamespace, computeInstanceNamespace, clusterOrderNamespace, baremetalInstanceNamespace string,
 	provider provisioning.ProvisioningProvider,
 	statusPollInterval time.Duration, maxJobHistory int, targetCluster multicluster.ClusterName,
+	resolver *dispatcher.Resolver, networkClassesClient privatev1.NetworkClassesClient,
 	networkProvisioningEnabled bool,
 ) error {
 	reconciler := controller.NewExternalIPAttachmentReconciler(
 		mgr, networkingNamespace, computeInstanceNamespace,
 		clusterOrderNamespace, baremetalInstanceNamespace,
 		provider, statusPollInterval, maxJobHistory, targetCluster,
+		resolver, networkClassesClient,
 	)
 	reconciler.NetworkProvisioningEnabled = networkProvisioningEnabled
 	if err := reconciler.SetupWithManager(mgr); err != nil {

--- a/osac-operator/internal/controller/constants_common.go
+++ b/osac-operator/internal/controller/constants_common.go
@@ -47,16 +47,6 @@ const (
 	// set on ExternalIP CRs
 	osacExternalIPPoolNameAnnotation = osacPrefix + "/externalippool-name"
 
-	// defaultExternalIPPoolImplementationStrategy is the fallback strategy when none is specified.
-	// Used by ExternalIPPool (from its own spec) and ExternalIP (inherited from parent pool).
-	defaultExternalIPPoolImplementationStrategy = "metallb-l2"
-
-	// defaultSecurityGroupImplementationStrategy is the fallback implementation strategy
-	// for SecurityGroup (standard Kubernetes NetworkPolicy) when neither the SecurityGroup
-	// spec nor the parent VirtualNetwork's NetworkClass (via the dispatcher path) resolve
-	// one.
-	defaultSecurityGroupImplementationStrategy = "network_policy"
-
 	conditionReasonConfigurationApplied  = "ConfigurationApplied"
 	conditionMessageConfigurationApplied = "Controller has processed the current spec"
 

--- a/osac-operator/internal/controller/dispatcher_helpers.go
+++ b/osac-operator/internal/controller/dispatcher_helpers.go
@@ -21,12 +21,23 @@ import (
 	"errors"
 	"fmt"
 
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/osac-project/osac/osac-operator/api/v1alpha1"
+	privatev1 "github.com/osac-project/osac/osac-operator/internal/api/osac/private/v1"
 	"github.com/osac-project/osac/osac-operator/pkg/dispatcher"
 	"github.com/osac-project/osac/osac-operator/pkg/provisioning"
 )
+
+// networkClassListPageSize is the page size used to list NetworkClasses. It matches
+// the fulfillment-service's maximum allowed limit, so listing every NetworkClass
+// takes the fewest possible round trips.
+//
+// A single unbounded List call is not sufficient: the server defaults an unset
+// limit to a fixed page size (currently 100) rather than "no limit", so without
+// paging, any NetworkClasses beyond the first page would be silently skipped.
+const networkClassListPageSize = 1000
 
 // resolveDispatchPlan resolves the full DispatchPlan for a resource kind.
 //
@@ -91,6 +102,79 @@ func resolveImplementationStrategy(
 		return legacyStrategy, nil
 	}
 	return target.Manager.Name, nil
+}
+
+// listAllNetworkClasses fetches every NetworkClass from the fulfillment service,
+// paging through results with offset/limit rather than issuing a single List call
+// with neither set (see networkClassListPageSize for why that would silently
+// truncate).
+func listAllNetworkClasses(
+	ctx context.Context, ncClient privatev1.NetworkClassesClient,
+) ([]*privatev1.NetworkClass, error) {
+	var items []*privatev1.NetworkClass
+	offset := int32(0)
+	for {
+		resp, err := ncClient.List(ctx, privatev1.NetworkClassesListRequest_builder{
+			Offset: ptr.To(offset),
+			Limit:  ptr.To(int32(networkClassListPageSize)),
+		}.Build())
+		if err != nil {
+			return nil, err
+		}
+
+		items = append(items, resp.GetItems()...)
+		offset += resp.GetSize()
+
+		// resp.GetSize() == 0 guards against an infinite loop if the server ever
+		// reports a total larger than what it actually returns.
+		if resp.GetSize() == 0 || offset >= resp.GetTotal() {
+			return items, nil
+		}
+	}
+}
+
+// lookupDefaultNetworkClassID returns the ID of the default NetworkClass for this
+// deployment, used by ExternalIP-family controllers that have no parent VirtualNetwork
+// to inherit a NetworkClass from.
+//
+// Returns ("", nil) when the dispatcher path is not available (nil client, no live
+// NetworkClass, or more than one live NetworkClass with none marked default) so the
+// caller falls through to its legacy implementation-strategy. List errors are returned
+// as real reconcile errors.
+//
+// Preference: a non-deleted NetworkClass with is_default=true, else the single live
+// NetworkClass if exactly one exists (one-per-deployment).
+func lookupDefaultNetworkClassID(
+	ctx context.Context, ncClient privatev1.NetworkClassesClient,
+) (string, error) {
+	if ncClient == nil {
+		return "", nil
+	}
+
+	items, err := listAllNetworkClasses(ctx, ncClient)
+	if err != nil {
+		return "", fmt.Errorf("listing NetworkClasses: %w", err)
+	}
+
+	var live, defaults []*privatev1.NetworkClass
+	for _, nc := range items {
+		if nc.GetMetadata().HasDeletionTimestamp() {
+			continue
+		}
+		live = append(live, nc)
+		if nc.GetIsDefault() {
+			defaults = append(defaults, nc)
+		}
+	}
+
+	switch {
+	case len(defaults) >= 1:
+		return defaults[0].GetId(), nil
+	case len(live) == 1:
+		return live[0].GetId(), nil
+	default:
+		return "", nil
+	}
 }
 
 // dispatchTargetProvider decorates a shared provisioning.ProvisioningProvider so that

--- a/osac-operator/internal/controller/dispatcher_helpers.go
+++ b/osac-operator/internal/controller/dispatcher_helpers.go
@@ -142,8 +142,10 @@ func listAllNetworkClasses(
 // caller falls through to its legacy implementation-strategy. List errors are returned
 // as real reconcile errors.
 //
-// Preference: a non-deleted NetworkClass with is_default=true, else the single live
-// NetworkClass if exactly one exists (one-per-deployment).
+// Selection order: a non-deleted NetworkClass with is_default=true (the first match in
+// list order if multiple are marked default — fulfillment-service enforces at most one
+// active default via a unique partial index, so this should not occur in normal
+// operation), else the single live NetworkClass if exactly one exists (one-per-deployment).
 func lookupDefaultNetworkClassID(
 	ctx context.Context, ncClient privatev1.NetworkClassesClient,
 ) (string, error) {

--- a/osac-operator/internal/controller/dispatcher_helpers_test.go
+++ b/osac-operator/internal/controller/dispatcher_helpers_test.go
@@ -18,9 +18,12 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -205,6 +208,109 @@ var _ = Describe("resolveImplementationStrategy", func() {
 		strategy, err := resolveImplementationStrategy(ctx, nil, "VirtualNetwork", "nc-any", "legacy-strategy")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(strategy).To(Equal("legacy-strategy"))
+	})
+})
+
+var _ = Describe("lookupDefaultNetworkClassID", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("returns an empty ID when the client is nil", func() {
+		id, err := lookupDefaultNetworkClassID(ctx, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(id).To(BeEmpty())
+	})
+
+	It("returns an empty ID when no NetworkClasses exist", func() {
+		stub := newListingNetworkClassClient(nil, &[]*privatev1.NetworkClass{})
+		id, err := lookupDefaultNetworkClassID(ctx, stub)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(id).To(BeEmpty())
+	})
+
+	It("returns the NetworkClass marked is_default", func() {
+		stub := newListingNetworkClassClient([]*privatev1.NetworkClass{
+			{Id: "nc-other"},
+			{Id: "nc-default", IsDefault: ptr.To(true)},
+		}, &[]*privatev1.NetworkClass{})
+		id, err := lookupDefaultNetworkClassID(ctx, stub)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(id).To(Equal("nc-default"))
+	})
+
+	It("returns the only live NetworkClass when none is marked default", func() {
+		stub := newListingNetworkClassClient([]*privatev1.NetworkClass{
+			{Id: "nc-singleton"},
+		}, &[]*privatev1.NetworkClass{})
+		id, err := lookupDefaultNetworkClassID(ctx, stub)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(id).To(Equal("nc-singleton"))
+	})
+
+	It("skips soft-deleted NetworkClasses when selecting the default", func() {
+		deleted := &privatev1.NetworkClass{
+			Id:        "nc-deleted-default",
+			IsDefault: ptr.To(true),
+			Metadata:  &privatev1.Metadata{DeletionTimestamp: timestamppb.Now()},
+		}
+		stub := newListingNetworkClassClient([]*privatev1.NetworkClass{
+			deleted,
+			{Id: "nc-live"},
+		}, &[]*privatev1.NetworkClass{})
+		id, err := lookupDefaultNetworkClassID(ctx, stub)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(id).To(Equal("nc-live"))
+	})
+
+	It("returns an empty ID when multiple live NetworkClasses exist and none is default", func() {
+		stub := newListingNetworkClassClient([]*privatev1.NetworkClass{
+			{Id: "nc-a"},
+			{Id: "nc-b"},
+		}, &[]*privatev1.NetworkClass{})
+		id, err := lookupDefaultNetworkClassID(ctx, stub)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(id).To(BeEmpty())
+	})
+
+	It("returns a reconcile error when List fails", func() {
+		stub := &stubNetworkClassesClient{
+			listFunc: func(_ context.Context, _ *privatev1.NetworkClassesListRequest, _ ...grpc.CallOption) (*privatev1.NetworkClassesListResponse, error) {
+				return nil, fmt.Errorf("list failed")
+			},
+		}
+		_, err := lookupDefaultNetworkClassID(ctx, stub)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("listing NetworkClasses"))
+	})
+
+	It("pages through List results until every NetworkClass is considered", func() {
+		all := []*privatev1.NetworkClass{
+			{Id: "nc-page-1"}, {Id: "nc-page-2"}, {Id: "nc-page-3"},
+			{Id: "nc-page-4", IsDefault: ptr.To(true)}, {Id: "nc-page-5"},
+		}
+		var offsetsSeen []int32
+		pageSize := 2
+		stub := &stubNetworkClassesClient{
+			listFunc: func(_ context.Context, in *privatev1.NetworkClassesListRequest, _ ...grpc.CallOption) (*privatev1.NetworkClassesListResponse, error) {
+				offsetsSeen = append(offsetsSeen, in.GetOffset())
+				start := min(int(in.GetOffset()), len(all))
+				end := min(start+pageSize, len(all))
+				page := all[start:end]
+				return &privatev1.NetworkClassesListResponse{
+					Items: page,
+					Size:  int32(len(page)),
+					Total: int32(len(all)),
+				}, nil
+			},
+		}
+
+		id, err := lookupDefaultNetworkClassID(ctx, stub)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(id).To(Equal("nc-page-4"))
+		Expect(offsetsSeen).To(Equal([]int32{0, 2, 4}))
 	})
 })
 

--- a/osac-operator/internal/controller/dispatcher_helpers_test.go
+++ b/osac-operator/internal/controller/dispatcher_helpers_test.go
@@ -241,6 +241,18 @@ var _ = Describe("lookupDefaultNetworkClassID", func() {
 		Expect(id).To(Equal("nc-default"))
 	})
 
+	It("returns the first default in list order when multiple live NetworkClasses are marked default", func() {
+		// fulfillment-service enforces at most one active default via a unique partial index;
+		// this documents operator behavior if that invariant is ever violated.
+		stub := newListingNetworkClassClient([]*privatev1.NetworkClass{
+			{Id: "nc-default-a", IsDefault: ptr.To(true)},
+			{Id: "nc-default-b", IsDefault: ptr.To(true)},
+		}, &[]*privatev1.NetworkClass{})
+		id, err := lookupDefaultNetworkClassID(ctx, stub)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(id).To(Equal("nc-default-a"))
+	})
+
 	It("returns the only live NetworkClass when none is marked default", func() {
 		stub := newListingNetworkClassClient([]*privatev1.NetworkClass{
 			{Id: "nc-singleton"},

--- a/osac-operator/internal/controller/dispatcher_resolver_helpers_test.go
+++ b/osac-operator/internal/controller/dispatcher_resolver_helpers_test.go
@@ -20,11 +20,15 @@ import (
 	"context"
 	"fmt"
 
+	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	privatev1 "github.com/osac-project/osac/osac-operator/internal/api/osac/private/v1"
+	"github.com/osac-project/osac/osac-operator/internal/dispatcheradapter"
+	"github.com/osac-project/osac/osac-operator/pkg/dispatcher"
 	"github.com/osac-project/osac/osac-operator/pkg/networkmanager"
 )
 
@@ -115,4 +119,18 @@ func newManagerConfigMap(name, namespace, managerName, labelKey, capabilities st
 			"capabilities": capabilities,
 		},
 	}
+}
+
+// wireExternalIPDispatcher builds a Resolver and NetworkClassesClient for ExternalIP-family
+// controller tests. ncs is the NetworkClass list returned by List/Get; callers must create
+// matching manager ConfigMaps on fakeClient in namespace before calling this.
+func wireExternalIPDispatcher(
+	fakeClient client.Client,
+	namespace string,
+	ncs []*privatev1.NetworkClass,
+) (*dispatcher.Resolver, privatev1.NetworkClassesClient) {
+	disc, err := networkmanager.NewDiscovery(fakeClient, namespace)
+	Expect(err).NotTo(HaveOccurred())
+	stub := newListingNetworkClassClient(ncs, &[]*privatev1.NetworkClass{})
+	return dispatcher.NewResolver(dispatcheradapter.NewNetworkClassAdapter(stub), disc), stub
 }

--- a/osac-operator/internal/controller/externalip_controller.go
+++ b/osac-operator/internal/controller/externalip_controller.go
@@ -228,18 +228,14 @@ func (r *ExternalIPReconciler) handleUpdate(ctx context.Context, externalIP *v1a
 	log.Info("resolved parent ExternalIPPool", "poolName", pool.Name, "poolUUID", externalIP.Spec.Pool)
 
 	// Resolve implementation strategy from the default NetworkClass via the
-	// dispatcher. The parent pool's spec.implementationStrategy (then the
-	// metallb-l2 constant) is only used when the dispatcher path is not active.
-	legacyStrategy := pool.Spec.ImplementationStrategy
-	if legacyStrategy == "" {
-		legacyStrategy = defaultExternalIPPoolImplementationStrategy
-	}
+	// dispatcher. The parent pool's spec.implementationStrategy is only used as a
+	// fallback when the dispatcher path is not active.
 	networkClassID, err := lookupDefaultNetworkClassID(ctx, r.networkClassesClient)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 	implementationStrategy, err := resolveImplementationStrategy(
-		ctx, r.Resolver, "ExternalIP", networkClassID, legacyStrategy)
+		ctx, r.Resolver, "ExternalIP", networkClassID, pool.Spec.ImplementationStrategy)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/osac-operator/internal/controller/externalip_controller.go
+++ b/osac-operator/internal/controller/externalip_controller.go
@@ -37,6 +37,8 @@ import (
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	"github.com/osac-project/osac/osac-operator/api/v1alpha1"
+	privatev1 "github.com/osac-project/osac/osac-operator/internal/api/osac/private/v1"
+	"github.com/osac-project/osac/osac-operator/pkg/dispatcher"
 	"github.com/osac-project/osac/osac-operator/pkg/provisioning"
 )
 
@@ -47,9 +49,10 @@ const (
 // ExternalIPReconciler reconciles ExternalIP CRs created by the fulfillment-service.
 //
 // Each ExternalIP belongs to a parent ExternalIPPool (referenced by UUID in spec.pool).
-// The controller adds a finalizer, inherits the implementation strategy from the
-// parent pool, then delegates to the shared provisioning lifecycle to trigger AAP
-// jobs for allocation and deallocation.
+// The controller adds a finalizer, resolves the implementation strategy from the
+// default NetworkClass via the dispatcher (falling back to the parent pool's spec
+// and defaultExternalIPPoolImplementationStrategy), then delegates to the shared
+// provisioning lifecycle to trigger AAP jobs for allocation and deallocation.
 //
 // Attach/detach is handled by the ExternalIPAttachment controller.
 //
@@ -64,6 +67,13 @@ type ExternalIPReconciler struct {
 	StatusPollInterval   time.Duration
 	MaxJobHistory        int
 	targetCluster        mc.ClusterName
+	// Resolver resolves a NetworkClass to its registered managers. Nil when the
+	// two-manager model isn't configured (no gRPC connection / networking namespace),
+	// in which case the controller always uses the legacy implementation-strategy path.
+	Resolver *dispatcher.Resolver
+	// networkClassesClient lists NetworkClasses to find the default/singleton used
+	// as the dispatcher input. Nil when gRPC is not configured.
+	networkClassesClient privatev1.NetworkClassesClient
 	// NetworkProvisioningEnabled controls whether the controller dispatches AAP
 	// provisioning jobs. When false, resources are set to Ready immediately
 	// with a placeholder address.
@@ -78,6 +88,8 @@ func NewExternalIPReconciler(
 	statusPollInterval time.Duration,
 	maxJobHistory int,
 	targetCluster mc.ClusterName,
+	resolver *dispatcher.Resolver,
+	networkClassesClient privatev1.NetworkClassesClient,
 ) *ExternalIPReconciler {
 	if mgr == nil {
 		panic("mgr must not be nil")
@@ -98,6 +110,8 @@ func NewExternalIPReconciler(
 		StatusPollInterval:   statusPollInterval,
 		MaxJobHistory:        maxJobHistory,
 		targetCluster:        targetCluster,
+		Resolver:             resolver,
+		networkClassesClient: networkClassesClient,
 	}
 }
 
@@ -213,11 +227,21 @@ func (r *ExternalIPReconciler) handleUpdate(ctx context.Context, externalIP *v1a
 	pool := &poolList.Items[0]
 	log.Info("resolved parent ExternalIPPool", "poolName", pool.Name, "poolUUID", externalIP.Spec.Pool)
 
-	// Inherit implementation strategy from the parent pool. Unlike ExternalIPPool (which
-	// reads strategy from its own spec), ExternalIP must look it up from the parent.
-	implementationStrategy := pool.Spec.ImplementationStrategy
-	if implementationStrategy == "" {
-		implementationStrategy = defaultExternalIPPoolImplementationStrategy
+	// Resolve implementation strategy from the default NetworkClass via the
+	// dispatcher. The parent pool's spec.implementationStrategy (then the
+	// metallb-l2 constant) is only used when the dispatcher path is not active.
+	legacyStrategy := pool.Spec.ImplementationStrategy
+	if legacyStrategy == "" {
+		legacyStrategy = defaultExternalIPPoolImplementationStrategy
+	}
+	networkClassID, err := lookupDefaultNetworkClassID(ctx, r.networkClassesClient)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	implementationStrategy, err := resolveImplementationStrategy(
+		ctx, r.Resolver, "ExternalIP", networkClassID, legacyStrategy)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	if externalIP.Annotations == nil {

--- a/osac-operator/internal/controller/externalip_controller_test.go
+++ b/osac-operator/internal/controller/externalip_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -37,6 +38,7 @@ import (
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	osacv1alpha1 "github.com/osac-project/osac/osac-operator/api/v1alpha1"
+	privatev1 "github.com/osac-project/osac/osac-operator/internal/api/osac/private/v1"
 	"github.com/osac-project/osac/osac-operator/pkg/provisioning"
 )
 
@@ -808,6 +810,92 @@ var _ = Describe("ExternalIPReconciler", func() {
 
 			Expect(updated.Finalizers).To(BeEmpty())
 			Expect(updated.Status.Phase).To(BeEmpty())
+		})
+	})
+
+	Context("dispatcher path", func() {
+		It("uses the resolved fabric manager name from the default NetworkClass", func() {
+			Expect(fakeClient.Create(testCtx, newFabricManagerConfigMap("fm-netris", testNamespace, "netris"))).To(Succeed())
+			resolver, ncClient := wireExternalIPDispatcher(fakeClient, testNamespace, []*privatev1.NetworkClass{{
+				Id: "nc-dispatch", FabricManager: ptr.To("netris"), IsDefault: ptr.To(true),
+			}})
+			reconciler.Resolver = resolver
+			reconciler.networkClassesClient = ncClient
+
+			key := types.NamespacedName{Name: publicIP.Name, Namespace: publicIP.Namespace}
+			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &osacv1alpha1.ExternalIP{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("netris"))
+		})
+
+		It("uses the k8s manager name when the NetworkClass has no fabricManager", func() {
+			Expect(fakeClient.Create(testCtx, newK8sManagerConfigMap("km-k8s-only", testNamespace, "k8s_only", "ipv4"))).To(Succeed())
+			resolver, ncClient := wireExternalIPDispatcher(fakeClient, testNamespace, []*privatev1.NetworkClass{{
+				Id: "nc-k8s", K8SManager: ptr.To("k8s_only"), IsDefault: ptr.To(true),
+			}})
+			reconciler.Resolver = resolver
+			reconciler.networkClassesClient = ncClient
+
+			key := types.NamespacedName{Name: publicIP.Name, Namespace: publicIP.Namespace}
+			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &osacv1alpha1.ExternalIP{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("k8s_only"))
+		})
+
+		It("falls back to the parent pool spec when the NetworkClass has no managers", func() {
+			resolver, ncClient := wireExternalIPDispatcher(fakeClient, testNamespace, []*privatev1.NetworkClass{{
+				Id: "nc-empty", IsDefault: ptr.To(true),
+			}})
+			reconciler.Resolver = resolver
+			reconciler.networkClassesClient = ncClient
+
+			key := types.NamespacedName{Name: publicIP.Name, Namespace: publicIP.Namespace}
+			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &osacv1alpha1.ExternalIP{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("metallb-l2"))
+		})
+
+		It("falls back to the parent pool spec when no NetworkClass is listed", func() {
+			resolver, ncClient := wireExternalIPDispatcher(fakeClient, testNamespace, nil)
+			reconciler.Resolver = resolver
+			reconciler.networkClassesClient = ncClient
+
+			key := types.NamespacedName{Name: publicIP.Name, Namespace: publicIP.Namespace}
+			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &osacv1alpha1.ExternalIP{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("metallb-l2"))
+		})
+
+		It("returns a reconcile error when the NetworkClass references an unregistered manager", func() {
+			resolver, ncClient := wireExternalIPDispatcher(fakeClient, testNamespace, []*privatev1.NetworkClass{{
+				Id: "nc-broken", FabricManager: ptr.To("does-not-exist"), IsDefault: ptr.To(true),
+			}})
+			reconciler.Resolver = resolver
+			reconciler.networkClassesClient = ncClient
+
+			key := types.NamespacedName{Name: publicIP.Name, Namespace: publicIP.Namespace}
+			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).To(HaveOccurred())
 		})
 	})
 

--- a/osac-operator/internal/controller/externalip_controller_test.go
+++ b/osac-operator/internal/controller/externalip_controller_test.go
@@ -244,9 +244,9 @@ var _ = Describe("ExternalIPReconciler", func() {
 			Expect(result.RequeueAfter).To(Equal(defaultPreconditionRequeueInterval))
 		})
 
-		It("should use default implementation strategy when pool has none", func() {
-			// A pool with no ImplementationStrategy in its spec should fall back
-			// to defaultExternalIPPoolImplementationStrategy ("metallb-l2").
+		It("should use empty implementation strategy when pool has none and no resolver is configured", func() {
+			// A pool with no ImplementationStrategy in its spec and no resolver
+			// configured results in an empty annotation (dispatcher must be configured).
 			poolNoStrategy := &osacv1alpha1.ExternalIPPool{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pool-no-strategy",
@@ -279,13 +279,13 @@ var _ = Describe("ExternalIPReconciler", func() {
 			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Pass 2: inherits default strategy since pool has none
+			// Pass 2: no pool spec.implementationStrategy and no resolver, so annotation is ""
 			_, err = reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 
 			updated := &osacv1alpha1.ExternalIP{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(defaultExternalIPPoolImplementationStrategy))
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(""))
 			Expect(updated.Annotations[osacExternalIPPoolNameAnnotation]).To(Equal("pool-no-strategy"))
 		})
 

--- a/osac-operator/internal/controller/externalipattachment_controller.go
+++ b/osac-operator/internal/controller/externalipattachment_controller.go
@@ -257,16 +257,12 @@ func (r *ExternalIPAttachmentReconciler) handleUpdate(ctx context.Context, attac
 	}
 	pool := &poolList.Items[0]
 
-	legacyStrategy := pool.Spec.ImplementationStrategy
-	if legacyStrategy == "" {
-		legacyStrategy = defaultExternalIPPoolImplementationStrategy
-	}
 	networkClassID, err := lookupDefaultNetworkClassID(ctx, r.networkClassesClient)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 	implementationStrategy, err := resolveImplementationStrategy(
-		ctx, r.Resolver, "ExternalIPAttachment", networkClassID, legacyStrategy)
+		ctx, r.Resolver, "ExternalIPAttachment", networkClassID, pool.Spec.ImplementationStrategy)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/osac-operator/internal/controller/externalipattachment_controller.go
+++ b/osac-operator/internal/controller/externalipattachment_controller.go
@@ -38,6 +38,8 @@ import (
 
 	bmfov1alpha1 "github.com/osac-project/osac/bare-metal-fulfillment-operator/api/v1alpha1"
 	"github.com/osac-project/osac/osac-operator/api/v1alpha1"
+	privatev1 "github.com/osac-project/osac/osac-operator/internal/api/osac/private/v1"
+	"github.com/osac-project/osac/osac-operator/pkg/dispatcher"
 	"github.com/osac-project/osac/osac-operator/pkg/provisioning"
 )
 
@@ -67,6 +69,13 @@ type ExternalIPAttachmentReconciler struct {
 	StatusPollInterval         time.Duration
 	MaxJobHistory              int
 	targetCluster              mc.ClusterName
+	// Resolver resolves a NetworkClass to its registered managers. Nil when the
+	// two-manager model isn't configured (no gRPC connection / networking namespace),
+	// in which case the controller always uses the legacy implementation-strategy path.
+	Resolver *dispatcher.Resolver
+	// networkClassesClient lists NetworkClasses to find the default/singleton used
+	// as the dispatcher input. Nil when gRPC is not configured.
+	networkClassesClient privatev1.NetworkClassesClient
 	// NetworkProvisioningEnabled controls whether the controller dispatches AAP
 	// provisioning jobs. When false, resources are set to Ready immediately.
 	NetworkProvisioningEnabled bool
@@ -83,6 +92,8 @@ func NewExternalIPAttachmentReconciler(
 	statusPollInterval time.Duration,
 	maxJobHistory int,
 	targetCluster mc.ClusterName,
+	resolver *dispatcher.Resolver,
+	networkClassesClient privatev1.NetworkClassesClient,
 ) *ExternalIPAttachmentReconciler {
 	if mgr == nil {
 		panic("mgr must not be nil")
@@ -115,6 +126,8 @@ func NewExternalIPAttachmentReconciler(
 		StatusPollInterval:         statusPollInterval,
 		MaxJobHistory:              maxJobHistory,
 		targetCluster:              targetCluster,
+		Resolver:                   resolver,
+		networkClassesClient:       networkClassesClient,
 	}
 }
 
@@ -244,9 +257,18 @@ func (r *ExternalIPAttachmentReconciler) handleUpdate(ctx context.Context, attac
 	}
 	pool := &poolList.Items[0]
 
-	implementationStrategy := pool.Spec.ImplementationStrategy
-	if implementationStrategy == "" {
-		implementationStrategy = defaultExternalIPPoolImplementationStrategy
+	legacyStrategy := pool.Spec.ImplementationStrategy
+	if legacyStrategy == "" {
+		legacyStrategy = defaultExternalIPPoolImplementationStrategy
+	}
+	networkClassID, err := lookupDefaultNetworkClassID(ctx, r.networkClassesClient)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	implementationStrategy, err := resolveImplementationStrategy(
+		ctx, r.Resolver, "ExternalIPAttachment", networkClassID, legacyStrategy)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	// BMI DNAT precondition: wait for primary IP to be discovered

--- a/osac-operator/internal/controller/externalipattachment_controller_test.go
+++ b/osac-operator/internal/controller/externalipattachment_controller_test.go
@@ -37,6 +37,7 @@ import (
 
 	bmfov1alpha1 "github.com/osac-project/osac/bare-metal-fulfillment-operator/api/v1alpha1"
 	osacv1alpha1 "github.com/osac-project/osac/osac-operator/api/v1alpha1"
+	privatev1 "github.com/osac-project/osac/osac-operator/internal/api/osac/private/v1"
 	"github.com/osac-project/osac/osac-operator/pkg/provisioning"
 )
 
@@ -325,6 +326,80 @@ var _ = Describe("ExternalIPAttachmentReconciler", func() {
 			updated := &osacv1alpha1.ExternalIPAttachment{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
 			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(defaultExternalIPPoolImplementationStrategy))
+		})
+	})
+
+	Context("dispatcher path", func() {
+		It("uses the resolved fabric manager name from the default NetworkClass", func() {
+			fakeClient = buildClient(attachment, publicIP, pool, ci)
+			setupReconciler(fakeClient)
+			Expect(fakeClient.Create(testCtx, newFabricManagerConfigMap("fm-netris", testNetworkingNamespace, "netris"))).To(Succeed())
+			resolver, ncClient := wireExternalIPDispatcher(fakeClient, testNetworkingNamespace, []*privatev1.NetworkClass{{
+				Id: "nc-dispatch", FabricManager: ptr.To("netris"), IsDefault: ptr.To(true),
+			}})
+			reconciler.Resolver = resolver
+			reconciler.networkClassesClient = ncClient
+
+			_, err := reconcileOnce()
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconcileOnce()
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &osacv1alpha1.ExternalIPAttachment{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("netris"))
+		})
+
+		It("uses the k8s manager name when the NetworkClass has no fabricManager", func() {
+			fakeClient = buildClient(attachment, publicIP, pool, ci)
+			setupReconciler(fakeClient)
+			Expect(fakeClient.Create(testCtx, newK8sManagerConfigMap("km-k8s-only", testNetworkingNamespace, "k8s_only", "ipv4"))).To(Succeed())
+			resolver, ncClient := wireExternalIPDispatcher(fakeClient, testNetworkingNamespace, []*privatev1.NetworkClass{{
+				Id: "nc-k8s", K8SManager: ptr.To("k8s_only"), IsDefault: ptr.To(true),
+			}})
+			reconciler.Resolver = resolver
+			reconciler.networkClassesClient = ncClient
+
+			_, err := reconcileOnce()
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconcileOnce()
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &osacv1alpha1.ExternalIPAttachment{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("k8s_only"))
+		})
+
+		It("falls back to the parent pool spec when the NetworkClass has no managers", func() {
+			fakeClient = buildClient(attachment, publicIP, pool, ci)
+			setupReconciler(fakeClient)
+			resolver, ncClient := wireExternalIPDispatcher(fakeClient, testNetworkingNamespace, []*privatev1.NetworkClass{{
+				Id: "nc-empty", IsDefault: ptr.To(true),
+			}})
+			reconciler.Resolver = resolver
+			reconciler.networkClassesClient = ncClient
+
+			_, err := reconcileOnce()
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconcileOnce()
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &osacv1alpha1.ExternalIPAttachment{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("metallb-l2"))
+		})
+
+		It("returns a reconcile error when the NetworkClass references an unregistered manager", func() {
+			fakeClient = buildClient(attachment, publicIP, pool, ci)
+			setupReconciler(fakeClient)
+			resolver, ncClient := wireExternalIPDispatcher(fakeClient, testNetworkingNamespace, []*privatev1.NetworkClass{{
+				Id: "nc-broken", FabricManager: ptr.To("does-not-exist"), IsDefault: ptr.To(true),
+			}})
+			reconciler.Resolver = resolver
+			reconciler.networkClassesClient = ncClient
+
+			_, err := reconcileOnce()
+			Expect(err).To(HaveOccurred())
 		})
 	})
 

--- a/osac-operator/internal/controller/externalipattachment_controller_test.go
+++ b/osac-operator/internal/controller/externalipattachment_controller_test.go
@@ -325,7 +325,8 @@ var _ = Describe("ExternalIPAttachmentReconciler", func() {
 
 			updated := &osacv1alpha1.ExternalIPAttachment{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(defaultExternalIPPoolImplementationStrategy))
+			// Pool has no spec.implementationStrategy and no resolver is configured, so annotation is ""
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(""))
 		})
 	})
 

--- a/osac-operator/internal/controller/externalippool_controller.go
+++ b/osac-operator/internal/controller/externalippool_controller.go
@@ -187,18 +187,14 @@ func (r *ExternalIPPoolReconciler) handleUpdate(ctx context.Context, pool *v1alp
 	}
 
 	// Resolve implementation strategy from the default NetworkClass via the
-	// dispatcher. pool spec.implementationStrategy (then the metallb-l2 constant)
-	// is only used when the dispatcher path is not active.
-	legacyStrategy := pool.Spec.ImplementationStrategy
-	if legacyStrategy == "" {
-		legacyStrategy = defaultExternalIPPoolImplementationStrategy
-	}
+	// dispatcher. pool spec.implementationStrategy is only used as a fallback
+	// when the dispatcher path is not active.
 	networkClassID, err := lookupDefaultNetworkClassID(ctx, r.networkClassesClient)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 	implementationStrategy, err := resolveImplementationStrategy(
-		ctx, r.Resolver, "ExternalIPPool", networkClassID, legacyStrategy)
+		ctx, r.Resolver, "ExternalIPPool", networkClassID, pool.Spec.ImplementationStrategy)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/osac-operator/internal/controller/externalippool_controller.go
+++ b/osac-operator/internal/controller/externalippool_controller.go
@@ -35,6 +35,8 @@ import (
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	"github.com/osac-project/osac/osac-operator/api/v1alpha1"
+	privatev1 "github.com/osac-project/osac/osac-operator/internal/api/osac/private/v1"
+	"github.com/osac-project/osac/osac-operator/pkg/dispatcher"
 	"github.com/osac-project/osac/osac-operator/pkg/provisioning"
 )
 
@@ -46,8 +48,9 @@ const (
 // ExternalIPPoolReconciler reconciles ExternalIPPool CRs created by the fulfillment-service.
 //
 // A ExternalIPPool defines a range of external IP addresses (CIDRs) that can be allocated
-// as individual ExternalIP resources. Unlike ExternalIP (which inherits its strategy from
-// the parent pool), ExternalIPPool reads the implementation strategy from its own spec.
+// as individual ExternalIP resources. Implementation strategy is resolved from the default
+// NetworkClass via the dispatcher; pool spec.implementationStrategy is a backward-compat
+// fallback (along with defaultExternalIPPoolImplementationStrategy).
 //
 // The controller adds a finalizer, triggers AAP provisioning/deprovisioning jobs via
 // the shared provisioning lifecycle, and transitions phases:
@@ -62,6 +65,13 @@ type ExternalIPPoolReconciler struct {
 	StatusPollInterval   time.Duration
 	MaxJobHistory        int
 	targetCluster        mc.ClusterName
+	// Resolver resolves a NetworkClass to its registered managers. Nil when the
+	// two-manager model isn't configured (no gRPC connection / networking namespace),
+	// in which case the controller always uses the legacy implementation-strategy path.
+	Resolver *dispatcher.Resolver
+	// networkClassesClient lists NetworkClasses to find the default/singleton used
+	// as the dispatcher input. Nil when gRPC is not configured.
+	networkClassesClient privatev1.NetworkClassesClient
 	// NetworkProvisioningEnabled controls whether the controller dispatches AAP
 	// provisioning jobs. When false, resources are set to Ready immediately.
 	NetworkProvisioningEnabled bool
@@ -75,6 +85,8 @@ func NewExternalIPPoolReconciler(
 	statusPollInterval time.Duration,
 	maxJobHistory int,
 	targetCluster mc.ClusterName,
+	resolver *dispatcher.Resolver,
+	networkClassesClient privatev1.NetworkClassesClient,
 ) *ExternalIPPoolReconciler {
 	if mgr == nil {
 		panic("mgr must not be nil")
@@ -95,6 +107,8 @@ func NewExternalIPPoolReconciler(
 		StatusPollInterval:   statusPollInterval,
 		MaxJobHistory:        maxJobHistory,
 		targetCluster:        targetCluster,
+		Resolver:             resolver,
+		networkClassesClient: networkClassesClient,
 	}
 }
 
@@ -104,7 +118,7 @@ func NewExternalIPPoolReconciler(
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=externalips,verbs=list
 
 // Reconcile handles create/update/delete for a ExternalIPPool CR.
-// On create/update it ensures a finalizer, reads the implementation strategy from spec,
+// On create/update it ensures a finalizer, resolves the implementation strategy,
 // and runs provisioning. On delete it triggers deprovisioning and removes the finalizer.
 func (r *ExternalIPPoolReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
 	log := ctrllog.FromContext(ctx)
@@ -172,10 +186,21 @@ func (r *ExternalIPPoolReconciler) handleUpdate(ctx context.Context, pool *v1alp
 		return ctrl.Result{}, nil
 	}
 
-	// Read implementation strategy from spec
-	implementationStrategy := pool.Spec.ImplementationStrategy
-	if implementationStrategy == "" {
-		implementationStrategy = defaultExternalIPPoolImplementationStrategy
+	// Resolve implementation strategy from the default NetworkClass via the
+	// dispatcher. pool spec.implementationStrategy (then the metallb-l2 constant)
+	// is only used when the dispatcher path is not active.
+	legacyStrategy := pool.Spec.ImplementationStrategy
+	if legacyStrategy == "" {
+		legacyStrategy = defaultExternalIPPoolImplementationStrategy
+	}
+	networkClassID, err := lookupDefaultNetworkClassID(ctx, r.networkClassesClient)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	implementationStrategy, err := resolveImplementationStrategy(
+		ctx, r.Resolver, "ExternalIPPool", networkClassID, legacyStrategy)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	// Stamp the implementation-strategy annotation so AAP playbooks can read it

--- a/osac-operator/internal/controller/externalippool_controller_test.go
+++ b/osac-operator/internal/controller/externalippool_controller_test.go
@@ -217,8 +217,10 @@ var _ = Describe("ExternalIPPoolReconciler", func() {
 			Expect(provisionCalled).To(BeTrue(), "AAP provisioning must be triggered after annotation is stamped")
 		})
 
-		It("should stamp default metallb-l2 annotation when spec.implementationStrategy is empty", func() {
-			// Create a pool that omits ImplementationStrategy (relies on the default).
+		It("should not stamp annotation when no strategy is resolved and spec.implementationStrategy is empty", func() {
+			// Create a pool that omits ImplementationStrategy. With no resolver configured
+			// and no spec.implementationStrategy, no annotation is set (dispatcher must be
+			// configured for a real strategy).
 			poolNoStrategy := &osacv1alpha1.ExternalIPPool{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pool-no-strategy",
@@ -234,15 +236,16 @@ var _ = Describe("ExternalIPPoolReconciler", func() {
 
 			key := types.NamespacedName{Name: poolNoStrategy.Name, Namespace: poolNoStrategy.Namespace}
 
-			// Pass 1: finalizer + annotation with defaultExternalIPPoolImplementationStrategy.
+			// Pass 1: finalizer. With no resolver and no spec.implementationStrategy,
+			// the resolved strategy is "" and no annotation update occurs (nil != "" is false
+			// because accessing a nil map returns the zero value).
 			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 
 			annotated := &osacv1alpha1.ExternalIPPool{}
 			Expect(fakeClient.Get(testCtx, key, annotated)).To(Succeed())
-			Expect(annotated.Annotations).To(HaveKeyWithValue(
-				osacImplementationStrategyAnnotation, defaultExternalIPPoolImplementationStrategy,
-			))
+			// Annotation is not set when the resolved strategy is empty
+			Expect(annotated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(""))
 		})
 
 		It("should set ConfigurationApplied condition to True", func() {

--- a/osac-operator/internal/controller/externalippool_controller_test.go
+++ b/osac-operator/internal/controller/externalippool_controller_test.go
@@ -27,12 +27,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
 	osacv1alpha1 "github.com/osac-project/osac/osac-operator/api/v1alpha1"
+	privatev1 "github.com/osac-project/osac/osac-operator/internal/api/osac/private/v1"
 	"github.com/osac-project/osac/osac-operator/pkg/provisioning"
 )
 
@@ -40,8 +42,9 @@ import (
 //
 // Key concepts for understanding these tests:
 //
-//   - Unlike ExternalIP (which inherits strategy from its parent pool), ExternalIPPool reads
-//     the implementation strategy from its own spec.implementationStrategy field.
+//   - Implementation strategy is resolved from the default NetworkClass via the dispatcher.
+//     pool spec.implementationStrategy (then metallb-l2) is a backward-compat fallback used
+//     when the dispatcher path is not active.
 //
 //   - The reconcile loop requires multiple passes because each pass does one thing and
 //     returns: first pass adds the finalizer (metadata write), second pass processes the
@@ -560,6 +563,86 @@ var _ = Describe("ExternalIPPoolReconciler", func() {
 			// Verify no finalizer was added (controller skipped it)
 			Expect(updated.Finalizers).To(BeEmpty())
 			Expect(updated.Status.Phase).To(BeEmpty())
+		})
+	})
+
+	Context("dispatcher path", func() {
+		const ns = "test-namespace"
+
+		It("uses the resolved fabric manager name from the default NetworkClass", func() {
+			Expect(fakeClient.Create(testCtx, newFabricManagerConfigMap("fm-netris", ns, "netris"))).To(Succeed())
+			resolver, ncClient := wireExternalIPDispatcher(fakeClient, ns, []*privatev1.NetworkClass{{
+				Id: "nc-dispatch", FabricManager: ptr.To("netris"), IsDefault: ptr.To(true),
+			}})
+			reconciler.Resolver = resolver
+			reconciler.networkClassesClient = ncClient
+
+			key := types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}
+			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &osacv1alpha1.ExternalIPPool{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("netris"))
+		})
+
+		It("uses the k8s manager name when the NetworkClass has no fabricManager", func() {
+			Expect(fakeClient.Create(testCtx, newK8sManagerConfigMap("km-k8s-only", ns, "k8s_only", "ipv4"))).To(Succeed())
+			resolver, ncClient := wireExternalIPDispatcher(fakeClient, ns, []*privatev1.NetworkClass{{
+				Id: "nc-k8s", K8SManager: ptr.To("k8s_only"), IsDefault: ptr.To(true),
+			}})
+			reconciler.Resolver = resolver
+			reconciler.networkClassesClient = ncClient
+
+			key := types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}
+			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &osacv1alpha1.ExternalIPPool{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("k8s_only"))
+		})
+
+		It("falls back to spec.implementationStrategy when the NetworkClass has no managers", func() {
+			resolver, ncClient := wireExternalIPDispatcher(fakeClient, ns, []*privatev1.NetworkClass{{
+				Id: "nc-empty", IsDefault: ptr.To(true),
+			}})
+			reconciler.Resolver = resolver
+			reconciler.networkClassesClient = ncClient
+
+			key := types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}
+			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &osacv1alpha1.ExternalIPPool{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("metallb-l2"))
+		})
+
+		It("falls back to spec.implementationStrategy when no NetworkClass is listed", func() {
+			resolver, ncClient := wireExternalIPDispatcher(fakeClient, ns, nil)
+			reconciler.Resolver = resolver
+			reconciler.networkClassesClient = ncClient
+
+			key := types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}
+			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &osacv1alpha1.ExternalIPPool{}
+			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("metallb-l2"))
+		})
+
+		It("returns a reconcile error when the NetworkClass references an unregistered manager", func() {
+			resolver, ncClient := wireExternalIPDispatcher(fakeClient, ns, []*privatev1.NetworkClass{{
+				Id: "nc-broken", FabricManager: ptr.To("does-not-exist"), IsDefault: ptr.To(true),
+			}})
+			reconciler.Resolver = resolver
+			reconciler.networkClassesClient = ncClient
+
+			key := types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}
+			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).To(HaveOccurred())
 		})
 	})
 

--- a/osac-operator/internal/controller/networkclass_capabilities_controller.go
+++ b/osac-operator/internal/controller/networkclass_capabilities_controller.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
@@ -107,15 +106,6 @@ func (r *NetworkClassCapabilitiesReconciler) Reconcile(ctx context.Context, _ ct
 	return ctrl.Result{}, r.resyncAll(ctx)
 }
 
-// networkClassListPageSize is the page size used to list NetworkClasses for a full
-// capabilities resync. It matches the fulfillment-service's maximum allowed limit, so
-// listing every NetworkClass takes the fewest possible round trips.
-//
-// A single unbounded List call is not sufficient here: the server defaults an unset
-// limit to a fixed page size (currently 100) rather than "no limit", so without paging,
-// any NetworkClasses beyond the first page would be silently skipped on every resync.
-const networkClassListPageSize = 1000
-
 // resyncAll recomputes capabilities for every NetworkClass, waiting for any resync
 // already in progress (e.g. a concurrent periodic tick) to finish first. Used by the
 // ConfigMap-triggered Reconcile path, where a ConfigMap change must eventually be
@@ -133,7 +123,7 @@ func (r *NetworkClassCapabilitiesReconciler) resyncAll(ctx context.Context) erro
 func (r *NetworkClassCapabilitiesReconciler) resyncAllLocked(ctx context.Context) error {
 	log := ctrllog.FromContext(ctx)
 
-	items, err := r.listAllNetworkClasses(ctx)
+	items, err := listAllNetworkClasses(ctx, r.networkClassesClient)
 	if err != nil {
 		return fmt.Errorf("listing network classes: %w", err)
 	}
@@ -148,30 +138,9 @@ func (r *NetworkClassCapabilitiesReconciler) resyncAllLocked(ctx context.Context
 	return errors.Join(errs...)
 }
 
-// listAllNetworkClasses fetches every NetworkClass from the fulfillment service,
-// paging through results with offset/limit rather than issuing a single List call with
-// neither set (see networkClassListPageSize for why that would silently truncate).
+// listAllNetworkClasses fetches every NetworkClass from the fulfillment service.
 func (r *NetworkClassCapabilitiesReconciler) listAllNetworkClasses(ctx context.Context) ([]*privatev1.NetworkClass, error) {
-	var items []*privatev1.NetworkClass
-	offset := int32(0)
-	for {
-		resp, err := r.networkClassesClient.List(ctx, privatev1.NetworkClassesListRequest_builder{
-			Offset: ptr.To(offset),
-			Limit:  ptr.To(int32(networkClassListPageSize)),
-		}.Build())
-		if err != nil {
-			return nil, err
-		}
-
-		items = append(items, resp.GetItems()...)
-		offset += resp.GetSize()
-
-		// resp.GetSize() == 0 guards against an infinite loop if the server ever
-		// reports a total larger than what it actually returns.
-		if resp.GetSize() == 0 || offset >= resp.GetTotal() {
-			return items, nil
-		}
-	}
+	return listAllNetworkClasses(ctx, r.networkClassesClient)
 }
 
 // syncOne resolves and applies the capability intersection for a single NetworkClass,

--- a/osac-operator/internal/controller/networkclass_capabilities_controller.go
+++ b/osac-operator/internal/controller/networkclass_capabilities_controller.go
@@ -138,11 +138,6 @@ func (r *NetworkClassCapabilitiesReconciler) resyncAllLocked(ctx context.Context
 	return errors.Join(errs...)
 }
 
-// listAllNetworkClasses fetches every NetworkClass from the fulfillment service.
-func (r *NetworkClassCapabilitiesReconciler) listAllNetworkClasses(ctx context.Context) ([]*privatev1.NetworkClass, error) {
-	return listAllNetworkClasses(ctx, r.networkClassesClient)
-}
-
 // syncOne resolves and applies the capability intersection for a single NetworkClass,
 // updating it via the fulfillment service only when the computed capabilities differ
 // from what's already stored.

--- a/osac-operator/internal/controller/networkclass_capabilities_controller_test.go
+++ b/osac-operator/internal/controller/networkclass_capabilities_controller_test.go
@@ -240,8 +240,7 @@ var _ = Describe("listAllNetworkClasses", func() {
 		}
 		stub, offsetsSeen := pagingNetworkClassClient(all, 2)
 
-		reconciler := NewNetworkClassCapabilitiesReconciler(stub, nil, "default")
-		items, err := reconciler.listAllNetworkClasses(ctx)
+		items, err := listAllNetworkClasses(ctx, stub)
 		Expect(err).NotTo(HaveOccurred())
 
 		ids := make([]string, 0, len(items))
@@ -256,8 +255,7 @@ var _ = Describe("listAllNetworkClasses", func() {
 	It("stops after a single call when the server reports no results", func() {
 		stub, offsetsSeen := pagingNetworkClassClient(nil, 2)
 
-		reconciler := NewNetworkClassCapabilitiesReconciler(stub, nil, "default")
-		items, err := reconciler.listAllNetworkClasses(ctx)
+		items, err := listAllNetworkClasses(ctx, stub)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(items).To(BeEmpty())
 		Expect(*offsetsSeen).To(Equal([]int32{0}))
@@ -270,8 +268,7 @@ var _ = Describe("listAllNetworkClasses", func() {
 			},
 		}
 
-		reconciler := NewNetworkClassCapabilitiesReconciler(stub, nil, "default")
-		_, err := reconciler.listAllNetworkClasses(ctx)
+		_, err := listAllNetworkClasses(ctx, stub)
 		Expect(err).To(MatchError(ContainSubstring("fulfillment-service unavailable")))
 	})
 })

--- a/osac-operator/internal/controller/securitygroup_controller.go
+++ b/osac-operator/internal/controller/securitygroup_controller.go
@@ -209,11 +209,10 @@ func (r *SecurityGroupReconciler) handleUpdate(ctx context.Context, sg *v1alpha1
 		log.Info("parent VirtualNetwork not found, using legacy implementation strategy", "uuid", sg.Spec.VirtualNetwork)
 	}
 
-	// Legacy fallback value; resolveImplementationStrategy below only uses it when the
-	// dispatcher path isn't available (see doc comment).
-	legacyStrategy := defaultSecurityGroupImplementationStrategy
-
-	implementationStrategy, err := resolveImplementationStrategy(ctx, r.Resolver, "SecurityGroup", networkClassID, legacyStrategy)
+	// resolveImplementationStrategy returns "" when the dispatcher path isn't available
+	// (resolver nil, networkClassID empty, or no manager configured). SecurityGroup
+	// has no resource-level fallback strategy — it exclusively uses the dispatcher.
+	implementationStrategy, err := resolveImplementationStrategy(ctx, r.Resolver, "SecurityGroup", networkClassID, "")
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/osac-operator/internal/controller/securitygroup_controller_test.go
+++ b/osac-operator/internal/controller/securitygroup_controller_test.go
@@ -193,10 +193,6 @@ var _ = Describe("SecurityGroupReconciler", func() {
 		It("should persist job status even when resource is concurrently modified", func() {
 			key := types.NamespacedName{Name: sg.Name, Namespace: sg.Namespace}
 
-			// First reconcile: adds finalizer + sets annotation, returns early
-			_, err := reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
-			Expect(err).NotTo(HaveOccurred())
-
 			// Simulate feedback controller: during TriggerProvision, modify
 			// the resource's metadata (add feedback finalizer) so the
 			// resourceVersion changes before the status flush runs.
@@ -213,9 +209,10 @@ var _ = Describe("SecurityGroupReconciler", func() {
 				}, nil
 			}
 
-			// Second reconcile: triggers job — the concurrent modification
-			// must not prevent the job from being recorded in status.
-			_, err = reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			// First reconcile: adds finalizer and triggers job (with no resolver,
+			// the annotation doesn't change so provisioning proceeds immediately).
+			// The concurrent modification must not prevent the job from being recorded.
+			_, err := reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify the job was persisted
@@ -252,7 +249,7 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			Expect(provisionCalled).To(BeTrue())
 		})
 
-		It("should default to network_policy strategy when spec has no implementationStrategy", func() {
+		It("should not stamp annotation when no resolver is configured", func() {
 			key := types.NamespacedName{Name: sg.Name, Namespace: sg.Namespace}
 
 			mockProvider.triggerProvisionFunc = func(ctx context.Context, resource client.Object) (*provisioning.ProvisionResult, error) {
@@ -263,7 +260,7 @@ var _ = Describe("SecurityGroupReconciler", func() {
 				}, nil
 			}
 
-			// Reconcile twice (first adds finalizer, second sets annotation and provisions)
+			// Reconcile twice (first adds finalizer, second attempts annotation and provisions)
 			_, err := reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 			_, err = reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
@@ -273,19 +270,19 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			updated := &osacv1alpha1.SecurityGroup{}
 			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
 
-			// Verify annotation was set to the default network_policy strategy
-			Expect(updated.Annotations).NotTo(BeNil())
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(defaultSecurityGroupImplementationStrategy))
+			// With no resolver configured, the resolved strategy is "" and no annotation
+			// update occurs (the existing value "" matches the resolved value "").
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(""))
 		})
 
 		It("should not update when annotation already matches implementation strategy", func() {
-			// Create SecurityGroup with annotation already set to the default
+			// Create SecurityGroup with annotation already set (no resolver, so "" is the resolved value)
 			sgWithAnnotation := &osacv1alpha1.SecurityGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "sg-with-annotation",
 					Namespace: "test-namespace",
 					Annotations: map[string]string{
-						osacImplementationStrategyAnnotation: defaultSecurityGroupImplementationStrategy,
+						osacImplementationStrategyAnnotation: "",
 					},
 				},
 				Spec: osacv1alpha1.SecurityGroupSpec{
@@ -315,7 +312,7 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
 
 			// Verify annotation still matches (no duplicate Update calls)
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(defaultSecurityGroupImplementationStrategy))
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(""))
 		})
 
 		It("should update annotation when it differs from the resolved strategy", func() {
@@ -354,8 +351,8 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			updated := &osacv1alpha1.SecurityGroup{}
 			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
 
-			// Verify annotation was updated to the default strategy
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(defaultSecurityGroupImplementationStrategy))
+			// With no resolver configured, annotation is updated to "" (dispatcher must be configured)
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(""))
 		})
 
 		It("should trigger provision job when no job exists", func() {
@@ -380,14 +377,12 @@ var _ = Describe("SecurityGroupReconciler", func() {
 
 			req := mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}}
 
-			// First reconcile adds finalizer and sets annotation, then requeues
+			// First reconcile adds finalizer and triggers the provision job (with no resolver,
+			// annotation doesn't change so provisioning proceeds immediately). Returns with
+			// RequeueAfter for status polling.
 			result, err := reconciler.Reconcile(ctx, req)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.RequeueAfter).To(BeZero())
-
-			// Second reconcile triggers the provision job
-			_, err = reconciler.Reconcile(ctx, req)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(reconciler.StatusPollInterval))
 
 			// Fetch updated SecurityGroup to check job state
 			updated := &osacv1alpha1.SecurityGroup{}
@@ -536,6 +531,15 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			toDelete := &osacv1alpha1.SecurityGroup{}
 			Expect(fakeClient.Get(ctx, key, toDelete)).To(Succeed())
 
+			// Set the implementation-strategy annotation to simulate a provisioned resource.
+			// Without a resolver, the annotation stays empty and deprovisioning is skipped.
+			if toDelete.Annotations == nil {
+				toDelete.Annotations = make(map[string]string)
+			}
+			toDelete.Annotations[osacImplementationStrategyAnnotation] = "test-strategy"
+			Expect(fakeClient.Update(ctx, toDelete)).To(Succeed())
+			Expect(fakeClient.Get(ctx, key, toDelete)).To(Succeed())
+
 			// Set deletion timestamp in memory and call handleDelete directly
 			// (fake client doesn't allow setting DeletionTimestamp via Update)
 			now := metav1.Now()
@@ -580,6 +584,15 @@ var _ = Describe("SecurityGroupReconciler", func() {
 
 			// Fetch the SecurityGroup
 			toDelete := &osacv1alpha1.SecurityGroup{}
+			Expect(fakeClient.Get(ctx, key, toDelete)).To(Succeed())
+
+			// Set the implementation-strategy annotation to simulate a provisioned resource.
+			// Without a resolver, the annotation stays empty and deprovisioning is skipped.
+			if toDelete.Annotations == nil {
+				toDelete.Annotations = make(map[string]string)
+			}
+			toDelete.Annotations[osacImplementationStrategyAnnotation] = "test-strategy"
+			Expect(fakeClient.Update(ctx, toDelete)).To(Succeed())
 			Expect(fakeClient.Get(ctx, key, toDelete)).To(Succeed())
 
 			// Set deletion timestamp in memory
@@ -872,7 +885,8 @@ var _ = Describe("SecurityGroupReconciler", func() {
 
 			updated := &osacv1alpha1.SecurityGroup{}
 			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(defaultSecurityGroupImplementationStrategy))
+			// With no resolver configured, annotation is "" (dispatcher must be configured)
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(""))
 		})
 
 		It("returns a reconcile error when the NetworkClass references an unregistered manager", func() {
@@ -920,7 +934,8 @@ var _ = Describe("SecurityGroupReconciler", func() {
 
 			updated := &osacv1alpha1.SecurityGroup{}
 			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(defaultSecurityGroupImplementationStrategy))
+			// Parent VirtualNetwork not found, so networkClassID is empty -> annotation is ""
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(""))
 		})
 
 		It("returns an error when multiple VirtualNetworks share the parent uuid label", func() {


### PR DESCRIPTION
Resolve implementation strategy from the default NetworkClass via the dispatcher instead of pool spec.implementationStrategy, so k8s-only deployments stamp k8s_only instead of hardcoded metallb-l2. Keep the spec field and metallb-l2 constant as a backward-compat fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic network implementation selection for external IP pools, external IPs, and attachments through the default NetworkClass.
  * Added Kubernetes-native networking support for VMaaS environments without a physical fabric, including IPv4, IPv6, and dual-stack configurations.
  * Added CUDN, NetworkPolicy, and MetalLB L2 integration for virtual networks, security groups, and external IPs.
* **Improvements**
  * Existing resource-level strategies remain available when automatic selection is unavailable.
  * Improved handling of multiple, deleted, and paginated NetworkClass entries.
  * Improved error handling for unavailable or unregistered network implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->