### PR TITLE
NO-ISSUE: Fix nightly download-artifact SHA pin

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -461,7 +461,7 @@ jobs:
         echo "Tagged: ${TAG}"
 
     - name: Download chart manifest
-      uses: actions/download-artifact@65a9edc588058a7f27ea910f833ef1ec12f0aefd  # v4.1.8
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
       with:
         name: nightly-${{ env.VERSION }}
         path: nightly-artifacts


### PR DESCRIPTION
## Summary
- Tag and notify failed at job setup: GitHub could not resolve `actions/download-artifact@65a9edc588058a7f27ea910f833ef1ec12f0aefd` ([run](https://github.com/osac-project/osac/actions/runs/33080422584/job/98572387955)).
- That SHA is a garbled v4.1.7 pin and does not exist on `actions/download-artifact`. Replace it with the real v4.1.8 commit `fa0a91b85d4f404e444e00e005971372dc801d16`.
- Same one-line change as Konflux [#512](https://github.com/osac-project/osac/pull/512), which is blocked on unrelated checks.

## Jira
N/A

## Test plan
- [x] `gh api repos/actions/download-artifact/commits/fa0a91b85d4f404e444e00e005971372dc801d16` returns the commit
- [x] `gh api repos/actions/download-artifact/commits/65a9edc588058a7f27ea910f833ef1ec12f0aefd` returns 422
- [ ] Nightly Tag and notify gets past Set up job after merge

---

_This PR description was drafted with AI assistance ([create-pr](https://github.com/osac-project/osac-workspace/tree/main/skills/create-pr) v0.1.3). Review for accuracy_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the nightly build workflow’s artifact download action to a newer pinned revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->