### PR TITLE
OSAC-3370: skip e2e rerun while PR run queued

### DIFF
--- a/.github/workflows/e2e-on-approval-fork.yml
+++ b/.github/workflows/e2e-on-approval-fork.yml
@@ -168,6 +168,7 @@ jobs:
           STARTED=0
           ERRORS=0
           SKIPPED=0
+          PENDING=0
           STALE=0
           TIMEOUTS=0
 
@@ -195,9 +196,13 @@ jobs:
             ' <<<"${runs}"
           }
 
+          # Returns: 0 = ok to rerun (run completed, not success),
+          #          2 = already going / already green (skip),
+          #          3 = readiness has not started (skip; in-flight run will pick up unlock),
+          #          1 = error / timeout.
           wait_until_rerun_or_skip() {
             local run_id="$1"
-            local view status conclusion busy
+            local view status conclusion busy readiness
             for _ in $(seq 1 90); do
               view=$(gh run view "${run_id}" -R "${REPO}" --json status,conclusion,jobs)
               status=$(jq -r '.status' <<<"${view}")
@@ -213,9 +218,25 @@ jobs:
                   end
               ' <<<"${view}")
 
+              # No expensive job yet. If readiness has not started, the in-flight
+              # PR run will see the unlock when it does: skip instead of waiting
+              # out GitHub's runner queue. If readiness is already running or
+              # done, keep waiting (may need rerun if the gate raced the unlock).
               if [[ "${busy}" == "unknown" && "${status}" != "completed" ]]; then
-                sleep 2
-                continue
+                readiness=$(jq -r '
+                  [.jobs[]
+                    | select(.name | test("readiness"; "i"))
+                    | select(.name | test("full-install"; "i") | not)
+                    | .status
+                  ]
+                  | if length == 0 then "missing" else .[0] end
+                ' <<<"${view}")
+                if [[ "${readiness}" != "missing" ]]; then
+                  sleep 2
+                  continue
+                fi
+                echo "Readiness has not started on run #${run_id}; skip rerun."
+                return 3
               fi
 
               if [[ "${busy}" == "true" ]]; then
@@ -293,6 +314,10 @@ jobs:
               SKIPPED=$((SKIPPED + 1))
               return
             fi
+            if [[ ${rc} -eq 3 ]]; then
+              PENDING=$((PENDING + 1))
+              return
+            fi
             if [[ ${rc} -ne 0 ]]; then
               TIMEOUTS=$((TIMEOUTS + 1))
               return
@@ -355,6 +380,9 @@ jobs:
             echo "- Started: ${STARTED}/${#E2E_WORKFLOWS[@]}"
             if [[ ${SKIPPED} -gt 0 ]]; then
               echo "- Already active/green (skipped rerun): ${SKIPPED}"
+            fi
+            if [[ ${PENDING} -gt 0 ]]; then
+              echo "- Readiness not started (in-flight run will pick up unlock): ${PENDING}"
             fi
             if [[ ${STALE} -gt 0 ]]; then
               echo "- Head moved or approval withdrawn (no rerun): ${STALE}"

--- a/.github/workflows/e2e-on-approval.yml
+++ b/.github/workflows/e2e-on-approval.yml
@@ -151,6 +151,7 @@ jobs:
           STARTED=0
           ERRORS=0
           SKIPPED=0
+          PENDING=0
           STALE=0
           TIMEOUTS=0
 
@@ -181,9 +182,13 @@ jobs:
             ' <<<"${runs}"
           }
 
+          # Returns: 0 = ok to rerun (run completed, not success),
+          #          2 = already going / already green (skip),
+          #          3 = readiness has not started (skip; in-flight run will pick up unlock),
+          #          1 = error / timeout.
           wait_until_rerun_or_skip() {
             local run_id="$1"
-            local view status conclusion busy
+            local view status conclusion busy readiness
             for _ in $(seq 1 90); do
               view=$(gh run view "${run_id}" -R "${REPO}" --json status,conclusion,jobs)
               status=$(jq -r '.status' <<<"${view}")
@@ -201,10 +206,25 @@ jobs:
                   end
               ' <<<"${view}")
 
-              # No expensive job matched yet: do not assume idle.
+              # No expensive job yet. If readiness has not started, the in-flight
+              # PR run will see the unlock when it does: skip instead of waiting
+              # out GitHub's runner queue. If readiness is already running or
+              # done, keep waiting (may need rerun if the gate raced the unlock).
               if [[ "${busy}" == "unknown" && "${status}" != "completed" ]]; then
-                sleep 2
-                continue
+                readiness=$(jq -r '
+                  [.jobs[]
+                    | select(.name | test("readiness"; "i"))
+                    | select(.name | test("full-install"; "i") | not)
+                    | .status
+                  ]
+                  | if length == 0 then "missing" else .[0] end
+                ' <<<"${view}")
+                if [[ "${readiness}" != "missing" ]]; then
+                  sleep 2
+                  continue
+                fi
+                echo "Readiness has not started on run #${run_id}; skip rerun."
+                return 3
               fi
 
               if [[ "${busy}" == "true" ]]; then
@@ -283,6 +303,10 @@ jobs:
               SKIPPED=$((SKIPPED + 1))
               return
             fi
+            if [[ ${rc} -eq 3 ]]; then
+              PENDING=$((PENDING + 1))
+              return
+            fi
             if [[ ${rc} -ne 0 ]]; then
               TIMEOUTS=$((TIMEOUTS + 1))
               return
@@ -346,6 +370,9 @@ jobs:
             echo "- Started: ${STARTED}/${#E2E_WORKFLOWS[@]}"
             if [[ ${SKIPPED} -gt 0 ]]; then
               echo "- Already active/green (skipped rerun): ${SKIPPED}"
+            fi
+            if [[ ${PENDING} -gt 0 ]]; then
+              echo "- Readiness not started (in-flight run will pick up unlock): ${PENDING}"
             fi
             if [[ ${STALE} -gt 0 ]]; then
               echo "- Head moved or approval withdrawn (no rerun): ${STALE}"

--- a/.github/workflows/e2e-on-label.yml
+++ b/.github/workflows/e2e-on-label.yml
@@ -117,6 +117,7 @@ jobs:
           STARTED=0
           ERRORS=0
           SKIPPED=0
+          PENDING=0
           STALE=0
           TIMEOUTS=0
 
@@ -149,10 +150,11 @@ jobs:
 
           # Returns: 0 = ok to rerun (run completed, not success),
           #          2 = already going / already green (skip),
+          #          3 = readiness has not started (skip; in-flight run will pick up unlock),
           #          1 = error / timeout.
           wait_until_rerun_or_skip() {
             local run_id="$1"
-            local view status conclusion busy
+            local view status conclusion busy readiness
             for _ in $(seq 1 90); do
               view=$(gh run view "${run_id}" -R "${REPO}" --json status,conclusion,jobs)
               status=$(jq -r '.status' <<<"${view}")
@@ -170,10 +172,25 @@ jobs:
                   end
               ' <<<"${view}")
 
-              # No expensive job matched yet: do not assume idle.
+              # No expensive job yet. If readiness has not started, the in-flight
+              # PR run will see the unlock when it does: skip instead of waiting
+              # out GitHub's runner queue. If readiness is already running or
+              # done, keep waiting (may need rerun if the gate raced the unlock).
               if [[ "${busy}" == "unknown" && "${status}" != "completed" ]]; then
-                sleep 2
-                continue
+                readiness=$(jq -r '
+                  [.jobs[]
+                    | select(.name | test("readiness"; "i"))
+                    | select(.name | test("full-install"; "i") | not)
+                    | .status
+                  ]
+                  | if length == 0 then "missing" else .[0] end
+                ' <<<"${view}")
+                if [[ "${readiness}" != "missing" ]]; then
+                  sleep 2
+                  continue
+                fi
+                echo "Readiness has not started on run #${run_id}; skip rerun."
+                return 3
               fi
 
               if [[ "${busy}" == "true" ]]; then
@@ -266,6 +283,10 @@ jobs:
               SKIPPED=$((SKIPPED + 1))
               return
             fi
+            if [[ ${rc} -eq 3 ]]; then
+              PENDING=$((PENDING + 1))
+              return
+            fi
             if [[ ${rc} -ne 0 ]]; then
               TIMEOUTS=$((TIMEOUTS + 1))
               return
@@ -343,6 +364,9 @@ jobs:
             echo "- Started: ${STARTED}/${#E2E_WORKFLOWS[@]}"
             if [[ ${SKIPPED} -gt 0 ]]; then
               echo "- Already active/green (skipped rerun): ${SKIPPED}"
+            fi
+            if [[ ${PENDING} -gt 0 ]]; then
+              echo "- Readiness not started (in-flight run will pick up unlock): ${PENDING}"
             fi
             if [[ ${STALE} -gt 0 ]]; then
               echo "- Head moved or label withdrawn (no rerun): ${STALE}"


### PR DESCRIPTION
## Summary
- Unlock starters (`e2e-on-label`, `e2e-on-approval`, fork replay) timed out after ~3 min when the PR e2e run was still in the GitHub queue with no `e2e-readiness` job yet.
- Skip rerun in that case: the in-flight run sees `lgtm` / CR / `/e2e-ready` when readiness starts. Still wait (and rerun if needed) if readiness is already running or the workflow already failed.

## Jira
https://issues.redhat.com/browse/OSAC-3370

## Test plan
- [ ] Apply `lgtm` while vmaas/bmaas/caas `pull_request` runs are still queued: starter should skip (not exit 1) and expensive jobs should start on the original runs.
- [ ] Apply `lgtm` after `e2e-readiness` already failed: starter should still rerun.
- [ ] Workflow YAML only — no unit/lint matrix for this change.

---

_This PR description was drafted with AI assistance ([create-pr](https://github.com/osac-project/osac-workspace/tree/main/skills/create-pr) v0.1.3). Review for accuracy_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end workflow rerun handling by accurately tracking readiness status.
  * Prevented unnecessary reruns when readiness checks have not started.
  * Continued waiting appropriately when readiness checks are active or complete.
  * Preserved correct handling for completed and concurrent workflow runs.
  * Added pending readiness status to pull-request workflow comments for clearer progress reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->