### PR TITLE
OSAC-4571: Pin nightly sub-component image tags to match chart versions

### DIFF
--- a/.github/workflows/check-floating-tags.yaml
+++ b/.github/workflows/check-floating-tags.yaml
@@ -8,6 +8,8 @@ on:
       - 'bare-metal-fulfillment-operator/charts/**/values.yaml'
       - 'osac-installer/charts/**/values.yaml'
       - 'osac-aap/charts/**/values.yaml'
+      - 'osac-metering/charts/**/values.yaml'
+      - 'osac-csi-driver/charts/**/values.yaml'
       - '.github/scripts/check-floating-tags.sh'
       - '.github/workflows/check-floating-tags.yaml'
 
@@ -49,6 +51,14 @@ jobs:
               - '.github/workflows/check-floating-tags.yaml'
             osac-aap:
               - 'osac-aap/charts/**/values.yaml'
+              - '.github/scripts/check-floating-tags.sh'
+              - '.github/workflows/check-floating-tags.yaml'
+            osac-metering:
+              - 'osac-metering/charts/**/values.yaml'
+              - '.github/scripts/check-floating-tags.sh'
+              - '.github/workflows/check-floating-tags.yaml'
+            osac-csi-driver:
+              - 'osac-csi-driver/charts/**/values.yaml'
               - '.github/scripts/check-floating-tags.sh'
               - '.github/workflows/check-floating-tags.yaml'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,8 @@ name: CodeQL
 on:
   pull_request:
     branches: [main]
+  # Invoked as a parallel "box" by nightly-build.yaml.
+  workflow_call:
 
 jobs:
   analyze:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,6 +14,8 @@ on:
   # don't all land on the same offset simultaneously.
   schedule:
     - cron: '47 */12 * * *'
+  # Invoked as a parallel "box" by nightly-build.yaml.
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -958,13 +958,25 @@ jobs:
           -d @/tmp/slack-payload.json
 
   # -------------------------------------------------------------------
-  # Job 8: Cleanup — delete temp branch (always, success or failure)
+  # Job 8: Cleanup — delete temp branch, success only. Deleting unconditionally
+  # (the previous `if: always()`) broke GitHub's "Re-run failed jobs": a retry
+  # reuses `prepare`'s cached temp-branch output from the original attempt,
+  # but that branch was already gone -- this job had deleted it the moment
+  # the first attempt reached ANY terminal state, including failure. Branches
+  # from failed runs are now left for cleanup-nightly-branches.yaml's 7-day
+  # TTL sweep instead, so a failed run can still be retried.
   # -------------------------------------------------------------------
   cleanup:
     name: Cleanup temp branch
     needs: [prepare, build, unit-tests, integration-tests, security-tests, e2e-vmaas-test, e2e-caas-test, e2e-bmaas-test, publish, tag-and-notify, notify-failure]
     runs-on: ubuntu-latest
-    if: always()
+    # notify-failure is routinely skipped whenever nothing fails, and GitHub
+    # skip-cascades a job whose needs include a skipped job regardless of a
+    # custom `if:` unless the expression includes always() -- so always() is
+    # required here even though this job only wants to act on real success.
+    # tag-and-notify succeeding is sufficient proof the whole pipeline (build,
+    # every test box, publish) already succeeded, since it's gated on that.
+    if: always() && needs.tag-and-notify.result == 'success'
     permissions:
       contents: write
     env:

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -246,6 +246,17 @@ jobs:
           stamp_umbrella_nested_field "${UMBRELLA_VALUES}" ui images ui "ghcr.io/osac-project/osac-ui:${UI_SUB_VERSION}"
         fi
 
+        # AAP's config-as-code sync pulls osac-aap's own Ansible automation
+        # (provisioning/restart/hardware-inventory playbooks, etc.) from
+        # aap.configAsCode.projectGitBranch/projectGitUri -- a floating git
+        # ref, same class of bug as a floating image tag, just pointing E2E's
+        # AAP jobs at whatever's on main instead of the exact commit under
+        # test. Pin it to this run's own commit unconditionally (independent
+        # of osac-aap's own release-tag status, which only gates image
+        # rebuilding above).
+        stamp_umbrella_nested_field "${UMBRELLA_VALUES}" aap configAsCode projectGitBranch "${GITHUB_SHA}"
+        stamp_umbrella_nested_field "${UMBRELLA_VALUES}" aap configAsCode projectGitUri "https://github.com/${GITHUB_REPOSITORY}"
+
         # The 4 CI overlay values files (osac-installer/values/*/instance.yaml)
         # have their own separate floating image tag overrides on top of the
         # umbrella chart's own values.yaml, and the e2e jobs below install using
@@ -267,6 +278,8 @@ jobs:
           [[ -n "${FULFILLMENT_VER}" ]] && stamp_ci_overlay_if_present "${overlay}" '.service.images.service' "ghcr.io/osac-project/fulfillment-service:${FULFILLMENT_VER}"
           [[ -n "${AAP_VER}" ]] && stamp_ci_overlay_if_present "${overlay}" '.aap.bootstrap.image' "ghcr.io/osac-project/osac-aap:${AAP_VER}"
           [[ -n "${AAP_VER}" ]] && stamp_ci_overlay_if_present "${overlay}" '.aap.configAsCode.eeImage' "ghcr.io/osac-project/osac-aap:${AAP_VER}"
+          stamp_ci_overlay_if_present "${overlay}" '.aap.configAsCode.projectGitBranch' "${GITHUB_SHA}"
+          stamp_ci_overlay_if_present "${overlay}" '.aap.configAsCode.projectGitUri' "https://github.com/${GITHUB_REPOSITORY}"
           [[ -n "${BMF_VER}" ]] && stamp_ci_overlay_if_present "${overlay}" '.bmf.image.tag' "${BMF_VER}"
           [[ -n "${METERING_VER}" ]] && stamp_ci_overlay_if_present "${overlay}" '.metering.image.tag' "${METERING_VER}"
           [[ -n "${METERING_VER}" ]] && stamp_ci_overlay_if_present "${overlay}" '.metering.echoAdapter.image.tag' "${METERING_VER}"

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -153,9 +153,9 @@ jobs:
     # Stamp every sub-chart's Chart.yaml + values.yaml, the umbrella's own
     # values.yaml, and the 4 CI overlay files to the exact versions resolved
     # above -- all of it now, before the temp branch is pushed, so both the
-    # parallel build phase and e2e-test operate on consistent, final
+    # parallel build phase and the e2e jobs operate on consistent, final
     # references. No image exists at these tags yet; the build phase
-    # (needs: prepare) produces them before e2e-test runs.
+    # (needs: prepare) produces them before the e2e jobs run.
     - name: Stamp charts and values for nightly
       env:
         COMPONENT_VERSIONS: ${{ steps.versions.outputs.component-versions }}
@@ -248,8 +248,8 @@ jobs:
 
         # The 4 CI overlay values files (osac-installer/values/*/instance.yaml)
         # have their own separate floating image tag overrides on top of the
-        # umbrella chart's own values.yaml, and e2e-test below installs using
-        # one of them. Without this, e2e-test would keep validating stale
+        # umbrella chart's own values.yaml, and the e2e jobs below install using
+        # one of them. Without this, e2e would keep validating stale
         # :latest images even after the published chart itself is correctly
         # pinned. Every version is already fully resolved above, so these
         # get the exact same final SUB_VERSION strings as everywhere else --
@@ -308,7 +308,7 @@ jobs:
   # Job 2: Build — one fresh image per mono-repo component, all in
   # parallel, each tagged directly with the exact SUB_VERSION resolved
   # and stamped into charts/values by prepare. Only if every one of
-  # these succeeds do we proceed to E2E -- e2e-test and publish
+  # these succeeds do we proceed to E2E -- the e2e jobs and publish
   # (below) never run against a partially-built set of images.
   #
   # Reuses each component's own `make -C <dir> image-build`/`image-push`
@@ -470,12 +470,45 @@ jobs:
         make -C "${{ matrix.dir }}" "${{ matrix.push_target }}" "${BUILD_ARGS[@]}"
 
   # -------------------------------------------------------------------
-  # Job 3: E2E validation — test temp branch, not github.sha. Depends on
-  # `build` too, not just `prepare`: e2e-test must never install against
-  # images that don't exist yet or (pre-this-change) a floating :latest.
+  # Job 3: Code quality — unit tests, integration tests, and CodeQL SAST
+  # as three independent parallel boxes. These test source code directly
+  # (github.sha), not the temp branch's stamped charts/images, so they
+  # have no dependency on `prepare`/`build` and start immediately alongside
+  # them. Each `uses:` a local reusable workflow that already exists and
+  # runs standalone on pull_request/schedule -- reused here rather than
+  # duplicated, same reasoning as `build` reusing each component's own
+  # Makefile targets instead of inlining build steps.
   # -------------------------------------------------------------------
-  e2e-test:
-    name: E2E validation
+  unit-tests:
+    name: Unit tests
+    permissions:
+      contents: read
+    uses: ./.github/workflows/unit-tests.yml
+
+  integration-tests:
+    name: Integration tests
+    permissions:
+      contents: read
+    uses: ./.github/workflows/integration-tests.yml
+
+  security-tests:
+    name: Security tests (CodeQL)
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    uses: ./.github/workflows/codeql.yml
+
+  # -------------------------------------------------------------------
+  # Job 4: E2E validation — vmaas, caas, and bmaas full-install suites as
+  # three independent parallel boxes, each testing the temp branch (not
+  # github.sha). All three depend on `build` too, not just `prepare`:
+  # none may install against images that don't exist yet or (pre-this-change)
+  # a floating :latest.
+  # -------------------------------------------------------------------
+  e2e-vmaas-test:
+    name: E2E validation (vmaas)
     needs: [prepare, build]
     permissions:
       contents: read
@@ -487,16 +520,42 @@ jobs:
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: main
 
+  e2e-caas-test:
+    name: E2E validation (caas)
+    needs: [prepare, build]
+    permissions:
+      contents: read
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-caas-full-install.yml@main
+    with:
+      test-suite: caas
+      installer-repo: ${{ github.repository }}
+      installer-ref: ${{ needs.prepare.outputs.temp-branch }}
+      test-infra-repository: osac-project/osac-test-infra
+      test-infra-ref: main
+
+  e2e-bmaas-test:
+    name: E2E validation (bmaas)
+    needs: [prepare, build]
+    permissions:
+      contents: read
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-full-install.yml@main
+    with:
+      test-suite: bmaas
+      installer-repo: ${{ github.repository }}
+      installer-ref: ${{ needs.prepare.outputs.temp-branch }}
+      test-infra-repository: osac-project/osac-test-infra
+      test-infra-ref: main
+
   # -------------------------------------------------------------------
