### PR TITLE
OSAC-4572: Helm-manage Metal3 secrets in bmaas-ci profile

### DIFF
--- a/osac-installer/values/bmaas-ci/instance.yaml
+++ b/osac-installer/values/bmaas-ci/instance.yaml
@@ -160,6 +160,10 @@ bmf:
     aapUrl: "http://osac-aap/api/controller"
     aapInsecureSkipVerify: "true"
     enableNetworkingProvisioning: "false"
+  metal3:
+    enabled: true
+    namespace: host-inventory
+    hostClass: metal3
 
 # --- Hub Access ---
 hubAccess:


### PR DESCRIPTION
## Summary
- Enable `bmf.metal3` in `osac-installer/values/bmaas-ci/instance.yaml` so the umbrella chart renders the `osac-inventory-config` and `osac-management-config` secrets, adopting the Helm support added in [OSAC-4139](https://redhat.atlassian.net/browse/OSAC-4139).
- Lets BMaaS E2E CI stop creating those secrets by hand via `oc apply` (see the companion osac-test-infra PR).
- `namespace` defaults to `host-inventory` (the workflow's default bmh-namespace) so `helm-validate` renders cleanly; CI overrides it per run via `--set-string bmf.metal3.namespace=...`.

## Jira
https://redhat.atlassian.net/browse/OSAC-4572 (follow-up to [OSAC-4139](https://redhat.atlassian.net/browse/OSAC-4139))

## Test plan
- [x] `helm template` renders both secrets for the bmaas-ci profile with `type: metal3` and the expected namespace
- [x] `--set-string bmf.metal3.namespace=...` override verified
- [x] All values profiles template cleanly with placeholder hostname overrides
- [x] `yamllint --strict` passes

---

_This PR description was drafted with AI assistance ([create-pr](https://github.com/osac-project/osac-workspace/tree/main/skills/create-pr) v0.2.0). Review for accuracy_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Metal3 integration for the BMaaS CI environment.
  * Added the required configuration, namespace, and host class settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->