### PR TITLE
OSAC-4565: deprovision default networking when a tenant's root project is deleted

### DIFF
--- a/fulfillment-service/internal/cmd/service/start/grpcserver/register_servers.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/register_servers.go
@@ -977,6 +977,7 @@ func RegisterResourceServers(ctx context.Context, registrar grpc.ServiceRegistra
 		SetAttributionLogic(deps.PrivateAttributionLogic).
 		SetTenancyLogic(deps.TenancyLogic).
 		SetMetricsRegisterer(deps.MetricsRegisterer).
+		SetDefaultNetworkingProvisioner(defaultNetworkingProvisioner).
 		Build()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create private projects server: %w", err)

--- a/fulfillment-service/internal/database/dao/generic_dao_delete.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_delete.go
@@ -199,7 +199,6 @@ func (r *DeleteRequest[O]) do(ctx context.Context) (response *DeleteResponse, er
 		data:            data,
 	})
 	if err != nil {
-		err = r.translateError(ctx, tenant, err)
 		return
 	}
 	err = r.fireEvent(ctx, Event{

--- a/fulfillment-service/internal/database/dao/generic_dao_request.go
+++ b/fulfillment-service/internal/database/dao/generic_dao_request.go
@@ -24,6 +24,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/prometheus/client_golang/prometheus"
@@ -121,11 +122,61 @@ func (r *request[O]) archive(ctx context.Context, args archiveArgs) error {
 		args.data,
 	)
 	if err != nil {
-		return err
+		return r.translateArchiveError(ctx, args.tenant, err)
 	}
 	sql = fmt.Sprintf(`delete from %s where id = $1`, r.dao.table)
 	_, err = r.exec(ctx, deleteOpType, sql, args.id)
-	return err
+	if err != nil {
+		return r.translateArchiveError(ctx, args.tenant, err)
+	}
+	return nil
+}
+
+// translateArchiveError translates a raw PostgreSQL error from either statement of archive() into
+// a domain-specific error type. Any foreign key violation means the object is still referenced by
+// other objects and cannot yet be removed — that is always an "in use" condition, regardless of
+// which specific constraint was violated, so unrecognized constraint names still produce a
+// FailedPrecondition instead of an opaque Internal error. The constraint name itself is logged but
+// not included in the returned error, since it exposes internal schema detail to API callers.
+func (r *request[O]) translateArchiveError(ctx context.Context, tenant string, err error) error {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return err
+	}
+	switch pgErr.Code {
+	case errInUseCode:
+		return &ErrInUse{
+			Reason: pgErr.Message,
+		}
+	case pgerrcode.ForeignKeyViolation:
+		switch pgErr.ConstraintName {
+		case "projects_tenant_fk":
+			return &ErrInUse{
+				Reason: fmt.Sprintf("tenant '%s' cannot be deleted because it still has projects", tenant),
+			}
+		default:
+			r.dao.logger.WarnContext(
+				ctx,
+				"Object cannot be deleted because it is still referenced by other objects",
+				slog.String("table", pgErr.TableName),
+				slog.String("constraint", pgErr.ConstraintName),
+			)
+			return &ErrInUse{
+				Reason: "object cannot be deleted because it is still referenced by other objects",
+			}
+		}
+	case pgerrcode.DeadlockDetected:
+		return &ErrDeadlock{}
+	default:
+		r.dao.logger.WarnContext(
+			ctx,
+			"Unknown error while archiving object",
+			slog.String("table", pgErr.TableName),
+			slog.String("constraint", pgErr.ConstraintName),
+			slog.Any("error", err),
+		)
+		return err
+	}
 }
 
 // addTenancyFilter adds a clause to restrict results to only those objects that belong to tenants the current user

--- a/fulfillment-service/internal/servers/default_networking_provisioner.go
+++ b/fulfillment-service/internal/servers/default_networking_provisioner.go
@@ -546,3 +546,192 @@ func (p *DefaultNetworkingProvisioner) updateExternalIPAttachedFlag(ctx context.
 	}
 	return nil
 }