-  # Job 4: Publish — package and push every chart (only if build + E2E
-  # both passed). All Chart.yaml/values.yaml stamping already happened
+  # Job 5: Publish — package and push every chart (only if build and every
+  # test box passed). All Chart.yaml/values.yaml stamping already happened
   # in prepare, and every image already exists at its final tag from the
   # build phase -- this job only packages/pushes the charts, using
   # whatever version prepare already wrote into each Chart.yaml.
   # -------------------------------------------------------------------
   publish:
     name: Publish nightly chart
-    needs: [prepare, build, e2e-test]
+    needs: [prepare, build, unit-tests, integration-tests, security-tests, e2e-vmaas-test, e2e-caas-test, e2e-bmaas-test]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -720,7 +779,7 @@ jobs:
         retention-days: 14
 
   # -------------------------------------------------------------------
-  # Job 5: Tag and notify — record success on temp branch + Slack
+  # Job 6: Tag and notify — record success on temp branch + Slack
   # Create osac/v<version> git tag at the temp branch commit (same pin E2E
   # tested and publish packaged). Download chart-sources.txt artifact; post
   # Slack summary with published chart OCI links.
@@ -828,11 +887,11 @@ jobs:
           -d @/tmp/slack-payload.json
 
   # -------------------------------------------------------------------
-  # Job 6: Notify on failure
+  # Job 7: Notify on failure
   # -------------------------------------------------------------------
   notify-failure:
     name: Notify failure
-    needs: [prepare, build, e2e-test, publish, tag-and-notify]
+    needs: [prepare, build, unit-tests, integration-tests, security-tests, e2e-vmaas-test, e2e-caas-test, e2e-bmaas-test, publish, tag-and-notify]
     runs-on: osac-ci
     timeout-minutes: 10
     if: failure()
@@ -889,11 +948,11 @@ jobs:
           -d @/tmp/slack-payload.json
 
   # -------------------------------------------------------------------
-  # Job 7: Cleanup — delete temp branch (always, success or failure)
+  # Job 8: Cleanup — delete temp branch (always, success or failure)
   # -------------------------------------------------------------------
   cleanup:
     name: Cleanup temp branch
-    needs: [prepare, build, e2e-test, publish, tag-and-notify, notify-failure]
+    needs: [prepare, build, unit-tests, integration-tests, security-tests, e2e-vmaas-test, e2e-caas-test, e2e-bmaas-test, publish, tag-and-notify, notify-failure]
     runs-on: ubuntu-latest
     if: always()
     permissions:

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -481,14 +481,24 @@ jobs:
   # -------------------------------------------------------------------
   unit-tests:
     name: Unit tests
+    # pull-requests: read matches what unit-tests.yml's own `changes` job
+    # declares (for dorny/paths-filter) -- unused on a workflow_call trigger
+    # (that step's own `if:` only matches pull_request/merge_group), but
+    # GitHub statically validates a called local reusable workflow's job
+    # permissions against the caller's grant regardless of runtime `if:`
+    # guards, so it still must be granted here or the whole run fails to
+    # start.
     permissions:
       contents: read
+      pull-requests: read
     uses: ./.github/workflows/unit-tests.yml
 
   integration-tests:
     name: Integration tests
+    # See unit-tests' comment above -- same reason.
     permissions:
       contents: read
+      pull-requests: read
     uses: ./.github/workflows/integration-tests.yml
 
   security-tests:

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -19,12 +19,11 @@ env:
 
 jobs:
   # -------------------------------------------------------------------
-  # Job 1: Prepare — pin osac-ui and push temp branch
-  # osac-ui is the only external dependency needing a gated pin per run.
-  # Resolve osac-ui@main HEAD (ls-remote); accept only when GHCR already
-  # has ghcr.io/.../osac-ui:sha-<7>. Write pinned/osac-ui.commit; stamp
-  # umbrella ui.images.ui and CI values files. Push nightly/<date>-<sha>-<run>
-  # temp branch — consumed by e2e-test and publish (one pin for whole run).
+  # Job 1: Prepare — resolve every component's nightly version upfront,
+  # stamp every Chart.yaml/values.yaml/CI-overlay reference to those
+  # exact versions, and push a temp branch. Nothing is built yet here;
+  # this just decides *what* every chart and image reference should say
+  # before the parallel build phase produces the images to match.
   # -------------------------------------------------------------------
   prepare:
     name: Prepare nightly state
@@ -35,7 +34,9 @@ jobs:
       temp-branch: ${{ steps.push.outputs.branch }}
       ui-sha: ${{ steps.ui.outputs.sha }}
       ui-short-sha: ${{ steps.ui.outputs.short-sha }}
-      ui-image-ref: ${{ steps.ui.outputs.image-ref }}
+      ui-sub-version: ${{ steps.versions.outputs.ui-sub-version }}
+      nightly-suffix: ${{ steps.versions.outputs.nightly-suffix }}
+      component-versions: ${{ steps.versions.outputs.component-versions }}
 
     steps:
     - name: Checkout repository
@@ -67,9 +68,8 @@ jobs:
         done < <(gh api --paginate "repos/${GITHUB_REPOSITORY}/git/matching-refs/heads/nightly/" --jq '.[].ref')
 
     # Resolve osac-ui@main HEAD once, but only accept it when ghcr.io/.../osac-ui:sha-<7>
-    # already exists (check_osac_ui_image). The full SHA is written to pinned/osac-ui.commit
-    # and propagated to E2E + publish via the temp branch outputs — same pin for the
-    # whole workflow run, matching the archived submodule bump model.
+    # already exists (check_osac_ui_image) -- osac-ui is a separate repo we
+    # don't build here, so we can only gate on an image it already published.
     - name: Resolve and gate osac-ui SHA
       id: ui
       run: |
@@ -78,23 +78,213 @@ jobs:
 
         UI_SHA=$(check_osac_ui_image osac-ui)
         UI_SHORT_SHA="${UI_SHA:0:7}"
-        # osac-ui is external; images always publish under ghcr.io/osac-project/osac-ui.
-        UI_IMAGE_REF=$(osac_ui_nightly_image_ref "${REGISTRY}/osac-project/osac-ui" "${UI_SHORT_SHA}")
 
         mkdir -p osac-installer/pinned
         printf '%s\n' "${UI_SHA}" > osac-installer/pinned/osac-ui.commit
-        stamp_umbrella_ui_values "${UI_IMAGE_REF}"
 
         echo "sha=${UI_SHA}" >> "$GITHUB_OUTPUT"
         echo "short-sha=${UI_SHORT_SHA}" >> "$GITHUB_OUTPUT"
