### PR TITLE
OSAC-3769: gate BareMetalInstance allocation on BMH readiness

### DIFF
--- a/bare-metal-fulfillment-operator/cmd/main.go
+++ b/bare-metal-fulfillment-operator/cmd/main.go
@@ -79,6 +79,7 @@ const (
 	envTryLockFailPollInterval   = "OSAC_TRY_LOCK_FAIL_POLL_INTERVAL"
 	envManagementRecheckInterval = "OSAC_MANAGEMENT_RECHECK_INTERVAL"
 	envProvisionPollInterval     = "OSAC_PROVISION_POLL_INTERVAL"
+	envHostReadinessPollInterval = "OSAC_HOST_READINESS_POLL_INTERVAL"
 
 	envAAPURL                       = "OSAC_AAP_URL"
 	envAAPToken                     = "OSAC_AAP_TOKEN"
@@ -483,6 +484,10 @@ func setupBareMetalInstanceController(
 		envProvisionPollInterval,
 		controller.DefaultProvisionPollIntervalDuration,
 	)
+	hostReadinessPollInterval := helpers.GetEnvWithDefault(
+		envHostReadinessPollInterval,
+		controller.DefaultHostReadinessPollIntervalDuration,
+	)
 	maxConcurrentReconciles := helpers.GetEnvWithDefault(
 		envBareMetalInstanceMaxConcurrentReconcile,
 		1,
@@ -502,6 +507,7 @@ func setupBareMetalInstanceController(
 		tryLockFailPollInterval,
 		managementRecheckInterval,
 		provisionPollInterval,
+		hostReadinessPollInterval,
 	).SetupWithManager(mgr, maxConcurrentReconciles); err != nil {
 		return fmt.Errorf("baremetalinstance controller: %w", err)
 	}
@@ -572,6 +578,8 @@ func createBCMInventoryClient(
 		}
 		bmhMgr = baremetalhost.NewManager(mgr.GetClient(), secretClient, ns)
 		setupLog.Info("BMH manager configured", "namespace", ns)
+	} else {
+		return nil, fmt.Errorf("BCM inventory requires Metal3 management backend (got %q)", managementCfg.Type)
 	}
 
 	client := inventory.NewBCMClient(bcmClient, bmhMgr, inventoryCfg.HostClass)

--- a/bare-metal-fulfillment-operator/internal/baremetalhost/manager.go
+++ b/bare-metal-fulfillment-operator/internal/baremetalhost/manager.go
@@ -290,6 +290,15 @@ func (m *Manager) IsBMHReady(ctx context.Context, name string) (bool, error) {
 
 	bmh := &metal3api.BareMetalHost{}
 	if err := m.client.Get(ctx, client.ObjectKey{Namespace: m.namespace, Name: name}, bmh); err != nil {
+		// IsBMHReady runs right after CreateBMH, so a NotFound here is almost
+		// always the informer cache not having observed the just-created BMH yet.
+		// Treat it as "not ready" so the caller requeues rather than erroring.
+		// It's safe even if the BMH were genuinely absent: ensureBMHExists
+		// re-creates it on the next reconcile before this check runs again.
+		if apierrors.IsNotFound(err) {
+			log.V(1).Info("BareMetalHost not observed yet, treating as not ready", "name", name)
+			return false, nil
+		}
 		return false, fmt.Errorf("failed to get BareMetalHost %s/%s: %w", m.namespace, name, err)
 	}
 

--- a/bare-metal-fulfillment-operator/internal/baremetalhost/manager_test.go
+++ b/bare-metal-fulfillment-operator/internal/baremetalhost/manager_test.go
@@ -287,11 +287,14 @@ var _ = Describe("BareMetalHost Manager", func() {
 			Expect(err.Error()).To(ContainSubstring("error status"))
 		})
 
-		It("should return error when BMH not found", func() {
+		It("should return not ready (no error) when the BMH is not found", func() {
+			// A NotFound is treated as not-ready so the readiness poll requeues
+			// instead of erroring on a just-created BMH the cache hasn't seen yet.
 			mgr := newTestManager()
 
-			_, err := mgr.IsBMHReady(ctx, "nonexistent")
-			Expect(err).To(HaveOccurred())
+			ready, err := mgr.IsBMHReady(ctx, "nonexistent")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ready).To(BeFalse())
 		})
 	})
 

--- a/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_controller.go
+++ b/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_controller.go
@@ -61,6 +61,7 @@ type BareMetalInstanceReconciler struct {
 	TryLockFailPollIntervalDuration   time.Duration
 	ManagementRecheckIntervalDuration time.Duration
 	ProvisionPollIntervalDuration     time.Duration
+	HostReadinessPollIntervalDuration time.Duration
 }
 
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=subnets,verbs=get;list;watch
@@ -81,6 +82,7 @@ func NewBareMetalInstanceReconciler(
 	tryLockFailPollIntervalDuration time.Duration,
 	managementRecheckIntervalDuration time.Duration,
 	provisionPollIntervalDuration time.Duration,
+	hostReadinessPollIntervalDuration time.Duration,
 ) *BareMetalInstanceReconciler {
 	if noFreeHostsPollIntervalDuration <= 0 {
 		noFreeHostsPollIntervalDuration = DefaultNoFreeHostsPollIntervalDuration
@@ -98,6 +100,10 @@ func NewBareMetalInstanceReconciler(
 		provisionPollIntervalDuration = DefaultProvisionPollIntervalDuration
 	}
 
+	if hostReadinessPollIntervalDuration <= 0 {
+		hostReadinessPollIntervalDuration = DefaultHostReadinessPollIntervalDuration
+	}
+
 	return &BareMetalInstanceReconciler{
 		Client:                            client,
 		Scheme:                            scheme,
@@ -111,6 +117,7 @@ func NewBareMetalInstanceReconciler(
 		AAPClient:                         aapClient,
 		ManagementRecheckIntervalDuration: managementRecheckIntervalDuration,
 		ProvisionPollIntervalDuration:     provisionPollIntervalDuration,
+		HostReadinessPollIntervalDuration: hostReadinessPollIntervalDuration,
 	}
 }
 
@@ -332,6 +339,16 @@ func (r *BareMetalInstanceReconciler) reconcileInventory(ctx context.Context, ba
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
+	}
+
+	// The host is reserved but the inventory backend may report it as not yet
+	// ready for provisioning (e.g. underlying hardware still completing
+	// registration/inspection). Keep the instance in Allocating (don't set
+	// HostClass/Allocated yet) and requeue until the host reports Ready.
+	if !inventoryHost.Ready {
+		log.V(1).Info("Host reserved but not ready yet, requeuing",
+			"InventoryHostID", bareMetalInstance.Spec.ExternalHostID)
+		return ctrl.Result{RequeueAfter: r.HostReadinessPollIntervalDuration}, nil
 	}
 
 	bareMetalInstance.Spec.HostClass = inventoryHost.HostClass

--- a/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_controller_test.go
+++ b/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_controller_test.go
@@ -219,6 +219,7 @@ var _ = Describe("BareMetalInstance Controller", func() {
 			0,
 			0,
 			0,
+			0,
 		)
 	})
 
@@ -238,6 +239,7 @@ var _ = Describe("BareMetalInstance Controller", func() {
 					0,
 					-5*time.Second,
 					0,
+					-1*time.Second,
 				)
 			})
 
@@ -246,6 +248,7 @@ var _ = Describe("BareMetalInstance Controller", func() {
 				Expect(reconciler.TryLockFailPollIntervalDuration).To(Equal(DefaultTryLockFailPollIntervalDuration))
 				Expect(reconciler.ManagementRecheckIntervalDuration).To(Equal(DefaultManagementRecheckIntervalDuration))
 				Expect(reconciler.ProvisionPollIntervalDuration).To(Equal(DefaultProvisionPollIntervalDuration))
+				Expect(reconciler.HostReadinessPollIntervalDuration).To(Equal(DefaultHostReadinessPollIntervalDuration))
 			})
 		})
 
