### PR TITLE
Retry transient Go module downloads in CI

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,6 +1,13 @@
 # Allowlist: exclude everything, then include only what Containerfiles need.
 *
 
+# Shared CI helper copied into Go build stages.
+!.github/
+.github/*
+!.github/scripts/
+.github/scripts/*
+!.github/scripts/go-network-retry.sh
+
 # Go workspace
 !go.work
 !go.work.sum

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -19,6 +19,10 @@ inputs:
     description: Directory containing go.mod (composite action steps don't inherit a calling job's defaults.run.working-directory)
     required: false
     default: '.'
+  install-ginkgo:
+    description: Install the ginkgo binary after downloading module dependencies
+    required: false
+    default: 'true'
 runs:
   using: composite
   steps:
@@ -28,16 +32,17 @@ runs:
   - shell: bash
     working-directory: ${{ inputs.working-directory }}
     run: |
-      go mod download
+      bash "${{ github.workspace }}/.github/scripts/go-network-retry.sh" mod download
   - id: ginkgo-cache
+    if: inputs.install-ginkgo == 'true'
     uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5
     with:
       key: ginkgo-${{ hashFiles(format('{0}/go.mod', inputs.working-directory)) }}
       path: ~/go/bin/ginkgo
-  - if: steps.ginkgo-cache.outputs.cache-hit != 'true'
+  - if: inputs.install-ginkgo == 'true' && steps.ginkgo-cache.outputs.cache-hit != 'true'
     shell: bash
     working-directory: ${{ inputs.working-directory }}
     run: |
       module="github.com/onsi/ginkgo/v2"
       version=$(go list -f '{{ .Version }}' -m "${module}")
-      go install "${module}/ginkgo@${version}"
+      bash "${{ github.workspace }}/.github/scripts/go-network-retry.sh" install "${module}/ginkgo@${version}"

--- a/.github/scripts/go-network-retry.sh
+++ b/.github/scripts/go-network-retry.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Retry Go fetch commands only for transient proxy/sumdb transport failures.
+# Real module resolution or checksum problems still fail on the first attempt.
+set -euo pipefail
+
+attempts="${GO_NETWORK_RETRY_ATTEMPTS:-3}"
+base_delay_seconds="${GO_NETWORK_RETRY_BASE_DELAY_SECONDS:-5}"
+
+if ! [[ "${attempts}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "go-network-retry: GO_NETWORK_RETRY_ATTEMPTS must be a positive integer" >&2
+  exit 2
+fi
+
+if ! [[ "${base_delay_seconds}" =~ ^[0-9]+$ ]]; then
+  echo "go-network-retry: GO_NETWORK_RETRY_BASE_DELAY_SECONDS must be a non-negative integer" >&2
+  exit 2
+fi
+
+if (( $# == 0 )); then
+  echo "usage: $0 <go arguments...>" >&2
+  exit 2
+fi
+
+readonly go_proxy_log_re='https://(proxy\.golang\.org|sum\.golang\.org)/'
+readonly transient_transport_re='stream error: stream ID [0-9]+; INTERNAL_ERROR|unexpected EOF|TLS handshake timeout|i/o timeout|connection reset by peer|context deadline exceeded|EOF|502 Bad Gateway|503 Service Unavailable|504 Gateway Timeout|proxyconnect tcp|dial tcp|temporary failure in name resolution|no such host|server misbehaving'
+
+run_go_command() {
+  local logfile="$1"
+  shift
+  local rc=0
+
+  set +e
+  go "$@" >"${logfile}" 2>&1
+  rc=$?
+  set -e
+
+  cat "${logfile}"
+  return "${rc}"
+}
+
+is_transient_go_fetch_failure() {
+  local logfile="$1"
+
+  grep -Eq "${go_proxy_log_re}" "${logfile}" && grep -Eq "${transient_transport_re}" "${logfile}"
+}
+
+for (( attempt = 1; attempt <= attempts; attempt++ )); do
+  logfile="$(mktemp)"
+
+  echo "go-network-retry: attempt ${attempt}/${attempts}: go $*" >&2
+
+  if run_go_command "${logfile}" "$@"; then
+    if (( attempt > 1 )); then
+      echo "go-network-retry: succeeded on attempt ${attempt}" >&2
+    fi
+    rm -f "${logfile}"
+    exit 0
+  else
+    rc=$?
+  fi
+
+  if ! is_transient_go_fetch_failure "${logfile}"; then
+    echo "go-network-retry: non-transient failure, not retrying" >&2
+    rm -f "${logfile}"
+    exit "${rc}"
+  fi
+
+  rm -f "${logfile}"
+
+  if (( attempt == attempts )); then
+    echo "go-network-retry: transient proxy or sumdb failure persisted after ${attempts} attempts" >&2
+    exit "${rc}"
+  fi
+
+  sleep_seconds=$(( base_delay_seconds * attempt ))
+  echo "go-network-retry: transient proxy or sumdb failure, retrying in ${sleep_seconds}s" >&2
+  sleep "${sleep_seconds}"
+done

--- a/bare-metal-fulfillment-operator/Containerfile
+++ b/bare-metal-fulfillment-operator/Containerfile
@@ -9,6 +9,7 @@ WORKDIR /opt/app-root/src
 # repo (see root .gitignore); `go mod download` below regenerates it inside
 # the build using the go.sum files already copied in per module.
 COPY --chown=1001:1001 go.work ./
+COPY --chown=1001:1001 .github/scripts/go-network-retry.sh /usr/local/bin/go-network-retry.sh
 COPY --chown=1001:1001 bare-metal-fulfillment-operator/go.mod bare-metal-fulfillment-operator/go.sum bare-metal-fulfillment-operator/
 COPY --chown=1001:1001 osac-operator/go.mod osac-operator/go.sum osac-operator/
 COPY --chown=1001:1001 osac-operator/api/go.mod osac-operator/api/go.sum osac-operator/api/
@@ -17,7 +18,7 @@ COPY --chown=1001:1001 osac-csi-driver/go.mod osac-csi-driver/go.sum osac-csi-dr
 COPY --chown=1001:1001 osac-metering/schema/go.mod osac-metering/schema/go.sum osac-metering/schema/
 COPY --chown=1001:1001 osac-metering/metering-service/go.mod osac-metering/metering-service/go.sum osac-metering/metering-service/
 COPY --chown=1001:1001 osac-metering/adapters/go.mod osac-metering/adapters/go.sum osac-metering/adapters/
-RUN cd bare-metal-fulfillment-operator && go mod download
+RUN cd bare-metal-fulfillment-operator && sh /usr/local/bin/go-network-retry.sh mod download
 
 COPY --chown=1001:1001 bare-metal-fulfillment-operator/ bare-metal-fulfillment-operator/
 COPY --chown=1001:1001 osac-operator/ osac-operator/

--- a/fulfillment-service/Containerfile
+++ b/fulfillment-service/Containerfile
@@ -10,6 +10,7 @@ ARG DEBUG=false
 # the build using the go.sum files already copied in per module.
 WORKDIR /opt/app-root/src
 COPY --chown=1001:1001 go.work ./
+COPY --chown=1001:1001 .github/scripts/go-network-retry.sh /usr/local/bin/go-network-retry.sh
 COPY --chown=1001:1001 fulfillment-service/go.mod fulfillment-service/go.sum fulfillment-service/
 COPY --chown=1001:1001 bare-metal-fulfillment-operator/go.mod bare-metal-fulfillment-operator/go.sum bare-metal-fulfillment-operator/
 COPY --chown=1001:1001 osac-operator/go.mod osac-operator/go.sum osac-operator/
@@ -20,7 +21,7 @@ COPY --chown=1001:1001 osac-metering/metering-service/go.mod osac-metering/meter
 COPY --chown=1001:1001 osac-metering/adapters/go.mod osac-metering/adapters/go.sum osac-metering/adapters/
 RUN \
   set -e; \
-  cd fulfillment-service && go mod download
+  cd fulfillment-service && sh /usr/local/bin/go-network-retry.sh mod download
 
 ARG VERSION=""
 

--- a/osac-csi-driver/Containerfile
+++ b/osac-csi-driver/Containerfile
@@ -9,6 +9,7 @@ WORKDIR /opt/app-root/src
 # repo (see root .gitignore); `go mod download` below regenerates it inside
 # the build using the go.sum files already copied in per module.
 COPY --chown=1001:1001 go.work ./
+COPY --chown=1001:1001 .github/scripts/go-network-retry.sh /usr/local/bin/go-network-retry.sh
 COPY --chown=1001:1001 osac-csi-driver/go.mod osac-csi-driver/go.sum osac-csi-driver/
 COPY --chown=1001:1001 fulfillment-service/go.mod fulfillment-service/go.sum fulfillment-service/
 COPY --chown=1001:1001 bare-metal-fulfillment-operator/go.mod bare-metal-fulfillment-operator/go.sum bare-metal-fulfillment-operator/
@@ -17,7 +18,7 @@ COPY --chown=1001:1001 osac-operator/api/go.mod osac-operator/api/go.sum osac-op
 COPY --chown=1001:1001 osac-metering/schema/go.mod osac-metering/schema/go.sum osac-metering/schema/
 COPY --chown=1001:1001 osac-metering/metering-service/go.mod osac-metering/metering-service/go.sum osac-metering/metering-service/
 COPY --chown=1001:1001 osac-metering/adapters/go.mod osac-metering/adapters/go.sum osac-metering/adapters/
-RUN cd osac-csi-driver && go mod download
+RUN cd osac-csi-driver && sh /usr/local/bin/go-network-retry.sh mod download
 
 COPY --chown=1001:1001 osac-csi-driver/ osac-csi-driver/
 

--- a/osac-metering/adapters/Containerfile.echo-adapter
+++ b/osac-metering/adapters/Containerfile.echo-adapter
@@ -5,7 +5,8 @@ ARG TARGETARCH
 WORKDIR /opt/app-root/src
 COPY --chown=1001:0 schema/ schema/
 COPY --chown=1001:0 adapters/go.mod adapters/go.sum adapters/
-RUN cd adapters && go mod download
+COPY --chown=1001:0 go-network-retry.sh /usr/local/bin/go-network-retry.sh
+RUN cd adapters && sh /usr/local/bin/go-network-retry.sh mod download
 
 COPY --chown=1001:0 adapters/ adapters/
 

--- a/osac-metering/adapters/Containerfile.m360-adapter
+++ b/osac-metering/adapters/Containerfile.m360-adapter
@@ -5,7 +5,8 @@ ARG TARGETARCH
 WORKDIR /opt/app-root/src
 COPY --chown=1001:0 schema/ schema/
 COPY --chown=1001:0 adapters/go.mod adapters/go.sum adapters/
-RUN cd adapters && go mod download
+COPY --chown=1001:0 go-network-retry.sh /usr/local/bin/go-network-retry.sh
+RUN cd adapters && sh /usr/local/bin/go-network-retry.sh mod download
 
 COPY --chown=1001:0 adapters/ adapters/
 

--- a/osac-metering/go-network-retry.sh
+++ b/osac-metering/go-network-retry.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Retry Go fetch commands only for transient proxy/sumdb transport failures.
+# Real module resolution or checksum problems still fail on the first attempt.
+set -euo pipefail
+
+attempts="${GO_NETWORK_RETRY_ATTEMPTS:-3}"
+base_delay_seconds="${GO_NETWORK_RETRY_BASE_DELAY_SECONDS:-5}"
+
+if ! [[ "${attempts}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "go-network-retry: GO_NETWORK_RETRY_ATTEMPTS must be a positive integer" >&2
+  exit 2
+fi
+
+if ! [[ "${base_delay_seconds}" =~ ^[0-9]+$ ]]; then
+  echo "go-network-retry: GO_NETWORK_RETRY_BASE_DELAY_SECONDS must be a non-negative integer" >&2
+  exit 2
+fi
+
+if (( $# == 0 )); then
+  echo "usage: $0 <go arguments...>" >&2
+  exit 2
+fi
+
+readonly go_proxy_log_re='https://(proxy\.golang\.org|sum\.golang\.org)/'
+readonly transient_transport_re='stream error: stream ID [0-9]+; INTERNAL_ERROR|unexpected EOF|TLS handshake timeout|i/o timeout|connection reset by peer|context deadline exceeded|EOF|502 Bad Gateway|503 Service Unavailable|504 Gateway Timeout|proxyconnect tcp|dial tcp|temporary failure in name resolution|no such host|server misbehaving'
+
+run_go_command() {
+  local logfile="$1"
+  shift
+  local rc=0
+
+  set +e
+  go "$@" >"${logfile}" 2>&1
+  rc=$?
+  set -e
+
+  cat "${logfile}"
+  return "${rc}"
+}
+
+is_transient_go_fetch_failure() {
+  local logfile="$1"
+
+  grep -Eq "${go_proxy_log_re}" "${logfile}" && grep -Eq "${transient_transport_re}" "${logfile}"
+}
+
+for (( attempt = 1; attempt <= attempts; attempt++ )); do
+  logfile="$(mktemp)"
+
+  echo "go-network-retry: attempt ${attempt}/${attempts}: go $*" >&2
+
+  if run_go_command "${logfile}" "$@"; then
+    if (( attempt > 1 )); then
+      echo "go-network-retry: succeeded on attempt ${attempt}" >&2
+    fi
+    rm -f "${logfile}"
+    exit 0
+  else
+    rc=$?
+  fi
+
+  if ! is_transient_go_fetch_failure "${logfile}"; then
+    echo "go-network-retry: non-transient failure, not retrying" >&2
+    rm -f "${logfile}"
+    exit "${rc}"
+  fi
+
+  rm -f "${logfile}"
+
+  if (( attempt == attempts )); then
+    echo "go-network-retry: transient proxy or sumdb failure persisted after ${attempts} attempts" >&2
+    exit "${rc}"
+  fi
+
+  sleep_seconds=$(( base_delay_seconds * attempt ))
+  echo "go-network-retry: transient proxy or sumdb failure, retrying in ${sleep_seconds}s" >&2
+  sleep "${sleep_seconds}"
+done

--- a/osac-metering/metering-service/Containerfile
+++ b/osac-metering/metering-service/Containerfile
@@ -5,7 +5,8 @@ ARG TARGETARCH
 WORKDIR /opt/app-root/src
 COPY --chown=1001:0 schema/ schema/
 COPY --chown=1001:0 metering-service/go.mod metering-service/go.sum metering-service/
-RUN cd metering-service && go mod download
+COPY --chown=1001:0 go-network-retry.sh /usr/local/bin/go-network-retry.sh
+RUN cd metering-service && sh /usr/local/bin/go-network-retry.sh mod download
 
 COPY --chown=1001:0 metering-service/ metering-service/
 

--- a/osac-operator/Containerfile
+++ b/osac-operator/Containerfile
@@ -9,6 +9,7 @@ WORKDIR /opt/app-root/src
 # repo (see root .gitignore); `go mod download` below regenerates it inside
 # the build using the go.sum files already copied in per module.
 COPY --chown=1001:1001 go.work ./
+COPY --chown=1001:1001 .github/scripts/go-network-retry.sh /usr/local/bin/go-network-retry.sh
 COPY --chown=1001:1001 osac-operator/go.mod osac-operator/go.sum osac-operator/
 COPY --chown=1001:1001 osac-operator/api/go.mod osac-operator/api/go.sum osac-operator/api/
 COPY --chown=1001:1001 bare-metal-fulfillment-operator/go.mod bare-metal-fulfillment-operator/go.sum bare-metal-fulfillment-operator/
@@ -17,7 +18,7 @@ COPY --chown=1001:1001 osac-csi-driver/go.mod osac-csi-driver/go.sum osac-csi-dr
 COPY --chown=1001:1001 osac-metering/schema/go.mod osac-metering/schema/go.sum osac-metering/schema/
 COPY --chown=1001:1001 osac-metering/metering-service/go.mod osac-metering/metering-service/go.sum osac-metering/metering-service/
 COPY --chown=1001:1001 osac-metering/adapters/go.mod osac-metering/adapters/go.sum osac-metering/adapters/
-RUN cd osac-operator && go mod download
+RUN cd osac-operator && sh /usr/local/bin/go-network-retry.sh mod download
 
 COPY --chown=1001:1001 osac-operator/ osac-operator/
 COPY --chown=1001:1001 bare-metal-fulfillment-operator/ bare-metal-fulfillment-operator/


### PR DESCRIPTION
## Summary
- add a shared retry helper for transient `proxy.golang.org` and `sum.golang.org` transport failures
- use the helper in the shared Go setup action and in Go-based container builds
- keep checksum and module integrity checks intact by retrying only transport-level failures

## Test plan
- [x] `git diff --check upstream/main...HEAD`
- [x] `bash .github/scripts/go-network-retry.sh definitely-not-a-go-command`
- [x] `bash ../.github/scripts/go-network-retry.sh mod download` from `osac-operator/`
- [x] `podman build --no-cache --target builder -f osac-metering/metering-service/Containerfile osac-metering`

Made with [Cursor](https://cursor.com)