-        echo "image-ref=${UI_IMAGE_REF}" >> "$GITHUB_OUTPUT"
-        echo "Pinned osac-ui ${UI_SHORT_SHA} (${UI_IMAGE_REF})"
+        echo "Pinned osac-ui ${UI_SHORT_SHA}"
+
+    # Needed only for resolve_bare_release_tag_at's `git describe` below --
+    # a local checkout of the pinned commit, not the file content (that's
+    # separately checked out again in publish, which packages its chart).
+    - name: Checkout osac-ui at pinned SHA
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6
+      with:
+        repository: osac-project/osac-ui
+        ref: ${{ steps.ui.outputs.sha }}
+        path: osac-ui
+        fetch-depth: 0
+        persist-credentials: false
+
+    # Resolve every mono-repo component's nightly SUB_VERSION (and osac-ui's)
+    # up front, before anything is stamped or built. component-versions is a
+    # JSON map so the build matrix (a separate job) can look up its own
+    # component's version without re-deriving it independently.
+    - name: Resolve nightly versions
+      id: versions
+      env:
+        UI_SHA: ${{ steps.ui.outputs.sha }}
+      run: |
+        set -euo pipefail
+        source osac-installer/scripts/nightly-charts.sh
+
+        DATE=$(date -u +%Y%m%d)
+        SHORT_SHA=$(git rev-parse --short=7 HEAD)
+        # GITHUB_RUN_NUMBER/GITHUB_RUN_ATTEMPT keep a "Re-run failed jobs" of
+        # the same run from colliding with a version it already tried
+        # (RUN_ID/RUN_NUMBER stay constant across a re-run; only
+        # RUN_ATTEMPT increments).
+        NIGHTLY_SUFFIX="nightly.${DATE}.${SHORT_SHA}.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+        echo "nightly-suffix=${NIGHTLY_SUFFIX}" >> "$GITHUB_OUTPUT"
+
+        declare -a COMPONENTS=(
+          osac-operator
+          fulfillment-service
+          osac-aap
+          bare-metal-fulfillment-operator
+          osac-metering
+          osac-csi-driver
+        )
+        json="{}"
+        for COMPONENT in "${COMPONENTS[@]}"; do
+          if ! BASE_TAG=$(resolve_release_tag . "${COMPONENT}"); then
+            safe_component=$(_gha_sanitize_for_message "${COMPONENT}")
+            echo "::warning::No ${safe_component}/vX.Y.Z release tag found yet -- ${safe_component} will be skipped this run"
+            continue
+          fi
+          BASE_VERSION="${BASE_TAG#"${COMPONENT}"/v}"
+          SUB_VERSION="${BASE_VERSION}-${NIGHTLY_SUFFIX}"
+          json=$(jq -c --arg k "${COMPONENT}" --arg v "${SUB_VERSION}" '. + {($k): $v}' <<<"${json}")
+          echo "${COMPONENT}: ${SUB_VERSION} (from tag ${BASE_TAG})"
+        done
+        echo "component-versions=${json}" >> "$GITHUB_OUTPUT"
+
+        # osac-ui uses bare vX.Y.Z tags on the external repo, not <component>/vX.Y.Z.
+        if UI_BASE_TAG=$(resolve_bare_release_tag_at osac-ui "${UI_SHA}"); then
+          UI_SUB_VERSION=$(compute_nightly_chart_version "${UI_BASE_TAG}" "${NIGHTLY_SUFFIX}")
+          echo "ui-sub-version=${UI_SUB_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "osac-ui: ${UI_SUB_VERSION} (from tag ${UI_BASE_TAG})"
+        else
+          echo "::warning title=osac-ui::No vX.Y.Z release tag found for osac-ui -- its own sub-chart won't be stamped/published this run"
+        fi
+
+    # Stamp every sub-chart's Chart.yaml + values.yaml, the umbrella's own
+    # values.yaml, and the 4 CI overlay files to the exact versions resolved
+    # above -- all of it now, before the temp branch is pushed, so both the
+    # parallel build phase and e2e-test operate on consistent, final
+    # references. No image exists at these tags yet; the build phase
+    # (needs: prepare) produces them before e2e-test runs.
+    - name: Stamp charts and values for nightly
+      env:
+        COMPONENT_VERSIONS: ${{ steps.versions.outputs.component-versions }}
+        UI_SUB_VERSION: ${{ steps.versions.outputs.ui-sub-version }}
+      run: |
+        set -euo pipefail
+        source osac-installer/scripts/nightly-charts.sh
+
+        UMBRELLA_VALUES="osac-installer/charts/osac/values.yaml"
+
+        declare -A SUB_CHARTS=(
+          ["osac-operator"]="osac-operator/charts/operator osac-operator/charts/operator-crds"
+          ["fulfillment-service"]="fulfillment-service/charts/service"
+          ["osac-aap"]="osac-aap/charts/aap"
+          ["bare-metal-fulfillment-operator"]="bare-metal-fulfillment-operator/charts/operator bare-metal-fulfillment-operator/charts/operator-crds"
+          ["osac-metering"]="osac-metering/charts/osac-metering"
+          ["osac-csi-driver"]="osac-csi-driver/charts/csi-driver osac-csi-driver/charts/csi-backends"
+        )
+
+        for COMPONENT in $(printf '%s\n' "${!SUB_CHARTS[@]}" | sort); do
+          SUB_VERSION=$(jq -r --arg k "${COMPONENT}" '.[$k] // empty' <<<"${COMPONENT_VERSIONS}")
+          if [[ -z "${SUB_VERSION}" ]]; then
+            safe_component=$(_gha_sanitize_for_message "${COMPONENT}")
+            echo "::warning::Skipping ${safe_component} sub-charts — no resolved nightly version"
+            continue
+          fi
+
+          echo "Stamping ${COMPONENT} sub-charts to version ${SUB_VERSION}..."
+
+          # Intentional word splitting: each SUB_CHARTS value lists multiple chart paths.
+          for CHART_DIR in ${SUB_CHARTS[$COMPONENT]}; do
+            SUB_VERSION="${SUB_VERSION}" yq -i '.version = strenv(SUB_VERSION)' "${CHART_DIR}/Chart.yaml"
+            SUB_VERSION="${SUB_VERSION}" yq -i '.appVersion = strenv(SUB_VERSION)' "${CHART_DIR}/Chart.yaml"
+
+            # Stamp every values.yaml field that references this component's
+            # image (its own sub-chart values.yaml, plus the umbrella's own
+            # values.yaml where applicable) to the same SUB_VERSION the
+            # build phase will tag its fresh image with. Charts with no
+            # image of their own (operator-crds, bmf-crds, csi-backends)
+            # fall through the case with no action.
+            case "${CHART_DIR}" in
+              "osac-operator/charts/operator")
+                SUB_VERSION="${SUB_VERSION}" yq -i '.image.tag = strenv(SUB_VERSION)' "${CHART_DIR}/values.yaml"
+                stamp_umbrella_nested_field "${UMBRELLA_VALUES}" operator image tag "${SUB_VERSION}"
+                ;;
+              "bare-metal-fulfillment-operator/charts/operator")
+                SUB_VERSION="${SUB_VERSION}" yq -i '.image.tag = strenv(SUB_VERSION)' "${CHART_DIR}/values.yaml"
+                stamp_umbrella_nested_field "${UMBRELLA_VALUES}" bmf image tag "${SUB_VERSION}"
+                ;;
+              "fulfillment-service/charts/service")
+                IMAGE_REF="ghcr.io/osac-project/fulfillment-service:${SUB_VERSION}" \
+                  yq -i '.images.service = strenv(IMAGE_REF)' "${CHART_DIR}/values.yaml"
+                stamp_umbrella_nested_field "${UMBRELLA_VALUES}" service images service "ghcr.io/osac-project/fulfillment-service:${SUB_VERSION}"
+                ;;
+              "osac-aap/charts/aap")
+                IMAGE_REF="ghcr.io/osac-project/osac-aap:${SUB_VERSION}" \
+                  yq -i '.bootstrap.image = strenv(IMAGE_REF)' "${CHART_DIR}/values.yaml"
+                stamp_umbrella_nested_field "${UMBRELLA_VALUES}" aap bootstrap image "ghcr.io/osac-project/osac-aap:${SUB_VERSION}"
+                ;;
+              "osac-metering/charts/osac-metering")
+                SUB_VERSION="${SUB_VERSION}" yq -i '.image.tag = strenv(SUB_VERSION)' "${CHART_DIR}/values.yaml"
+                stamp_umbrella_nested_field "${UMBRELLA_VALUES}" metering image tag "${SUB_VERSION}"
+                # m360Adapter has no umbrella-level override field -- stamp
+                # only the subchart's own values.yaml. Stamped
+                # unconditionally even though disabled by default: cheap,
+                # and avoids a stale :latest surfacing the moment someone
+                # flips m360Adapter.enabled=true on a nightly install.
+                # (echoAdapter's image block is commented out by default in
+                # this chart -- only the vmaas-ci CI overlay enables and
+                # overrides it, stamped separately below.)
+                SUB_VERSION="${SUB_VERSION}" yq -i '.m360Adapter.image.tag = strenv(SUB_VERSION)' "${CHART_DIR}/values.yaml"
+                ;;
+              "osac-csi-driver/charts/csi-driver")
+                SUB_VERSION="${SUB_VERSION}" yq -i '.image.tag = strenv(SUB_VERSION)' "${CHART_DIR}/values.yaml"
+                stamp_umbrella_nested_field "${UMBRELLA_VALUES}" csiDriver image tag "${SUB_VERSION}"
+                ;;
+            esac
+          done
+        done
+
+        # osac-ui: stamp only the umbrella's own ui.images.ui field here.
+        # Its own sub-chart Chart.yaml/values.yaml are stamped and packaged
+        # later in the publish job, which checks out osac-ui again itself
+        # for that purpose (this job's own osac-ui/ checkout above is used
+        # only for git describe in "Resolve nightly versions", and is
+        # deleted below before it can interfere with this job's own commit).
+        if [[ -n "${UI_SUB_VERSION}" ]]; then
+          stamp_umbrella_nested_field "${UMBRELLA_VALUES}" ui images ui "ghcr.io/osac-project/osac-ui:${UI_SUB_VERSION}"
+        fi
+
+        # The 4 CI overlay values files (osac-installer/values/*/instance.yaml)
+        # have their own separate floating image tag overrides on top of the
+        # umbrella chart's own values.yaml, and e2e-test below installs using
+        # one of them. Without this, e2e-test would keep validating stale
+        # :latest images even after the published chart itself is correctly
+        # pinned. Every version is already fully resolved above, so these
+        # get the exact same final SUB_VERSION strings as everywhere else --
+        # no intermediate placeholder needed.
+        OPERATOR_VER=$(jq -r '.["osac-operator"] // empty' <<<"${COMPONENT_VERSIONS}")
+        FULFILLMENT_VER=$(jq -r '.["fulfillment-service"] // empty' <<<"${COMPONENT_VERSIONS}")
+        AAP_VER=$(jq -r '.["osac-aap"] // empty' <<<"${COMPONENT_VERSIONS}")
+        BMF_VER=$(jq -r '.["bare-metal-fulfillment-operator"] // empty' <<<"${COMPONENT_VERSIONS}")
+        METERING_VER=$(jq -r '.["osac-metering"] // empty' <<<"${COMPONENT_VERSIONS}")
+        CSI_VER=$(jq -r '.["osac-csi-driver"] // empty' <<<"${COMPONENT_VERSIONS}")
+
+        for overlay in "${NIGHTLY_CI_OVERLAY_VALUES[@]}"; do
+          [[ -f "${overlay}" ]] || continue
+          [[ -n "${OPERATOR_VER}" ]] && stamp_ci_overlay_if_present "${overlay}" '.operator.image.tag' "${OPERATOR_VER}"
+          [[ -n "${FULFILLMENT_VER}" ]] && stamp_ci_overlay_if_present "${overlay}" '.service.images.service' "ghcr.io/osac-project/fulfillment-service:${FULFILLMENT_VER}"
+          [[ -n "${AAP_VER}" ]] && stamp_ci_overlay_if_present "${overlay}" '.aap.bootstrap.image' "ghcr.io/osac-project/osac-aap:${AAP_VER}"
+          [[ -n "${AAP_VER}" ]] && stamp_ci_overlay_if_present "${overlay}" '.aap.configAsCode.eeImage' "ghcr.io/osac-project/osac-aap:${AAP_VER}"
+          [[ -n "${BMF_VER}" ]] && stamp_ci_overlay_if_present "${overlay}" '.bmf.image.tag' "${BMF_VER}"
+          [[ -n "${METERING_VER}" ]] && stamp_ci_overlay_if_present "${overlay}" '.metering.image.tag' "${METERING_VER}"
+          [[ -n "${METERING_VER}" ]] && stamp_ci_overlay_if_present "${overlay}" '.metering.echoAdapter.image.tag' "${METERING_VER}"
+          [[ -n "${METERING_VER}" ]] && stamp_ci_overlay_if_present "${overlay}" '.metering.m360Adapter.image.tag' "${METERING_VER}"
+          [[ -n "${CSI_VER}" ]] && stamp_ci_overlay_if_present "${overlay}" '.csiDriver.image.tag' "${CSI_VER}"
+          [[ -n "${UI_SUB_VERSION}" ]] && stamp_ci_overlay_if_present "${overlay}" '.ui.images.ui' "ghcr.io/osac-project/osac-ui:${UI_SUB_VERSION}"
+          echo "Stamped ${overlay} (fields present in that file only)"
+        done
 
     - name: Push temporary branch
       id: push
       run: |
         set -euo pipefail
-        source osac-installer/scripts/nightly-charts.sh
+        # osac-ui was checked out earlier (own nested .git) purely for git
+        # describe in "Resolve nightly versions" -- it is not part of this
+        # repo's tree and must not be staged as an embedded repository.
+        rm -rf osac-ui
+
         DATE=$(date -u +%Y%m%d)
         SHORT_SHA=$(git rev-parse --short=7 HEAD)
         BRANCH="nightly/${DATE}-${SHORT_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
@@ -102,15 +292,12 @@ jobs:
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git checkout -b "${BRANCH}"
-        git add osac-installer/pinned/osac-ui.commit
-        for values_yaml in "${NIGHTLY_UMBRELLA_UI_VALUES[@]}"; do
-          [[ -f "${values_yaml}" ]] && git add "${values_yaml}"
-        done
+        git add -A
         if git diff --cached --quiet; then
-          echo "::error::No osac-ui pin changes staged — refusing to push empty temp branch"
+          echo "::error::No nightly stamping changes staged — refusing to push empty temp branch"
           exit 1
         fi
-        git commit -m "nightly: pin osac-ui SHA and umbrella ui.images.ui"
+        git commit -m "nightly: stamp chart versions and image tags for this run"
 
         git push origin "${BRANCH}"
 
@@ -118,15 +305,178 @@ jobs:
         echo "Pushed temp branch: ${BRANCH}"
 
   # -------------------------------------------------------------------