@@ -264,12 +267,14 @@ var _ = Describe("BareMetalInstance Controller", func() {
 					2*time.Second,
 					15*time.Second,
 					60*time.Second,
+					90*time.Second,
 				)
 
 				Expect(customReconciler.NoFreeHostsPollIntervalDuration).To(Equal(45 * time.Second))
 				Expect(customReconciler.TryLockFailPollIntervalDuration).To(Equal(2 * time.Second))
 				Expect(customReconciler.ManagementRecheckIntervalDuration).To(Equal(15 * time.Second))
 				Expect(customReconciler.ProvisionPollIntervalDuration).To(Equal(60 * time.Second))
+				Expect(customReconciler.HostReadinessPollIntervalDuration).To(Equal(90 * time.Second))
 			})
 		})
 	})
@@ -410,6 +415,7 @@ var _ = Describe("BareMetalInstance Controller", func() {
 					return &inventory.Host{
 						InventoryHostID: inventoryHostID,
 						HostClass:       hostClass,
+						Ready:           true,
 					}, nil
 				}
 			})
@@ -426,6 +432,27 @@ var _ = Describe("BareMetalInstance Controller", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(Equal(ctrl.Result{}))
 				Expect(bareMetalInstance.Status.Phase).To(Equal(v1alpha1.BareMetalInstancePhaseProgressing))
+			})
+
+			It("should requeue without setting HostClass when the host is not ready", func() {
+				mockInvClient.assignHostFunc = func(ctx context.Context, inventoryHostID string, bareMetalInstanceID string, labels map[string]string) (*inventory.Host, error) {
+					return &inventory.Host{
+						InventoryHostID: inventoryHostID,
+						HostClass:       hostClass,
+						Ready:           false,
+					}, nil
+				}
+				// When the host is not ready the controller must requeue *before*
+				// writing HostClass — so Update must never be called on this path.
+				mockK8sClient.updateFunc = func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+					Fail("Update must not be called while the host is not ready")
+					return nil
+				}
+
+				result, err := reconciler.reconcileInventory(ctx, bareMetalInstance)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.RequeueAfter).To(Equal(reconciler.HostReadinessPollIntervalDuration))
 			})
 		})
 
