### PR TITLE
OSAC-1927: rename hub secret prefix to lvms-tenant-config

### DIFF
--- a/osac-installer/scripts/refresh-after-snapshot.py
+++ b/osac-installer/scripts/refresh-after-snapshot.py
@@ -604,7 +604,7 @@ def find_csv(*, namespace: str, deploy_name: str) -> str:
 
 
 def adopt_resources_for_helm(config: RefreshConfig) -> None:
-    """Adopt vast-tenant-config-* secrets for Helm.
+    """Adopt lvms-tenant-config-* secrets for Helm.
 
     The osac-operator chart creates these as empty shells (tenants.yaml
     template), then AAP's storage_provider role deletes and recreates them
@@ -614,7 +614,7 @@ def adopt_resources_for_helm(config: RefreshConfig) -> None:
     """
     result = oc("get", "secret", "-n", config.namespace, "-o", "name", capture=True)
     resources = [r for r in result.stdout.strip().splitlines()
-                 if r.startswith("secret/vast-tenant-config-")]
+                 if r.startswith("secret/lvms-tenant-config-")]
     if not resources:
         return
     print(f"  Adopting {len(resources)} tenant secret(s) for Helm...")

--- a/osac-operator/charts/operator/templates/tenants.yaml
+++ b/osac-operator/charts/operator/templates/tenants.yaml
@@ -4,11 +4,13 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vast-tenant-config-{{ .name }}
+  name: lvms-tenant-config-{{ .name }}
   namespace: {{ $.Release.Namespace }}
   labels:
     osac.openshift.io/tenant: {{ .name | quote }}
+    osac.openshift.io/storage-provider: lvms
 type: Opaque
-data: {}
+stringData:
+  provider: lvms
 {{- end }}
 {{- end }}

--- a/osac-operator/cmd/main.go
+++ b/osac-operator/cmd/main.go
@@ -85,7 +85,7 @@ const (
 	envBareMetalInstanceNamespace = "OSAC_BARE_METAL_INSTANCE_NAMESPACE"
 	envVolumeNamespace            = "OSAC_VOLUME_NAMESPACE"
 	// envStorageConfigNamespace is the namespace holding the per-tenant
-	// "vast-tenant-config-<tenant>" Secrets the Volume controller reads.
+	// "lvms-tenant-config-<tenant>" Secrets the storage controller reads.
 	envStorageConfigNamespace = "OSAC_STORAGE_CONFIG_NAMESPACE"
 	// envVendorControllers maps StorageBackend names to vendor CSI controller
 	// gRPC endpoints, comma-separated (e.g.

--- a/osac-operator/internal/controller/storage_controller.go
+++ b/osac-operator/internal/controller/storage_controller.go
@@ -228,7 +228,7 @@ func (r *StorageReconciler) patchClusterOrderStorageStatus(ctx context.Context, 
 //   - stop: when true, the caller should return (result, err) immediately
 //   - error: any unexpected failure
 func (r *StorageReconciler) handleBackendReadiness(ctx context.Context, instance *v1alpha1.Tenant, tenantName string) (hubSecretReady bool, result ctrl.Result, stop bool, err error) {
-	hubSecretReady, err = r.hubSecretExists(ctx, tenantName)
+	hubSecretReady, err = r.hubSecretExists(ctx, tenantName, "")
 	if err != nil {
 		return false, ctrl.Result{}, true, err
 	}
@@ -870,7 +870,7 @@ func (r *StorageReconciler) handleBackendDeprovisioning(ctx context.Context, ins
 		return ctrl.Result{}, nil
 	}
 
-	hubSecretReady, err := r.hubSecretExists(ctx, instance.GetName())
+	hubSecretReady, err := r.hubSecretExists(ctx, instance.GetName(), "")
 	if err != nil {
 		log.Error(err, "failed to check hub Secret existence, requeueing")
 		return ctrl.Result{RequeueAfter: r.StatusPollInterval}, nil
@@ -897,11 +897,15 @@ func (r *StorageReconciler) handleBackendDeprovisioning(ctx context.Context, ins
 
 // --- Helpers ---
 
-func (r *StorageReconciler) hubSecretExists(ctx context.Context, tenantName string) (bool, error) {
+func (r *StorageReconciler) hubSecretExists(ctx context.Context, tenantName string, provider string) (bool, error) {
+	labels := map[string]string{osacTenantKey: tenantName}
+	if provider != "" {
+		labels[osacStorageProviderLabel] = provider
+	}
 	var secretList corev1.SecretList
 	if err := r.List(ctx, &secretList,
 		client.InNamespace(storageConfigNamespace()),
-		client.MatchingLabels{osacTenantKey: tenantName},
+		client.MatchingLabels(labels),
 	); err != nil {
 		return false, err
 	}

--- a/osac-operator/internal/controller/storage_controller_test.go
+++ b/osac-operator/internal/controller/storage_controller_test.go
@@ -107,14 +107,15 @@ func createReadyTenantForStorage(ctx context.Context, name, namespace string) {
 func createHubSecret(ctx context.Context, tenantName, namespace string) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("vast-tenant-config-%s", tenantName),
+			Name:      fmt.Sprintf("lvms-tenant-config-%s", tenantName),
 			Namespace: namespace,
 			Labels: map[string]string{
-				osacTenantKey: tenantName,
+				osacTenantKey:            tenantName,
+				osacStorageProviderLabel: "lvms",
 			},
 		},
-		Data: map[string][]byte{
-			"vast_tenant_id": []byte("123"),
+		StringData: map[string]string{
+			"provider": "lvms",
 		},
 	}
 	Expect(k8sClient.Create(ctx, secret)).To(Succeed())
@@ -1566,7 +1567,7 @@ var _ = Describe("Storage Controller", func() {
 
 			secret := &corev1.Secret{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf("vast-tenant-config-%s", name),
+				Name:      fmt.Sprintf("lvms-tenant-config-%s", name),
 				Namespace: secretsNamespace,
 			}, secret)).To(Succeed())
 			Expect(k8sClient.Delete(ctx, secret)).To(Succeed())
@@ -1588,6 +1589,51 @@ var _ = Describe("Storage Controller", func() {
 				g.Expect(cond).NotTo(BeNil())
 				g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
 			}, 5*time.Second, 100*time.Millisecond).Should(Succeed())
+		})
+	})
+
+	Context("hubSecretExists provider filtering", func() {
+		It("should filter by storage-provider label when provider is non-empty", func() {
+			name := "storage-test-provider-filter"
+			// Create a secret with the lvms storage-provider label
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("lvms-tenant-config-%s", name),
+					Namespace: secretsNamespace,
+					Labels: map[string]string{
+						osacTenantKey:            name,
+						osacStorageProviderLabel: "lvms",
+					},
+				},
+				StringData: map[string]string{
+					"provider": "lvms",
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, secret))).To(Succeed())
+			})
+
+			r := NewStorageReconciler(
+				testMcManager, testNamespace, mcmanager.LocalCluster,
+				nil, nil, pollInterval,
+				provisioning.DefaultMaxJobHistory,
+			)
+
+			// provider="lvms" → should find the secret
+			found, err := r.hubSecretExists(ctx, name, "lvms")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue(), "expected hub secret to be found when filtering by provider=lvms")
+
+			// provider="vast" → should NOT find the secret (wrong provider)
+			found, err = r.hubSecretExists(ctx, name, "vast")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeFalse(), "expected hub secret NOT to be found when filtering by provider=vast")
+
+			// provider="" → should find the secret (backward compat, no provider filter)
+			found, err = r.hubSecretExists(ctx, name, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue(), "expected hub secret to be found when provider is empty (backward compat)")
 		})
 	})
 

--- a/osac-operator/internal/controller/tenant_names.go
+++ b/osac-operator/internal/controller/tenant_names.go
@@ -56,6 +56,9 @@ var (
 
 	// osacStorageTierLabel is the label key that identifies the storage tier of a StorageClass
 	osacStorageTierLabel string = fmt.Sprintf("%s/storage-tier", osacPrefix)
+
+	// osacStorageProviderLabel is the label key that identifies the storage provider of a hub Secret
+	osacStorageProviderLabel string = fmt.Sprintf("%s/storage-provider", osacPrefix)
 )
 
 func tenantNamespacePredicate(namespace string) predicate.Predicate {


### PR DESCRIPTION
## Summary

[OSAC-1927](https://redhat.atlassian.net/browse/OSAC-1927): renames the per-tenant hub Secret prefix in `osac-operator`'s `tenants.yaml` Helm template from `vast-tenant-config-` to `lvms-tenant-config-`, matching the prefix the Ansible `lvms_storage` role actually uses when it creates these Secrets. Also adds an optional `provider` filter to `hubSecretExists()` for future multi-backend lookups.

This supersedes #505 (opened via chai-bot), which had the same core fix but bundled in a since-redundant proto-regeneration commit and had drifted into merge conflict with `main`.

## Why

The hub Secret prefix mismatch (`vast-tenant-config-` in the Helm template vs. `lvms-tenant-config-` actually written by the `lvms_storage` AAP role) meant the storage controller could never find the hub Secret for a tenant, leaving `Tenant.status.storageClasses` empty on SNO installs and causing VM provisioning to fail. This is "Fix 1" from the [OSAC-1927](https://redhat.atlassian.net/browse/OSAC-1927) investigation.

`hubSecretExists()` also gains an optional `provider` parameter (both call sites currently pass `""`, so no behavior change today) so a future second storage backend can filter hub Secret lookups by provider without another rename.

#505 additionally carried a proto-regeneration commit to pick up [OSAC-4195](https://redhat.atlassian.net/browse/OSAC-4195) (cleanapi annotations). That's dropped here since [OSAC-4195](https://redhat.atlassian.net/browse/OSAC-4195) already landed on `main` directly via #417 — carrying it forward would have just reintroduced merge conflicts for no benefit.

## Testing

- `go build ./...` passes
- `go vet ./...` passes
- `gofmt -l` clean on changed files
- `helm lint osac-operator/charts/operator` passes
- Ginkgo `internal/controller` suite (`--focus "Storage"` and full `-r` run) passes locally, including:
  - `hubSecretExists(provider="lvms")` matches an LVMS-labeled secret
  - `hubSecretExists(provider="vast")` does not match
  - `hubSecretExists(provider="")` matches any (backward compatible)
- `test/integration` suite requires a live Kind cluster and wasn't run locally (unrelated to this change; covered by CI)

## Related PRs

Supersedes osac-project/osac#505

## Ticket

[OSAC-1927](https://redhat.atlassian.net/browse/OSAC-1927)

<br>

<small>Signed-off-by: akshaynadkarni <25892229+akshaynadkarni@users.noreply.github.com></small>
<small>Assisted-by: Cursor/Claude</small>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tenant storage configuration now uses LVMS-specific secrets and labels.
  * Storage readiness and teardown support provider-specific secret filtering while retaining compatibility with unfiltered lookups.

* **Bug Fixes**
  * Updated resource adoption and tenant secret handling to consistently recognize LVMS configuration.

* **Tests**
  * Added coverage for provider-specific and backward-compatible secret lookups.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->