-  # Job 2: E2E validation — test temp branch, not github.sha
-  # Reusable vmaas full-install workflow; installer-ref = prepare temp branch.
-  # Mono-repo components (operator, fulfillment-service, etc.) share that
-  # branch commit. osac-ui pin travels on the branch via pinned/osac-ui.commit
-  # and stamped umbrella ui.images.ui — same SHA E2E will install as publish.
+  # Job 2: Build — one fresh image per mono-repo component, all in
+  # parallel, each tagged directly with the exact SUB_VERSION resolved
+  # and stamped into charts/values by prepare. Only if every one of
+  # these succeeds do we proceed to E2E -- e2e-test and publish
+  # (below) never run against a partially-built set of images.
+  #
+  # Reuses each component's own `make -C <dir> image-build`/`image-push`
+  # target (the same targets a human runs locally) rather than
+  # duplicating build-step logic here or in each component's own
+  # per-push build workflow.
+  #
+  # osac-ui is the one exception: it's an external repo we don't build
+  # here, so its entry retags (skopeo, server-side, no rebuild) the
+  # already-published sha-<short> image prepare already gated on, to
+  # the same UI_SUB_VERSION, instead of running `make`.
+  # -------------------------------------------------------------------
+  build:
+    name: Build ${{ matrix.name }}
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: osac-operator
+            component: osac-operator
+            dir: osac-operator
+            target: image-build
+            push_target: image-push
+            image: ghcr.io/osac-project/osac-operator
+          - name: bare-metal-fulfillment-operator
+            component: bare-metal-fulfillment-operator
+            dir: bare-metal-fulfillment-operator
+            target: image-build
+            push_target: image-push
+            image: ghcr.io/osac-project/bare-metal-fulfillment-operator
+          - name: fulfillment-service
+            component: fulfillment-service
+            dir: fulfillment-service
+            target: image-build
+            push_target: image-push
+            image: ghcr.io/osac-project/fulfillment-service
+            version_arg: true
+          - name: osac-aap
+            component: osac-aap
+            dir: osac-aap
+            target: execution-environment-build
+            push_target: execution-environment-push
+            image: ghcr.io/osac-project/osac-aap
+          - name: osac-metering-service
+            component: osac-metering
+            dir: osac-metering/metering-service
+            target: image-build
+            push_target: image-push
+            image: ghcr.io/osac-project/metering-service
+          - name: osac-metering-m360-adapter
+            component: osac-metering
+            dir: osac-metering/adapters
+            target: image-build-m360-adapter
+            push_target: image-push-m360-adapter
+            image: ghcr.io/osac-project/metering-m360-adapter
+            image_var: IMG_M360_ADAPTER
+          - name: osac-metering-echo-adapter
+            component: osac-metering
+            dir: osac-metering/adapters
+            target: image-build-echo-adapter
+            push_target: image-push-echo-adapter
+            image: ghcr.io/osac-project/metering-echo-adapter
+            image_var: IMG_ECHO_ADAPTER
+          - name: osac-csi-driver
+            component: osac-csi-driver
+            dir: osac-csi-driver
+            target: image-build
+            push_target: image-push
+            image: ghcr.io/osac-project/osac-csi-driver
+            version_arg: true
+          - name: osac-ui
+            retag: true
+            image: ghcr.io/osac-project/osac-ui
+
+    steps:
+    - name: Checkout temporary branch
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6
+      with:
+        ref: ${{ needs.prepare.outputs.temp-branch }}
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Log in to GHCR
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Install skopeo
+      if: matrix.retag == true
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq skopeo
+
+    # osac-ui: alias-tag (no rebuild) rather than build -- see job comment.
+    - name: Retag osac-ui image
+      if: matrix.retag == true
+      env:
+        UI_SHORT_SHA: ${{ needs.prepare.outputs.ui-short-sha }}
+        UI_SUB_VERSION: ${{ needs.prepare.outputs.ui-sub-version }}
+      run: |
+        set -euo pipefail
+        source osac-installer/scripts/nightly-charts.sh
+        if [[ -z "${UI_SUB_VERSION}" ]]; then
+          echo "::notice::No resolved osac-ui nightly version -- skipping retag"
+          exit 0
+        fi
+        retag_component_image "${{ matrix.image }}" "${UI_SHORT_SHA}" "${UI_SUB_VERSION}"
+
+    # osac-aap's execution-environment-build target shells out to `uv`
+    # (ansible-builder is invoked via `uv tool run`) -- not present on
+    # ubuntu-latest by default. Mirrors execution-environment.yml's own setup.
+    - name: Install uv
+      if: matrix.name == 'osac-aap'
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
+
+    - name: Set up Python
+      if: matrix.name == 'osac-aap'
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+      with:
+        python-version-file: osac-aap/pyproject.toml
+
+    - name: Resolve component version
+      if: matrix.retag != true
+      id: resolve
+      env:
+        COMPONENT_VERSIONS: ${{ needs.prepare.outputs.component-versions }}
+      run: |
+        set -euo pipefail
+        VERSION=$(jq -r --arg k "${{ matrix.component }}" '.[$k] // empty' <<<"${COMPONENT_VERSIONS}")
+        if [[ -z "${VERSION}" ]]; then
+          echo "::notice::No resolved nightly version for ${{ matrix.component }} -- skipping build"
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        echo "skip=false" >> "$GITHUB_OUTPUT"
+        echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+    - name: Build and push image
+      if: matrix.retag != true && steps.resolve.outputs.skip != 'true'
+      env:
+        VERSION: ${{ steps.resolve.outputs.version }}
+        IMAGE_VAR: ${{ matrix.image_var || 'IMG' }}
+      run: |
+        set -euo pipefail
+        IMG_REF="${{ matrix.image }}:${VERSION}"
+        BUILD_ARGS=("${IMAGE_VAR}=${IMG_REF}")
+        if [[ "${{ matrix.version_arg }}" == "true" ]]; then
+          BUILD_ARGS+=("VERSION=${VERSION}")
+        fi
+        make -C "${{ matrix.dir }}" "${{ matrix.target }}" "${BUILD_ARGS[@]}"
+        make -C "${{ matrix.dir }}" "${{ matrix.push_target }}" "${BUILD_ARGS[@]}"
+
+  # -------------------------------------------------------------------
+  # Job 3: E2E validation — test temp branch, not github.sha. Depends on
+  # `build` too, not just `prepare`: e2e-test must never install against
+  # images that don't exist yet or (pre-this-change) a floating :latest.
   # -------------------------------------------------------------------
   e2e-test:
     name: E2E validation
-    needs: prepare
+    needs: [prepare, build]
     permissions:
       contents: read
     uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main
@@ -138,15 +488,15 @@ jobs:
       test-infra-ref: main
 
   # -------------------------------------------------------------------
-  # Job 3: Publish — version and push all charts (only if E2E passes)
-  # Checkout prepare temp branch; reuse gated osac-ui SHA (not osac-ui@main).
-  # Stamp, package, and push every mono-repo sub-chart plus osac-ui sub-chart
-  # and the umbrella osac chart to GHCR OCI. Charts only — does not build
-  # or push container images (mono-repo images stay :latest in values).
+  # Job 4: Publish — package and push every chart (only if build + E2E
+  # both passed). All Chart.yaml/values.yaml stamping already happened
+  # in prepare, and every image already exists at its final tag from the
+  # build phase -- this job only packages/pushes the charts, using
+  # whatever version prepare already wrote into each Chart.yaml.
   # -------------------------------------------------------------------
   publish:
     name: Publish nightly chart
-    needs: [prepare, e2e-test]
+    needs: [prepare, build, e2e-test]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -169,10 +519,6 @@ jobs:
     # resolves one gated SHA per run (ls-remote main + GHCR sha-<7> manifest check)
     # and records it in osac-installer/pinned/osac-ui.commit on the temp branch.
     # Publish reuses that exact commit — do not checkout ref: main here.
-    # Reproducibility is enforced by:
-    #   - resolve_bare_release_tag_at() for chart semver baseline (git describe on pinned SHA)
-    #   - image pin ghcr.io/.../osac-ui:sha-<short-sha> (also stamped on umbrella ui.images.ui)
-    #   - rewrite_umbrella_osac_ui_dependency_and_rebuild() after publishing the nightly chart
     - name: Checkout osac-ui at pinned SHA
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6
       with:
@@ -199,115 +545,87 @@ jobs:
     - name: Generate nightly version
       id: version
       working-directory: osac-installer
+      env:
+        NIGHTLY_SUFFIX: ${{ needs.prepare.outputs.nightly-suffix }}
       run: |
         set -euo pipefail
         source ./scripts/lib.sh
-        DATE=$(date -u +%Y%m%d)
-        SHORT_SHA=$(git rev-parse --short=7 HEAD)
-        # GITHUB_RUN_NUMBER/GITHUB_RUN_ATTEMPT keep a "Re-run failed jobs" of
-        # the same run from colliding with the chart version it already
-        # tried to publish (RUN_ID/RUN_NUMBER stay constant across a re-run;
-        # only RUN_ATTEMPT increments).
-        NIGHTLY_SUFFIX="nightly.${DATE}.${SHORT_SHA}.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
 
         # Use the umbrella chart's own latest real release tag (not the
         # Chart.yaml placeholder, which is never bumped) so the nightly
         # version reflects where this build actually sits relative to
-        # real releases.
+        # real releases. Reuse prepare's NIGHTLY_SUFFIX (not a freshly
+        # computed one) so every artifact from this run shares the same
+        # date/sha/run/attempt suffix.
         BASE_TAG=$(resolve_release_tag . osac)
         BASE_VERSION="${BASE_TAG#osac/v}"
         VERSION="${BASE_VERSION}-${NIGHTLY_SUFFIX}"
 
         echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
         echo "base-version=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
-        echo "short-sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
-        echo "nightly-suffix=${NIGHTLY_SUFFIX}" >> "$GITHUB_OUTPUT"
         echo "Nightly version: ${VERSION} (base: ${BASE_VERSION})"
 
-    - name: Stamp and package sub-charts
-      env:
-        NIGHTLY_SUFFIX: ${{ steps.version.outputs.nightly-suffix }}
-        UI_SHA: ${{ needs.prepare.outputs.ui-sha }}
-        UI_SHORT_SHA: ${{ needs.prepare.outputs.ui-short-sha }}
-        UI_IMAGE_REF: ${{ needs.prepare.outputs.ui-image-ref }}
+    - name: Package and push sub-charts
       run: |
         set -euo pipefail
         # Repo root (not osac-installer/) — sub-charts live under component directories.
         source osac-installer/scripts/nightly-charts.sh
 
-        # Ensure target packaging directory exists
         mkdir -p ./packaged-charts
         : > chart-sources.txt
 