@@ -1530,7 +1557,7 @@ var _ = Describe("BareMetalInstance Controller", func() {
 				invClient,
 				&mockManagementClient{},
 				nil, nil, nil, nil,
-				0, 0, 0, 0,
+				0, 0, 0, 0, 0,
 			)
 			bmi = &v1alpha1.BareMetalInstance{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1685,6 +1712,7 @@ var _ = Describe("BareMetalInstance network handoff reboot (OSAC-1448)", func() 
 			0,
 			5*time.Second,
 			5*time.Second,
+			0,
 		)
 
 		bareMetalInstance = &v1alpha1.BareMetalInstance{
@@ -1960,6 +1988,7 @@ var _ = Describe("BareMetalInstance network offboard shutdown (OSAC-1448)", func
 			0,
 			5*time.Second,
 			5*time.Second,
+			0,
 		)
 
 		bareMetalInstance = &v1alpha1.BareMetalInstance{
@@ -2142,7 +2171,7 @@ var _ = Describe("BareMetalInstance networking feature gate (OSAC_ENABLE_NETWORK
 				k8sClient, k8sClient.Scheme(),
 				nil, mockMgmtClient,
 				nil, nil, nil, nil,
-				0, 0, 5*time.Second, 5*time.Second,
+				0, 0, 5*time.Second, 5*time.Second, 0,
 			)
 		})
 
@@ -2175,7 +2204,7 @@ var _ = Describe("BareMetalInstance networking feature gate (OSAC_ENABLE_NETWORK
 				k8sClient, k8sClient.Scheme(),
 				nil, mockMgmtClient,
 				nil, &mockProvisioningProvider{}, nil, nil,
-				0, 0, 5*time.Second, 5*time.Second,
+				0, 0, 5*time.Second, 5*time.Second, 0,
 			)
 		})
 

--- a/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_metal3_integration_test.go
+++ b/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_metal3_integration_test.go
@@ -85,7 +85,7 @@ func newMetal3Reconciler() *BareMetalInstanceReconciler {
 		nil, // networking provider
 		nil, // IP discovery provider
 		nil, // AAP client
-		0, 0, 0, 0,
+		0, 0, 0, 0, 0,
 	)
 }
 
