### PR TITLE
NO-ISSUE: Cancel stale merge-queue reruns on unit-tests/integration-tests/pre-commit

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,10 +17,6 @@ on:
   # Invoked as a parallel "box" by nightly-build.yaml.
   workflow_call:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 permissions:
   contents: read
 
@@ -36,6 +32,7 @@ jobs:
       # workflow_dispatch always run. Job-level `if:` skip reports success
       # so docs-only PRs (and merge groups) are not blocked.
       should-run: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || steps.filter.outputs.code == 'true' }}
+      concurrency-key: ${{ steps.concurrency-key.outputs.key }}
     steps:
       # dorny/paths-filter uses git diff on merge_group (not the PR Files API),
       # so the repo must be checked out with enough history for base..head.
@@ -62,6 +59,40 @@ jobs:
               - '!.design/**'
               - '!.skillsaw.yaml'
               - '!.pre-commit-config.yaml'
+      # A job-level `concurrency:` block can reference `needs.*.outputs.*`,
+      # unlike a workflow-level one (removed above), which is evaluated
+      # before any job runs and so cannot depend on a computed value -- this
+      # is why the key is computed here and consumed by each test job's own
+      # concurrency block below.
+      #
+      # github.sha (the merge-preview commit) changes on every GitHub
+      # merge-queue rebase, so keying on it -- as the removed workflow-level
+      # block did -- can never collapse a stale rerun from an earlier rebase
+      # of the same PR. github.ref_name is stable enough to extract from:
+      # for merge_group it's gh-readonly-queue/<base>/pr-<number>-<sha>, and
+      # the pr-<number> segment stays constant across rebases -- confirmed
+      # against this repo's own run history (gh api
+      # .../actions/runs?event=merge_group): PR #503 was requeued at
+      # .../pr-503-b2986acb...61 and .../pr-503-f05965f9...53 sixteen
+      # minutes apart, PR #307 similarly at .../pr-307-18b1c7ed...58 and
+      # .../pr-307-0c86346b...c1 -- both pairs extract to the same
+      # "pr-<number>" despite the trailing sha differing every time.
+      - name: Compute stable per-PR concurrency key
+        id: concurrency-key
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REF_NAME: ${{ github.ref_name }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            KEY="pr-${PR_NUMBER}"
+          elif [[ "${EVENT_NAME}" == "merge_group" ]]; then
+            KEY=$(echo "${REF_NAME}" | grep -oE 'pr-[0-9]+')
+          else
+            KEY="run-${RUN_ID}"
+          fi
+          echo "key=${KEY}" >> "$GITHUB_OUTPUT"
 
   # fulfillment-service, osac-operator, and bare-metal-fulfillment-operator now
   # all follow the same Kind cluster + root Makefile step sequence (only the
@@ -74,6 +105,9 @@ jobs:
     name: Run integration test (fulfillment-service)
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
+    concurrency:
+      group: integration-fulfillment-service-${{ needs.changes.outputs.concurrency-key }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 75  # ginkgo --timeout 1h (Makefile) + ~15m for install/setup/log-collection
     steps:
@@ -128,6 +162,9 @@ jobs:
     name: Run integration test (osac-operator)
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
+    concurrency:
+      group: integration-osac-operator-${{ needs.changes.outputs.concurrency-key }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45  # ginkgo --timeout 30m (Makefile) + ~15m for install/setup/log-collection
     steps:
@@ -179,6 +216,9 @@ jobs:
     name: Run integration test (bare-metal-fulfillment-operator)
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
+    concurrency:
+      group: integration-bare-metal-fulfillment-operator-${{ needs.changes.outputs.concurrency-key }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45  # ginkgo --timeout 30m (Makefile) + ~15m for install/setup/log-collection
     steps:
@@ -236,6 +276,9 @@ jobs:
     name: Run integration test (osac-aap)
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
+    concurrency:
+      group: integration-osac-aap-${{ needs.changes.outputs.concurrency-key }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -282,6 +325,9 @@ jobs:
     name: Run integration test (osac-installer)
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
+    concurrency:
+      group: integration-osac-installer-${{ needs.changes.outputs.concurrency-key }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -88,7 +88,14 @@ jobs:
           if [[ "${EVENT_NAME}" == "pull_request" ]]; then
             KEY="pr-${PR_NUMBER}"
           elif [[ "${EVENT_NAME}" == "merge_group" ]]; then
-            KEY=$(echo "${REF_NAME}" | grep -oE 'pr-[0-9]+')
+            # tail -1 takes the rightmost match, in case the base branch
+            # name itself happens to contain a pr-<digits> substring. The
+            # `|| true` plus empty-check fallback covers a ref that doesn't
+            # match this shape at all -- GitHub Actions runs `run:` steps
+            # with `set -eo pipefail`, so an unmatched grep would otherwise
+            # abort this step and skip every downstream test job via `needs`.
+            KEY=$(echo "${REF_NAME}" | grep -oE 'pr-[0-9]+' | tail -1 || true)
+            [[ -z "${KEY}" ]] && KEY="run-${RUN_ID}"
           else
             KEY="run-${RUN_ID}"
           fi

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -24,8 +24,11 @@ jobs:
   # sixteen minutes apart, PR #307 similarly at .../pr-307-18b1c7ed...58 and
   # .../pr-307-0c86346b...c1 -- both pairs extract to the same "pr-<number>"
   # despite the trailing sha differing every time.
-  concurrency-key:
+  compute-concurrency-key:
     runs-on: ubuntu-latest
+    # No checkout, no API calls -- this job only derives a string from
+    # already-available event context, so it needs no token access at all.
+    permissions: {}
     outputs:
       key: ${{ steps.concurrency-key.outputs.key }}
     steps:
@@ -40,16 +43,23 @@ jobs:
           if [[ "${EVENT_NAME}" == "pull_request" ]]; then
             KEY="pr-${PR_NUMBER}"
           elif [[ "${EVENT_NAME}" == "merge_group" ]]; then
-            KEY=$(echo "${REF_NAME}" | grep -oE 'pr-[0-9]+')
+            # tail -1 takes the rightmost match, in case the base branch
+            # name itself happens to contain a pr-<digits> substring. The
+            # `|| true` plus empty-check fallback covers a ref that doesn't
+            # match this shape at all -- GitHub Actions runs `run:` steps
+            # with `set -eo pipefail`, so an unmatched grep would otherwise
+            # abort this step and skip every downstream test job via `needs`.
+            KEY=$(echo "${REF_NAME}" | grep -oE 'pr-[0-9]+' | tail -1 || true)
+            [[ -z "${KEY}" ]] && KEY="run-${RUN_ID}"
           else
             KEY="run-${RUN_ID}"
           fi
           echo "key=${KEY}" >> "$GITHUB_OUTPUT"
 
   pre-commit:
-    needs: concurrency-key
+    needs: compute-concurrency-key
     concurrency:
-      group: pre-commit-${{ needs.concurrency-key.outputs.key }}
+      group: pre-commit-${{ needs.compute-concurrency-key.outputs.key }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -5,7 +5,52 @@ on:
   merge_group:
 
 jobs:
+  # This repo's other two heavy CI workflows (unit-tests.yml,
+  # integration-tests.yml) compute this same key inside their existing
+  # `changes` job; pre-commit.yaml has no such job, so it gets its own tiny
+  # one instead of computing the key inline in `pre-commit` itself -- a
+  # job-level `concurrency:` block is evaluated before that job's own steps
+  # run, so it can only reference `needs.<other job>.outputs.*`, never a
+  # step output from within the same job.
+  #
+  # github.sha (the merge-preview commit) changes on every GitHub
+  # merge-queue rebase, so keying on it can never collapse a stale rerun
+  # from an earlier rebase of the same PR. github.ref_name is stable enough
+  # to extract from: for merge_group it's
+  # gh-readonly-queue/<base>/pr-<number>-<sha>, and the pr-<number> segment
+  # stays constant across rebases -- confirmed against this repo's own run
+  # history (gh api .../actions/runs?event=merge_group): PR #503 was
+  # requeued at .../pr-503-b2986acb...61 and .../pr-503-f05965f9...53
+  # sixteen minutes apart, PR #307 similarly at .../pr-307-18b1c7ed...58 and
+  # .../pr-307-0c86346b...c1 -- both pairs extract to the same "pr-<number>"
+  # despite the trailing sha differing every time.
+  concurrency-key:
+    runs-on: ubuntu-latest
+    outputs:
+      key: ${{ steps.concurrency-key.outputs.key }}
+    steps:
+      - name: Compute stable per-PR concurrency key
+        id: concurrency-key
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REF_NAME: ${{ github.ref_name }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            KEY="pr-${PR_NUMBER}"
+          elif [[ "${EVENT_NAME}" == "merge_group" ]]; then
+            KEY=$(echo "${REF_NAME}" | grep -oE 'pr-[0-9]+')
+          else
+            KEY="run-${RUN_ID}"
+          fi
+          echo "key=${KEY}" >> "$GITHUB_OUTPUT"
+
   pre-commit:
+    needs: concurrency-key
+    concurrency:
+      group: pre-commit-${{ needs.concurrency-key.outputs.key }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -102,7 +102,14 @@ jobs:
           if [[ "${EVENT_NAME}" == "pull_request" ]]; then
             KEY="pr-${PR_NUMBER}"
           elif [[ "${EVENT_NAME}" == "merge_group" ]]; then
-            KEY=$(echo "${REF_NAME}" | grep -oE 'pr-[0-9]+')
+            # tail -1 takes the rightmost match, in case the base branch
+            # name itself happens to contain a pr-<digits> substring. The
+            # `|| true` plus empty-check fallback covers a ref that doesn't
+            # match this shape at all -- GitHub Actions runs `run:` steps
+            # with `set -eo pipefail`, so an unmatched grep would otherwise
+            # abort this step and skip every downstream test job via `needs`.
+            KEY=$(echo "${REF_NAME}" | grep -oE 'pr-[0-9]+' | tail -1 || true)
+            [[ -z "${KEY}" ]] && KEY="run-${RUN_ID}"
           else
             KEY="run-${RUN_ID}"
           fi

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -46,6 +46,7 @@ jobs:
       # workflow_dispatch always run. Job-level `if:` skip reports success
       # so docs-only PRs (and merge groups) are not blocked.
       should-run: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || steps.filter.outputs.code == 'true' }}
+      concurrency-key: ${{ steps.concurrency-key.outputs.key }}
     steps:
       # dorny/paths-filter uses git diff on merge_group (not the PR Files API),
       # so the repo must be checked out with enough history for base..head.
@@ -72,11 +73,48 @@ jobs:
               - '!.design/**'
               - '!.skillsaw.yaml'
               - '!.pre-commit-config.yaml'
+      # A job-level `concurrency:` block can reference `needs.*.outputs.*`,
+      # unlike a workflow-level one, which is evaluated before any job runs
+      # and so cannot depend on a computed value -- this is why the key is
+      # computed here and consumed by each test job's own concurrency block
+      # below, rather than in a single top-of-file block.
+      #
+      # github.sha (the merge-preview commit) changes on every GitHub
+      # merge-queue rebase, so keying on it can never collapse a stale rerun
+      # from an earlier rebase of the same PR. github.ref_name is stable
+      # enough to extract from: for merge_group it's
+      # gh-readonly-queue/<base>/pr-<number>-<sha>, and the pr-<number>
+      # segment stays constant across rebases -- confirmed against this
+      # repo's own run history (gh api .../actions/runs?event=merge_group):
+      # PR #503 was requeued at .../pr-503-b2986acb...61 and
+      # .../pr-503-f05965f9...53 sixteen minutes apart, PR #307 similarly at
+      # .../pr-307-18b1c7ed...58 and .../pr-307-0c86346b...c1 -- both pairs
+      # extract to the same "pr-<number>" despite the trailing sha differing
+      # every time.
+      - name: Compute stable per-PR concurrency key
+        id: concurrency-key
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REF_NAME: ${{ github.ref_name }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            KEY="pr-${PR_NUMBER}"
+          elif [[ "${EVENT_NAME}" == "merge_group" ]]; then
+            KEY=$(echo "${REF_NAME}" | grep -oE 'pr-[0-9]+')
+          else
+            KEY="run-${RUN_ID}"
+          fi
+          echo "key=${KEY}" >> "$GITHUB_OUTPUT"
 
   run-unit-tests:
     name: Run unit tests
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
+    concurrency:
+      group: run-unit-tests-${{ needs.changes.outputs.concurrency-key }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -93,6 +131,9 @@ jobs:
     name: Run unit tests (osac-metering)
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
+    concurrency:
+      group: run-osac-metering-tests-${{ needs.changes.outputs.concurrency-key }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -109,6 +150,9 @@ jobs:
     name: Run unit tests (osac-metering/adapters)
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
+    concurrency:
+      group: run-osac-metering-adapters-tests-${{ needs.changes.outputs.concurrency-key }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -125,6 +169,9 @@ jobs:
     name: Run unit tests (osac-metering/schema)
     needs: changes
     if: needs.changes.outputs.should-run == 'true'
+    concurrency:
+      group: run-osac-metering-schema-tests-${{ needs.changes.outputs.concurrency-key }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1


### PR DESCRIPTION
#544 scoped full test execution on `merge_group` down to a lightweight compile-check and was correctly rejected -- the owner wants the FULL Unit Tests and Integration Tests suites to keep running on `merge_group` exactly as #418 intended, and live data showed the 180-concurrent-job Enterprise runner ceiling wasn't even close to being hit (~30-40 in use at the time).

**Nothing from #544 is reintroduced here: no compile-check job, no gating the heavy test jobs off of `merge_group`, no change to what runs or when.** This PR only cancels superseded/stale runs.

## The actual problem

None of `unit-tests.yml`, `integration-tests.yml`, or `pre-commit.yaml` cancel a stale run when GitHub's merge queue rebases a PR onto a new ephemeral `gh-readonly-queue` ref -- normal, routine merge-queue behavior that will keep happening regardless of the ref-staleness git-clone incident fixed separately. Every rebase spawns a brand-new full run of these 3 workflows for that PR; the previous run for the now-superseded ref is not cancelled and keeps consuming a runner until it finishes naturally.

Confirmed live: **13 concurrent Unit Tests runs and 10 concurrent Integration Tests runs** against only **4 active merge-queue slots** (`max_entries_to_build: 4`, confirmed via `gh api repos/osac-project/osac/rulesets`) -- consistent with a handful of PRs each stacking up multiple stale, uncancelled reruns from repeated rebases. Also confirmed this repo's real hosted-runner concurrency (~30-40 in use) is nowhere near the plan's 180-job ceiling, so a hard concurrency limit is not the bottleneck here -- the queue stalls because cheap, load-bearing jobs (`label-gate`, `auto-queue`, Slash Command) get starved behind piles of stale heavy runs, not because of a runner cap.

`integration-tests.yml` already had a `concurrency:` block, but its non-PR fallback key was `github.sha` -- the merge-preview commit, which changes on every rebase. So the group key itself changed every rebase and could never collapse a prior run even with `cancel-in-progress` true for `merge_group`. `unit-tests.yml` and `pre-commit.yaml` had no `concurrency:` block at all.

## The fix, and why the key is actually stable

`github.ref_name` for a `merge_group` event is GitHub's ephemeral `gh-readonly-queue/<base>/pr-<number>-<sha>` ref. The `pr-<number>` segment is constant across rebases of the same PR; only the trailing sha changes.

**Verified directly against this repo's own run history** (`gh api repos/osac-project/osac/actions/runs?event=merge_group`), not assumed:

- PR #503 requeued at `gh-readonly-queue/main/pr-503-b2986acb...61` and `.../pr-503-f05965f9...53`, 16 minutes apart.
- PR #307 requeued at `gh-readonly-queue/main/pr-307-18b1c7ed...58` and `.../pr-307-0c86346b...c1`.
- PR #502 requeued at `gh-readonly-queue/main/pr-502-25cf0673...26` and `.../pr-502-ade9ac85...04`.

All three pairs extract to the identical `pr-503`/`pr-307`/`pr-502` via `grep -oE 'pr-[0-9]+'`, despite the trailing sha differing every time -- this is the key that actually collapses repeated rebases.

Workflow-level `concurrency:` blocks are evaluated before any job runs and can't reference a computed value, so this can't be a single top-of-file block (GitHub Actions expressions have no substring-extraction function to pull `pr-<number>` out of the ref inline). Instead:

- **`unit-tests.yml`, `integration-tests.yml`**: the existing `changes` job gets one new step that computes the stable key (`pr-<number>` for `pull_request`, the extracted `pr-<number>` for `merge_group`, `run-<id>` as a no-op fallback for `schedule`/`workflow_dispatch`) and exposes it as a new `concurrency-key` output. Every test-execution job already `needs: changes`, so each gets its own job-level `concurrency:` block referencing `needs.changes.outputs.concurrency-key` -- job-level blocks, unlike workflow-level ones, can reference `needs.*.outputs.*`.
- **`pre-commit.yaml`**: has no `changes` job, so it gets a new, tiny `concurrency-key` job computing the same thing, and `pre-commit` now `needs:` it and carries the same job-level `concurrency:` block.
- `integration-tests.yml`'s old workflow-level block is removed entirely, superseded by the per-job blocks above.

`cancel-in-progress` is `true` for both `pull_request` and `merge_group` on every one of these blocks -- `pull_request` behavior is unchanged in substance (still cancels on new pushes), `merge_group` now actually works.

## Explicitly not changed

- No job is skipped or gated off `merge_group`. Every test-execution job that ran before still runs, on the same triggers, with the same coverage.
- No new compile-check job.
- `pre-commit.yaml`'s actual gitleaks/lint logic is untouched -- only the new upstream `concurrency-key` job and the `needs:`/`concurrency:` addition on `pre-commit` itself.

## Verification

- [x] `actionlint` on all 3 changed files -- clean (also ran actionlint against the whole `.github/workflows/` tree; the only findings are pre-existing, in unrelated files, and not introduced by this PR)
- [x] All 3 files validated as parseable YAML
- [x] Concurrency-key extraction regex verified against 6 real `head_branch` values pulled from this repo's own run history (3 rebase pairs, listed above)
- [ ] A real merge-queue rebase exercises the cancellation end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **CI:** Added stable per-PR concurrency keys to the unit-test, integration-test, and pre-commit workflows.
- **CI:** Cancel superseded pull-request and merge-group runs with `cancel-in-progress: true`.
- **CI:** Added `pr-<number>` extraction, `run-<run-id>` fallbacks, and restricted permissions for key computation.
- **CI:** Preserved existing triggers, test coverage, and behavior for scheduled, manual, and other events.
- **API, controllers, database, auth, deployment, and documentation:** No changes.

### Backward compatibility

No application or public API behavior changes. CI behavior changes only for overlapping pull-request and merge-group runs. End-to-end cancellation during an actual merge-queue rebase remains unverified.

## Risk classification

**risk:show** — The change affects CI execution and can cancel in-progress workflows, but it does not change application behavior, deployment behavior, public APIs, or test coverage. It was close to **risk:ship** because the scope is limited to workflow configuration, but unverified merge-queue cancellation behavior requires visible review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->