-        # Define sub-component map (component_dir -> chart_paths). Version baselines
-        # come from per-component git tags (<component>/vX.Y.Z), not static files.
-        # Components without a release tag yet (currently osac-metering and
-        # osac-csi-driver) are skipped here with a ::warning:: — they are not
-        # published to GHCR until their first <component>/vX.Y.Z tag exists. The
-        # umbrella chart still embeds them via file:// at Chart.yaml placeholder
-        # versions (0.0.0); installs work, but those sub-charts are not
-        # independently pullable from the OCI registry until published.
-        # TODO: derive SUB_CHARTS from umbrella file:// dependencies instead of hardcoding.
-        declare -A SUB_CHARTS=(
-          ["osac-operator"]="osac-operator/charts/operator osac-operator/charts/operator-crds"
-          ["fulfillment-service"]="fulfillment-service/charts/service"
-          ["osac-aap"]="osac-aap/charts/aap"
-          ["bare-metal-fulfillment-operator"]="bare-metal-fulfillment-operator/charts/operator bare-metal-fulfillment-operator/charts/operator-crds"
-          ["osac-metering"]="osac-metering/charts/osac-metering"
-          ["osac-csi-driver"]="osac-csi-driver/charts/csi-driver osac-csi-driver/charts/csi-backends"
+        # Components without a release tag yet are skipped by prepare's
+        # stamping step (Chart.yaml stays at its committed 0.0.0
+        # placeholder) -- detect that here and skip packaging too, rather
+        # than publishing an unversioned/placeholder chart.
+        declare -a CHART_DIRS=(
+          osac-operator/charts/operator
+          osac-operator/charts/operator-crds
+          fulfillment-service/charts/service
+          osac-aap/charts/aap
+          bare-metal-fulfillment-operator/charts/operator
+          bare-metal-fulfillment-operator/charts/operator-crds
+          osac-metering/charts/osac-metering
+          osac-csi-driver/charts/csi-driver
+          osac-csi-driver/charts/csi-backends
         )
 
-        for COMPONENT in $(printf '%s\n' "${!SUB_CHARTS[@]}" | sort); do
-          if ! BASE_TAG=$(resolve_release_tag . "${COMPONENT}"); then
-            safe_component=$(_gha_sanitize_for_message "${COMPONENT}")
-            echo "::warning::Skipping ${safe_component} sub-charts — no ${safe_component}/vX.Y.Z release tag found yet"
+        for CHART_DIR in "${CHART_DIRS[@]}"; do
+          CHART_NAME=$(read_validated_chart_name "${CHART_DIR}")
+          SUB_VERSION=$(yq -r '.version' "${CHART_DIR}/Chart.yaml")
+          if [[ -z "${SUB_VERSION}" || "${SUB_VERSION}" == "0.0.0" ]]; then
+            safe_chart=$(_gha_sanitize_for_message "${CHART_NAME}")
+            echo "::warning::Skipping ${safe_chart} — not stamped this run (no release tag yet)"
             continue
           fi
-          # Per-component base semver (independent of umbrella BASE_VERSION in the version step).
-          BASE_VERSION="${BASE_TAG#"${COMPONENT}"/v}"
-          SUB_VERSION="${BASE_VERSION}-${NIGHTLY_SUFFIX}"
 
-          echo "Stamping ${COMPONENT} sub-charts to version ${SUB_VERSION} (from tag ${BASE_TAG})..."
-
-          # Intentional word splitting: each SUB_CHARTS value lists multiple chart paths.
-          for CHART_DIR in ${SUB_CHARTS[$COMPONENT]}; do
-            CHART_NAME=$(read_validated_chart_name "${CHART_DIR}")
-
-            # Update Chart.yaml version fields (strenv avoids shell interpolation in yq)
-            SUB_VERSION="${SUB_VERSION}" yq -i '.version = strenv(SUB_VERSION)' "${CHART_DIR}/Chart.yaml"
-            SUB_VERSION="${SUB_VERSION}" yq -i '.appVersion = strenv(SUB_VERSION)' "${CHART_DIR}/Chart.yaml"
-
-            # Package sub-chart
-            helm package "${CHART_DIR}" --destination ./packaged-charts
-
-            # Push individual sub-chart to OCI registry (GHCR)
-            helm push "./packaged-charts/${CHART_NAME}-${SUB_VERSION}.tgz" "oci://${REGISTRY}/${CHARTS_REPO}"
-            append_chart_source chart-sources.txt "${CHART_NAME}" "${SUB_VERSION}"
-          done
+          echo "Packaging ${CHART_NAME} ${SUB_VERSION}..."
+          helm package "${CHART_DIR}" --destination ./packaged-charts
+          helm push "./packaged-charts/${CHART_NAME}-${SUB_VERSION}.tgz" "oci://${REGISTRY}/${CHARTS_REPO}"
+          append_chart_source chart-sources.txt "${CHART_NAME}" "${SUB_VERSION}"
         done
 
-        # osac-ui is required for nightly umbrella installs (ui.enabled). GHCR image
-        # existence was verified in prepare; baseline semver uses git describe on the
-        # pinned commit (not highest merged tag). Parent umbrella ui.images.ui was
-        # already stamped on the temp branch; subchart values stamp is defense-in-depth.
-        echo "Stamping osac-ui chart from pinned SHA ${UI_SHORT_SHA}..."
-        if ! UI_BASE_TAG=$(resolve_bare_release_tag_at osac-ui "${UI_SHA}"); then
-          echo "::warning title=osac-ui::No vX.Y.Z release tag found for osac-ui — skipping sub-chart stamping"
-        else
+        # osac-ui: stamp its own sub-chart now (needs the checkout above,
+        # unlike the umbrella-values-only stamp prepare already did), then
+        # package/push, mirroring every other component. Its image at
+        # UI_SUB_VERSION already exists -- retagged by the build job.
+        UI_SUB_VERSION="${{ needs.prepare.outputs.ui-sub-version }}"
+        if [[ -n "${UI_SUB_VERSION}" ]]; then
           UI_CHART_DIR="osac-ui/charts/ui"
           UI_CHART_NAME=$(read_validated_chart_name "${UI_CHART_DIR}")
-          UI_SUB_VERSION=$(compute_nightly_chart_version "${UI_BASE_TAG}" "${NIGHTLY_SUFFIX}")
+          UI_IMAGE_REF="ghcr.io/osac-project/osac-ui:${UI_SUB_VERSION}"
           stamp_osac_ui_chart "${UI_CHART_DIR}" "${UI_SUB_VERSION}" "${UI_IMAGE_REF}"
           helm package "${UI_CHART_DIR}" --destination ./packaged-charts
           helm push "./packaged-charts/${UI_CHART_NAME}-${UI_SUB_VERSION}.tgz" "oci://${REGISTRY}/${CHARTS_REPO}"
-          append_chart_source chart-sources.txt "${UI_CHART_NAME}" "${UI_SUB_VERSION}" "${UI_SHORT_SHA}" "${UI_SHA}"
+          append_chart_source chart-sources.txt "${UI_CHART_NAME}" "${UI_SUB_VERSION}" "${{ needs.prepare.outputs.ui-short-sha }}" "${{ needs.prepare.outputs.ui-sha }}"
           echo "${UI_SUB_VERSION}" > osac-ui-nightly-version.txt
+        else
+          echo "::warning title=osac-ui::No resolved osac-ui nightly version — skipping sub-chart packaging"
         fi
 
     - name: Build umbrella chart dependencies
       env:
         OCI_REPO: oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
-        UI_IMAGE_REF: ${{ needs.prepare.outputs.ui-image-ref }}
       run: |
         set -euo pipefail
         source osac-installer/scripts/nightly-charts.sh
@@ -318,8 +636,6 @@ jobs:
         else
           helm dependency build osac-installer/charts/osac/
         fi
-        # Re-stamp all NIGHTLY_UMBRELLA_UI_VALUES paths (same set as prepare; idempotent defense-in-depth).
-        stamp_umbrella_ui_values "${UI_IMAGE_REF}"
 
     - name: Lint chart
       working-directory: osac-installer
@@ -363,7 +679,6 @@ jobs:
       env:
         VERSION: ${{ steps.version.outputs.version }}
         BASE_VERSION: ${{ steps.version.outputs.base-version }}
-        SHORT_SHA: ${{ steps.version.outputs.short-sha }}
         UI_SHORT_SHA: ${{ needs.prepare.outputs.ui-short-sha }}
       run: |
         set -euo pipefail
@@ -388,7 +703,7 @@ jobs:
 
         echo "" >> images.txt
         echo "# Chart source & version" >> images.txt
-        echo "# osac: source=v${BASE_VERSION} (${SHORT_SHA}), chart=oci://${REGISTRY}/${CHARTS_REPO}/osac:${VERSION}" >> images.txt
+        echo "# osac: source=v${BASE_VERSION} (${GITHUB_SHA:0:7}), chart=oci://${REGISTRY}/${CHARTS_REPO}/osac:${VERSION}" >> images.txt
         echo "# osac-ui: source=sha-${UI_SHORT_SHA}, chart=oci://${REGISTRY}/${CHARTS_REPO}/osac-ui (see chart-sources.txt)" >> images.txt
 
         echo "--- images.txt ---"
@@ -405,7 +720,7 @@ jobs:
         retention-days: 14
 
   # -------------------------------------------------------------------
-  # Job 4: Tag and notify — record success on temp branch + Slack
+  # Job 5: Tag and notify — record success on temp branch + Slack
   # Create osac/v<version> git tag at the temp branch commit (same pin E2E
   # tested and publish packaged). Download chart-sources.txt artifact; post
   # Slack summary with published chart OCI links.
@@ -513,11 +828,11 @@ jobs:
           -d @/tmp/slack-payload.json
 
   # -------------------------------------------------------------------
-  # Job 5: Notify on failure
+  # Job 6: Notify on failure
   # -------------------------------------------------------------------
   notify-failure:
     name: Notify failure
-    needs: [prepare, e2e-test, publish, tag-and-notify]
+    needs: [prepare, build, e2e-test, publish, tag-and-notify]
     runs-on: osac-ci
     timeout-minutes: 10
     if: failure()
@@ -574,11 +889,11 @@ jobs:
           -d @/tmp/slack-payload.json
 
   # -------------------------------------------------------------------
-  # Job 6: Cleanup — delete temp branch (always, success or failure)
+  # Job 7: Cleanup — delete temp branch (always, success or failure)
   # -------------------------------------------------------------------
   cleanup:
     name: Cleanup temp branch
-    needs: [prepare, e2e-test, publish, tag-and-notify, notify-failure]
+    needs: [prepare, build, e2e-test, publish, tag-and-notify, notify-failure]
     runs-on: ubuntu-latest
     if: always()
     permissions:

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -588,16 +588,18 @@ jobs:
 
     - name: Update image tag in values.yaml
       working-directory: osac-csi-driver
-      # sed exits 0 even when a pattern matches zero lines, so a future values.yaml
-      # format change could silently leave the placeholder unpinned. Verify the
-      # expected replacement actually landed and fail the release instead of
-      # packaging stale values (same pattern as publish-osac-aap-chart above).
+      # yq sets .image.tag directly by field path rather than matching the
+      # placeholder's exact text, so it's not dependent on the placeholder
+      # comment's exact wording (verified inconsistent across components).
+      # Still verify the expected value actually landed and fail the release
+      # instead of packaging stale values (same pattern as
+      # publish-osac-aap-chart above).
+      env:
+        VERSION: v${{ steps.version.outputs.version }}
       run: |
-        OLD="tag: main  # PLACEHOLDER -- overwritten at release time"
-        NEW="tag: v${{ steps.version.outputs.version }}"
-        sed -i "s|${OLD}|${NEW}|" charts/csi-driver/values.yaml
-        if ! grep -qF -- "${NEW}" charts/csi-driver/values.yaml; then
-          echo "::error::Expected '${NEW}' not found in charts/csi-driver/values.yaml after substitution (placeholder may be missing or already changed)" >&2
+        yq -i '.image.tag = strenv(VERSION)' charts/csi-driver/values.yaml
+        if ! grep -qF -- "tag: ${VERSION}" charts/csi-driver/values.yaml; then
+          echo "::error::Expected 'tag: ${VERSION}' not found in charts/csi-driver/values.yaml after yq substitution" >&2
           exit 1
         fi
 

--- a/.github/workflows/publish-osac-installer-chart.yaml
+++ b/.github/workflows/publish-osac-installer-chart.yaml
@@ -136,7 +136,9 @@ jobs:
           .aap.bootstrap.image = \"ghcr.io/osac-project/osac-aap:v${VERSION}\" |
           .aap.configAsCode.eeImage = \"ghcr.io/osac-project/osac-aap:v${VERSION}\" |
           .ui.images.ui = \"ghcr.io/osac-project/osac-ui:v${UI_VER}\" |
-          .dbMigrate.image = \"ghcr.io/osac-project/fulfillment-service:v${VERSION}\"
+          .dbMigrate.image = \"ghcr.io/osac-project/fulfillment-service:v${VERSION}\" |
+          .metering.image.tag = \"v${VERSION}\" |
+          .csiDriver.image.tag = \"v${VERSION}\"
         " osac-installer/charts/osac/values.yaml
 
         echo "--- Updated values.yaml image references ---"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,6 +28,8 @@ on:
   # don't all land on the same offset simultaneously.
   schedule:
     - cron: '13 */12 * * *'
+  # Invoked as a parallel "box" by nightly-build.yaml.
+  workflow_call:
 
 permissions:
   contents: read

--- a/fulfillment-service/Makefile
+++ b/fulfillment-service/Makefile
@@ -1,0 +1,21 @@
+# Image URL to use for building/pushing image targets
+IMG ?= ghcr.io/osac-project/fulfillment-service:latest
+# Name of Containerfile
+CONTAINERFILE ?= Containerfile
+# CONTAINER_TOOL defines the container tool to be used for building images.
+CONTAINER_TOOL ?= podman
+# Embedded into the binary via ldflags (see Containerfile's VERSION build
+# arg); falls back to `git describe` inside the build if left empty.
+VERSION ?=
+
+# The Containerfile copies go.work plus every workspace module's go.mod/go.sum
+# (see the Containerfile's own header comment), so the build context must be
+# the mono-repo root, not fulfillment-service/ alone -- matches
+# publish-image.yaml's `context: .`, `file: fulfillment-service/Containerfile`.
+.PHONY: image-build
+image-build: ## Build container image.
+	$(CONTAINER_TOOL) build -t ${IMG} -f ${CONTAINERFILE} --build-arg VERSION=$(VERSION) ..
+
+.PHONY: image-push
+image-push: ## Push container image.
+	$(CONTAINER_TOOL) push ${IMG}

--- a/osac-aap/Makefile
+++ b/osac-aap/Makefile
@@ -1,7 +1,7 @@
 # Integration tests for osac.workflows collection
 # Note: Must be run from repository root directory
 
-.PHONY: test lint
+.PHONY: test lint execution-environment-build execution-environment-push
 
 test:
 	@echo "=== Setting up test environment ==="
@@ -15,3 +15,23 @@ test:
 
 lint:
 	uv run ansible-lint
+
+# Not a generic docker/Containerfile build like the other components --
+# ansible-builder assembles the execution environment image from
+# execution-environment.yaml, producing a local EE_LOCAL_TAG, which is
+# then aliased to the real registry-qualified IMG (mirrors
+# execution-environment.yml's own build+tag+push steps).
+EE_LOCAL_TAG ?= osac-ee
+IMG ?= ghcr.io/osac-project/osac-aap:latest
+CONTAINER_TOOL ?= podman
+
+execution-environment-build:
+	uv sync --locked --all-extras --group development
+	uv tool run ansible-builder build -vvv \
+		--container-runtime $(CONTAINER_TOOL) \
+		--tag "$(EE_LOCAL_TAG)" \
+		-f "./execution-environment/execution-environment.yaml"
+	$(CONTAINER_TOOL) tag "$(EE_LOCAL_TAG)" "$(IMG)"
+
+execution-environment-push:
+	$(CONTAINER_TOOL) push "$(IMG)"

--- a/osac-csi-driver/charts/csi-driver/values.yaml
+++ b/osac-csi-driver/charts/csi-driver/values.yaml
@@ -4,7 +4,7 @@ driverName: csi.osac.openshift.io
 
 image:
   repository: ghcr.io/osac-project/osac-csi-driver
-  tag: main  # PLACEHOLDER -- overwritten at release time
+  tag: main  # PLACEHOLDER -- overwritten at release time by publish-charts.yaml
   pullPolicy: Always
 
 controller:

--- a/osac-installer/scripts/nightly-charts.sh
+++ b/osac-installer/scripts/nightly-charts.sh
@@ -22,9 +22,11 @@ readonly NIGHTLY_CHART_SLACK_ORDER=(
     osac
 )
 
-# Umbrella and CI values files that override osac-ui subchart .Values.images.ui.
-readonly NIGHTLY_UMBRELLA_UI_VALUES=(
-    osac-installer/charts/osac/values.yaml
+# CI overlay values files with their own separate floating image tag
+# overrides for mono-repo components (operator/aap/bmf/metering/csiDriver),
+# on top of the umbrella chart's own values.yaml. Not every file overrides
+# every component -- see stamp_ci_overlay_if_present.
+readonly NIGHTLY_CI_OVERLAY_VALUES=(
     osac-installer/values/dev/instance.yaml
     osac-installer/values/vmaas-ci/instance.yaml
     osac-installer/values/bmaas-ci/instance.yaml
@@ -98,6 +100,49 @@ check_osac_ui_image() {
     echo "${sha}"
 }
 
+# Usage: retag_component_image <image_repo> <source_short_sha> <target_version>
+# Alias-tags the already-built <image_repo>:sha-<source_short_sha> image to
+# <image_repo>:<target_version> via a server-side skopeo copy (no rebuild).
+# <image_repo>:sha-<source_short_sha> is expected to already exist -- every
+# mono-repo component's image-build workflow triggers unconditionally on
+# push to main with no path filter, so a sha-<short> tag for main's current
+# HEAD is reliably present in GHCR by the time nightly runs. If it isn't
+# (e.g. a very recent merge whose build is still in flight), skopeo copy
+# itself fails with a clear "manifest unknown" error under set -euo
+# pipefail -- that failure IS the existence check; no separate pre-flight
+# HEAD request is needed. Fails loudly, no silent fallback, no retry.
+retag_component_image() {
+    local image_repo="$1" source_short_sha="$2" target_version="$3"
+    local source_tag="sha-${source_short_sha}"
+    local safe_repo safe_source safe_target
+
+    if [[ ! "${image_repo}" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+        safe_repo=$(_gha_sanitize_for_message "${image_repo}")
+        echo "::error::Invalid image repo '${safe_repo}'" >&2
+        return 1
+    fi
+    if [[ ! "${source_short_sha}" =~ ^[0-9a-f]{7,40}$ ]]; then
+        safe_source=$(_gha_sanitize_for_message "${source_short_sha}")
+        echo "::error::Invalid source SHA '${safe_source}' for ${image_repo}" >&2
+        return 1
+    fi
+    if [[ ! "${target_version}" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+        safe_target=$(_gha_sanitize_for_message "${target_version}")
+        echo "::error::Invalid target version '${safe_target}' for ${image_repo}" >&2
+        return 1
+    fi
+
+    echo "Retagging ${image_repo}:${source_tag} -> ${image_repo}:${target_version}..."
+    if ! skopeo copy --all \
+        "docker://${image_repo}:${source_tag}" \
+        "docker://${image_repo}:${target_version}"; then
+        safe_repo=$(_gha_sanitize_for_message "${image_repo}")
+        echo "::error::Could not retag ${safe_repo}:${source_tag} -> ${target_version} — source image not found in GHCR yet (its build may still be in flight); failing nightly run rather than silently skipping or falling back to an older commit" >&2
+        return 1
+    fi
+    skopeo inspect "docker://${image_repo}:${target_version}" > /dev/null
+}
+
 # Strip characters that break or inject GitHub Actions workflow commands.
 _gha_sanitize_for_message() {
     local value="$1"
@@ -146,71 +191,92 @@ compute_nightly_chart_version() {
     printf '%s-%s' "${base_version}" "${nightly_suffix}"
 }
 
-# Usage: osac_ui_nightly_image_ref <image_repo> <short_sha>
-osac_ui_nightly_image_ref() {
-    local image_repo="$1" short_sha="$2"
-    printf '%s:sha-%s' "${image_repo}" "${short_sha}"
-}
-
-# Usage: stamp_umbrella_ui_image_ref <values_yaml> <image_ref>
-stamp_umbrella_ui_image_ref() {
-    local values_yaml="$1" image_ref="$2"
+# Usage: stamp_umbrella_nested_field <values_yaml> <top_key> <nested_key> <leaf_key> <new_value> [optional]
+# Awk-based rewrite of a single "<top_key>:\n  <nested_key>:\n    <leaf_key>: <value>"
+# scalar field, preserving every other line byte-for-byte.
+#
+# Uses awk instead of yq -i because yq reformats the entire YAML file on
+# write — removing blank lines and normalizing inline comment spacing from
+# 2 spaces to 1 space before '#'. This causes ct lint's yamllint (which
+# requires 2-space comment padding via ~/.ct/lintconf.yaml) to fail during
+# the nightly publish job. awk preserves all formatting outside the target
+# line.
+#
+# If [optional] is passed as a truthy 6th arg, a field not found in this
+# file is a silent no-op (return 0) instead of a hard error — needed for CI
+# overlay files, where not every environment overrides every component's
+# image. Without it (the umbrella chart's own values.yaml, where every
+# field is a mandatory always-present placeholder), a miss is a hard
+# ::error::/return 1, since that would indicate real corruption.
+stamp_umbrella_nested_field() {
+    local values_yaml="$1" top_key="$2" nested_key="$3" leaf_key="$4" new_value="$5"
+    local optional="${6:-false}"
     local safe_values_yaml tmp
+
     if [[ ! -f "${values_yaml}" ]]; then
         safe_values_yaml=$(_gha_sanitize_for_message "${values_yaml}")
-        echo "::warning title=Missing values file::Values file not found: ${safe_values_yaml} — skipping ui.images.ui stamp" >&2
+        echo "::warning title=Missing values file::Values file not found: ${safe_values_yaml} — skipping ${top_key}.${nested_key}.${leaf_key} stamp" >&2
         return 0
     fi
-    if ! grep -qE '[[:space:]]ui:' "${values_yaml}"; then
-        safe_values_yaml=$(_gha_sanitize_for_message "${values_yaml}")
-        echo "::error::ui.images.ui key not found in ${safe_values_yaml}" >&2
-        return 1
-    fi
-    # stamp_umbrella_ui_image_ref uses awk instead of yq -i because yq reformats
-    # the entire YAML file on write — removing blank lines and normalizing inline
-    # comment spacing from 2 spaces to 1 space before '#'. This causes ct lint's
-    # yamllint (which requires 2-space comment padding via ~/.ct/lintconf.yaml) to
-    # fail during the nightly publish job. awk preserves all formatting outside the
-    # target line.
+
     tmp="$(mktemp)"
-    if ! awk -v ref="${image_ref}" '
-        BEGIN { in_ui=0; in_ui_images=0; stamped=0; ui_key_indent="" }
-        /^ui:/ { in_ui=1; in_ui_images=0; ui_key_indent="" }
-        /^[^ #\t]/ && !/^ui:/ { in_ui=0; in_ui_images=0; ui_key_indent="" }
-        in_ui && /^[[:space:]]+images:/ {
+    if ! awk -v top="${top_key}:" -v nested_pat="^[[:space:]]+${nested_key}:" \
+            -v leaf="${leaf_key}" -v val="${new_value}" '
+        BEGIN { in_top=0; in_nested=0; stamped=0; nested_indent="" }
+        $0 == top { in_top=1; in_nested=0; nested_indent=""; print; next }
+        /^[^ #\t]/ && $0 != top { in_top=0; in_nested=0; nested_indent="" }
+        in_top && $0 ~ nested_pat {
             match($0, /^[[:space:]]+/)
-            ui_key_indent = substr($0, RSTART, RLENGTH) "  "
-            in_ui_images=1
+            nested_indent = substr($0, RSTART, RLENGTH) "  "
+            in_nested=1
+            print
+            next
         }
-        in_ui_images && ui_key_indent != "" && match($0, "^" ui_key_indent "ui:[[:space:]]") {
-            print ui_key_indent "ui: " ref
-            in_ui_images=0
+        in_nested && nested_indent != "" && match($0, "^" nested_indent leaf ":[[:space:]]") {
+            print nested_indent leaf ": " val
+            in_nested=0
             stamped=1
             next
         }
         { print }
         END { exit(stamped ? 0 : 1) }
     ' "${values_yaml}" > "${tmp}"; then
-        safe_values_yaml=$(_gha_sanitize_for_message "${values_yaml}")
-        echo "::error::ui.images.ui key not found under ui.images in ${safe_values_yaml}" >&2
         rm -f "${tmp}"
+        if [[ "${optional}" == true ]]; then
+            return 0
+        fi
+        safe_values_yaml=$(_gha_sanitize_for_message "${values_yaml}")
+        echo "::error::${top_key}.${nested_key}.${leaf_key} not found in ${safe_values_yaml}" >&2
         return 1
     fi
     chmod --reference="${values_yaml}" "${tmp}"
     mv "${tmp}" "${values_yaml}"
-    if ! grep -qF "${image_ref}" "${values_yaml}"; then
+    if ! grep -qF "${new_value}" "${values_yaml}"; then
         safe_values_yaml=$(_gha_sanitize_for_message "${values_yaml}")
-        echo "::error::Failed to stamp ui.images.ui in ${safe_values_yaml}" >&2
+        echo "::error::Failed to stamp ${top_key}.${nested_key}.${leaf_key} in ${safe_values_yaml}" >&2
         return 1
     fi
 }
 
-# Usage: stamp_umbrella_ui_values <image_ref>
-stamp_umbrella_ui_values() {
-    local image_ref="$1" values_yaml
-    for values_yaml in "${NIGHTLY_UMBRELLA_UI_VALUES[@]}"; do
-        stamp_umbrella_ui_image_ref "${values_yaml}" "${image_ref}"
-    done
+# Usage: stamp_ci_overlay_if_present <values_yaml> <yq_path> <new_value>
+# Stamps an arbitrary-depth field (e.g. .metering.echoAdapter.image.tag) in a
+# CI overlay file (osac-installer/values/*/instance.yaml), only if that path
+# already resolves to a non-null value in the file -- `yq -e <path> <file>`
+# exits non-zero when the path is absent/null, which we use purely as an
+# existence check (its own stdout/stderr is discarded). This avoids yq -i's
+# default auto-vivification behavior, which would otherwise silently create
+# a whole new key structure (e.g. add a `csiDriver:` block) in overlay files
+# that don't already configure that component. Unlike
+# stamp_umbrella_nested_field, this uses yq -i directly (not awk): these CI
+# overlay files are not yamllint/ct-lint-checked anywhere in this pipeline,
+# and changes here only ever live on the ephemeral nightly/* temp branch
+# (never merged, deleted by the cleanup job), so yq's whole-file comment
+# reformatting has no consequence.
+stamp_ci_overlay_if_present() {
+    local values_yaml="$1" yq_path="$2" new_value="$3"
+    if yq -e "${yq_path}" "${values_yaml}" > /dev/null 2>&1; then
+        VALUE="${new_value}" yq -i "${yq_path} = strenv(VALUE)" "${values_yaml}"
+    fi
 }
 
 # Usage: _chart_slack_rank <chart_name>

--- a/osac-metering/adapters/Makefile
+++ b/osac-metering/adapters/Makefile
@@ -8,10 +8,17 @@
 GO_VERSION ?= $(shell grep '^go ' go.mod | cut -d' ' -f2)
 GOTOOLCHAIN ?= go$(GO_VERSION)
 GINKGO ?= go run github.com/onsi/ginkgo/v2/ginkgo
+CONTAINER_TOOL ?= podman
+
+# Image URLs for building/pushing the two adapter images.
+IMG_M360_ADAPTER ?= ghcr.io/osac-project/metering-m360-adapter:latest
+IMG_ECHO_ADAPTER ?= ghcr.io/osac-project/metering-echo-adapter:latest
 
 include $(shell git rev-parse --show-toplevel)/tools/golangci-lint.mk
 
-.PHONY: all build-echo-adapter build-m360-adapter test lint clean
+.PHONY: all build-echo-adapter build-m360-adapter test lint clean \
+	image-build-m360-adapter image-push-m360-adapter \
+	image-build-echo-adapter image-push-echo-adapter
 
 all: build-echo-adapter build-m360-adapter
 
@@ -28,6 +35,22 @@ test:
 
 lint: golangci-lint
 	$(GOLANGCI_LINT) run ./...
+
+# Context is `..` (osac-metering/), not `.` -- both adapter Containerfiles
+# also COPY the sibling schema/ directory, which only exists one level up
+# from adapters/ (matches build-metering-{m360,echo}-adapter-image.yaml's
+# `context: osac-metering`, `file: osac-metering/adapters/Containerfile.*`).
+image-build-m360-adapter:
+	$(CONTAINER_TOOL) build -t $(IMG_M360_ADAPTER) -f Containerfile.m360-adapter ..
+
+image-push-m360-adapter:
+	$(CONTAINER_TOOL) push $(IMG_M360_ADAPTER)
+
+image-build-echo-adapter:
+	$(CONTAINER_TOOL) build -t $(IMG_ECHO_ADAPTER) -f Containerfile.echo-adapter ..
+
+image-push-echo-adapter:
+	$(CONTAINER_TOOL) push $(IMG_ECHO_ADAPTER)
 
 clean:
 	rm -rf bin/

--- a/osac-metering/charts/osac-metering/values.yaml
+++ b/osac-metering/charts/osac-metering/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/osac-project/metering-service
-  tag: latest
+  tag: latest  # PLACEHOLDER -- overwritten at release time by publish-charts.yaml
   pullPolicy: Always
 
 # Fulfillment address is auto-derived from release namespace.
@@ -52,7 +52,7 @@ m360Adapter:
   enabled: false
   image:
     repository: ghcr.io/osac-project/metering-m360-adapter
-    tag: latest
+    tag: latest  # PLACEHOLDER -- overwritten at release time by publish-charts.yaml
     pullPolicy: Always
   m360:
     apiUrl: ""

--- a/osac-metering/metering-service/Makefile
+++ b/osac-metering/metering-service/Makefile
@@ -7,13 +7,14 @@
 
 BINARY_NAME ?= metering-service
 IMG ?= ghcr.io/osac-project/metering-service:latest
+CONTAINER_TOOL ?= podman
 GO_VERSION ?= $(shell grep '^go ' go.mod | cut -d' ' -f2)
 GOTOOLCHAIN ?= go$(GO_VERSION)
 GINKGO ?= go run github.com/onsi/ginkgo/v2/ginkgo
 
 include $(shell git rev-parse --show-toplevel)/tools/golangci-lint.mk
 
-.PHONY: build test lint generate image-build clean
+.PHONY: build test lint generate image-build image-push clean
 
 build:
 	go build -o bin/$(BINARY_NAME) ./cmd/metering-service
@@ -27,8 +28,15 @@ lint: golangci-lint
 generate:
 	buf generate
 
+# Context is `..` (osac-metering/), not `.` -- the Containerfile also
+# COPYs the sibling schema/ directory, which only exists one level up
+# from metering-service/ (matches build-metering-service-image.yaml's
+# `context: osac-metering`, `file: osac-metering/metering-service/Containerfile`).
 image-build:
-	podman build -t $(IMG) -f Containerfile .
+	$(CONTAINER_TOOL) build -t $(IMG) -f Containerfile ..
+
+image-push:
+	$(CONTAINER_TOOL) push $(IMG)
 
 clean:
 	rm -rf bin/


### PR DESCRIPTION
## Summary

Nightly Helm charts published sub-component images with `tag: latest`/`main` placeholders instead of pinned, reproducible tags. Root cause: `nightly-build.yaml`'s stamp loop resolves each component's own `SUB_VERSION` and stamps it into `Chart.yaml`, but never touched the actual image tag fields in `values.yaml`.

## What changed

- **New parallel `build` job**: builds one fresh image per mono-repo component (`osac-operator`, `bare-metal-fulfillment-operator`, `fulfillment-service`, `osac-aap`, `osac-metering` [service + m360Adapter + echoAdapter], `osac-csi-driver`) as a matrix — all builds run concurrently, and E2E only runs once every one of them succeeds. This tests the exact images the run will ship, not whatever happened to already be sitting in GHCR from an unrelated prior commit.
- **Shared `make image-build`/`image-push` targets**: each build matrix entry runs `make -C <dir> image-build`/`image-push`, the same targets a human would run locally, instead of duplicating build logic inline. 3 of 8 targets already existed (`osac-operator`, `bare-metal-fulfillment-operator`, `osac-csi-driver`); 5 are new in this PR (`metering-service`, `m360-adapter`, `echo-adapter`, `fulfillment-service`, `osac-aap`'s `execution-environment-build`). These are **not** yet wired into the 6 existing per-push production build workflows — each already has its own working `docker/build-push-action` step; consolidating onto the same Makefile targets is a separate follow-up (deliberately out of scope here).
- **Image tag equals chart version everywhere**: every component's nightly `SUB_VERSION` is resolved and stamped into every `Chart.yaml`/`values.yaml`/CI-overlay reference upfront, in the `prepare` job, before the temp branch is even pushed — so `build`, `e2e-test`, and `publish` all agree on the same tag before any image exists at it.
- **`publish` is now just packaging**: with all stamping done in `prepare` and all images already built and pushed at their final tags by `build`, `publish` no longer stamps or retags anything — it packages and pushes whatever `prepare` already wrote into each `Chart.yaml`.
- **osac-ui stays alias-tagged**: it's a separate external repo we don't build here, so its `build` matrix entry retags the already-published `sha-<short>` image (`skopeo copy`, no rebuild — same pattern as `mirror-envoy.yaml`) to its own final `SUB_VERSION`, unifying it onto the same tag-equals-chart-version scheme as everything else.
- **The 4 CI overlay files** (`values/{dev,vmaas-ci,bmaas-ci,full-ci}/instance.yaml`) get the exact same final `SUB_VERSION` strings as the charts (not a separate placeholder) — `e2e-test` installs from one of these, so without this fix E2E would keep validating stale `:latest` images even after the chart itself was fixed.
- **`publish-osac-installer-chart.yaml`** (the umbrella *release* workflow) had the same gap for real tagged releases — its bulk substitution list predates `osac-metering`/`osac-csi-driver`. Added the two missing fields.
- **`publish-charts.yaml`**'s csi-driver image-tag substitution switched from `sed` (dependent on exact placeholder comment text, which was inconsistent) to `yq` field-path assignment, matching the already-robust pattern used for `fulfillment-service`/`osac-aap`.
- **`check-floating-tags.yaml`** now covers `osac-metering`/`osac-csi-driver` (previously missing from its path filters), and their two previously-unmarked floating tags got the standard `# PLACEHOLDER` comment so future regressions are caught on PRs.

## New/changed job graph (`nightly-build.yaml`)

```
                     ┌─ unit-tests ──────────────┐
                     ├─ integration-tests ───────┤
prepare  →  build ──┼─ security-tests (CodeQL) ─┼─→  publish  →  tag-and-notify
         └──────────┼─ e2e-vmaas-test ──────────┤              ↘  notify-failure (on failure)
                     ├─ e2e-caas-test ───────────┤              ↘  cleanup (always)
                     └─ e2e-bmaas-test ──────────┘
```

`prepare` now does all version resolution and stamping (previously spread across `prepare`/`publish`); `build` is new. Six independent parallel "boxes" gate `publish`: `unit-tests`, `integration-tests`, and `security-tests` (CodeQL) run immediately against source (no dependency on `prepare`/`build` — they test code, not the stamped charts/images), while `e2e-vmaas-test`/`e2e-caas-test`/`e2e-bmaas-test` each depend on `build` too (installing the temp branch's freshly-built images). `publish` only runs once every one of the six has passed, and is simplified to packaging only.

## New test coverage

- **3 parallel E2E suites** instead of 1: `e2e-caas-test`/`e2e-bmaas-test` added alongside the existing `e2e-vmaas-test` (renamed from `e2e-test`), each calling `osac-test-infra`'s existing `e2e-{caas,bmaas}-full-install.yml` reusable workflows against the same temp branch — same wiring the vmaas suite already used.
- **Unit and integration tests**: `unit-tests.yml`/`integration-tests.yml` gained `workflow_call` as an additional trigger (their `pull_request`/`schedule`/`merge_group` triggers are unchanged) and are now invoked as their own parallel jobs, reusing the existing per-component job definitions rather than duplicating them.
- **Security (SAST)**: `codeql.yml` likewise gained `workflow_call` and runs as its own parallel job — nightly now gets a CodeQL pass (Go + Python) on every run, not just PRs.

## New/changed shared functions (`osac-installer/scripts/nightly-charts.sh`)

- `retag_component_image` — skopeo alias-tag with fail-loud error handling (now used only for osac-ui)
- `stamp_umbrella_nested_field` — generalizes the previous UI-only awk-based stamper to any 2-level-nested field (stays awk, not yq, since the umbrella's values.yaml is yamllint-checked by `ct lint` and yq reformats the whole file on write)
- `stamp_ci_overlay_if_present` — yq-based, arbitrary depth, existence-checked before writing so it never auto-vivifies a field a given overlay doesn't already define

## Verification

- Validated `nightly-build.yaml` with `actionlint` (zero new findings — only pre-existing unrelated self-hosted-runner-label warnings) and `bash -n` on every modified `run:` block
- Simulated the full "Stamp charts and values for nightly" step against real chart files in this repo (mocked version inputs) — confirmed all 7 umbrella fields + every sub-chart's own field stamp to the exact same version string, all 4 CI overlays get every field present in that file, and zero collateral changes elsewhere (diffed byte-for-byte)
- Ran real `podman build`s locally against 3 of the 5 new Makefile targets (`metering-service`, `m360-adapter`, `fulfillment-service`) to confirm build context/args are correct; dry-run (`make -n`) verified for the other 2 (`echo-adapter`, `osac-aap` execution-environment) and the 3 pre-existing targets
- Ran `.github/scripts/check-floating-tags.sh` against every component directory before and after the comment fixes — confirmed it currently fails at exactly the expected 2 lines in `osac-metering`, and passes cleanly everywhere after the fix
- Dispatched this branch against upstream end-to-end (with e2e temporarily stubbed out during iteration, since reverted): confirmed all 9 build matrix entries, `publish`, and `tag-and-notify` succeed, and that the published chart's image tags match their component versions exactly — verified by pulling `oci://ghcr.io/osac-project/charts/osac` and diffing every image field. Along the way, found and fixed a GHCR cross-repo permission gap for the osac-ui package, a missing `uv`/Python setup for the osac-aap build entry, an unquoted multi-line `jq` output bug, and a missing `fulfillment-service` CI-overlay stamp — see commit history for details.

## Follow-up (separate Jira tickets, not in this PR)

- `osac-metering` has no independent tagged-release job in `publish-charts.yaml` at all — filed as [OSAC-4573](https://redhat.atlassian.net/browse/OSAC-4573).
- Wiring the 6 existing per-push production build workflows onto the same shared Makefile targets introduced here — deferred, this PR only adds the targets and uses them in the new nightly `build` phase.
- Security testing here is CodeQL (SAST) only, reusing the existing PR gate. Container image vulnerability scanning (e.g. Trivy) of the freshly-built nightly images is a natural follow-up nightly is now uniquely positioned for, but isn't in scope here.
- Found (pre-existing, unrelated to this PR): `integration-tests.yml`'s `osac-installer` job silently fails `helm install`/`helm upgrade` (missing `trust-manager` CRD for `cert-manager`), masked by `continue-on-error: true` — reproduced on an unrelated open PR too, so it's not caused by anything here. Filed as [OSAC-4633](https://redhat.atlassian.net/browse/OSAC-4633).
- Found via the new vmaas E2E box (first time it's run unattended rather than PR-gated): after a ComputeInstance restart, a later gRPC fetch fails with an invalid-UTF-8 unmarshal error, breaking test teardown — reproduced identically across 2 separate nightly runs. Filed as [OSAC-4638](https://redhat.atlassian.net/browse/OSAC-4638).
- Found via the new bmaas E2E box (same reason): `osac describe baremetalinstance` always renders an empty `Network Interfaces: (none)` section, even though the underlying BMH/CR/gRPC data all correctly have the NIC/MAC info — a CLI rendering bug. Reproduced identically across 2 separate nightly runs. Filed as [OSAC-4639](https://redhat.atlassian.net/browse/OSAC-4639).
  - **Root-caused and fixed both [OSAC-4638](https://redhat.atlassian.net/browse/OSAC-4638) and [OSAC-4639](https://redhat.atlassian.net/browse/OSAC-4639)**: both were caused by `aap.configAsCode.projectGitBranch`/`projectGitUri` being left pinned to a floating `"main"` — the exact same class of bug this PR fixes for container image tags, just for AAP's config-as-code Git ref. AAP's config-as-code sync pulls `osac-aap`'s own Ansible automation (provisioning, restart handling, hardware/NIC discovery, storage registration, etc.) from that ref, so every E2E run was exercising `osac-operator`/`fulfillment-service` from the commit under test while AAP ran playbooks from whatever was on `main` at that moment. Found by diffing the actual rendered Helm manifests between this PR's build path and the existing periodic `components:`-build path (which already overrides this correctly) — the diff isolated this as the one meaningful non-image difference between the two. Now stamped to `github.sha`/the repo URL in the umbrella chart's values.yaml and all 4 CI overlay files, unconditionally. **Verified**: re-ran both vmaas and bmaas E2E solo with only this fix applied — all four previously-failing tests now pass (`test_compute_instance_restart`, `test_compute_instance_restart_past_timestamp_ignored`, `test_baremetal_instance_lifecycle` including its NIC assertions). Likely also explains OSAC-4634's intermittent caas failures (its storage registration also runs through AAP), not yet independently re-verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved nightly builds with consistent versioning, chart stamping, and image retagging.
  - Added image build and push workflows for fulfillment, execution environments, metering adapters, and metering services.
  - Added support for updating image references across umbrella and component chart configurations.
- **Bug Fixes**
  - Improved chart publishing reliability with validated image-tag updates.
  - Expanded floating-tag checks to cover metering and CSI driver charts.
- **Documentation**
  - Updated image-tag placeholder guidance in chart configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