+
+// Deprovision removes the default networking resources previously created by Provision for the
+// given tenant. It is idempotent: if no default VirtualNetwork exists for the tenant, it returns
+// nil immediately.
+//
+// This bypasses the "default resources are system-managed" protection enforced by
+// validateNotDefault() in the private servers' Delete() handlers, because it operates on the DAOs
+// directly rather than going through those handlers — it is the system removing what it itself
+// created, not a user request going through the normal API path.
+func (p *DefaultNetworkingProvisioner) Deprovision(ctx context.Context, tenantName string) error {
+	vn, err := p.findDefaultVirtualNetwork(ctx, tenantName)
+	if err != nil {
+		return fmt.Errorf("failed to find default VirtualNetwork: %w", err)
+	}
+	if vn == nil {
+		p.logger.InfoContext(ctx, "No default networking resources to deprovision")
+		return nil
+	}
+	vnID := vn.GetId()
+
+	if err := p.deprovisionDefaultNATGateway(ctx, vnID); err != nil {
+		return fmt.Errorf("failed to deprovision default NATGateway: %w", err)
+	}
+
+	if err := deleteByVirtualNetwork(ctx, p.securityGroupDao, vnID); err != nil {
+		return fmt.Errorf("failed to delete default SecurityGroup: %w", err)
+	}
+
+	if err := deleteByVirtualNetwork(ctx, p.subnetDao, vnID); err != nil {
+		return fmt.Errorf("failed to delete default Subnets: %w", err)
+	}
+
+	if _, err := p.virtualNetworkDao.Delete().SetId(vnID).Do(ctx); err != nil {
+		return fmt.Errorf("failed to delete default VirtualNetwork: %w", err)
+	}
+
+	p.logger.InfoContext(ctx, "Default networking resources deprovisioned successfully")
+	return nil
+}
+
+// findDefaultVirtualNetwork returns the default VirtualNetwork for the given tenant, or nil if
+// none exists. Provision always names it "default", so matching on tenant + name is sufficient
+// and avoids depending on CEL map-literal syntax for label lookups.
+func (p *DefaultNetworkingProvisioner) findDefaultVirtualNetwork(
+	ctx context.Context, tenantName string,
+) (*privatev1.VirtualNetwork, error) {
+	filter := fmt.Sprintf(`this.metadata.tenant == %q && this.metadata.name == "default"`, tenantName)
+	listResponse, err := p.virtualNetworkDao.List().SetFilter(filter).Do(ctx)
+	if err != nil {
+		return nil, err
+	}
+	items := listResponse.GetItems()
+	if len(items) == 0 {
+		return nil, nil
+	}
+	return items[0], nil
+}
+
+// deprovisionDefaultNATGateway deletes every default-labeled NATGateway attached to the given
+// VirtualNetwork, along with each one's ExternalIP and the corresponding pool capacity release.
+// Only resources labeled osac.openshift.io/default are matched: a tenant is free to attach its
+// own NATGateways to its default VirtualNetwork, and those must not be swept up here — if any
+// remain, the subsequent VirtualNetwork delete correctly fails with a foreign key violation
+// instead of silently destroying tenant-owned resources. It pages through matches rather than
+// relying on a single List() call, since the list defaults to a 100-item page.
+//
+// Delete() only archives (fully removes) an object once its finalizers are empty; if the
+// NATGateway controller has already attached its finalizer, Delete() just sets
+// deletion_timestamp and the row keeps matching this filter. Real removal then depends on that
+// controller's own, asynchronous cleanup — which cannot complete within this single request's
+// transaction — so each matching id is attempted at most once per call, and if a pass makes no
+// further progress, this returns an in-use error instead of looping forever.
+func (p *DefaultNetworkingProvisioner) deprovisionDefaultNATGateway(ctx context.Context, vnID string) error {
+	filter := fmt.Sprintf(
+		`this.metadata.labels["%s"] == "true" && this.spec.virtual_network.id == %q`,
+		defaultLabel, vnID,
+	)
+	attempted := map[string]bool{}
+	for {
+		listResponse, err := p.natGatewayDao.List().SetFilter(filter).Do(ctx)
+		if err != nil {
+			return err
+		}
+		items := listResponse.GetItems()
+		if len(items) == 0 {
+			return nil
+		}
+		progress := false
+		for _, ng := range items {
+			id := ng.GetId()
+			if attempted[id] {
+				continue
+			}
+			attempted[id] = true
+			progress = true
+			// If the NATGateway already has a finalizer, Delete() below only soft-deletes it —
+			// its ExternalIP must be left alone until the NATGateway is actually archived, or the
+			// ExternalIP would be released while the NATGateway still references it.
+			archived := len(ng.GetMetadata().GetFinalizers()) == 0
+			externalIPID := ng.GetSpec().GetExternalIp().GetId()
+			if _, err := p.natGatewayDao.Delete().SetId(id).Do(ctx); err != nil {
+				return err
+			}
+			if !archived || externalIPID == "" {
+				continue
+			}
+			if err := p.deprovisionDefaultExternalIP(ctx, externalIPID); err != nil {
+				return err
+			}
+		}
+		if !progress {
+			return &dao.ErrInUse{
+				Reason: fmt.Sprintf(
+					"%d default NATGateway(s) still awaiting asynchronous controller cleanup, retry later",
+					len(items),
+				),
+			}
+		}
+	}
+}
+
+// deprovisionDefaultExternalIP deletes the given ExternalIP and releases its pool capacity.
+func (p *DefaultNetworkingProvisioner) deprovisionDefaultExternalIP(ctx context.Context, externalIPID string) error {
+	getResponse, err := p.externalIPDao.Get().SetId(externalIPID).Do(ctx)
+	if err != nil {
+		return err
+	}
+	poolID := getResponse.GetObject().GetSpec().GetPool().GetId()
+	if _, err := p.externalIPDao.Delete().SetId(externalIPID).Do(ctx); err != nil {
+		return err
+	}
+	if poolID == "" {
+		return nil
+	}
+	return p.updatePoolCapacity(ctx, poolID, int64(-1))
+}
+
+// deleteByVirtualNetwork deletes every default-labeled object of type O whose spec references the
+// given VirtualNetwork by id. Used to clean up the default Subnets and SecurityGroup attached to a
+// default VirtualNetwork before deleting the VirtualNetwork itself. Only resources labeled
+// osac.openshift.io/default are matched: a tenant is free to attach its own Subnets/SecurityGroups
+// to its default VirtualNetwork, and those must not be swept up here — if any remain, the
+// subsequent VirtualNetwork delete correctly fails with a foreign key violation instead of
+// silently destroying tenant-owned resources. It pages through matches rather than relying on a
+// single List() call, since the list defaults to a 100-item page.
+//
+// Delete() only archives (fully removes) an object once its finalizers are empty; if the owning
+// controller has already attached its finalizer, Delete() just sets deletion_timestamp and the row
+// keeps matching this filter. Real removal then depends on that controller's own, asynchronous
+// cleanup — which cannot complete within this single request's transaction — so each matching id
+// is attempted at most once per call, and if a pass makes no further progress, this returns an
+// in-use error instead of looping forever.
+func deleteByVirtualNetwork[O dao.Object](ctx context.Context, d *dao.GenericDAO[O], vnID string) error {
+	filter := fmt.Sprintf(
+		`this.metadata.labels["%s"] == "true" && this.spec.virtual_network.id == %q`,
+		defaultLabel, vnID,
+	)
+	attempted := map[string]bool{}
+	for {
+		listResponse, err := d.List().SetFilter(filter).Do(ctx)
+		if err != nil {
+			return err
+		}
+		items := listResponse.GetItems()
+		if len(items) == 0 {
+			return nil
+		}
+		progress := false
+		for _, item := range items {
+			id := item.GetId()
+			if attempted[id] {
+				continue
+			}
+			attempted[id] = true
+			progress = true
+			if _, err := d.Delete().SetId(id).Do(ctx); err != nil {
+				return err
+			}
+		}
+		if !progress {
+			return &dao.ErrInUse{
+				Reason: fmt.Sprintf(
+					"%d default networking object(s) still awaiting asynchronous controller cleanup, retry later",
+					len(items),
+				),
+			}
+		}
+	}
+}

