### PR TITLE
OSAC-4251: Metal3 inventory — use InspectionMode field and HardwareData resource

### DIFF
--- a/bare-metal-fulfillment-operator/AGENTS.md
+++ b/bare-metal-fulfillment-operator/AGENTS.md
@@ -150,5 +150,5 @@ CRDs must stay in sync: after `make manifests`, run `make helm-crds` (uses `hack
 - `internal/controller/*_integration_test.go` — Metal3 integration tests
 - `test/integration/` — integration tests against a pre-existing, persistent Kind cluster (named `osac-dev`)
 - `test/utils/` — test utilities
-- `test/crds/` — external CRDs (metal3.io_baremetalhosts.yaml)
+- `test/crds/` — external CRDs (metal3.io_baremetalhosts.yaml, metal3.io_hardwaredata.yaml)
 - **ENVTEST_K8S_VERSION**: Auto-detected from k8s.io/api version in go.mod (e.g., 1.36)

--- a/bare-metal-fulfillment-operator/charts/operator/templates/clusterrole.yaml
+++ b/bare-metal-fulfillment-operator/charts/operator/templates/clusterrole.yaml
@@ -19,6 +19,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - metal3.io
+  resources:
+  - hardwaredata
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - osac.openshift.io
   resources:
   - baremetalinstances

--- a/bare-metal-fulfillment-operator/config/rbac/role.yaml
+++ b/bare-metal-fulfillment-operator/config/rbac/role.yaml
@@ -17,6 +17,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - metal3.io
+  resources:
+  - hardwaredata
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - osac.openshift.io
   resources:
   - baremetalinstances

--- a/bare-metal-fulfillment-operator/internal/baremetalhost/hardwaredata.go
+++ b/bare-metal-fulfillment-operator/internal/baremetalhost/hardwaredata.go
@@ -23,19 +23,33 @@ import (
 // ResolveHardwareDetails selects the Metal3 hardware inventory to read NIC
 // data from, preferring the standalone HardwareData resource over the
 // deprecated BareMetalHost.Status.HardwareDetails. It returns
-// hd.Spec.HardwareDetails when that carries NIC inventory, otherwise
-// bmh.Status.HardwareDetails (which may itself be nil). hd may be nil when no
-// companion HardwareData exists, and bmh may be nil when the caller only has
-// HardwareData in hand. An empty HardwareData does not shadow a populated
-// status: precedence means "prefer HardwareData when it actually has NIC
-// data". This is the single place to change if strict presence-precedence is
-// ever wanted.
+// hd.Spec.HardwareDetails when that carries usable NIC inventory (at least one
+// NIC with a non-empty MAC), otherwise bmh.Status.HardwareDetails (which may
+// itself be nil). hd may be nil when no companion HardwareData exists, and bmh
+// may be nil when the caller only has HardwareData in hand. An empty or
+// all-empty-MAC HardwareData does not shadow a populated status: precedence
+// means "prefer HardwareData when it actually has usable NIC data". Gating on a
+// usable MAC (rather than NIC count) matters because NIC.MAC is
+// json:"mac,omitempty", so a NIC entry can exist with no MAC — callers
+// (metal3HostNICs, hardwareMACs) drop such entries, so treating them as
+// present here would strand the status fallback.
 func ResolveHardwareDetails(hd *metal3api.HardwareData, bmh *metal3api.BareMetalHost) *metal3api.HardwareDetails {
-	if hd != nil && hd.Spec.HardwareDetails != nil && len(hd.Spec.HardwareDetails.NIC) > 0 {
+	if hd != nil && hd.Spec.HardwareDetails != nil && hasUsableNIC(hd.Spec.HardwareDetails) {
 		return hd.Spec.HardwareDetails
 	}
 	if bmh != nil {
 		return bmh.Status.HardwareDetails
 	}
 	return nil
+}
+
+// hasUsableNIC reports whether details carries at least one NIC with a
+// non-empty MAC address.
+func hasUsableNIC(details *metal3api.HardwareDetails) bool {
+	for _, nic := range details.NIC {
+		if nic.MAC != "" {
+			return true
+		}
+	}
+	return false
 }

--- a/bare-metal-fulfillment-operator/internal/baremetalhost/hardwaredata.go
+++ b/bare-metal-fulfillment-operator/internal/baremetalhost/hardwaredata.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package baremetalhost
+
+import (
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+)
+
+// ResolveHardwareDetails selects the Metal3 hardware inventory to read NIC
+// data from, preferring the standalone HardwareData resource over the
+// deprecated BareMetalHost.Status.HardwareDetails. It returns
+// hd.Spec.HardwareDetails when that carries NIC inventory, otherwise
+// bmh.Status.HardwareDetails (which may itself be nil). hd may be nil when no
+// companion HardwareData exists, and bmh may be nil when the caller only has
+// HardwareData in hand. An empty HardwareData does not shadow a populated
+// status: precedence means "prefer HardwareData when it actually has NIC
+// data". This is the single place to change if strict presence-precedence is
+// ever wanted.
+func ResolveHardwareDetails(hd *metal3api.HardwareData, bmh *metal3api.BareMetalHost) *metal3api.HardwareDetails {
+	if hd != nil && hd.Spec.HardwareDetails != nil && len(hd.Spec.HardwareDetails.NIC) > 0 {
+		return hd.Spec.HardwareDetails
+	}
+	if bmh != nil {
+		return bmh.Status.HardwareDetails
+	}
+	return nil
+}

--- a/bare-metal-fulfillment-operator/internal/baremetalhost/hardwaredata_test.go
+++ b/bare-metal-fulfillment-operator/internal/baremetalhost/hardwaredata_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package baremetalhost
+
+import (
+	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
+	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
+	. "github.com/onsi/gomega"    //nolint:revive,staticcheck
+)
+
+func hdWithNICs(nics ...metal3api.NIC) *metal3api.HardwareData {
+	return &metal3api.HardwareData{
+		Spec: metal3api.HardwareDataSpec{
+			HardwareDetails: &metal3api.HardwareDetails{NIC: nics},
+		},
+	}
+}
+
+func bmhWithStatusNICs(nics ...metal3api.NIC) *metal3api.BareMetalHost {
+	return &metal3api.BareMetalHost{
+		Status: metal3api.BareMetalHostStatus{
+			HardwareDetails: &metal3api.HardwareDetails{NIC: nics},
+		},
+	}
+}
+
+var _ = Describe("ResolveHardwareDetails", func() {
+	hdNIC := metal3api.NIC{MAC: "aa:bb:cc:dd:ee:01"}
+	statusNIC := metal3api.NIC{MAC: "11:22:33:44:55:66"}
+
+	It("returns the HardwareData details when they carry NICs", func() {
+		hd := hdWithNICs(hdNIC)
+		bmh := bmhWithStatusNICs(statusNIC)
+
+		details := ResolveHardwareDetails(hd, bmh)
+		Expect(details).To(Equal(hd.Spec.HardwareDetails))
+		Expect(details.NIC).To(ConsistOf(hdNIC))
+	})
+
+	It("falls back to the BMH status details when HardwareData is nil", func() {
+		bmh := bmhWithStatusNICs(statusNIC)
+
+		details := ResolveHardwareDetails(nil, bmh)
+		Expect(details).To(Equal(bmh.Status.HardwareDetails))
+		Expect(details.NIC).To(ConsistOf(statusNIC))
+	})
+
+	It("falls back to the BMH status details when HardwareData has no NICs", func() {
+		hd := hdWithNICs() // present but empty
+		bmh := bmhWithStatusNICs(statusNIC)
+
+		details := ResolveHardwareDetails(hd, bmh)
+		Expect(details).To(Equal(bmh.Status.HardwareDetails))
+		Expect(details.NIC).To(ConsistOf(statusNIC))
+	})
+
+	It("does not let an empty HardwareData shadow a populated status", func() {
+		hd := &metal3api.HardwareData{Spec: metal3api.HardwareDataSpec{}} // no HardwareDetails at all
+		bmh := bmhWithStatusNICs(statusNIC)
+
+		details := ResolveHardwareDetails(hd, bmh)
+		Expect(details).To(Equal(bmh.Status.HardwareDetails))
+	})
+
+	It("returns nil when neither source has NICs", func() {
+		Expect(ResolveHardwareDetails(nil, nil)).To(BeNil())
+		Expect(ResolveHardwareDetails(hdWithNICs(), &metal3api.BareMetalHost{})).To(BeNil())
+	})
+
+	It("returns the nil BMH status when HardwareData is empty and BMH has none", func() {
+		hd := hdWithNICs()
+		bmh := &metal3api.BareMetalHost{} // Status.HardwareDetails is nil
+
+		Expect(ResolveHardwareDetails(hd, bmh)).To(BeNil())
+	})
+})

--- a/bare-metal-fulfillment-operator/internal/baremetalhost/hardwaredata_test.go
+++ b/bare-metal-fulfillment-operator/internal/baremetalhost/hardwaredata_test.go
@@ -68,6 +68,30 @@ var _ = Describe("ResolveHardwareDetails", func() {
 		Expect(details.NIC).To(ConsistOf(statusNIC))
 	})
 
+	It("falls back to the BMH status when HardwareData NICs all have empty MACs", func() {
+		hd := hdWithNICs(metal3api.NIC{MAC: ""}, metal3api.NIC{MAC: ""})
+		bmh := bmhWithStatusNICs(statusNIC)
+
+		details := ResolveHardwareDetails(hd, bmh)
+		Expect(details).To(Equal(bmh.Status.HardwareDetails))
+		Expect(details.NIC).To(ConsistOf(statusNIC))
+	})
+
+	It("prefers HardwareData when at least one NIC has a non-empty MAC", func() {
+		hd := hdWithNICs(metal3api.NIC{MAC: ""}, hdNIC)
+		bmh := bmhWithStatusNICs(statusNIC)
+
+		details := ResolveHardwareDetails(hd, bmh)
+		Expect(details).To(Equal(hd.Spec.HardwareDetails))
+	})
+
+	It("returns nil when HardwareData has only empty MACs and BMH has none", func() {
+		hd := hdWithNICs(metal3api.NIC{MAC: ""})
+		bmh := &metal3api.BareMetalHost{} // Status.HardwareDetails is nil
+
+		Expect(ResolveHardwareDetails(hd, bmh)).To(BeNil())
+	})
+
 	It("does not let an empty HardwareData shadow a populated status", func() {
 		hd := &metal3api.HardwareData{Spec: metal3api.HardwareDataSpec{}} // no HardwareDetails at all
 		bmh := bmhWithStatusNICs(statusNIC)

--- a/bare-metal-fulfillment-operator/internal/baremetalhost/manager.go
+++ b/bare-metal-fulfillment-operator/internal/baremetalhost/manager.go
@@ -251,32 +251,52 @@ func (m *Manager) DeleteBMH(ctx context.Context, name string) error {
 	return nil
 }
 
-// GetHardwareNICs returns the lowercased MAC addresses from the BareMetalHost
-// status.hardware.nics (Metal3 hardware inspection data). Returns nil when
-// the BMH has no hardware details or no NICs recorded.
+// GetHardwareNICs returns the lowercased MAC addresses for the host's NICs,
+// sourcing them from the standalone HardwareData resource and falling back to
+// the deprecated BareMetalHost.Status.HardwareDetails. Returns nil when neither
+// source has NIC data.
 func (m *Manager) GetHardwareNICs(ctx context.Context, name string) ([]string, error) {
 	log := ctrllog.FromContext(ctx)
 
+	key := client.ObjectKey{Namespace: m.namespace, Name: name}
+
 	bmh := &metal3api.BareMetalHost{}
-	if err := m.client.Get(ctx, client.ObjectKey{Namespace: m.namespace, Name: name}, bmh); err != nil {
+	if err := m.client.Get(ctx, key, bmh); err != nil {
 		return nil, fmt.Errorf("failed to get BareMetalHost %s/%s: %w", m.namespace, name, err)
 	}
-	if bmh.Status.HardwareDetails == nil || len(bmh.Status.HardwareDetails.NIC) == 0 {
+
+	hd := &metal3api.HardwareData{}
+	if err := m.client.Get(ctx, key, hd); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to get HardwareData %s/%s: %w", m.namespace, name, err)
+		}
+		hd = nil
+	}
+
+	macs := managerHardwareMACs(ResolveHardwareDetails(hd, bmh))
+	if len(macs) == 0 {
 		log.V(1).Info("BareMetalHost has no hardware NIC data",
 			"name", name, "namespace", m.namespace)
 		return nil, nil
 	}
-	macs := make([]string, 0, len(bmh.Status.HardwareDetails.NIC))
-	for _, nic := range bmh.Status.HardwareDetails.NIC {
+
+	log.V(1).Info("Retrieved hardware NICs",
+		"name", name, "namespace", m.namespace, "count", len(macs))
+	return macs, nil
+}
+
+func managerHardwareMACs(details *metal3api.HardwareDetails) []string {
+	if details == nil || len(details.NIC) == 0 {
+		return nil
+	}
+	macs := make([]string, 0, len(details.NIC))
+	for _, nic := range details.NIC {
 		if nic.MAC == "" {
 			continue
 		}
 		macs = append(macs, strings.ToLower(nic.MAC))
 	}
-
-	log.V(1).Info("Retrieved hardware NICs from BareMetalHost",
-		"name", name, "namespace", m.namespace, "count", len(macs))
-	return macs, nil
+	return macs
 }
 
 // IsBMHReady checks whether the BMH has completed Metal3 registration and is

--- a/bare-metal-fulfillment-operator/internal/baremetalhost/manager.go
+++ b/bare-metal-fulfillment-operator/internal/baremetalhost/manager.go
@@ -273,7 +273,7 @@ func (m *Manager) GetHardwareNICs(ctx context.Context, name string) ([]string, e
 		hd = nil
 	}
 
-	macs := managerHardwareMACs(ResolveHardwareDetails(hd, bmh))
+	macs := hardwareMACs(ResolveHardwareDetails(hd, bmh))
 	if len(macs) == 0 {
 		log.V(1).Info("BareMetalHost has no hardware NIC data",
 			"name", name, "namespace", m.namespace)
@@ -285,7 +285,7 @@ func (m *Manager) GetHardwareNICs(ctx context.Context, name string) ([]string, e
 	return macs, nil
 }
 
-func managerHardwareMACs(details *metal3api.HardwareDetails) []string {
+func hardwareMACs(details *metal3api.HardwareDetails) []string {
 	if details == nil || len(details.NIC) == 0 {
 		return nil
 	}

--- a/bare-metal-fulfillment-operator/internal/baremetalhost/manager_test.go
+++ b/bare-metal-fulfillment-operator/internal/baremetalhost/manager_test.go
@@ -185,6 +185,88 @@ var _ = Describe("BareMetalHost Manager", func() {
 		})
 	})
 
+	Describe("GetHardwareNICs", func() {
+		bmhWithStatus := func(name string, nics ...metal3api.NIC) *metal3api.BareMetalHost {
+			bmh := &metal3api.BareMetalHost{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+			}
+			if len(nics) > 0 {
+				bmh.Status.HardwareDetails = &metal3api.HardwareDetails{NIC: nics}
+			}
+			return bmh
+		}
+		hardwareData := func(name string, nics ...metal3api.NIC) *metal3api.HardwareData {
+			return &metal3api.HardwareData{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+				Spec: metal3api.HardwareDataSpec{
+					HardwareDetails: &metal3api.HardwareDetails{NIC: nics},
+				},
+			}
+		}
+
+		It("returns lowercased MACs from HardwareData when present", func() {
+			mgr := newTestManager(
+				bmhWithStatus("node001"),
+				hardwareData("node001", metal3api.NIC{MAC: "AA:BB:CC:DD:EE:01"}, metal3api.NIC{MAC: "ff:00:11:22:33:44"}),
+			)
+
+			macs, err := mgr.GetHardwareNICs(ctx, "node001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(macs).To(Equal([]string{"aa:bb:cc:dd:ee:01", "ff:00:11:22:33:44"}))
+		})
+
+		It("falls back to Status.HardwareDetails when HardwareData is absent", func() {
+			mgr := newTestManager(
+				bmhWithStatus("node001", metal3api.NIC{MAC: "AA:BB:CC:DD:EE:01"}),
+			)
+
+			macs, err := mgr.GetHardwareNICs(ctx, "node001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(macs).To(Equal([]string{"aa:bb:cc:dd:ee:01"}))
+		})
+
+		It("prefers HardwareData over Status.HardwareDetails when both are populated", func() {
+			mgr := newTestManager(
+				bmhWithStatus("node001", metal3api.NIC{MAC: "11:22:33:44:55:66"}),
+				hardwareData("node001", metal3api.NIC{MAC: "AA:BB:CC:DD:EE:01"}),
+			)
+
+			macs, err := mgr.GetHardwareNICs(ctx, "node001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(macs).To(Equal([]string{"aa:bb:cc:dd:ee:01"}))
+		})
+
+		It("returns nil without error when neither source has NICs", func() {
+			mgr := newTestManager(bmhWithStatus("node001"))
+
+			macs, err := mgr.GetHardwareNICs(ctx, "node001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(macs).To(BeNil())
+		})
+
+		It("skips empty MAC entries", func() {
+			mgr := newTestManager(
+				bmhWithStatus("node001"),
+				hardwareData("node001",
+					metal3api.NIC{MAC: "AA:BB:CC:DD:EE:01"},
+					metal3api.NIC{MAC: ""},
+					metal3api.NIC{MAC: "FF:00:11:22:33:44"},
+				),
+			)
+
+			macs, err := mgr.GetHardwareNICs(ctx, "node001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(macs).To(Equal([]string{"aa:bb:cc:dd:ee:01", "ff:00:11:22:33:44"}))
+		})
+
+		It("returns an error when the BareMetalHost is not found", func() {
+			mgr := newTestManager()
+
+			_, err := mgr.GetHardwareNICs(ctx, "nonexistent")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	Describe("IsBMHReady", func() {
 		It("should return true when available and OK", func() {
 			bmh := &metal3api.BareMetalHost{

--- a/bare-metal-fulfillment-operator/internal/baremetalhost/manager_test.go
+++ b/bare-metal-fulfillment-operator/internal/baremetalhost/manager_test.go
@@ -259,6 +259,17 @@ var _ = Describe("BareMetalHost Manager", func() {
 			Expect(macs).To(Equal([]string{"aa:bb:cc:dd:ee:01", "ff:00:11:22:33:44"}))
 		})
 
+		It("falls back to Status.HardwareDetails when HardwareData NICs all have empty MACs", func() {
+			mgr := newTestManager(
+				bmhWithStatus("node001", metal3api.NIC{MAC: "AA:BB:CC:DD:EE:01"}),
+				hardwareData("node001", metal3api.NIC{MAC: ""}, metal3api.NIC{MAC: ""}),
+			)
+
+			macs, err := mgr.GetHardwareNICs(ctx, "node001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(macs).To(Equal([]string{"aa:bb:cc:dd:ee:01"}))
+		})
+
 		It("returns an error when the BareMetalHost is not found", func() {
 			mgr := newTestManager()
 

--- a/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_controller.go
+++ b/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_controller.go
@@ -125,10 +125,7 @@ func NewBareMetalInstanceReconciler(
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=baremetalinstances/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=baremetalinstances/finalizers,verbs=update
 // +kubebuilder:rbac:groups=metal3.io,resources=baremetalhosts,verbs=create;delete;get;list;watch;update;patch
-// NOTE: Secret access is intentionally NOT a cluster-wide rule. The operator
-// only reads/creates BMC credential Secrets in the Metal3 (BMH) namespace, so
-// that permission is granted via a namespace-scoped Role+RoleBinding in the
-// Helm chart (templates/bmc-secret-role.yaml), not this cluster-scoped role.
+// +kubebuilder:rbac:groups=metal3.io,resources=hardwaredata,verbs=get;list;watch
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=subnets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=networkclasses,verbs=get;list;watch
 

--- a/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_metal3_integration_test.go
+++ b/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_metal3_integration_test.go
@@ -63,13 +63,25 @@ func createMetal3BMH(name string, labels map[string]string, opStatus metal3api.O
 
 	// Status is a subresource — Create does not persist it. Re-set and update
 	// separately so envtest stores the desired operational/provisioning state.
-	// HardwareDetails is required so FindFreeHost does not skip this host.
 	bmh.Status.OperationalStatus = opStatus
 	bmh.Status.Provisioning.State = provState
-	bmh.Status.HardwareDetails = &metal3api.HardwareDetails{
-		NIC: []metal3api.NIC{{MAC: "aa:bb:cc:dd:ee:01"}},
-	}
 	ExpectWithOffset(1, k8sClient.Status().Update(ctx, bmh)).To(Succeed())
+
+	// NIC inventory is sourced from the companion HardwareData resource (same
+	// name/namespace as the BMH), so create it — without NIC data FindFreeHost
+	// skips the host.
+	hd := &metal3api.HardwareData{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metal3TestNS,
+		},
+		Spec: metal3api.HardwareDataSpec{
+			HardwareDetails: &metal3api.HardwareDetails{
+				NIC: []metal3api.NIC{{MAC: "aa:bb:cc:dd:ee:01"}},
+			},
+		},
+	}
+	ExpectWithOffset(1, k8sClient.Create(ctx, hd)).To(Succeed())
 	return bmh
 }
 
@@ -102,7 +114,12 @@ func getBMH(name string) *metal3api.BareMetalHost { return getBMHInNS(metal3Test
 
 func cleanupBMI(name string) { cleanupBMIInNS(metal3TestNS, name) }
 
-func cleanupBMH(name string) { cleanupBMHInNS(metal3TestNS, name) }
+func cleanupBMH(name string) {
+	hd := &metal3api.HardwareData{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: metal3TestNS}}
+	ExpectWithOffset(1, client.IgnoreNotFound(k8sClient.Delete(ctx, hd))).NotTo(HaveOccurred())
+
+	cleanupBMHInNS(metal3TestNS, name)
+}
 
 var _ = Describe("BareMetalInstance Metal3 Integration", func() {
 	var ns *corev1.Namespace

--- a/bare-metal-fulfillment-operator/internal/inventory/metal3.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/metal3.go
@@ -175,7 +175,7 @@ func (m *Metal3Client) FindFreeHost(ctx context.Context, matchExpressions map[st
 			continue
 		}
 
-		if bmh.Annotations["inspect.metal3.io"] == "disabled" {
+		if bmh.InspectionDisabled() {
 			log.V(1).Info("Skipping BareMetalHost: hardware inspection disabled", "host", bmh.Name)
 			continue
 		}

--- a/bare-metal-fulfillment-operator/internal/inventory/metal3.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/metal3.go
@@ -26,6 +26,7 @@ import (
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
@@ -163,11 +164,18 @@ func (m *Metal3Client) FindFreeHost(ctx context.Context, matchExpressions map[st
 		return nil, fmt.Errorf("failed to list BareMetalHosts: %w", err)
 	}
 
+	// HardwareData is the preferred NIC-data source, but the CRD is absent on
+	// older Metal3 installs. Treat a missing CRD (NoMatchError) as "no
+	// HardwareData present" and fall back to BareMetalHost.Status.HardwareDetails
+	// via ResolveHardwareDetails below, rather than failing host selection.
+	hardwareDataByName := map[string]*metal3api.HardwareData{}
 	hdList := &metal3api.HardwareDataList{}
 	if err := m.client.List(ctx, hdList, client.InNamespace(m.namespace)); err != nil {
-		return nil, fmt.Errorf("failed to list HardwareData: %w", err)
+		if !meta.IsNoMatchError(err) {
+			return nil, fmt.Errorf("failed to list HardwareData: %w", err)
+		}
+		log.V(1).Info("HardwareData CRD not installed; falling back to BareMetalHost.Status.HardwareDetails")
 	}
-	hardwareDataByName := make(map[string]*metal3api.HardwareData, len(hdList.Items))
 	for i := range hdList.Items {
 		hardwareDataByName[hdList.Items[i].Name] = &hdList.Items[i]
 	}
@@ -283,16 +291,21 @@ func (m *Metal3Client) GetHostNICs(ctx context.Context, inventoryHostID string) 
 
 	key := client.ObjectKey{Namespace: namespace, Name: name}
 
+	// HardwareData is the preferred NIC-data source. A NotFound (no HardwareData
+	// for this host) or a NoMatchError (CRD absent on older Metal3) both mean we
+	// fall back to BareMetalHost.Status.HardwareDetails below.
 	hd := &metal3api.HardwareData{}
 	if err := m.client.Get(ctx, key, hd); err != nil {
-		if !apierrors.IsNotFound(err) {
+		if !apierrors.IsNotFound(err) && !meta.IsNoMatchError(err) {
 			return nil, fmt.Errorf("failed to get HardwareData %s: %w", inventoryHostID, err)
 		}
 		hd = nil
 	}
 
-	if nics := metal3HostNICs(baremetalhost.ResolveHardwareDetails(hd, nil)); len(nics) > 0 {
-		return nics, nil
+	if hd != nil {
+		if nics := metal3HostNICs(baremetalhost.ResolveHardwareDetails(hd, nil)); len(nics) > 0 {
+			return nics, nil
+		}
 	}
 
 	bmh := &metal3api.BareMetalHost{}

--- a/bare-metal-fulfillment-operator/internal/inventory/metal3.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/metal3.go
@@ -25,6 +25,7 @@ import (
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
@@ -32,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/baremetalhost"
 	"github.com/osac-project/osac/bare-metal-fulfillment-operator/internal/shared"
 )
 
@@ -161,6 +163,15 @@ func (m *Metal3Client) FindFreeHost(ctx context.Context, matchExpressions map[st
 		return nil, fmt.Errorf("failed to list BareMetalHosts: %w", err)
 	}
 
+	hdList := &metal3api.HardwareDataList{}
+	if err := m.client.List(ctx, hdList, client.InNamespace(m.namespace)); err != nil {
+		return nil, fmt.Errorf("failed to list HardwareData: %w", err)
+	}
+	hardwareDataByName := make(map[string]*metal3api.HardwareData, len(hdList.Items))
+	for i := range hdList.Items {
+		hardwareDataByName[hdList.Items[i].Name] = &hdList.Items[i]
+	}
+
 	candidates := make([]metal3api.BareMetalHost, 0, len(bmhList.Items))
 	for _, bmh := range bmhList.Items {
 		if bmh.Status.OperationalStatus != metal3api.OperationalStatusOK {
@@ -180,7 +191,8 @@ func (m *Metal3Client) FindFreeHost(ctx context.Context, matchExpressions map[st
 			continue
 		}
 
-		if bmh.Status.HardwareDetails == nil || len(bmh.Status.HardwareDetails.NIC) == 0 {
+		details := baremetalhost.ResolveHardwareDetails(hardwareDataByName[bmh.Name], &bmh)
+		if details == nil || len(details.NIC) == 0 {
 			log.Error(nil, "Skipping BareMetalHost: available but NIC inventory is missing — host may be misconfigured or inspection incomplete", "host", bmh.Name)
 			continue
 		}
@@ -269,20 +281,41 @@ func (m *Metal3Client) GetHostNICs(ctx context.Context, inventoryHostID string) 
 		return nil, err
 	}
 
+	key := client.ObjectKey{Namespace: namespace, Name: name}
+
+	hd := &metal3api.HardwareData{}
+	if err := m.client.Get(ctx, key, hd); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to get HardwareData %s: %w", inventoryHostID, err)
+		}
+		hd = nil
+	}
+
+	if nics := metal3HostNICs(baremetalhost.ResolveHardwareDetails(hd, nil)); len(nics) > 0 {
+		return nics, nil
+	}
+
 	bmh := &metal3api.BareMetalHost{}
-	if err := m.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, bmh); err != nil {
+	if err := m.client.Get(ctx, key, bmh); err != nil {
 		return nil, fmt.Errorf("failed to get BareMetalHost %s: %w", inventoryHostID, err)
 	}
 
-	if bmh.Status.HardwareDetails == nil || len(bmh.Status.HardwareDetails.NIC) == 0 {
+	nics := metal3HostNICs(baremetalhost.ResolveHardwareDetails(hd, bmh))
+	if len(nics) == 0 {
 		return nil, fmt.Errorf("BareMetalHost %s has no NIC inventory despite being allocated", inventoryHostID)
 	}
+	return nics, nil
+}
 
-	nics := make([]HostNIC, 0, len(bmh.Status.HardwareDetails.NIC))
-	for _, n := range bmh.Status.HardwareDetails.NIC {
+func metal3HostNICs(details *metal3api.HardwareDetails) []HostNIC {
+	if details == nil || len(details.NIC) == 0 {
+		return nil
+	}
+	nics := make([]HostNIC, 0, len(details.NIC))
+	for _, n := range details.NIC {
 		nics = append(nics, HostNIC{MAC: strings.ToLower(n.MAC)})
 	}
-	return nics, nil
+	return nics
 }
 
 func (m *Metal3Client) UnassignHost(ctx context.Context, inventoryHostID string, labels []string) error {

--- a/bare-metal-fulfillment-operator/internal/inventory/metal3.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/metal3.go
@@ -313,6 +313,9 @@ func metal3HostNICs(details *metal3api.HardwareDetails) []HostNIC {
 	}
 	nics := make([]HostNIC, 0, len(details.NIC))
 	for _, n := range details.NIC {
+		if n.MAC == "" {
+			continue
+		}
 		nics = append(nics, HostNIC{MAC: strings.ToLower(n.MAC)})
 	}
 	return nics

--- a/bare-metal-fulfillment-operator/internal/inventory/metal3_test.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/metal3_test.go
@@ -22,10 +22,13 @@ import (
 
 	metal3api "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 const (
@@ -45,6 +48,50 @@ func newMetal3ClientForTest(objects ...client.Object) *Metal3Client {
 		WithScheme(scheme).
 		WithObjects(objects...).
 		WithStatusSubresource(&metal3api.BareMetalHost{}).
+		Build()
+	return &Metal3Client{
+		client:    fakeClient,
+		namespace: testNamespace,
+		hostClass: testHostClass,
+	}
+}
+
+// newMetal3ClientNoHardwareDataCRD builds a client that behaves as if the
+// HardwareData CRD is not installed (older Metal3): any Get/List of a
+// HardwareData object returns a NoMatchError, while BareMetalHost operations
+// pass through to the underlying fake client. This exercises the fallback to
+// BareMetalHost.Status.HardwareDetails.
+func newMetal3ClientNoHardwareDataCRD(objects ...client.Object) *Metal3Client {
+	noMatch := &meta.NoKindMatchError{
+		GroupKind: schema.GroupKind{Group: "metal3.io", Kind: "HardwareData"},
+	}
+	isHardwareData := func(obj runtime.Object) bool {
+		switch obj.(type) {
+		case *metal3api.HardwareData, *metal3api.HardwareDataList:
+			return true
+		default:
+			return false
+		}
+	}
+	scheme := newTestScheme()
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithStatusSubresource(&metal3api.BareMetalHost{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if isHardwareData(obj) {
+					return noMatch
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if isHardwareData(list) {
+					return noMatch
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).
 		Build()
 	return &Metal3Client{
 		client:    fakeClient,
@@ -459,6 +506,21 @@ func TestFindFreeHost(t *testing.T) {
 		}
 	})
 
+	t.Run("falls back to Status.HardwareDetails when HardwareData CRD is not installed", func(t *testing.T) {
+		bmh := newBMHBuilder("host-no-hd-crd").
+			WithStatusNICs(testNIC("AA:BB:CC:DD:EE:01")).
+			Build()
+
+		m := newMetal3ClientNoHardwareDataCRD(bmh)
+		host, err := m.FindFreeHost(ctx, map[string]string{"hostType": "gpu-node"})
+		if err != nil {
+			t.Fatalf("unexpected error (missing HardwareData CRD should not fail host selection): %v", err)
+		}
+		if host == nil {
+			t.Fatal("expected host from Status.HardwareDetails fallback, got nil")
+		}
+	})
+
 	t.Run("skips host with inspect.metal3.io disabled annotation", func(t *testing.T) {
 		objs := newBMHBuilder("host-inspect-disabled").
 			WithAnnotations(map[string]string{"inspect.metal3.io": "disabled"}).
@@ -743,6 +805,28 @@ func TestGetHostNICs(t *testing.T) {
 		nics, err := m.GetHostNICs(ctx, testNamespace+"/host-status-only")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+		wantMACs := []string{"aa:bb:cc:dd:ee:01", "ff:00:11:22:33:44"}
+		if len(nics) != len(wantMACs) {
+			t.Fatalf("expected %d NICs, got %d", len(wantMACs), len(nics))
+		}
+		for i, want := range wantMACs {
+			if nics[i].MAC != want {
+				t.Errorf("NIC[%d].MAC = %q, want %q", i, nics[i].MAC, want)
+			}
+		}
+	})
+
+	t.Run("falls back to Status.HardwareDetails when HardwareData CRD is not installed", func(t *testing.T) {
+		bmh := newBMHBuilder("host-no-hd-crd").WithStatusNICs(
+			testNIC("AA:BB:CC:DD:EE:01"),
+			testNIC("FF:00:11:22:33:44"),
+		).Build()
+
+		m := newMetal3ClientNoHardwareDataCRD(bmh)
+		nics, err := m.GetHostNICs(ctx, testNamespace+"/host-no-hd-crd")
+		if err != nil {
+			t.Fatalf("unexpected error (missing HardwareData CRD should not fail NIC lookup): %v", err)
 		}
 		wantMACs := []string{"aa:bb:cc:dd:ee:01", "ff:00:11:22:33:44"}
 		if len(nics) != len(wantMACs) {

--- a/bare-metal-fulfillment-operator/internal/inventory/metal3_test.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/metal3_test.go
@@ -71,6 +71,7 @@ type bmhBuilder struct {
 	opStatus           metal3api.OperationalStatus
 	provState          metal3api.ProvisioningState
 	consumerRef        *corev1.ObjectReference
+	inspectionMode     metal3api.InspectionMode
 	nics               []metal3api.NIC
 	hasHardwareDetails bool
 }
@@ -109,6 +110,11 @@ func (b *bmhBuilder) WithConsumerRef(ref *corev1.ObjectReference) *bmhBuilder {
 	return b
 }
 
+func (b *bmhBuilder) WithInspectionMode(mode metal3api.InspectionMode) *bmhBuilder {
+	b.inspectionMode = mode
+	return b
+}
+
 func (b *bmhBuilder) WithNICs(nics ...metal3api.NIC) *bmhBuilder {
 	b.hasHardwareDetails = true
 	b.nics = nics
@@ -128,7 +134,8 @@ func (b *bmhBuilder) Build() *metal3api.BareMetalHost {
 			Annotations: b.annotations,
 		},
 		Spec: metal3api.BareMetalHostSpec{
-			ConsumerRef: b.consumerRef,
+			ConsumerRef:    b.consumerRef,
+			InspectionMode: b.inspectionMode,
 		},
 		Status: metal3api.BareMetalHostStatus{
 			OperationalStatus: b.opStatus,
@@ -407,6 +414,22 @@ func TestFindFreeHost(t *testing.T) {
 		}
 		if host != nil {
 			t.Errorf("expected nil (inspection disabled), got %+v", host)
+		}
+	})
+
+	t.Run("skips host with InspectionMode disabled field", func(t *testing.T) {
+		bmh := newBMHBuilder("host-inspect-mode-disabled").
+			WithInspectionMode(metal3api.InspectionModeDisabled).
+			WithNICs(testNIC("AA:BB:CC:DD:EE:01")).
+			Build()
+
+		m := newMetal3ClientForTest(bmh)
+		host, err := m.FindFreeHost(ctx, map[string]string{"hostType": "gpu-node"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if host != nil {
+			t.Errorf("expected nil (InspectionMode disabled), got %+v", host)
 		}
 	})
 

--- a/bare-metal-fulfillment-operator/internal/inventory/metal3_test.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/metal3_test.go
@@ -774,6 +774,29 @@ func TestGetHostNICs(t *testing.T) {
 		}
 	})
 
+	t.Run("skips NIC entries with empty MACs", func(t *testing.T) {
+		objs := newBMHBuilder("host-empty-macs").WithHardwareDataNICs(
+			testNIC("AA:BB:CC:DD:EE:01"),
+			testNIC(""),
+			testNIC("FF:00:11:22:33:44"),
+		).BuildObjects()
+
+		m := newMetal3ClientForTest(objs...)
+		nics, err := m.GetHostNICs(ctx, testNamespace+"/host-empty-macs")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		wantMACs := []string{"aa:bb:cc:dd:ee:01", "ff:00:11:22:33:44"}
+		if len(nics) != len(wantMACs) {
+			t.Fatalf("expected %d NICs (empty MAC skipped), got %d", len(wantMACs), len(nics))
+		}
+		for i, want := range wantMACs {
+			if nics[i].MAC != want {
+				t.Errorf("NIC[%d].MAC = %q, want %q", i, nics[i].MAC, want)
+			}
+		}
+	})
+
 	t.Run("returns error when neither source has NICs", func(t *testing.T) {
 		bmh := newBMHBuilder("host-no-hw").Build()
 

--- a/bare-metal-fulfillment-operator/internal/inventory/metal3_test.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/metal3_test.go
@@ -839,6 +839,22 @@ func TestGetHostNICs(t *testing.T) {
 		}
 	})
 
+	t.Run("falls back to Status.HardwareDetails when HardwareData NICs all have empty MACs", func(t *testing.T) {
+		objs := newBMHBuilder("host-empty-mac-hd").
+			WithHardwareDataNICs(testNIC(""), testNIC("")).
+			WithStatusNICs(testNIC("AA:BB:CC:DD:EE:01")).
+			BuildObjects()
+
+		m := newMetal3ClientForTest(objs...)
+		nics, err := m.GetHostNICs(ctx, testNamespace+"/host-empty-mac-hd")
+		if err != nil {
+			t.Fatalf("unexpected error (all-empty-MAC HardwareData should fall back to status): %v", err)
+		}
+		if len(nics) != 1 || nics[0].MAC != "aa:bb:cc:dd:ee:01" {
+			t.Fatalf("expected status NIC aa:bb:cc:dd:ee:01, got %+v", nics)
+		}
+	})
+
 	t.Run("returns HardwareData NICs when both sources are populated", func(t *testing.T) {
 		objs := newBMHBuilder("host-both").
 			WithHardwareDataNICs(testNIC("AA:BB:CC:DD:EE:01")).

--- a/bare-metal-fulfillment-operator/internal/inventory/metal3_test.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/metal3_test.go
@@ -65,15 +65,17 @@ func testNIC(mac string) metal3api.NIC {
 }
 
 type bmhBuilder struct {
-	name               string
-	labels             map[string]string
-	annotations        map[string]string
-	opStatus           metal3api.OperationalStatus
-	provState          metal3api.ProvisioningState
-	consumerRef        *corev1.ObjectReference
-	inspectionMode     metal3api.InspectionMode
-	nics               []metal3api.NIC
-	hasHardwareDetails bool
+	name             string
+	labels           map[string]string
+	annotations      map[string]string
+	opStatus         metal3api.OperationalStatus
+	provState        metal3api.ProvisioningState
+	consumerRef      *corev1.ObjectReference
+	inspectionMode   metal3api.InspectionMode
+	statusNICs       []metal3api.NIC
+	hasStatusNICs    bool
+	hardwareDataNICs []metal3api.NIC
+	hasHardwareData  bool
 }
 
 func newBMHBuilder(name string) *bmhBuilder {
@@ -115,10 +117,26 @@ func (b *bmhBuilder) WithInspectionMode(mode metal3api.InspectionMode) *bmhBuild
 	return b
 }
 
-func (b *bmhBuilder) WithNICs(nics ...metal3api.NIC) *bmhBuilder {
-	b.hasHardwareDetails = true
-	b.nics = nics
+// WithHardwareDataNICs seeds the companion HardwareData resource (the preferred
+// NIC source). Calling it with no NICs seeds a present-but-empty HardwareData.
+func (b *bmhBuilder) WithHardwareDataNICs(nics ...metal3api.NIC) *bmhBuilder {
+	b.hasHardwareData = true
+	b.hardwareDataNICs = nics
 	return b
+}
+
+// WithStatusNICs seeds the deprecated bmh.Status.HardwareDetails (the fallback
+// NIC source).
+func (b *bmhBuilder) WithStatusNICs(nics ...metal3api.NIC) *bmhBuilder {
+	b.hasStatusNICs = true
+	b.statusNICs = nics
+	return b
+}
+
+// WithNICs seeds the companion HardwareData source — the new default NIC
+// source — so existing call sites exercise the primary read path.
+func (b *bmhBuilder) WithNICs(nics ...metal3api.NIC) *bmhBuilder {
+	return b.WithHardwareDataNICs(nics...)
 }
 
 func (b *bmhBuilder) Build() *metal3api.BareMetalHost {
@@ -144,10 +162,34 @@ func (b *bmhBuilder) Build() *metal3api.BareMetalHost {
 			},
 		},
 	}
-	if b.hasHardwareDetails {
-		bmh.Status.HardwareDetails = &metal3api.HardwareDetails{NIC: b.nics}
+	if b.hasStatusNICs {
+		bmh.Status.HardwareDetails = &metal3api.HardwareDetails{NIC: b.statusNICs}
 	}
 	return bmh
+}
+
+// BuildObjects returns the BMH plus a companion HardwareData object when the
+// HardwareData source was seeded (including the present-but-empty case). When
+// only the status source is seeded, no HardwareData is emitted — modelling an
+// absent HardwareData object and exercising the fallback path.
+func (b *bmhBuilder) BuildObjects() []client.Object {
+	objs := []client.Object{b.Build()}
+	if b.hasHardwareData {
+		objs = append(objs, hardwareDataFor(b.name, b.hardwareDataNICs))
+	}
+	return objs
+}
+
+func hardwareDataFor(name string, nics []metal3api.NIC) *metal3api.HardwareData {
+	return &metal3api.HardwareData{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: metal3api.HardwareDataSpec{
+			HardwareDetails: &metal3api.HardwareDetails{NIC: nics},
+		},
+	}
 }
 
 // --- ParseHostID ---
@@ -223,9 +265,9 @@ func TestFindFreeHost(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("returns matching unassigned host", func(t *testing.T) {
-		bmh := newBMHBuilder("host-1").WithNICs(testNIC("AA:BB:CC:DD:EE:01")).Build()
+		objs := newBMHBuilder("host-1").WithNICs(testNIC("AA:BB:CC:DD:EE:01")).BuildObjects()
 
-		m := newMetal3ClientForTest(bmh)
+		m := newMetal3ClientForTest(objs...)
 		host, err := m.FindFreeHost(ctx, map[string]string{"hostType": "gpu-node"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -295,10 +337,10 @@ func TestFindFreeHost(t *testing.T) {
 	t.Run("filters by host type label", func(t *testing.T) {
 		gpuLabels := map[string]string{Metal3HostTypeLabel: "gpu-node", Metal3ManagedByLabel: "baremetal"}
 		cpuLabels := map[string]string{Metal3HostTypeLabel: "cpu-node", Metal3ManagedByLabel: "baremetal"}
-		gpuHost := newBMHBuilder("host-gpu").WithLabels(gpuLabels).WithNICs(testNIC("AA:BB:CC:DD:EE:01")).Build()
-		cpuHost := newBMHBuilder("host-cpu").WithLabels(cpuLabels).WithNICs(testNIC("AA:BB:CC:DD:EE:02")).Build()
+		gpuObjs := newBMHBuilder("host-gpu").WithLabels(gpuLabels).WithNICs(testNIC("AA:BB:CC:DD:EE:01")).BuildObjects()
+		cpuObjs := newBMHBuilder("host-cpu").WithLabels(cpuLabels).WithNICs(testNIC("AA:BB:CC:DD:EE:02")).BuildObjects()
 
-		m := newMetal3ClientForTest(gpuHost, cpuHost)
+		m := newMetal3ClientForTest(append(gpuObjs, cpuObjs...)...)
 		host, err := m.FindFreeHost(ctx, map[string]string{"hostType": "gpu-node"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -327,9 +369,9 @@ func TestFindFreeHost(t *testing.T) {
 
 	t.Run("filters by explicit managed-by match expression", func(t *testing.T) {
 		labels := map[string]string{Metal3HostTypeLabel: "gpu-node", Metal3ManagedByLabel: "agent"}
-		bmh := newBMHBuilder("host-agent").WithLabels(labels).WithNICs(testNIC("AA:BB:CC:DD:EE:01")).Build()
+		objs := newBMHBuilder("host-agent").WithLabels(labels).WithNICs(testNIC("AA:BB:CC:DD:EE:01")).BuildObjects()
 
-		m := newMetal3ClientForTest(bmh)
+		m := newMetal3ClientForTest(objs...)
 		host, err := m.FindFreeHost(ctx, map[string]string{
 			"hostType":  "gpu-node",
 			"managedBy": "agent",
@@ -355,9 +397,9 @@ func TestFindFreeHost(t *testing.T) {
 
 	t.Run("matches hosts without hostType filter", func(t *testing.T) {
 		labels := map[string]string{Metal3ManagedByLabel: "baremetal"}
-		bmh := newBMHBuilder("host-any").WithLabels(labels).WithNICs(testNIC("AA:BB:CC:DD:EE:01")).Build()
+		objs := newBMHBuilder("host-any").WithLabels(labels).WithNICs(testNIC("AA:BB:CC:DD:EE:01")).BuildObjects()
 
-		m := newMetal3ClientForTest(bmh)
+		m := newMetal3ClientForTest(objs...)
 		host, err := m.FindFreeHost(ctx, map[string]string{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -369,9 +411,9 @@ func TestFindFreeHost(t *testing.T) {
 
 	t.Run("defaults managed-by to baremetal when label is absent", func(t *testing.T) {
 		labels := map[string]string{Metal3HostTypeLabel: "gpu-node"}
-		bmh := newBMHBuilder("host-no-managed-by").WithLabels(labels).WithNICs(testNIC("AA:BB:CC:DD:EE:01")).Build()
+		objs := newBMHBuilder("host-no-managed-by").WithLabels(labels).WithNICs(testNIC("AA:BB:CC:DD:EE:01")).BuildObjects()
 
-		m := newMetal3ClientForTest(bmh)
+		m := newMetal3ClientForTest(objs...)
 		host, err := m.FindFreeHost(ctx, map[string]string{"hostType": "gpu-node"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -401,13 +443,29 @@ func TestFindFreeHost(t *testing.T) {
 		}
 	})
 
+	t.Run("selects host when only Status.HardwareDetails has NICs", func(t *testing.T) {
+		objs := newBMHBuilder("host-status-nics").WithStatusNICs(testNIC("AA:BB:CC:DD:EE:01")).BuildObjects()
+
+		m := newMetal3ClientForTest(objs...)
+		host, err := m.FindFreeHost(ctx, map[string]string{"hostType": "gpu-node"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if host == nil {
+			t.Fatal("expected host (Status.HardwareDetails fallback), got nil")
+		}
+		if host.Name != "host-status-nics" {
+			t.Errorf("expected host-status-nics, got %q", host.Name)
+		}
+	})
+
 	t.Run("skips host with inspect.metal3.io disabled annotation", func(t *testing.T) {
-		bmh := newBMHBuilder("host-inspect-disabled").
+		objs := newBMHBuilder("host-inspect-disabled").
 			WithAnnotations(map[string]string{"inspect.metal3.io": "disabled"}).
 			WithNICs(testNIC("AA:BB:CC:DD:EE:01")).
-			Build()
+			BuildObjects()
 
-		m := newMetal3ClientForTest(bmh)
+		m := newMetal3ClientForTest(objs...)
 		host, err := m.FindFreeHost(ctx, map[string]string{"hostType": "gpu-node"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -418,12 +476,12 @@ func TestFindFreeHost(t *testing.T) {
 	})
 
 	t.Run("skips host with InspectionMode disabled field", func(t *testing.T) {
-		bmh := newBMHBuilder("host-inspect-mode-disabled").
+		objs := newBMHBuilder("host-inspect-mode-disabled").
 			WithInspectionMode(metal3api.InspectionModeDisabled).
 			WithNICs(testNIC("AA:BB:CC:DD:EE:01")).
-			Build()
+			BuildObjects()
 
-		m := newMetal3ClientForTest(bmh)
+		m := newMetal3ClientForTest(objs...)
 		host, err := m.FindFreeHost(ctx, map[string]string{"hostType": "gpu-node"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -434,12 +492,12 @@ func TestFindFreeHost(t *testing.T) {
 	})
 
 	t.Run("includes host when inspect.metal3.io annotation has non-disabled value", func(t *testing.T) {
-		bmh := newBMHBuilder("host-inspect-other").
+		objs := newBMHBuilder("host-inspect-other").
 			WithAnnotations(map[string]string{"inspect.metal3.io": "metadata"}).
 			WithNICs(testNIC("AA:BB:CC:DD:EE:01")).
-			Build()
+			BuildObjects()
 
-		m := newMetal3ClientForTest(bmh)
+		m := newMetal3ClientForTest(objs...)
 		host, err := m.FindFreeHost(ctx, map[string]string{"hostType": "gpu-node"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -449,8 +507,8 @@ func TestFindFreeHost(t *testing.T) {
 		}
 	})
 
-	t.Run("skips host with nil HardwareDetails", func(t *testing.T) {
-		bmh := newBMHBuilder("host-no-hardware").Build()
+	t.Run("skips host when neither source has NICs", func(t *testing.T) {
+		bmh := newBMHBuilder("host-no-nics").Build()
 
 		m := newMetal3ClientForTest(bmh)
 		host, err := m.FindFreeHost(ctx, map[string]string{"hostType": "gpu-node"})
@@ -458,37 +516,37 @@ func TestFindFreeHost(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if host != nil {
-			t.Errorf("expected nil (HardwareDetails is nil), got %+v", host)
+			t.Errorf("expected nil (no NIC data in either source), got %+v", host)
 		}
 	})
 
-	t.Run("skips host with empty NIC list", func(t *testing.T) {
-		bmh := newBMHBuilder("host-empty-nics").WithNICs().Build()
+	t.Run("skips host when HardwareData is present but empty and status is empty", func(t *testing.T) {
+		objs := newBMHBuilder("host-empty-hw").WithHardwareDataNICs().BuildObjects()
 
-		m := newMetal3ClientForTest(bmh)
+		m := newMetal3ClientForTest(objs...)
 		host, err := m.FindFreeHost(ctx, map[string]string{"hostType": "gpu-node"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if host != nil {
-			t.Errorf("expected nil (HardwareDetails has no NICs), got %+v", host)
+			t.Errorf("expected nil (empty HardwareData, empty status), got %+v", host)
 		}
 	})
 
-	t.Run("selects host with HardwareDetails when multiple candidates exist", func(t *testing.T) {
-		noHardware := newBMHBuilder("host-no-hw").Build()
-		withHW := newBMHBuilder("host-with-hw").WithNICs(testNIC("AA:BB:CC:DD:EE:01")).Build()
+	t.Run("selects the candidate that has NIC data when others do not", func(t *testing.T) {
+		noNICs := newBMHBuilder("host-no-nics").BuildObjects()
+		withNICs := newBMHBuilder("host-with-nics").WithNICs(testNIC("AA:BB:CC:DD:EE:01")).BuildObjects()
 
-		m := newMetal3ClientForTest(noHardware, withHW)
+		m := newMetal3ClientForTest(append(noNICs, withNICs...)...)
 		host, err := m.FindFreeHost(ctx, map[string]string{"hostType": "gpu-node"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if host == nil {
-			t.Fatal("expected host (one candidate has HardwareDetails), got nil")
+			t.Fatal("expected host (one candidate has NIC data), got nil")
 		}
-		if host.Name != "host-with-hw" {
-			t.Errorf("expected host-with-hw, got %q", host.Name)
+		if host.Name != "host-with-nics" {
+			t.Errorf("expected host-with-nics, got %q", host.Name)
 		}
 	})
 }
@@ -652,14 +710,14 @@ func TestUnassignHost(t *testing.T) {
 func TestGetHostNICs(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("returns lowercased MACs from HardwareDetails NIC list", func(t *testing.T) {
-		bmh := newBMHBuilder("host-1").WithNICs(
+	t.Run("returns lowercased MACs from HardwareData when present", func(t *testing.T) {
+		objs := newBMHBuilder("host-1").WithHardwareDataNICs(
 			testNIC("AA:BB:CC:DD:EE:01"),
 			testNIC("aa:bb:cc:dd:ee:02"),
 			testNIC("FF:00:11:22:33:44"),
-		).Build()
+		).BuildObjects()
 
-		m := newMetal3ClientForTest(bmh)
+		m := newMetal3ClientForTest(objs...)
 		nics, err := m.GetHostNICs(ctx, testNamespace+"/host-1")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -675,23 +733,64 @@ func TestGetHostNICs(t *testing.T) {
 		}
 	})
 
-	t.Run("returns error when HardwareDetails is nil", func(t *testing.T) {
+	t.Run("returns lowercased MACs from Status.HardwareDetails when HardwareData is absent", func(t *testing.T) {
+		bmh := newBMHBuilder("host-status-only").WithStatusNICs(
+			testNIC("AA:BB:CC:DD:EE:01"),
+			testNIC("FF:00:11:22:33:44"),
+		).Build()
+
+		m := newMetal3ClientForTest(bmh)
+		nics, err := m.GetHostNICs(ctx, testNamespace+"/host-status-only")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		wantMACs := []string{"aa:bb:cc:dd:ee:01", "ff:00:11:22:33:44"}
+		if len(nics) != len(wantMACs) {
+			t.Fatalf("expected %d NICs, got %d", len(wantMACs), len(nics))
+		}
+		for i, want := range wantMACs {
+			if nics[i].MAC != want {
+				t.Errorf("NIC[%d].MAC = %q, want %q", i, nics[i].MAC, want)
+			}
+		}
+	})
+
+	t.Run("returns HardwareData NICs when both sources are populated", func(t *testing.T) {
+		objs := newBMHBuilder("host-both").
+			WithHardwareDataNICs(testNIC("AA:BB:CC:DD:EE:01")).
+			WithStatusNICs(testNIC("11:22:33:44:55:66")).
+			BuildObjects()
+
+		m := newMetal3ClientForTest(objs...)
+		nics, err := m.GetHostNICs(ctx, testNamespace+"/host-both")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(nics) != 1 {
+			t.Fatalf("expected 1 NIC, got %d", len(nics))
+		}
+		if nics[0].MAC != "aa:bb:cc:dd:ee:01" {
+			t.Errorf("NIC[0].MAC = %q, want HardwareData source %q", nics[0].MAC, "aa:bb:cc:dd:ee:01")
+		}
+	})
+
+	t.Run("returns error when neither source has NICs", func(t *testing.T) {
 		bmh := newBMHBuilder("host-no-hw").Build()
 
 		m := newMetal3ClientForTest(bmh)
 		_, err := m.GetHostNICs(ctx, testNamespace+"/host-no-hw")
 		if err == nil {
-			t.Fatal("expected error for nil HardwareDetails, got nil")
+			t.Fatal("expected error when no NIC data in either source, got nil")
 		}
 	})
 
-	t.Run("returns error when NIC list is empty despite completed inspection", func(t *testing.T) {
-		bmh := newBMHBuilder("host-empty-nics").WithNICs().Build()
+	t.Run("returns error when HardwareData is present but empty and status is empty", func(t *testing.T) {
+		objs := newBMHBuilder("host-empty-hw").WithHardwareDataNICs().BuildObjects()
 
-		m := newMetal3ClientForTest(bmh)
-		_, err := m.GetHostNICs(ctx, testNamespace+"/host-empty-nics")
+		m := newMetal3ClientForTest(objs...)
+		_, err := m.GetHostNICs(ctx, testNamespace+"/host-empty-hw")
 		if err == nil {
-			t.Fatal("expected error for empty NIC list, got nil")
+			t.Fatal("expected error for empty HardwareData and empty status, got nil")
 		}
 	})
 

--- a/bare-metal-fulfillment-operator/test/crds/metal3.io_hardwaredata.yaml
+++ b/bare-metal-fulfillment-operator/test/crds/metal3.io_hardwaredata.yaml
@@ -1,0 +1,237 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: hardwaredata.metal3.io
+spec:
+  group: metal3.io
+  names:
+    kind: HardwareData
+    listKind: HardwareDataList
+    plural: hardwaredata
+    shortNames:
+    - hd
+    singular: hardwaredata
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of HardwareData
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: HardwareData is the Schema for the hardwaredata API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HardwareDataSpec defines the desired state of HardwareData.
+            properties:
+              hardware:
+                description: The hardware discovered on the host during its inspection.
+                properties:
+                  cpu:
+                    description: Details of the CPU(s) in the system.
+                    properties:
+                      arch:
+                        type: string
+                      clockMegahertz:
+                        description: ClockSpeed is a clock speed in MHz
+                        format: double
+                        type: number
+                      count:
+                        type: integer
+                      flags:
+                        items:
+                          type: string
+                        type: array
+                      model:
+                        type: string
+                    type: object
+                  firmware:
+                    description: System firmware information.
+                    properties:
+                      bios:
+                        description: The BIOS for this firmware
+                        properties:
+                          date:
+                            description: The release/build date for this BIOS
+                            type: string
+                          vendor:
+                            description: The vendor name for this BIOS
+                            type: string
+                          version:
+                            description: The version of the BIOS
+                            type: string
+                        type: object
+                    type: object
+                  hostname:
+                    description: Name of the host at the inspection time.
+                    type: string
+                  nics:
+                    description: List of network interfaces for the host.
+                    items:
+                      description: NIC describes one network interface on the host.
+                      properties:
+                        ip:
+                          description: |-
+                            The IP address of the interface. This will be an IPv4 or IPv6 address
+                            if one is present.  If both IPv4 and IPv6 addresses are present in a
+                            dual-stack environment, two nics will be output, one with each IP.
+                          type: string
+                        lldp:
+                          description: LLDP data for this interface
+                          properties:
+                            portID:
+                              description: The switch port ID from LLDP
+                              type: string
+                            switchID:
+                              description: The switch chassis ID from LLDP
+                              type: string
+                            switchSystemName:
+                              description: The switch system name from LLDP
+                              type: string
+                          type: object
+                        mac:
+                          description: The device MAC address
+                          pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
+                          type: string
+                        model:
+                          description: The vendor and product IDs of the NIC, e.g.
+                            "0x8086 0x1572"
+                          type: string
+                        name:
+                          description: The name of the network interface, e.g. "en0"
+                          type: string
+                        pciAddress:
+                          description: The NIC PCI address
+                          type: string
+                        pxe:
+                          description: Whether the NIC is PXE Bootable
+                          type: boolean
+                        speedGbps:
+                          description: The speed of the device in Gigabits per second
+                          type: integer
+                        vlanId:
+                          description: The untagged VLAN ID
+                          format: int32
+                          maximum: 4094
+                          minimum: 0
+                          type: integer
+                        vlans:
+                          description: The VLANs available
+                          items:
+                            description: VLAN represents the name and ID of a VLAN.
+                            properties:
+                              id:
+                                description: VLANID is a 12-bit 802.1Q VLAN identifier
+                                format: int32
+                                maximum: 4094
+                                minimum: 0
+                                type: integer
+                              name:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  ramMebibytes:
+                    description: The host's amount of memory in Mebibytes.
+                    type: integer
+                  storage:
+                    description: List of storage (disk, SSD, etc.) available to the
+                      host.
+                    items:
+                      description: Storage describes one storage device (disk, SSD,
+                        etc.) on the host.
+                      properties:
+                        alternateNames:
+                          description: |-
+                            A list of alternate Linux device names of the disk, e.g. "/dev/sda".
+                            Note that this list is not exhaustive, and names may not be stable
+                            across reboots.
+                          items:
+                            type: string
+                          type: array
+                        hctl:
+                          description: The SCSI location of the device
+                          type: string
+                        model:
+                          description: Hardware model
+                          type: string
+                        name:
+                          description: |-
+                            A Linux device name of the disk, e.g.
+                            "/dev/disk/by-path/pci-0000:01:00.0-scsi-0:2:0:0". This will be a name
+                            that is stable across reboots if one is available.
+                          type: string
+                        rotational:
+                          description: |-
+                            Whether this disk represents rotational storage.
+                            This field is not recommended for usage, please
+                            prefer using 'Type' field instead, this field
+                            will be deprecated eventually.
+                          type: boolean
+                        serialNumber:
+                          description: The serial number of the device
+                          type: string
+                        sizeBytes:
+                          description: The size of the disk in Bytes
+                          format: int64
+                          type: integer
+                        type:
+                          description: 'Device type, one of: HDD, SSD, NVME.'
+                          enum:
+                          - HDD
+                          - SSD
+                          - NVME
+                          type: string
+                        vendor:
+                          description: The name of the vendor of the device
+                          type: string
+                        wwn:
+                          description: The WWN of the device
+                          type: string
+                        wwnVendorExtension:
+                          description: The WWN Vendor extension of the device
+                          type: string
+                        wwnWithExtension:
+                          description: The WWN with the extension
+                          type: string
+                      type: object
+                    type: array
+                  systemVendor:
+                    description: System vendor information.
+                    properties:
+                      manufacturer:
+                        type: string
+                      productName:
+                        type: string
+                      serialNumber:
+                        type: string
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}


### PR DESCRIPTION
## [OSAC-4251](https://redhat.atlassian.net/browse/OSAC-4251): Metal3 inventory — use InspectionMode field and HardwareData resource

**Jira:** https://redhat.atlassian.net/browse/OSAC-4251
**Story type:** [DEV]
**Follow-up to:** [OSAC-4201](https://redhat.atlassian.net/browse/OSAC-4201) (#410) — raised by @dtantsur (Metal3 maintainer) in review.

### Summary

Moves the Metal3 inventory backend onto current Metal3 APIs so future Metal3
upgrades don't break NIC-metadata discovery. Host-selection behavior (which
hosts are selectable, which MACs are returned) is preserved and made more robust
across Metal3 versions by reading from the newer sources with backward-compatible
fallbacks.

### Changes

**Metal3 inventory (`internal/inventory/metal3.go`)**
- `FindFreeHost` inspection gate now uses `BareMetalHost.InspectionDisabled()`,
  which checks the `Spec.InspectionMode` field first and falls back to the legacy
  `inspect.metal3.io: disabled` annotation.
- `FindFreeHost` and `GetHostNICs` source NIC data from the standalone
  `HardwareData` resource, falling back to the deprecated
  `BareMetalHost.Status.HardwareDetails` when `HardwareData` is absent or carries
  no NICs. `FindFreeHost` lists `HardwareData` once and indexes by name (one extra
  API call); `GetHostNICs` reads `HardwareData` first and only fetches the BMH on
  the fallback path.

**Shared resolver (`internal/baremetalhost/hardwaredata.go`)**
- New exported `ResolveHardwareDetails(hd, bmh)` implements the
  new-source-precedence rule (prefer `HardwareData` when it has NICs, else fall
  back to `Status.HardwareDetails`; an empty `HardwareData` does not shadow a
  populated status). Reused by both inventory backends — the single place to
  change if strict presence-precedence is ever wanted.

**BCM inventory parity (`internal/baremetalhost/manager.go`)**
- `GetHardwareNICs` (the BCM backend's NIC source) gets the same
  `HardwareData`-with-fallback read via the shared resolver, keeping both
  inventory backends consistent. Its existing `nil, nil` (no-error) contract when
  no NIC data exists is preserved.

**RBAC**
- Adds a `metal3.io/hardwaredata` `get;list;watch` grant (kubebuilder marker +
  regenerated `config/rbac/role.yaml` + operator chart ClusterRole) so the new
  in-cluster read is permitted at runtime.

### Compatibility note

Per driver feedback, the deprecated `Status.HardwareDetails` read is **retained as
a transitional fallback** behind the `HardwareData` source rather than removed
outright — a host may have only one source populated during a Metal3 version
transition. The fallback can be dropped in a later change once the fleet is fully
on `HardwareData`.

### Testing

- **Unit tests:** `metal3_test.go` (HardwareData primary, `Status.HardwareDetails`
  fallback, precedence-when-both, inspection-disabled via field and annotation,
  skip/error when neither source has NICs), `hardwaredata_test.go` (resolver
  precedence/fallback), `manager_test.go` (BCM `GetHardwareNICs` sources +
  `nil, nil` contract + empty-MAC skip).
- **Integration tests:** Metal3 controller envtest updated to create a companion
  `HardwareData` (new primary source); new `test/crds/metal3.io_hardwaredata.yaml`
  fixture.
- **Coverage:** new code exceeds 90% (`ResolveHardwareDetails`/`metal3HostNICs`/
  `managerHardwareMACs` at 100%; `GetHostNICs` 94%, `GetHardwareNICs` 94%,
  `FindFreeHost` 92%). `make test`, `make lint`, `make check-helm-crds` all pass.

### Acceptance Criteria

- [ ] AC-1: `FindFreeHost` inspection gate also checks the `InspectionMode` field, not just the deprecated annotation.
- [ ] AC-2: `FindFreeHost` and `GetHostNICs` fetch NIC data from the `HardwareData` resource (with `Status.HardwareDetails` fallback).
- [ ] AC-3: Unit tests updated to cover the new code paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for discovering host hardware and network interfaces from Kubernetes HardwareData resources.
  - Added the HardwareData resource definition with validation for hardware inventory fields.
  - Enabled required access for controllers to read HardwareData resources.

- **Bug Fixes**
  - Improved NIC discovery with consistent MAC address formatting and filtering of invalid entries.
  - Added fallback to existing host status details when HardwareData is missing, incomplete, or unavailable.
  - Ensured host discovery continues when HardwareData support is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->