@@ -314,7 +314,7 @@ var _ = Describe("BareMetalInstance Metal3 Integration", func() {
 				inventory.NewMetal3ClientForTest(k8sClient, metal3TestNS, metal3HostClass),
 				management.NewMetal3ClientForTest(k8sClient, metal3TestNS),
 				nil, nil, nil, nil,
-				0, 0, 0, 0,
+				0, 0, 0, 0, 0,
 			)
 
 			// Allocation (finalizer, find, assign) — no conflict yet.

--- a/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_names.go
+++ b/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_names.go
@@ -43,6 +43,10 @@ const (
 	// DefaultProvisionPollIntervalDuration is the default interval to poll provisioning job status
 	DefaultProvisionPollIntervalDuration = provisioning.DefaultStatusPollInterval
 
+	// DefaultHostReadinessPollIntervalDuration is the default interval to poll a reserved
+	// inventory host's readiness for provisioning (see inventory.Host.Ready).
+	DefaultHostReadinessPollIntervalDuration = 30 * time.Second
+
 	autoCreatedLabel         = shared.OsacPrefix + "/auto-created"
 	autoCreatedForLabel      = shared.OsacPrefix + "/auto-created-for"
 	bareMetalInstanceIDLabel = shared.OsacPrefix + "/baremetalinstance-uuid"

--- a/bare-metal-fulfillment-operator/internal/inventory/bcm.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/bcm.go
@@ -271,10 +271,18 @@ func (c *BCMClient) AssignHost(ctx context.Context, inventoryHostID string, bare
 	if err != nil || device == nil {
 		return nil, err
 	}
+	// Ensure the BareMetalHost exists (idempotent), then report readiness. The
+	// controller keeps the instance in Allocating and requeues until Ready.
 	if err := c.ensureBMHExists(ctx, device, bareMetalInstanceID); err != nil {
 		return nil, err
 	}
-	return c.buildHost(device), nil
+	ready, err := c.bmhManager.IsBMHReady(ctx, device.Hostname)
+	if err != nil {
+		return nil, err
+	}
+	host := c.buildHost(device)
+	host.Ready = ready
+	return host, nil
 }
 
 // reserveDevice fetches the BCM device and reserves it (writes osac_instance_id)

--- a/bare-metal-fulfillment-operator/internal/inventory/bcm_test.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/bcm_test.go
@@ -278,6 +278,7 @@ var _ = Describe("BCM Inventory Adapter", func() {
 				mockAPI.EXPECT().GetDevice(gomock.Any(), "node001").Return(verifiedDevice, nil),
 			)
 			bmhMgr.EXPECT().EnsureBMCSecret(gomock.Any(), "node001-bmc-secret", "root", "calvin").Return(nil)
+			bmhMgr.EXPECT().IsBMHReady(gomock.Any(), "node001").Return(true, nil)
 			bmhMgr.EXPECT().CreateBMH(gomock.Any(), gomock.Any()).DoAndReturn(
 				func(_ context.Context, params baremetalhost.CreateParams) error {
 					Expect(params.Name).To(Equal("node001"))
@@ -307,6 +308,7 @@ var _ = Describe("BCM Inventory Adapter", func() {
 			mockAPI.EXPECT().GetDevice(gomock.Any(), "node001").Return(device, nil)
 			bmhMgr.EXPECT().EnsureBMCSecret(gomock.Any(), "node001-bmc-secret", "root", "calvin").Return(nil)
 			bmhMgr.EXPECT().CreateBMH(gomock.Any(), gomock.Any()).Return(nil)
+			bmhMgr.EXPECT().IsBMHReady(gomock.Any(), "node001").Return(true, nil)
 
 			client := NewBCMClient(mockAPI, bmhMgr, "bcm")
 			host, err := client.AssignHost(ctx, bmhNamespace+"/node001", "bmi-123", nil)
@@ -397,6 +399,7 @@ var _ = Describe("BCM Inventory Adapter", func() {
 			)
 			bmhMgr.EXPECT().EnsureBMCSecret(gomock.Any(), "node001-bmc-secret", "root", "calvin").Return(nil)
 			bmhMgr.EXPECT().CreateBMH(gomock.Any(), gomock.Any()).Return(nil)
+			bmhMgr.EXPECT().IsBMHReady(gomock.Any(), "node001").Return(true, nil)
 
 			client := NewBCMClient(mockAPI, bmhMgr, "bcm")
 			host, err := client.AssignHost(ctx, bmhNamespace+"/node001", "bmi-123", nil)
@@ -570,6 +573,7 @@ var _ = Describe("BCM Inventory Adapter", func() {
 				Return("/redfish/v1/Systems/1", nil)
 			mockAPI.EXPECT().UpdateDevice(gomock.Any(), gomock.Any()).Return(&bcmclient.UpdateResponse{Success: true}, nil)
 			bmhMgr.EXPECT().EnsureBMCSecret(gomock.Any(), "node001-bmc-secret", "root", "calvin").Return(nil)
+			bmhMgr.EXPECT().IsBMHReady(gomock.Any(), "node001").Return(true, nil)
 			bmhMgr.EXPECT().CreateBMH(gomock.Any(), gomock.Any()).DoAndReturn(
 				func(_ context.Context, params baremetalhost.CreateParams) error {
 					Expect(params.BMCAddress).To(Equal("redfish-virtualmedia+https://10.141.0.1/redfish/v1/Systems/1"))
@@ -594,6 +598,7 @@ var _ = Describe("BCM Inventory Adapter", func() {
 			)
 			mockAPI.EXPECT().UpdateDevice(gomock.Any(), gomock.Any()).Return(&bcmclient.UpdateResponse{Success: true}, nil)
 			bmhMgr.EXPECT().EnsureBMCSecret(gomock.Any(), "node001-bmc-secret", "root", "calvin").Return(nil)
+			bmhMgr.EXPECT().IsBMHReady(gomock.Any(), "node001").Return(true, nil)
 			bmhMgr.EXPECT().CreateBMH(gomock.Any(), gomock.Any()).DoAndReturn(
 				func(_ context.Context, params baremetalhost.CreateParams) error {
 					Expect(params.BMCAddress).To(Equal("ipmi://10.141.0.1"))
@@ -627,6 +632,7 @@ var _ = Describe("BCM Inventory Adapter", func() {
 				})
 			bmhMgr.EXPECT().EnsureBMCSecret(gomock.Any(), "node001-bmc-secret", "root", "calvin").Return(nil)
 			bmhMgr.EXPECT().CreateBMH(gomock.Any(), gomock.Any()).Return(nil)
+			bmhMgr.EXPECT().IsBMHReady(gomock.Any(), "node001").Return(true, nil)
 
 			client := NewBCMClient(mockAPI, bmhMgr, "bcm")
 			client.SetBMCDiscoverer(mockDisc)
@@ -671,6 +677,7 @@ var _ = Describe("BCM Inventory Adapter", func() {
 			device := makeDevice(`{"hostname":"node001","mac":"aa:bb:cc:dd:ee:01","bmcSettings":{"userName":"root","password":"calvin","userID":2},"extra_values":{"resource_class":"h100","osac_instance_id":"bmi-123","osac_bmc_address":"ipmi://10.0.0.1"}}`)
 			mockAPI.EXPECT().GetDevice(gomock.Any(), "node001").Return(device, nil)
 			bmhMgr.EXPECT().EnsureBMCSecret(gomock.Any(), "node001-bmc-secret", "root", "calvin").Return(nil)
+			bmhMgr.EXPECT().IsBMHReady(gomock.Any(), "node001").Return(true, nil)
 			bmhMgr.EXPECT().CreateBMH(gomock.Any(), gomock.Any()).DoAndReturn(
 				func(_ context.Context, params baremetalhost.CreateParams) error {
 					Expect(params.CredentialsSecret).To(Equal("node001-bmc-secret"))
@@ -691,6 +698,7 @@ var _ = Describe("BCM Inventory Adapter", func() {
 			}, nil)
 			bmhMgr.EXPECT().EnsureBMCSecret(gomock.Any(), "node001-bmc-secret", "bright", "wSXp5sQq").Return(nil)
 			bmhMgr.EXPECT().CreateBMH(gomock.Any(), gomock.Any()).Return(nil)
+			bmhMgr.EXPECT().IsBMHReady(gomock.Any(), "node001").Return(true, nil)
 
 			client := NewBCMClient(mockAPI, bmhMgr, "bcm")
 			host, err := client.AssignHost(ctx, bmhNamespace+"/node001", "bmi-123", nil)
@@ -706,6 +714,7 @@ var _ = Describe("BCM Inventory Adapter", func() {
 			}, nil)
 			bmhMgr.EXPECT().EnsureBMCSecret(gomock.Any(), "node001-bmc-secret", "part-user", "part-pass").Return(nil)
 			bmhMgr.EXPECT().CreateBMH(gomock.Any(), gomock.Any()).Return(nil)
+			bmhMgr.EXPECT().IsBMHReady(gomock.Any(), "node001").Return(true, nil)
 
 			client := NewBCMClient(mockAPI, bmhMgr, "bcm")
 			host, err := client.AssignHost(ctx, bmhNamespace+"/node001", "bmi-123", nil)
@@ -727,6 +736,50 @@ var _ = Describe("BCM Inventory Adapter", func() {
 			host, err := client.AssignHost(ctx, bmhNamespace+"/node001", "bmi-123", nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("no BMC credentials configured in BCM"))
+			Expect(host).To(BeNil())
+		})
+
+		// OSAC-3769: BMH readiness gating. These use the skip-write path
+		// (osac_instance_id already set) with a Priority-1 address so the focus
+		// is the IsBMHReady result.
+		It("should return Host with Ready=false when the BareMetalHost is not ready", func(ctx context.Context) {
+			device := makeDevice(`{"hostname":"node001","mac":"aa:bb:cc:dd:ee:01","bmcSettings":{"userName":"root","password":"calvin"},"extra_values":{"resource_class":"h100","osac_instance_id":"bmi-123","osac_bmc_address":"ipmi://10.0.0.1"}}`)
+			mockAPI.EXPECT().GetDevice(gomock.Any(), "node001").Return(device, nil)
+			bmhMgr.EXPECT().EnsureBMCSecret(gomock.Any(), "node001-bmc-secret", "root", "calvin").Return(nil)
+			bmhMgr.EXPECT().CreateBMH(gomock.Any(), gomock.Any()).Return(nil)
+			bmhMgr.EXPECT().IsBMHReady(gomock.Any(), "node001").Return(false, nil)
+
+			client := NewBCMClient(mockAPI, bmhMgr, "bcm")
+			host, err := client.AssignHost(ctx, bmhNamespace+"/node001", "bmi-123", nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(host).NotTo(BeNil())
+			Expect(host.Ready).To(BeFalse())
+		})
+
+		It("should return Host with Ready=true when the BareMetalHost is ready", func(ctx context.Context) {
+			device := makeDevice(`{"hostname":"node001","mac":"aa:bb:cc:dd:ee:01","bmcSettings":{"userName":"root","password":"calvin"},"extra_values":{"resource_class":"h100","osac_instance_id":"bmi-123","osac_bmc_address":"ipmi://10.0.0.1"}}`)
+			mockAPI.EXPECT().GetDevice(gomock.Any(), "node001").Return(device, nil)
+			bmhMgr.EXPECT().EnsureBMCSecret(gomock.Any(), "node001-bmc-secret", "root", "calvin").Return(nil)
+			bmhMgr.EXPECT().CreateBMH(gomock.Any(), gomock.Any()).Return(nil)
+			bmhMgr.EXPECT().IsBMHReady(gomock.Any(), "node001").Return(true, nil)
+
+			client := NewBCMClient(mockAPI, bmhMgr, "bcm")
+			host, err := client.AssignHost(ctx, bmhNamespace+"/node001", "bmi-123", nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(host).NotTo(BeNil())
+			Expect(host.Ready).To(BeTrue())
+		})
+
+		It("should surface an error when the BareMetalHost is in an error state", func(ctx context.Context) {
+			device := makeDevice(`{"hostname":"node001","mac":"aa:bb:cc:dd:ee:01","bmcSettings":{"userName":"root","password":"calvin"},"extra_values":{"resource_class":"h100","osac_instance_id":"bmi-123","osac_bmc_address":"ipmi://10.0.0.1"}}`)
+			mockAPI.EXPECT().GetDevice(gomock.Any(), "node001").Return(device, nil)
+			bmhMgr.EXPECT().EnsureBMCSecret(gomock.Any(), "node001-bmc-secret", "root", "calvin").Return(nil)
+			bmhMgr.EXPECT().CreateBMH(gomock.Any(), gomock.Any()).Return(nil)
+			bmhMgr.EXPECT().IsBMHReady(gomock.Any(), "node001").Return(false, fmt.Errorf("BareMetalHost in error state"))
+
+			client := NewBCMClient(mockAPI, bmhMgr, "bcm")
+			host, err := client.AssignHost(ctx, bmhNamespace+"/node001", "bmi-123", nil)
+			Expect(err).To(HaveOccurred())
 			Expect(host).To(BeNil())
 		})
 	})

--- a/bare-metal-fulfillment-operator/internal/inventory/client.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/client.go
@@ -39,6 +39,11 @@ type Host struct {
 	HostClass           string
 	ProvisionState      string
 	ManagedBy           string
+	// Ready reports whether the underlying host is ready for provisioning.
+	// Backends managing pre-existing resources (Metal3, OpenStack) always set
+	// true; the BCM backend sets false until the on-demand BareMetalHost has
+	// completed Metal3 registration/inspection.
+	Ready bool
 }
 
 // HostNIC represents a physical network interface on an inventory host.

--- a/bare-metal-fulfillment-operator/internal/inventory/metal3.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/metal3.go
@@ -342,5 +342,6 @@ func bmhToHost(bmh *metal3api.BareMetalHost, hostClass string) *Host {
 		HostClass:           hostClass,
 		ProvisionState:      string(bmh.Status.Provisioning.State),
 		ManagedBy:           managedBy,
+		Ready:               true, // Metal3 BMHs are pre-existing, immediately usable
 	}
 }

--- a/bare-metal-fulfillment-operator/internal/inventory/openstack.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/openstack.go
@@ -348,6 +348,7 @@ func (c *OpenStackClient) assignHost(ctx context.Context, inventoryHostID string
 		HostClass:           c.HostClass,
 		ProvisionState:      node.ProvisionState,
 		ManagedBy:           managedBy,
+		Ready:               true, // Ironic nodes are immediately usable after label assignment
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

Prevents a BareMetalInstance from being marked **Allocated** before its on-demand BareMetalHost has completed Metal3 registration/inspection. The instance stays in **Allocating** and the controller requeues until the host reports ready.

Implements [OSAC-3769](https://redhat.atlassian.net/browse/OSAC-3769) (part of [OSAC-1339](https://redhat.atlassian.net/browse/OSAC-1339) BCM backend).

> **Note:** this is a **fresh reimplementation on `main`**, replacing #496. #496 was branched from #477's admin-secret design, which was superseded by the operator-managed redesign in #521. Rebasing would have conflicted against renamed/deleted code, so the readiness logic was re-applied cleanly onto the current `ensureBMHExists`/`buildHost` structure. **#496 should be closed.**

## Changes

- **inventory contract**: add `Host.Ready`. Metal3 and OpenStack backends (which manage pre-existing resources) return `Ready=true`.
- **BCM `AssignHost`**: after ensuring the BMH (idempotent), report `IsBMHReady`; `buildHost` carries `Ready`. An error from `IsBMHReady` (BMH in error state) is surfaced.
- **controller `reconcileInventory`**: when `!Ready`, don't set `HostClass`/`Allocated` — requeue after `BMHReadinessPollIntervalDuration`.
- **config**: `OSAC_BMH_READINESS_POLL_INTERVAL` env var (default 30s).
- **tests**: BCM `Ready` true/false + BMH-error paths; controller not-ready requeue; constructor default/override.

## Deferred (tracked in the [OSAC-1339](https://redhat.atlassian.net/browse/OSAC-1339) roadmap)

- Readiness **metric** `osac_bmh_readiness_wait_seconds` (D3).
- **`BCMHostAssigned` event** — part of the shared event-recorder task (D1).
- **BMH-exists poll short-circuit** optimization (D4): the readiness poll currently re-runs credential/address resolution + `EnsureBMCSecret` + idempotent `CreateBMH` each cycle; a `BMHExists` pre-check could skip that.

## Test plan

- [x] `make build` / `make test` (all packages)
- [x] `make lint` (0 issues)
- [x] `make check-helm-crds` (no drift)

_Developed with AI assistance (Claude Code). Review for accuracy._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added readiness tracking for provisioned bare-metal hosts.
  - Instances remain in the Allocating phase until the assigned host is ready.
  - Added configurable readiness polling, defaulting to 30 seconds.
- **Bug Fixes**
  - Readiness-check errors are now surfaced instead of being silently overlooked.
  - Missing hosts are treated as not ready while provisioning continues.
  - Existing Metal3 and OpenStack hosts continue to be treated as immediately ready.
  - Unsupported management backends are now rejected with a clear error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->