--- a/fulfillment-service/internal/servers/default_networking_provisioner_test.go
+++ b/fulfillment-service/internal/servers/default_networking_provisioner_test.go
@@ -387,4 +387,318 @@ var _ = Describe("Default networking provisioner", func() {
 			Expect(vnList.GetItems()).To(BeEmpty())
 		})
 	})
+
+	Describe("Deprovision", func() {
+		Context("when no default VirtualNetwork exists", func() {
+			It("returns nil without touching any resources", func() {
+				err := provisioner.Deprovision(ctx, "test-tenant")
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when default networking resources exist without a NATGateway", func() {
+			BeforeEach(func() {
+				createNetworkClass(privatev1.NetworkDefaults_builder{
+					VirtualNetworkIpv4Cidr: "10.0.0.0/16",
+					SubnetIpv4Cidr:         "10.0.1.0/24",
+					SubnetIpv6Cidr:         "fd00:0:0:1::/64",
+				}.Build())
+				err := provisioner.Provision(ctx, "test-tenant")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("removes the VirtualNetwork, its Subnets and its SecurityGroup", func() {
+				err := provisioner.Deprovision(ctx, "test-tenant")
+				Expect(err).ToNot(HaveOccurred())
+
+				vnList, err := provisioner.virtualNetworkDao.List().
+					SetFilter("this.metadata.tenant == 'test-tenant'").
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vnList.GetItems()).To(BeEmpty())
+
+				subnetList, err := provisioner.subnetDao.List().
+					SetFilter("this.metadata.tenant == 'test-tenant'").
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(subnetList.GetItems()).To(BeEmpty())
+
+				sgList, err := provisioner.securityGroupDao.List().
+					SetFilter("this.metadata.tenant == 'test-tenant'").
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sgList.GetItems()).To(BeEmpty())
+			})
+
+			It("is idempotent when called a second time", func() {
+				err := provisioner.Deprovision(ctx, "test-tenant")
+				Expect(err).ToNot(HaveOccurred())
+
+				err = provisioner.Deprovision(ctx, "test-tenant")
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("when a default NATGateway exists", func() {
+			var pool *privatev1.ExternalIPPool
+
+			BeforeEach(func() {
+				createTenant("nat-tenant")
+				createNetworkClass(privatev1.NetworkDefaults_builder{
+					VirtualNetworkIpv4Cidr: "10.0.0.0/16",
+					SubnetIpv4Cidr:         "10.0.1.0/24",
+					EnableNatGateway:       true,
+				}.Build())
+				pool = createExternalIPPool("test-pool", "system", 10)
+
+				err := provisioner.Provision(ctx, "nat-tenant")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("removes the NATGateway and ExternalIP, and releases pool capacity", func() {
+				err := provisioner.Deprovision(ctx, "nat-tenant")
+				Expect(err).ToNot(HaveOccurred())
+
+				ngList, err := provisioner.natGatewayDao.List().
+					SetFilter("this.metadata.tenant == 'nat-tenant'").
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ngList.GetItems()).To(BeEmpty())
+
+				eipList, err := provisioner.externalIPDao.List().
+					SetFilter("this.metadata.tenant == 'nat-tenant'").
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(eipList.GetItems()).To(BeEmpty())
+
+				vnList, err := provisioner.virtualNetworkDao.List().
+					SetFilter("this.metadata.tenant == 'nat-tenant'").
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vnList.GetItems()).To(BeEmpty())
+
+				poolResp, err := provisioner.externalIPPoolDao.Get().
+					SetId(pool.GetId()).
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(poolResp.GetObject().GetStatus().GetAllocated()).To(Equal(int64(0)))
+				Expect(poolResp.GetObject().GetStatus().GetAvailable()).To(Equal(int64(10)))
+			})
+		})
+
+		Context("when a default resource already has a controller finalizer attached", func() {
+			It("fails with an in-use error instead of looping forever on the Subnet", func() {
+				createNetworkClass(privatev1.NetworkDefaults_builder{
+					VirtualNetworkIpv4Cidr: "10.0.0.0/16",
+					SubnetIpv4Cidr:         "10.0.1.0/24",
+				}.Build())
+				err := provisioner.Provision(ctx, "test-tenant")
+				Expect(err).ToNot(HaveOccurred())
+
+				subnetList, err := provisioner.subnetDao.List().
+					SetFilter("this.metadata.tenant == 'test-tenant'").
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(subnetList.GetItems()).To(HaveLen(1))
+				subnet := subnetList.GetItems()[0]
+
+				// Simulate the Subnet controller having already picked up this object, as it
+				// normally would shortly after creation:
+				subnet.GetMetadata().SetFinalizers([]string{"osac.openshift.io/subnet-controller"})
+				_, err = provisioner.subnetDao.Update().SetObject(subnet).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Delete() on a finalized object only soft-deletes it, so a naive loop would spin
+				// forever. This call must terminate with a clear, typed error instead.
+				err = provisioner.Deprovision(ctx, "test-tenant")
+				Expect(err).To(HaveOccurred())
+				var inUseErr *dao.ErrInUse
+				Expect(errors.As(err, &inUseErr)).To(BeTrue())
+				Expect(inUseErr.Error()).To(ContainSubstring("awaiting asynchronous controller cleanup"))
+
+				// The SecurityGroup had no finalizer, so it was already removed before the Subnet
+				// loop gave up — confirming partial progress isn't silently discarded:
+				sgList, err := provisioner.securityGroupDao.List().
+					SetFilter("this.metadata.tenant == 'test-tenant'").
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sgList.GetItems()).To(BeEmpty())
+
+				// The VirtualNetwork itself must not have been deleted, since the Subnet still
+				// references it:
+				vnList, err := provisioner.virtualNetworkDao.List().
+					SetFilter("this.metadata.tenant == 'test-tenant'").
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(vnList.GetItems()).To(HaveLen(1))
+			})
+
+			It("fails with an in-use error instead of looping forever on the NATGateway", func() {
+				createTenant("nat-tenant")
+				createNetworkClass(privatev1.NetworkDefaults_builder{
+					VirtualNetworkIpv4Cidr: "10.0.0.0/16",
+					SubnetIpv4Cidr:         "10.0.1.0/24",
+					EnableNatGateway:       true,
+				}.Build())
+				createExternalIPPool("test-pool", "system", 10)
+
+				err := provisioner.Provision(ctx, "nat-tenant")
+				Expect(err).ToNot(HaveOccurred())
+
+				ngList, err := provisioner.natGatewayDao.List().
+					SetFilter("this.metadata.tenant == 'nat-tenant'").
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ngList.GetItems()).To(HaveLen(1))
+				natGateway := ngList.GetItems()[0]
+
+				// Simulate the NATGateway controller having already picked up this object:
+				natGateway.GetMetadata().SetFinalizers([]string{"osac.openshift.io/nat-gateway-controller"})
+				_, err = provisioner.natGatewayDao.Update().SetObject(natGateway).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = provisioner.Deprovision(ctx, "nat-tenant")
+				Expect(err).To(HaveOccurred())
+				var inUseErr *dao.ErrInUse
+				Expect(errors.As(err, &inUseErr)).To(BeTrue())
+				Expect(inUseErr.Error()).To(ContainSubstring("awaiting asynchronous controller cleanup"))
+
+				// The ExternalIP must not have been deprovisioned either, since its owning
+				// NATGateway was never actually removed:
+				eipList, err := provisioner.externalIPDao.List().
+					SetFilter("this.metadata.tenant == 'nat-tenant'").
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(eipList.GetItems()).To(HaveLen(1))
+			})
+		})
+
+		Context("when the default Subnet is still in use by a live ComputeInstance", func() {
+			It("fails with a typed in-use error instead of deleting the Subnet", func() {
+				createNetworkClass(privatev1.NetworkDefaults_builder{
+					VirtualNetworkIpv4Cidr: "10.0.0.0/16",
+					SubnetIpv4Cidr:         "10.0.1.0/24",
+				}.Build())
+				err := provisioner.Provision(ctx, "test-tenant")
+				Expect(err).ToNot(HaveOccurred())
+
+				subnetList, err := provisioner.subnetDao.List().
+					SetFilter("this.metadata.tenant == 'test-tenant'").
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(subnetList.GetItems()).To(HaveLen(1))
+				subnetID := subnetList.GetItems()[0].GetId()
+
+				computeInstanceDao, err := dao.NewGenericDAO[*privatev1.ComputeInstance]().
+					SetLogger(logger).
+					SetTenancyLogic(tenancy).
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+				_, err = computeInstanceDao.Create().SetObject(privatev1.ComputeInstance_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:   "test-instance",
+						Tenant: "test-tenant",
+					}.Build(),
+					Spec: privatev1.ComputeInstanceSpec_builder{
+						NetworkAttachments: []*privatev1.ComputeNetworkAttachment{
+							privatev1.ComputeNetworkAttachment_builder{
+								Subnet: privatev1.SubnetLocalReference_builder{Id: subnetID}.Build(),
+							}.Build(),
+						},
+					}.Build(),
+				}.Build()).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				// The Postgres trigger raises an error inside the current transaction, which aborts
+				// it — no further statements can run against ctx's transaction after this, so this
+				// must be the test's last database interaction.
+				err = provisioner.Deprovision(ctx, "test-tenant")
+				Expect(err).To(HaveOccurred())
+				var inUseErr *dao.ErrInUse
+				Expect(errors.As(err, &inUseErr)).To(BeTrue())
+				Expect(inUseErr.Error()).To(ContainSubstring(subnetID))
+				Expect(inUseErr.Error()).To(ContainSubstring("in use by at least one compute instance"))
+			})
+		})
+
+		Context("when the tenant has attached its own resources to the default VirtualNetwork", func() {
+			It("leaves a tenant-owned Subnet in place instead of deleting it", func() {
+				createNetworkClass(privatev1.NetworkDefaults_builder{
+					VirtualNetworkIpv4Cidr: "10.0.0.0/16",
+					SubnetIpv4Cidr:         "10.0.1.0/24",
+				}.Build())
+				err := provisioner.Provision(ctx, "test-tenant")
+				Expect(err).ToNot(HaveOccurred())
+
+				vnList, err := provisioner.virtualNetworkDao.List().
+					SetFilter("this.metadata.tenant == 'test-tenant'").
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				vnID := vnList.GetItems()[0].GetId()
+
+				// A tenant-created Subnet, not labeled as a default resource, attached to the same
+				// default VirtualNetwork:
+				_, err = provisioner.subnetDao.Create().SetObject(privatev1.Subnet_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:   "custom-subnet",
+						Tenant: "test-tenant",
+					}.Build(),
+					Spec: privatev1.SubnetSpec_builder{
+						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
+						Ipv4Cidr:       new("10.0.2.0/24"),
+					}.Build(),
+				}.Build()).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				// If deleteByVirtualNetwork ignored the default label and deleted this Subnet too,
+				// Deprovision would succeed here despite having destroyed a tenant-owned resource.
+				// Instead, the custom Subnet must be left in place, and the database's own
+				// check_virtual_network_not_in_use trigger must block the VirtualNetwork delete
+				// because of it. The Postgres error this raises aborts the current transaction, so
+				// this must be the test's last database interaction.
+				err = provisioner.Deprovision(ctx, "test-tenant")
+				Expect(err).To(HaveOccurred())
+				var inUseErr *dao.ErrInUse
+				Expect(errors.As(err, &inUseErr)).To(BeTrue())
+				Expect(inUseErr.Error()).To(ContainSubstring(vnID))
+				Expect(inUseErr.Error()).To(ContainSubstring("Subnet(s) still reference it"))
+			})
+
+			It("leaves a tenant-owned SecurityGroup in place instead of deleting it", func() {
+				createNetworkClass(privatev1.NetworkDefaults_builder{
+					VirtualNetworkIpv4Cidr: "10.0.0.0/16",
+				}.Build())
+				err := provisioner.Provision(ctx, "test-tenant")
+				Expect(err).ToNot(HaveOccurred())
+
+				vnList, err := provisioner.virtualNetworkDao.List().
+					SetFilter("this.metadata.tenant == 'test-tenant'").
+					Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				vnID := vnList.GetItems()[0].GetId()
+
+				// A tenant-created SecurityGroup, likewise not labeled as default:
+				_, err = provisioner.securityGroupDao.Create().SetObject(privatev1.SecurityGroup_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:   "custom-sg",
+						Tenant: "test-tenant",
+					}.Build(),
+					Spec: privatev1.SecurityGroupSpec_builder{
+						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
+					}.Build(),
+				}.Build()).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Same reasoning as the Subnet case above: the check_virtual_network_not_in_use
+				// trigger must block the VirtualNetwork delete because of the surviving
+				// tenant-owned SecurityGroup. This must be the test's last database interaction.
+				err = provisioner.Deprovision(ctx, "test-tenant")
+				Expect(err).To(HaveOccurred())
+				var inUseErr *dao.ErrInUse
+				Expect(errors.As(err, &inUseErr)).To(BeTrue())
+				Expect(inUseErr.Error()).To(ContainSubstring(vnID))
+				Expect(inUseErr.Error()).To(ContainSubstring("SecurityGroup(s) still reference it"))
+			})
+		})
+	})
 })

