### PR TITLE
NO-ISSUE: Stop running full unit/integration test matrices on merge_group

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,8 +16,8 @@ on:
     - cron: '47 */12 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
 
 permissions:
   contents: read
@@ -71,7 +71,7 @@ jobs:
   fulfillment-service:
     name: Run integration test (fulfillment-service)
     needs: changes
-    if: needs.changes.outputs.should-run == 'true'
+    if: needs.changes.outputs.should-run == 'true' && github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 75  # ginkgo --timeout 1h (Makefile) + ~15m for install/setup/log-collection
     steps:
@@ -125,7 +125,7 @@ jobs:
   osac-operator:
     name: Run integration test (osac-operator)
     needs: changes
-    if: needs.changes.outputs.should-run == 'true'
+    if: needs.changes.outputs.should-run == 'true' && github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 45  # ginkgo --timeout 30m (Makefile) + ~15m for install/setup/log-collection
     steps:
@@ -176,7 +176,7 @@ jobs:
   bare-metal-fulfillment-operator:
     name: Run integration test (bare-metal-fulfillment-operator)
     needs: changes
-    if: needs.changes.outputs.should-run == 'true'
+    if: needs.changes.outputs.should-run == 'true' && github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 45  # ginkgo --timeout 30m (Makefile) + ~15m for install/setup/log-collection
     steps:
@@ -233,7 +233,7 @@ jobs:
   osac-aap:
     name: Run integration test (osac-aap)
     needs: changes
-    if: needs.changes.outputs.should-run == 'true'
+    if: needs.changes.outputs.should-run == 'true' && github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -279,7 +279,7 @@ jobs:
   osac-installer:
     name: Run integration test (osac-installer)
     needs: changes
-    if: needs.changes.outputs.should-run == 'true'
+    if: needs.changes.outputs.should-run == 'true' && github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -375,3 +375,34 @@ jobs:
           --set dbMigrate.enabled=false \
           --timeout 10m \
           --wait
+
+  # The merge queue doesn't need the full Kind-cluster integration suite
+  # re-run -- that already ran at the PR level before this commit entered
+  # the queue. What it does need is a real compile check: none of the jobs
+  # above are in this repo's required_status_checks (only e2e-*-gate and
+  # check-labels are), so on merge_group they were previously running at
+  # full cost for zero merge-gating benefit. This is the actual minimal
+  # thing needed to catch a compile break slipping through the queue (the
+  # original motivation for adding merge_group to this workflow at all) --
+  # go vet, like go build, type-checks _test.go files without executing
+  # them, so a break there is still caught without paying for a full Kind
+  # cluster + ginkgo run.
+  merge-queue-compile-check:
+    name: Compile check (merge queue)
+    needs: changes
+    if: needs.changes.outputs.should-run == 'true' && github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      with:
+        persist-credentials: false
+    - uses: ./.github/actions/setup-go
+      # Default working-directory (repo root): go.work covers all 8 modules
+      # in one invocation, but each must be named explicitly below --
+      # verified directly that a bare `./...` from repo root fails with
+      # "directory prefix . does not contain modules listed in go.work",
+      # since the root itself isn't a workspace member.
+    - run: |
+        MODS="./bare-metal-fulfillment-operator/... ./fulfillment-service/... ./osac-csi-driver/... ./osac-metering/adapters/... ./osac-metering/metering-service/... ./osac-metering/schema/... ./osac-operator/... ./osac-operator/api/..."
+        go build $MODS
+        go vet $MODS

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,6 +29,10 @@ on:
   schedule:
     - cron: '13 */12 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+
 permissions:
   contents: read
 
@@ -74,7 +78,7 @@ jobs:
   run-unit-tests:
     name: Run unit tests
     needs: changes
-    if: needs.changes.outputs.should-run == 'true'
+    if: needs.changes.outputs.should-run == 'true' && github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -90,7 +94,7 @@ jobs:
   run-osac-metering-tests:
     name: Run unit tests (osac-metering)
     needs: changes
-    if: needs.changes.outputs.should-run == 'true'
+    if: needs.changes.outputs.should-run == 'true' && github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -106,7 +110,7 @@ jobs:
   run-osac-metering-adapters-tests:
     name: Run unit tests (osac-metering/adapters)
     needs: changes
-    if: needs.changes.outputs.should-run == 'true'
+    if: needs.changes.outputs.should-run == 'true' && github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -122,7 +126,7 @@ jobs:
   run-osac-metering-schema-tests:
     name: Run unit tests (osac-metering/schema)
     needs: changes
-    if: needs.changes.outputs.should-run == 'true'
+    if: needs.changes.outputs.should-run == 'true' && github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -134,3 +138,33 @@ jobs:
     - working-directory: osac-metering/schema
       run: |
         ginkgo run -r .
+
+  # The merge queue doesn't need the full test suite re-run -- that already
+  # ran at the PR level before this commit entered the queue. What it does
+  # need is a real compile check: none of the jobs above are in this repo's
+  # required_status_checks (only e2e-*-gate and check-labels are), so on
+  # merge_group they were previously running at full cost for zero
+  # merge-gating benefit. This is the actual minimal thing needed to catch a
+  # compile break slipping through the queue (the original motivation for
+  # adding merge_group to this workflow at all) -- go vet, like go build,
+  # type-checks _test.go files without executing them, so a break there is
+  # still caught without paying for the full ginkgo run.
+  merge-queue-compile-check:
+    name: Compile check (merge queue)
+    needs: changes
+    if: needs.changes.outputs.should-run == 'true' && github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      with:
+        persist-credentials: false
+    - uses: ./.github/actions/setup-go
+      # Default working-directory (repo root): go.work covers all 8 modules
+      # in one invocation, but each must be named explicitly below --
+      # verified directly that a bare `./...` from repo root fails with
+      # "directory prefix . does not contain modules listed in go.work",
+      # since the root itself isn't a workspace member.
+    - run: |
+        MODS="./bare-metal-fulfillment-operator/... ./fulfillment-service/... ./osac-csi-driver/... ./osac-metering/adapters/... ./osac-metering/metering-service/... ./osac-metering/schema/... ./osac-operator/... ./osac-operator/api/..."
+        go build $MODS
+        go vet $MODS


