### PR TITLE
NO-ISSUE: report generated-code on merge_group

### DIFF
--- a/.github/workflows/check-generated-code.yaml
+++ b/.github/workflows/check-generated-code.yaml
@@ -15,6 +15,7 @@ on:
       - '!osac-operator/**/*.md'
       - '!osac-operator/docs/**'
       - '!osac-operator/.claude/**'
+  merge_group:
 
 permissions:
   contents: read
@@ -24,12 +25,20 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       changes: ${{ steps.filter.outputs.changes || '[]' }}
     steps:
+      # dorny/paths-filter uses git diff on merge_group (not the PR Files API),
+      # so the repo must be checked out with enough history for base..head.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        if: github.event_name == 'merge_group'
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         id: filter
         with:
           predicate-quantifier: 'every'
@@ -42,7 +51,8 @@ jobs:
               - '!fulfillment-service/docs/**'
               - '!fulfillment-service/.claude/**'
             osac-operator:
-              - 'osac-operator/**'
+              # buf.gen.yaml reads ../fulfillment-service/proto/private
+              - '{osac-operator,fulfillment-service/proto/private}/**'
               - '!osac-operator/OWNERS'
               - '!osac-operator/LICENSE'
               - '!osac-operator/**/*.md'
@@ -52,21 +62,38 @@ jobs:
   check-generated-code:
     name: Check generated code (${{ matrix.component }})
     needs: changes
+    # Run even if `changes` failed: a skipped job reports success, which would
+    # let required checks pass without buf generate. Fail in the first step.
+    if: ${{ always() }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
-        component: ${{ fromJSON(needs.changes.outputs.changes) }}
-    if: needs.changes.outputs.changes != '[]'
+        # Fixed list so both required names always exist. Skip is on steps
+        # (`matrix` is not valid in a job-level `if:`).
+        component:
+          - fulfillment-service
+          - osac-operator
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+    - name: Fail if path filter failed
+      if: needs.changes.result != 'success'
+      run: exit 1
+    - id: should-run
+      if: needs.changes.result == 'success' && contains(fromJSON(needs.changes.outputs.changes), matrix.component)
+      run: echo "run=true" >> "$GITHUB_OUTPUT"
+    - if: steps.should-run.outputs.run
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
         persist-credentials: false
-    - uses: bufbuild/buf-action@8c6a16e16f12ba20b6470afa9c2ba9b5ba8c97c3  # v1
+    - if: steps.should-run.outputs.run
+      uses: bufbuild/buf-action@8c6a16e16f12ba20b6470afa9c2ba9b5ba8c97c3  # v1
       with:
         version: '1.50.0'
         setup_only: true
-    - working-directory: ${{ matrix.component }}
+    - if: steps.should-run.outputs.run
+      working-directory: ${{ matrix.component }}
       run: |
         buf generate
         git diff --exit-code -- .


### PR DESCRIPTION
## Summary
- Run `check-generated-code` on `merge_group` so merge queue gets pass/skip on the speculative SHA (same pattern as osac#418).
- Keep the matrix. Use a fixed `fulfillment-service` / `osac-operator` list so both required names always exist. Skip unmatched components on the steps (`matrix` is not valid in a job-level `if:`).
- Keep `pull_request.paths` so matching PRs still run this before enqueue.
- Include osac#527: osac-operator generation also runs when `fulfillment-service/proto/private` changes (`buf.gen.yaml` reads those protos).

## Test plan
- [ ] PR that touches `fulfillment-service/**` or `osac-operator/**` still runs the matching matrix leg
- [ ] After enqueue, merge-group SHA shows both `Check generated code (fulfillment-service)` and `Check generated code (osac-operator)` (run or skip, not missing)
- [ ] Unrelated merge group still reports both names (steps skipped, success); does not stall queue
- [ ] Change only under `fulfillment-service/proto/private/**` runs osac-operator generation
- [ ] Do **not** re-apply github-config required checks until this is on `main`

osac#418 is on `main` (the other 10 of 12 checks). Supersedes osac#527.