--- a/fulfillment-service/internal/servers/generic_server.go
+++ b/fulfillment-service/internal/servers/generic_server.go
@@ -828,6 +828,10 @@ func (s *GenericServer[O]) translateUpdateError(ctx context.Context, requestId s
 	if errors.As(err, &referenceErr) {
 		return grpcstatus.Errorf(grpccodes.FailedPrecondition, "%s", referenceErr.Error())
 	}
+	var inUseErr *dao.ErrInUse
+	if errors.As(err, &inUseErr) {
+		return grpcstatus.Errorf(grpccodes.FailedPrecondition, "%s", inUseErr.Error())
+	}
 	var notUniqueErr *dao.ErrNotUnique
 	if errors.As(err, &notUniqueErr) {
 		return grpcstatus.Errorf(grpccodes.AlreadyExists, "%s", notUniqueErr.Error())

--- a/fulfillment-service/internal/servers/private_projects_server.go
+++ b/fulfillment-service/internal/servers/private_projects_server.go
@@ -27,6 +27,7 @@ import (
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/auth"
 	"github.com/osac-project/osac/fulfillment-service/internal/database"
+	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 )
 
 // PrivateProjectsServerBuilder contains the data and logic needed to create a private projects server.
@@ -37,6 +38,7 @@ type PrivateProjectsServerBuilder struct {
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
 	filterDesc        protoreflect.MessageDescriptor
+	defaultNetworking *DefaultNetworkingProvisioner
 }
 
 var _ privatev1.ProjectsServer = (*PrivateProjectsServer)(nil)
@@ -44,8 +46,9 @@ var _ privatev1.ProjectsServer = (*PrivateProjectsServer)(nil)
 // PrivateProjectsServer is the implementation of the private projects gRPC service.
 type PrivateProjectsServer struct {
 	privatev1.UnimplementedProjectsServer
-	logger  *slog.Logger
-	generic *GenericServer[*privatev1.Project]
+	logger            *slog.Logger
+	generic           *GenericServer[*privatev1.Project]
+	defaultNetworking *DefaultNetworkingProvisioner
 }
 
 // NewPrivateProjectsServer creates a new builder for the private projects server.
@@ -91,6 +94,16 @@ func (b *PrivateProjectsServerBuilder) SetFilterDesc(value protoreflect.MessageD
 	return b
 }
 
+// SetDefaultNetworkingProvisioner sets the provisioner used to deprovision a tenant's default
+// networking resources when its root project is deleted. This is optional; if unset, root project
+// deletion will fail whenever default networking resources still exist for the tenant.
+func (b *PrivateProjectsServerBuilder) SetDefaultNetworkingProvisioner(
+	value *DefaultNetworkingProvisioner,
+) *PrivateProjectsServerBuilder {
+	b.defaultNetworking = value
+	return b
+}
+
 // Build creates the private projects server.
 func (b *PrivateProjectsServerBuilder) Build() (result *PrivateProjectsServer, err error) {
 	// Check parameters:
@@ -105,7 +118,8 @@ func (b *PrivateProjectsServerBuilder) Build() (result *PrivateProjectsServer, e
 
 	// Create the server early, so that we can use its methods:
 	s := &PrivateProjectsServer{
-		logger: b.logger,
+		logger:            b.logger,
+		defaultNetworking: b.defaultNetworking,
 	}
 
 	// Create the generic server:
@@ -199,8 +213,46 @@ func (s *PrivateProjectsServer) Update(ctx context.Context,
 
 func (s *PrivateProjectsServer) Delete(ctx context.Context,
 	request *privatev1.ProjectsDeleteRequest) (response *privatev1.ProjectsDeleteResponse, err error) {
+	// The root project (empty name) owns whatever default networking resources Provision created
+	// for the tenant. Those are protected from direct deletion via the API (see
+	// validateNotDefault), so nothing else ever removes them — deprovision them here, before the
+	// root project's own deletion is attempted, or that deletion will fail with a foreign key
+	// violation.
+	if s.defaultNetworking != nil {
+		getRequest := &privatev1.ProjectsGetRequest{}
+		getRequest.SetId(request.GetId())
+		var getResponse *privatev1.ProjectsGetResponse
+		if err = s.generic.Get(ctx, getRequest, &getResponse); err != nil {
+			return
+		}
+		project := getResponse.GetObject()
+		if project.GetMetadata().GetName() == "" {
+			tenantName := project.GetMetadata().GetTenant()
+			if deprovisionErr := s.defaultNetworking.Deprovision(ctx, tenantName); deprovisionErr != nil {
+				err = s.translateDeprovisionError(ctx, tenantName, deprovisionErr)
+				return
+			}
+		}
+	}
 	err = s.generic.Delete(ctx, request, &response)
 	return
+}
+
+// translateDeprovisionError translates an error from deprovisioning default networking resources
+// into a gRPC status. It mirrors GenericServer.Delete's translation so that, for example, a
+// Subnet still in use by a live ComputeInstance surfaces as an actionable FailedPrecondition
+// instead of an opaque Internal error.
+func (s *PrivateProjectsServer) translateDeprovisionError(ctx context.Context, tenantName string, err error) error {
+	if inUseErr, ok := errors.AsType[*dao.ErrInUse](err); ok {
+		return grpcstatus.Errorf(grpccodes.FailedPrecondition, "%s", inUseErr.Error())
+	}
+	if _, ok := errors.AsType[*dao.ErrDeadlock](err); ok {
+		return grpcstatus.Errorf(grpccodes.Aborted, "concurrent modification detected, please retry")
+	}
+	s.logger.ErrorContext(ctx, "Failed to deprovision default networking",
+		slog.String("tenant", tenantName),
+		slog.Any("error", err))
+	return grpcstatus.Errorf(grpccodes.Internal, "failed to deprovision default networking resources")
 }
 
 func (s *PrivateProjectsServer) Signal(ctx context.Context,

--- a/fulfillment-service/internal/servers/private_projects_server_test.go
+++ b/fulfillment-service/internal/servers/private_projects_server_test.go
@@ -281,6 +281,123 @@ var _ = Describe("Private projects server", func() {
 		Expect(project.GetMetadata().GetProject()).To(BeEmpty())
 	})
 
+	Describe("Default networking deprovisioning on delete", func() {
+		var provisioner *DefaultNetworkingProvisioner
+
+		BeforeEach(func() {
+			var err error
+			provisioner, err = NewDefaultNetworkingProvisioner().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			networkClass := privatev1.NetworkClass_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   "test-network-class",
+					Tenant: "system",
+				}.Build(),
+				IsDefault:     new(true),
+				FabricManager: new("netris"),
+				Spec: privatev1.NetworkClassSpec_builder{
+					Defaults: privatev1.NetworkDefaults_builder{
+						VirtualNetworkIpv4Cidr: "10.0.0.0/16",
+						SubnetIpv4Cidr:         "10.0.1.0/24",
+					}.Build(),
+				}.Build(),
+				Status: privatev1.NetworkClassStatus_builder{
+					State: privatev1.NetworkClassState_NETWORK_CLASS_STATE_READY,
+				}.Build(),
+			}.Build()
+			_, err = provisioner.networkClassDao.Create().SetObject(networkClass).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		findRootProject := func(tenant string) *privatev1.Project {
+			listResponse, err := privateServer.List(ctx, privatev1.ProjectsListRequest_builder{
+				Filter: new(fmt.Sprintf("this.metadata.tenant == '%s' && this.metadata.name == ''", tenant)),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			projects := listResponse.GetItems()
+			Expect(projects).To(HaveLen(1))
+			return projects[0]
+		}
+
+		It("does not deprovision when deleting a non-root project", func() {
+			serverWithProvisioner, err := NewPrivateProjectsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				SetDefaultNetworkingProvisioner(provisioner).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(provisioner.Provision(ctx, "my-tenant")).To(Succeed())
+
+			createResp, err := serverWithProvisioner.Create(ctx, privatev1.ProjectsCreateRequest_builder{
+				Object: privatev1.Project_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:   "my-project",
+						Tenant: "my-tenant",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = serverWithProvisioner.Delete(ctx, privatev1.ProjectsDeleteRequest_builder{
+				Id: createResp.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			vnList, err := provisioner.virtualNetworkDao.List().
+				SetFilter("this.metadata.tenant == 'my-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vnList.GetItems()).To(HaveLen(1))
+		})
+
+		It("deprovisions default networking before deleting the root project", func() {
+			serverWithProvisioner, err := NewPrivateProjectsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				SetDefaultNetworkingProvisioner(provisioner).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(provisioner.Provision(ctx, "my-tenant")).To(Succeed())
+			rootProject := findRootProject("my-tenant")
+
+			_, err = serverWithProvisioner.Delete(ctx, privatev1.ProjectsDeleteRequest_builder{
+				Id: rootProject.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			vnList, err := provisioner.virtualNetworkDao.List().
+				SetFilter("this.metadata.tenant == 'my-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vnList.GetItems()).To(BeEmpty())
+		})
+
+		It("still deletes the root project when there is no default networking to deprovision", func() {
+			serverWithProvisioner, err := NewPrivateProjectsServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				SetDefaultNetworkingProvisioner(provisioner).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			rootProject := findRootProject("your-tenant")
+
+			_, err = serverWithProvisioner.Delete(ctx, privatev1.ProjectsDeleteRequest_builder{
+				Id: rootProject.GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
 	Describe("Tenant Validation", func() {
 		It("Rejects creation when tenant is explicitly set to 'shared'", func() {
 			_, err := privateServer.Create(ctx, privatev1.ProjectsCreateRequest_builder{


### PR DESCRIPTION


Provision() creates default VirtualNetwork/Subnet/SecurityGroup/NATGateway resources for every tenant, but there was no counterpart to remove them. Since those resources are protected from direct user deletion, deleting a tenant's root project (and thus the tenant itself) always failed with a foreign key violation.

Add DefaultNetworkingProvisioner.Deprovision(), called from PrivateProjectsServer.Delete() when the project being deleted is a tenant's root project, mirroring how Provision() is already called from PrivateTenantsServer.Create(). Also centralize foreign-key-violation translation for the archive-on-delete path so both the direct-delete and finalizer-removal-triggers-archive code paths surface FailedPrecondition instead of an opaque Internal error, and propagate the underlying reason (e.g. a live ComputeInstance still attached to the default Subnet) instead of swallowing it.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deleting a root project now removes its associated default networking resources, including virtual networks, subnets, security groups, NAT gateways, and external IPs.
  * Cleanup is safe to repeat and preserves networking for non-root project deletions.

* **Bug Fixes**
  * Improved deletion errors for resources that are still in use, deadlocks, and tenant-related references.
  * API responses now clearly indicate when deletion is blocked by existing dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->