### PR DESCRIPTION
## Problem

PR #418 added `merge_group:` to `unit-tests.yml`, `integration-tests.yml`, and
`pre-commit.yaml` to close a real gap: the merge queue never compiled
`_test.go` files, which let a PVCRef compile break slip through previously.
The intent is correct and is preserved by this PR -- the `merge_group`
trigger stays on all 3 files, this only changes what runs on it.

The mechanism was too expensive:

- **None of these 3 workflows are required checks.** Confirmed via
  `gh api repos/osac-project/osac/rulesets`: the `ci-status-checks` ruleset's
  `required_status_checks` list is exactly `e2e-bmaas-gate`, `check-labels`,
  `e2e-caas-gate`, `e2e-vmaas-gate`. `unit-tests.yml`/`integration-tests.yml`
  are not on it.
- **They fan out to a real matrix.** `unit-tests.yml` has 4 test-execution
  jobs (`run-unit-tests`, `run-osac-metering-tests`,
  `run-osac-metering-adapters-tests`, `run-osac-metering-schema-tests`);
  `integration-tests.yml` has 5, 4 of which spin up a Kind cluster
  (`fulfillment-service`, `osac-operator`, `bare-metal-fulfillment-operator`,
  `osac-aap`, `osac-installer`).
- **Combined with queue concurrency, this saturates the shared runner pool.**
  `max_entries_to_build: 4` (confirmed via the same rulesets API call) times
  9 heavy jobs per queue entry, against a ~90 open PR backlog, was starving
  cheap-but-load-bearing jobs (`label-gate`, `auto-queue`, Slash Command) for
  hours. Confirmed via `gh api repos/osac-project/osac/actions/runs`: ~72
  queued + ~89 in-progress runs at time of writing.

## Fix

**`unit-tests.yml` and `integration-tests.yml`:**
- Added one new `merge-queue-compile-check` job to each, gated
  `if: needs.changes.outputs.should-run == 'true' && github.event_name == 'merge_group'`.
  It runs `go build` + `go vet` across all 8 `go.work` modules
  (`bare-metal-fulfillment-operator`, `fulfillment-service`,
  `osac-csi-driver`, `osac-metering/adapters`, `osac-metering/metering-service`,
  `osac-metering/schema`, `osac-operator`, `osac-operator/api`). `go vet`
  type-checks `_test.go` files without executing them -- a PVCRef-style
  compile break is still caught, without paying for a full `ginkgo run` or a
  Kind cluster per merge-queue entry.
  - Verified locally that a bare `./...` from repo root does **not** work in
    this workspace (`directory prefix . does not contain modules listed in
    go.work` -- the root itself isn't a workspace member), so each of the 8
    module paths is listed explicitly. Also verified `go build`/`go vet` with
    the explicit list succeed locally against current `main`.
- The existing heavy jobs -- `run-unit-tests`, `run-osac-metering-tests`,
  `run-osac-metering-adapters-tests`, `run-osac-metering-schema-tests` in
  `unit-tests.yml`; `fulfillment-service`, `osac-operator`,
  `bare-metal-fulfillment-operator`, `osac-aap`, `osac-installer` in
  `integration-tests.yml` -- get `&& github.event_name != 'merge_group'`
  added to their existing `if: needs.changes.outputs.should-run == 'true'`
  gate. Their `pull_request`/`schedule`/`workflow_dispatch` behavior is
  unchanged.

**`pre-commit.yaml`:** left untouched at the job level. Only 2 jobs, not a
meaningful contributor to the capacity problem.

**All 3 files:** added/extended a `concurrency:` block so a stale
`merge_group` run for the same queue entry gets cancelled instead of piling
up:
- `unit-tests.yml`, `pre-commit.yaml` had no concurrency block at all --
  added `group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`,
  `cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}`.
- `integration-tests.yml` already had a concurrency block, but
  `cancel-in-progress` only covered `pull_request`. Extended it to also cover
  `merge_group`, and switched the non-PR fallback key from `github.sha` to
  `github.ref` for consistency with the other two files -- `github.ref` for a
  `merge_group` event is GitHub's ephemeral `gh-readonly-queue/main/pr-NNN-<sha>`
  ref, which is naturally scoped per PR/queue-entry, whereas `github.sha` (the
  merge-preview commit) changes on every requeue attempt regardless, so it
  wouldn't actually dedupe repeated queue attempts for the same PR.

## Explicitly not done

- The `merge_group` trigger itself is untouched on all 3 files.
- `pre-commit.yaml`'s 2 jobs are untouched.

## Test plan
- [x] `gh api repos/osac-project/osac/rulesets` -- confirmed required checks
- [x] `gh api repos/osac-project/osac/actions/runs?status=queued|in_progress` -- confirmed current backlog
- [x] All 3 changed files validated as parseable YAML
- [x] `go build`/`go vet` with the explicit 8-module list run successfully locally against current `main`
- [ ] A real merge-queue run exercises the new `merge-queue-compile-check` job end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Superseded pull request and merge-queue checks are now canceled automatically.
  * Merge-queue validation now uses focused Go compilation and vet checks.
  * Standard integration and unit-test jobs no longer run redundantly during merge-queue processing.
  * Validation continues to run selectively when relevant code changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->