### PR TITLE
OSAC-3958: Clone skill-relative sibling repos on bootstrap

### DIFF
--- a/.claude/hooks/statusline.sh
+++ b/.claude/hooks/statusline.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# Project statusline: extends user statusline with osac + ai-workflows sync status
+# Project statusline: extends user statusline with osac, osac-ai-skills, and
+# ai-workflows sync status.
 # Opt out: set CLAUDE_REPO_STATUSLINE_DISABLED=1 in .claude/settings.local.json env
-# to skip the osac + ai-workflows sync status (the user's own statusline still runs)
+# to skip the repo sync status (the user's own statusline still runs)
 
 input=$(cat)
 
@@ -43,10 +44,20 @@ repo_status() {
   fi
 }
 
+resolve_osac_ai_skills_dir() {
+  if [[ -d "${HOME}/.osac-ai-skills/.git" ]]; then
+    printf '%s\n' "${HOME}/.osac-ai-skills"
+  else
+    printf '%s\n' "${REPO_DIR}/.osac-ai-skills"
+  fi
+}
+
 REPO_DIR="${project_dir:-$(printf '%s' "$input" | jq -r '.workspace.project_dir // empty' 2>/dev/null)}"
 AI_DIR="${HOME}/.ai-workflows"
+SKILLS_DIR="$(resolve_osac_ai_skills_dir)"
 
 ws=$(repo_status "$REPO_DIR" "osac")
+sk=$(repo_status "$SKILLS_DIR" "osac-ai-skills")
 ai=$(repo_status "$AI_DIR" "ai-workflows")
 
-printf '%b %b %b\n' "$ws" "${GRAY}|${RESET}" "$ai"
+printf '%b %b %b %b %b\n' "$ws" "${GRAY}|${RESET}" "$sk" "${GRAY}|${RESET}" "$ai"

--- a/.claude/hooks/statusline.sh
+++ b/.claude/hooks/statusline.sh
@@ -60,10 +60,11 @@ REPO_DIR="${project_dir:-$(printf '%s' "$input" | jq -r '.workspace.project_dir 
 
 resolve_osac_ai_skills_dir() {
   local home_skills="${HOME}/.osac-ai-skills"
+  local repo_skills="${REPO_DIR}/.osac-ai-skills"
   if is_git_work_tree_root "${home_skills}"; then
     printf '%s\n' "${home_skills}"
   else
-    printf '%s\n' "${REPO_DIR}/.osac-ai-skills"
+    printf '%s\n' "${repo_skills}"
   fi
 }
 

--- a/.claude/hooks/statusline.sh
+++ b/.claude/hooks/statusline.sh
@@ -44,6 +44,8 @@ repo_status() {
   fi
 }
 
+REPO_DIR="${project_dir:-$(printf '%s' "$input" | jq -r '.workspace.project_dir // empty' 2>/dev/null)}"
+
 resolve_osac_ai_skills_dir() {
   if [[ -d "${HOME}/.osac-ai-skills/.git" ]]; then
     printf '%s\n' "${HOME}/.osac-ai-skills"
@@ -52,7 +54,6 @@ resolve_osac_ai_skills_dir() {
   fi
 }
 
-REPO_DIR="${project_dir:-$(printf '%s' "$input" | jq -r '.workspace.project_dir // empty' 2>/dev/null)}"
 AI_DIR="${HOME}/.ai-workflows"
 SKILLS_DIR="$(resolve_osac_ai_skills_dir)"
 

--- a/.claude/hooks/statusline.sh
+++ b/.claude/hooks/statusline.sh
@@ -28,9 +28,21 @@ log_info() { printf '%b%s%b' "$GREEN" "$1" "$RESET"; }
 log_warning() { printf '%b%s%b' "$YELLOW" "$1" "$RESET"; }
 log_muted() { printf '%b%s%b' "$GRAY" "$1" "$RESET"; }
 
+# True only for the root of a clone or linked worktree. A leftover directory
+# inside some other checkout would otherwise inherit that parent's branch.
+is_git_work_tree_root() {
+  local dir="$1"
+  [[ -n "$dir" && -d "$dir" ]] \
+    && git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+    && [[ -z "$(git -C "$dir" rev-parse --show-prefix 2>/dev/null)" ]]
+}
+
 repo_status() {
   local dir="$1" name="$2"
-  [[ -d "$dir" ]] || { log_muted "$name: not found"; return; }
+  if ! is_git_work_tree_root "$dir"; then
+    log_muted "$name: not found"
+    return
+  fi
 
   local branch behind
   branch=$(git -C "$dir" branch --show-current 2>/dev/null) || branch="detached"
@@ -47,12 +59,8 @@ repo_status() {
 REPO_DIR="${project_dir:-$(printf '%s' "$input" | jq -r '.workspace.project_dir // empty' 2>/dev/null)}"
 
 resolve_osac_ai_skills_dir() {
-  # Linked worktrees store .git as a file, so [[ -d .git ]] misses them.
-  # --show-prefix must be empty so a plain dir inside some parent git checkout
-  # (for example $HOME itself) does not count as ~/.osac-ai-skills.
   local home_skills="${HOME}/.osac-ai-skills"
-  if git -C "${home_skills}" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
-     && [[ -z "$(git -C "${home_skills}" rev-parse --show-prefix 2>/dev/null)" ]]; then
+  if is_git_work_tree_root "${home_skills}"; then
     printf '%s\n' "${home_skills}"
   else
     printf '%s\n' "${REPO_DIR}/.osac-ai-skills"

--- a/.claude/hooks/statusline.sh
+++ b/.claude/hooks/statusline.sh
@@ -68,7 +68,17 @@ resolve_osac_ai_skills_dir() {
   fi
 }
 
-AI_DIR="${HOME}/.ai-workflows"
+resolve_ai_workflows_dir() {
+  local home_wf="${HOME}/.ai-workflows"
+  local repo_wf="${REPO_DIR}/.ai-workflows"
+  if is_git_work_tree_root "${home_wf}"; then
+    printf '%s\n' "${home_wf}"
+  else
+    printf '%s\n' "${repo_wf}"
+  fi
+}
+
+AI_DIR="$(resolve_ai_workflows_dir)"
 SKILLS_DIR="$(resolve_osac_ai_skills_dir)"
 
 ws=$(repo_status "$REPO_DIR" "osac")

--- a/.claude/hooks/statusline.sh
+++ b/.claude/hooks/statusline.sh
@@ -47,8 +47,13 @@ repo_status() {
 REPO_DIR="${project_dir:-$(printf '%s' "$input" | jq -r '.workspace.project_dir // empty' 2>/dev/null)}"
 
 resolve_osac_ai_skills_dir() {
-  if [[ -d "${HOME}/.osac-ai-skills/.git" ]]; then
-    printf '%s\n' "${HOME}/.osac-ai-skills"
+  # Linked worktrees store .git as a file, so [[ -d .git ]] misses them.
+  # --show-prefix must be empty so a plain dir inside some parent git checkout
+  # (for example $HOME itself) does not count as ~/.osac-ai-skills.
+  local home_skills="${HOME}/.osac-ai-skills"
+  if git -C "${home_skills}" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+     && [[ -z "$(git -C "${home_skills}" rev-parse --show-prefix 2>/dev/null)" ]]; then
+    printf '%s\n' "${home_skills}"
   else
     printf '%s\n' "${REPO_DIR}/.osac-ai-skills"
   fi

--- a/.claude/hooks/update-ai-context.sh
+++ b/.claude/hooks/update-ai-context.sh
@@ -48,9 +48,11 @@ fetch_and_rebase() {
 }
 
 home_wf="${HOME}/.ai-workflows"
-proj_wf="${CLAUDE_PROJECT_DIR:-}/.ai-workflows"
 if is_git_work_tree_root "$home_wf"; then
   fetch_and_rebase "$home_wf" "ai-workflows"
-elif is_git_work_tree_root "$proj_wf"; then
-  fetch_and_rebase "$proj_wf" "ai-workflows"
+elif [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+  proj_wf="${CLAUDE_PROJECT_DIR}/.ai-workflows"
+  if is_git_work_tree_root "$proj_wf"; then
+    fetch_and_rebase "$proj_wf" "ai-workflows"
+  fi
 fi

--- a/.claude/hooks/update-ai-context.sh
+++ b/.claude/hooks/update-ai-context.sh
@@ -2,9 +2,26 @@
 # SessionStart hook: fetch+rebase ai-workflows so the AI agent
 # always has the latest skills and workflow phases.
 
+# True only for the root of a clone or linked worktree. A leftover directory
+# inside some other checkout would otherwise inherit that parent
+# (git -C would fetch/rebase the enclosing repo).
+is_git_work_tree_root() {
+  local dir="$1"
+  [[ -n "$dir" && -d "$dir" ]] \
+    && git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+    && [[ -z "$(git -C "$dir" rev-parse --show-prefix 2>/dev/null)" ]]
+}
+
 fetch_and_rebase() {
   local dir="$1" name="$2"
-  [[ -d "$dir" ]] || return 0
+  is_git_work_tree_root "$dir" || return 0
+
+  local branch
+  branch=$(git -C "$dir" symbolic-ref --short HEAD 2>/dev/null || echo "")
+  if [[ "$branch" != "main" ]]; then
+    echo "$name: on ${branch:-unknown}, skipped"
+    return 0
+  fi
 
   if ! git -C "$dir" fetch origin -q 2>/dev/null; then
     echo "$name: fetch failed"
@@ -30,4 +47,10 @@ fetch_and_rebase() {
   trap - INT TERM
 }
 
-fetch_and_rebase "${HOME}/.ai-workflows" "ai-workflows"
+home_wf="${HOME}/.ai-workflows"
+proj_wf="${CLAUDE_PROJECT_DIR:-}/.ai-workflows"
+if is_git_work_tree_root "$home_wf"; then
+  fetch_and_rebase "$home_wf" "ai-workflows"
+elif is_git_work_tree_root "$proj_wf"; then
+  fetch_and_rebase "$proj_wf" "ai-workflows"
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,14 @@ skills/
 # this path and drop the ignore.
 .osac-ai-skills/
 
+# Skill-relative sibling checkouts (tools/bootstrap.sh). osac-docs is
+# osac-project/docs — do not ignore docs/ (in-tree ARCHITECTURE/CONVENTIONS).
+enhancement-proposals/
+osac-ux/
+osac-ui/
+osac-test-infra/
+osac-docs/
+
 # Harness output and osac-ai-skills fan-out. Keep repo-local Claude settings
 # and hook *scripts* tracked; fan-out only adds .claude/hooks/README.md.
 .claude/*

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ skills/
 
 # Skill-relative sibling checkouts (tools/bootstrap.sh). osac-docs is
 # osac-project/docs — do not ignore docs/ (in-tree ARCHITECTURE/CONVENTIONS).
+# osac-test-infra/ is kept so leftover clones from older bootstrap runs
+# are not committed; bootstrap no longer creates it (E2E is tests/e2e/).
 enhancement-proposals/
 osac-ux/
 osac-ui/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ After clone, run `tools/bootstrap.sh` to vendor AI skills and workflows (see [AI
 
 ### Parallel worktrees
 
-Source [`tools/osac-helpers.sh`](tools/osac-helpers.sh) and run `osac-new-worktree <branch>` from this repo. It adds a sibling worktree (`../osac-<branch-basename>`), runs `tools/bootstrap.sh` there, and appends Jira context to `.claude/CLAUDE.md` when the branch name contains `OSAC-NNNN`. Override the parent directory with `OSAC_WORKTREE_PARENT`. Clean up with `git worktree remove ../osac-<suffix>`.
+Source [`tools/osac-helpers.sh`](tools/osac-helpers.sh) and run `osac-new-worktree <branch>` from this repo. It adds a sibling worktree (`../osac-<branch-basename>`), runs `tools/bootstrap.sh` there, and appends Jira context to `.claude/CLAUDE.md` when the branch name contains `OSAC-NNNN`. Override the parent directory with `OSAC_WORKTREE_PARENT`. Clean up with `git worktree remove` on that path (default `../osac-<suffix>`; with `OSAC_WORKTREE_PARENT`, `$OSAC_WORKTREE_PARENT/osac-<suffix>`).
 
 ## Components
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,14 +39,39 @@ covers broader project-level architecture guides and diagrams).
 
 ## External Repos
 
-Clone as siblings for cross-repo workflows:
+`tools/bootstrap.sh` clones these into gitignored directories at this repo
+root (skill-relative paths when this checkout is the project root):
 
-| Repo | Description |
-|------|-------------|
-| [osac-test-infra](https://github.com/osac-project/osac-test-infra) | E2E pytest tests against the fulfillment-service gRPC API |
-| [osac-ui](https://github.com/osac-project/osac-ui) | Web console (React, PatternFly 6) |
-| [enhancement-proposals](https://github.com/osac-project/enhancement-proposals) | PRDs and design documents (two-stage EP flow) |
-| [docs](https://github.com/osac-project/docs) | Architecture docs and guides |
+| Repo | Local path | Description |
+|------|------------|-------------|
+| [osac-test-infra](https://github.com/osac-project/osac-test-infra) | `osac-test-infra/` | E2E pytest tests against the fulfillment-service gRPC API |
+| [osac-ui](https://github.com/osac-project/osac-ui) | `osac-ui/` | Web console (React, PatternFly 6) |
+| [osac-ux](https://github.com/osac-project/osac-ux) | `osac-ux/` | Read-only UI reference (`@temp-api` types) |
+| [enhancement-proposals](https://github.com/osac-project/enhancement-proposals) | `enhancement-proposals/` | PRDs and design documents (two-stage EP flow) |
+| [docs](https://github.com/osac-project/docs) | `osac-docs/` | Architecture guides and personas |
+
+In-tree [`docs/`](docs/) (`ARCHITECTURE.md`, `CONVENTIONS.md`) is **not** that
+repo. Skills read `osac-docs/personas.md`.
+
+## UI Reference (osac-ux)
+
+`osac-ux/` is cloned read-only from [osac-project/osac-ux](https://github.com/osac-project/osac-ux).
+No PRs against it from backend workflow sessions.
+
+### What to read during /design:research and /implement:ingest
+
+| Path | Purpose |
+|------|---------|
+| `osac-ux/libs/ui-components/src/pages/tenant/` | Tenant screens — form fields, list columns, actions |
+| `osac-ux/libs/ui-components/src/pages/provider/` | Provider admin screens |
+| `osac-ux/libs/ui-components/src/pages/admin/` | Tenant admin screens |
+| `osac-ux/libs/ui-components/src/api/v1/` | @temp-api types — use as primary proto field input |
+| `osac-ux/apps/e2e/cypress/e2e/flows/` | User journeys for Cypress scenario planning |
+
+For **any EP**, if `osac-ux/libs/ui-components/src/api/v1/<resource>.ts` exists,
+use those TypeScript fields as proto names (camelCase → snake_case) and include
+a `## UX Alignment` mapping table. `cd osac-ux && node scripts/gen-api-diff.mjs`
+surfaces API gaps against the current UI.
 
 ## AI-Assisted Development
 
@@ -60,7 +85,8 @@ aborts (override: `OSAC_ALLOW_NESTED_BOOTSTRAP=1`). Use the workspace
 `./bootstrap.sh` instead.
 
 Edit OSAC-native skills only in `osac-project/osac-ai-skills`. Local `skills/`
-and `.osac-ai-skills/` are bootstrap-managed and gitignored. Bump
+and `.osac-ai-skills/` are bootstrap-managed and gitignored, as are the
+sibling checkouts listed under [External Repos](#external-repos). Bump
 `metadata.version` in any skill you change (see [Critical Rules](#critical-rules)).
 PRD/design ingest reads `.design/context/` (fan-out from osac-ai-skills).
 
@@ -106,8 +132,9 @@ osac/                              Mono-repo: fulfillment-service + osac-operato
   osac-metering                    Metering pipeline for usage events and Kafka publishing
 osac-test-infra                    E2E test playbooks against fulfillment-service gRPC API
 osac-ui                            Web console (React, PatternFly 6)
+osac-ux                            Read-only UI reference (@temp-api)
 enhancement-proposals              Design documents and RFCs
-docs                               Architecture docs and guides
+osac-docs                          Architecture docs and guides (osac-project/docs)
 ```
 
 ### Resource Hierarchy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,15 +40,20 @@ covers broader project-level architecture guides and diagrams).
 ## External Repos
 
 `tools/bootstrap.sh` clones these into gitignored directories at this repo
-root (skill-relative paths when this checkout is the project root):
+root (skill-relative paths when this checkout is the project root). By
+default it also forks the writeable four to your GitHub account (`origin` =
+osac-project, `fork` = you) so `/create-pr` has a push remote. Never forked:
+`osac-ux`, `.osac-ai-skills`, `.ai-workflows`. Pass `--no-fork` for
+read-only or CI clones (requires no `gh`). Default path requires
+authenticated `gh`.
 
-| Repo | Local path | Description |
-|------|------------|-------------|
-| [osac-test-infra](https://github.com/osac-project/osac-test-infra) | `osac-test-infra/` | E2E pytest tests against the fulfillment-service gRPC API |
-| [osac-ui](https://github.com/osac-project/osac-ui) | `osac-ui/` | Web console (React, PatternFly 6) |
-| [osac-ux](https://github.com/osac-project/osac-ux) | `osac-ux/` | Read-only UI reference (`@temp-api` types) |
-| [enhancement-proposals](https://github.com/osac-project/enhancement-proposals) | `enhancement-proposals/` | PRDs and design documents (two-stage EP flow) |
-| [docs](https://github.com/osac-project/docs) | `osac-docs/` | Architecture guides and personas |
+| Repo | Local path | Fork remote | Description |
+|------|------------|-------------|-------------|
+| [osac-test-infra](https://github.com/osac-project/osac-test-infra) | `osac-test-infra/` | yes | E2E pytest tests against the fulfillment-service gRPC API |
+| [osac-ui](https://github.com/osac-project/osac-ui) | `osac-ui/` | yes | Web console (React, PatternFly 6) |
+| [osac-ux](https://github.com/osac-project/osac-ux) | `osac-ux/` | no | Read-only UI reference (`@temp-api` types) |
+| [enhancement-proposals](https://github.com/osac-project/enhancement-proposals) | `enhancement-proposals/` | yes | PRDs and design documents (two-stage EP flow) |
+| [docs](https://github.com/osac-project/docs) | `osac-docs/` | yes | Architecture guides and personas |
 
 In-tree [`docs/`](docs/) (`ARCHITECTURE.md`, `CONVENTIONS.md`) is **not** that
 repo. Skills read `osac-docs/personas.md`.
@@ -77,12 +82,14 @@ surfaces API gaps against the current UI.
 
 Run `tools/bootstrap.sh` once after clone (and anytime to refresh). It vendors
 [`osac-ai-skills`](https://github.com/osac-project/osac-ai-skills) and
-[`flightctl/ai-workflows`](https://github.com/flightctl/ai-workflows), then links
-Claude Code / Cursor / Gemini CLI skill discovery under this repo. No separate
-checkout of `osac-workspace` or a manual `osac-ai-skills` clone is required.
+[`flightctl/ai-workflows`](https://github.com/flightctl/ai-workflows), clones
+the [External Repos](#external-repos), and links Claude Code / Cursor / Gemini
+CLI skill discovery under this repo. No separate checkout of `osac-workspace`
+or a manual `osac-ai-skills` clone is required.
 Do not run this script from an `osac/` nested inside `osac-workspace` — it
 aborts (override: `OSAC_ALLOW_NESTED_BOOTSTRAP=1`). Use the workspace
-`./bootstrap.sh` instead.
+`./bootstrap.sh` instead. For a clone-only sibling pass (no GitHub forks),
+use `tools/bootstrap.sh --no-fork`.
 
 Edit OSAC-native skills only in `osac-project/osac-ai-skills`. Local `skills/`
 and `.osac-ai-skills/` are bootstrap-managed and gitignored, as are the
@@ -104,6 +111,41 @@ the canonical copy is [`.claude/rules/dev-conventions.md`](.claude/rules/dev-con
 (a symlink into the vendored osac-ai-skills tree). `resolve-remotes.sh` is
 hosted in osac-ai-skills and available at `~/.osac-ai-skills` or
 `./.osac-ai-skills`.
+
+### PRD and design publish remotes
+
+flightctl `/prd:publish` and `/design:publish` Step 5 literally say
+`git push -u origin {branch}` and `gh pr create --head {branch}`. **Do not
+run those commands** here. After bootstrap, `origin` is `osac-project/*`
+(the PR target). Pushing to it either fails (no write) or publishes a
+branch on the canonical repo (org members). `--head {branch}` then looks
+for that branch on osac-project, not on your fork.
+
+Substitute the same remotes `/create-pr` uses. `git fetch origin` in those
+skills is correct (upstream). Only the push and `--head` are wrong.
+
+```bash
+docs="{docs_repo_path}"  # typically $REPO/enhancement-proposals
+for d in "$HOME/.osac-ai-skills" "./.osac-ai-skills"; do
+  [[ -x "$d/tools/resolve-remotes.sh" ]] && { RR="$d/tools/resolve-remotes.sh"; break; }
+done
+[[ -n "${RR:-}" ]] || { echo "resolve-remotes.sh not found; run tools/bootstrap.sh" >&2; exit 1; }
+eval "$("$RR" "$docs")"
+[[ -n "${PUSH_REMOTE:-}" ]] || {
+  echo "No push remote — re-run tools/bootstrap.sh without --no-fork." >&2
+  exit 1
+}
+git -C "$docs" push -u "$PUSH_REMOTE" "{branch-name}"
+UPSTREAM=$(gh repo view "$(git -C "$docs" remote get-url "$UPSTREAM_REMOTE")" --json nameWithOwner -q .nameWithOwner)
+FORK_OWNER=$(gh repo view "$(git -C "$docs" remote get-url "$PUSH_REMOTE")" --json owner -q .owner.login)
+gh pr create --draft --repo "$UPSTREAM" --head "$FORK_OWNER:{branch-name}" --base main ...
+```
+
+`/prd:respond`'s `git push` (no remote) follows the branch's tracking
+remote. After the first fork-aware push it tracks `fork`. The same
+origin-push appears in flightctl `/implement:publish` and `/e2e:publish`;
+OSAC code PRs use `/create-pr` instead. Patching those skill files belongs
+in `flightctl/ai-workflows`, not this repo.
 
 ## Cross-Component Changes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,8 @@ PRD/design ingest reads `.design/context/` (fan-out from osac-ai-skills).
 
 Recommended skill sequence (Feature → PRD → Design → Jira sync → Implement →
 E2E) lives in osac-ai-skills, not in this repo. After bootstrap, see
-`.osac-ai-skills/README.md` (section **Recommended Skill Sequence**), or the
+`~/.osac-ai-skills/README.md` or `.osac-ai-skills/README.md` (section
+**Recommended Skill Sequence**), or the
 [upstream README](https://github.com/osac-project/osac-ai-skills#recommended-skill-sequence).
 
 ## Git Workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,14 +75,15 @@ authenticated `gh`.
 | [enhancement-proposals](https://github.com/osac-project/enhancement-proposals) | `enhancement-proposals/` | yes | PRDs and design documents (two-stage EP flow) |
 | [docs](https://github.com/osac-project/docs) | `osac-docs/` | yes | Architecture guides and personas |
 
-[osac-test-infra](https://github.com/osac-project/osac-test-infra) is **not**
-cloned. E2E pytest suites live in [`tests/e2e/`](tests/e2e/). That
-repo keeps infrastructure backends, reusable e2e caller workflows, and a
-`tests/` placeholder — do not add or modify suites there. Clone it only for
-infra or `/debug-e2e` work.
+In-tree [`docs/`](docs/) (`ARCHITECTURE.md`, `CONVENTIONS.md`) is **not**
+the osac-project/docs checkout at `osac-docs/`. Skills read
+`osac-docs/personas.md`.
 
-In-tree [`docs/`](docs/) (`ARCHITECTURE.md`, `CONVENTIONS.md`) is **not** that
-repo. Skills read `osac-docs/personas.md`.
+[osac-test-infra](https://github.com/osac-project/osac-test-infra) is **not**
+cloned. E2E pytest suites live in [`tests/e2e/`](tests/e2e/).
+osac-test-infra keeps infrastructure backends, reusable e2e caller
+workflows, and a `tests/` placeholder — do not add or modify suites
+there. Clone osac-test-infra only for infra or `/debug-e2e` work.
 
 ## UI Reference (osac-ux)
 
@@ -174,8 +175,8 @@ is canonical — see also [`fulfillment-service/AGENTS.md`](fulfillment-service/
 `/e2e` writes pytest suites in [`tests/e2e/`](tests/e2e/) in this repo.
 Discover patterns from `tests/e2e/<suite>/` and
 `tests/core/`. Do not add, modify, or delete test suites in
-[osac-test-infra](https://github.com/osac-project/osac-test-infra) — that
-repo's `tests/` tree is a placeholder plus the infrastructure backend
+[osac-test-infra](https://github.com/osac-project/osac-test-infra) —
+osac-test-infra's `tests/` tree is a placeholder plus the infrastructure backend
 contract. `/debug-e2e` still lives there; clone that repo only when
 debugging Prow or changing infra backends.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ OSAC (Open Sovereign AI Cloud) is a fulfillment system for provisioning Kubernet
 
 ### Distrobox (Linux/x86_64)
 
-Fedora 42 image (`tools/distrobox/Containerfile`). Requires [podman](https://podman.io/) and [distrobox](https://distrobox.it/) on Linux. Image tool binaries are x86_64 only.
+See `tools/distrobox/Containerfile`. Requires [podman](https://podman.io/) and [distrobox](https://distrobox.it/) on Linux. Image tool binaries are x86_64 only.
 
 ```bash
 make enter                     # Build image and enter distrobox

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,41 +112,6 @@ the canonical copy is [`.claude/rules/dev-conventions.md`](.claude/rules/dev-con
 hosted in osac-ai-skills and available at `~/.osac-ai-skills` or
 `./.osac-ai-skills`.
 
-### PRD and design publish remotes
-
-flightctl `/prd:publish` and `/design:publish` Step 5 literally say
-`git push -u origin {branch}` and `gh pr create --head {branch}`. **Do not
-run those commands** here. After bootstrap, `origin` is `osac-project/*`
-(the PR target). Pushing to it either fails (no write) or publishes a
-branch on the canonical repo (org members). `--head {branch}` then looks
-for that branch on osac-project, not on your fork.
-
-Substitute the same remotes `/create-pr` uses. `git fetch origin` in those
-skills is correct (upstream). Only the push and `--head` are wrong.
-
-```bash
-docs="{docs_repo_path}"  # typically $REPO/enhancement-proposals
-for d in "$HOME/.osac-ai-skills" "./.osac-ai-skills"; do
-  [[ -x "$d/tools/resolve-remotes.sh" ]] && { RR="$d/tools/resolve-remotes.sh"; break; }
-done
-[[ -n "${RR:-}" ]] || { echo "resolve-remotes.sh not found; run tools/bootstrap.sh" >&2; exit 1; }
-eval "$("$RR" "$docs")"
-[[ -n "${PUSH_REMOTE:-}" ]] || {
-  echo "No push remote — re-run tools/bootstrap.sh without --no-fork." >&2
-  exit 1
-}
-git -C "$docs" push -u "$PUSH_REMOTE" "{branch-name}"
-UPSTREAM=$(gh repo view "$(git -C "$docs" remote get-url "$UPSTREAM_REMOTE")" --json nameWithOwner -q .nameWithOwner)
-FORK_OWNER=$(gh repo view "$(git -C "$docs" remote get-url "$PUSH_REMOTE")" --json owner -q .owner.login)
-gh pr create --draft --repo "$UPSTREAM" --head "$FORK_OWNER:{branch-name}" --base main ...
-```
-
-`/prd:respond`'s `git push` (no remote) follows the branch's tracking
-remote. After the first fork-aware push it tracks `fork`. The same
-origin-push appears in flightctl `/implement:publish` and `/e2e:publish`;
-OSAC code PRs use `/create-pr` instead. Patching those skill files belongs
-in `flightctl/ai-workflows`, not this repo.
-
 ## Cross-Component Changes
 
 A feature spanning multiple components lands in a single branch and PR. Apply changes in dependency order:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,11 +14,31 @@ OSAC (Open Sovereign AI Cloud) is a fulfillment system for provisioning Kubernet
 
 ## Dev Environment
 
-Local toolchain: install Go, Node.js, buf, kubectl, kind, jira CLI, gh CLI, and jq.
+### Distrobox (recommended)
 
-For a local Kind cluster, see `osac-installer/AGENTS.md` (`PLATFORM=kind`, e.g. `make test PLATFORM=kind PROFILE=dev NS=osac SUITE=fulfillment`) and `fulfillment-service/README.md` for service-level setup. Distrobox/Containerfile tooling lives in `osac-workspace` and is not ported here.
+All dev tools are packaged in a Fedora 42 container (`tools/distrobox/Containerfile`). Requires `podman` and `distrobox`.
+
+```bash
+make enter                     # Build image and enter distrobox
+make status                    # Check image and distrobox status
+make rebuild                   # Rebuild image from scratch
+```
+
+The distrobox shares your home directory by default (override with `HOME_DIR`). See `make help`.
+
+### Local toolchain
+
+Install Go, Node.js, buf, kubectl, kind, jira CLI, gh CLI, and jq.
+
+### Local Kind cluster
+
+See `osac-installer/AGENTS.md` (`PLATFORM=kind`, e.g. `make test PLATFORM=kind PROFILE=dev NS=osac SUITE=fulfillment`) and `fulfillment-service/README.md` for service-level setup.
 
 After clone, run `tools/bootstrap.sh` to vendor AI skills and workflows (see [AI-Assisted Development](#ai-assisted-development)).
+
+### Parallel worktrees
+
+Source [`tools/osac-helpers.sh`](tools/osac-helpers.sh) and run `osac-new-worktree <branch>` from this repo. It adds a sibling worktree (`../osac-<branch-basename>`), runs `tools/bootstrap.sh` there, and appends Jira context to `.claude/CLAUDE.md` when the branch name contains `OSAC-NNNN`. Override the parent directory with `OSAC_WORKTREE_PARENT`. Clean up with `git worktree remove ../osac-<suffix>`.
 
 ## Components
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,9 @@ OSAC (Open Sovereign AI Cloud) is a fulfillment system for provisioning Kubernet
 
 ## Dev Environment
 
-### Distrobox (recommended)
+### Distrobox (Linux/x86_64)
 
-All dev tools are packaged in a Fedora 42 container (`tools/distrobox/Containerfile`). Requires `podman` and `distrobox`.
+Fedora 42 image (`tools/distrobox/Containerfile`). Requires [podman](https://podman.io/) and [distrobox](https://distrobox.it/) on Linux. Image tool binaries are x86_64 only.
 
 ```bash
 make enter                     # Build image and enter distrobox

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,12 +84,13 @@ Run `tools/bootstrap.sh` once after clone (and anytime to refresh). It vendors
 [`osac-ai-skills`](https://github.com/osac-project/osac-ai-skills) and
 [`flightctl/ai-workflows`](https://github.com/flightctl/ai-workflows), clones
 the [External Repos](#external-repos), and links Claude Code / Cursor / Gemini
-CLI skill discovery under this repo. No separate checkout of `osac-workspace`
-or a manual `osac-ai-skills` clone is required.
-Do not run this script from an `osac/` nested inside `osac-workspace` — it
-aborts (override: `OSAC_ALLOW_NESTED_BOOTSTRAP=1`). Use the workspace
-`./bootstrap.sh` instead. For a clone-only sibling pass (no GitHub forks),
-use `tools/bootstrap.sh --no-fork`.
+CLI skill discovery under this repo. This checkout is the project root — no
+separate `osac-workspace` or manual `osac-ai-skills` clone is required.
+
+A directory nested as `osac-workspace/osac/` still aborts (override:
+`OSAC_ALLOW_NESTED_BOOTSTRAP=1`) so it cannot install a second skill overlay.
+Use a standalone clone or worktree of this repo, not that nested copy. For a
+clone-only sibling pass (no GitHub forks), use `tools/bootstrap.sh --no-fork`.
 
 Edit OSAC-native skills only in `osac-project/osac-ai-skills`. Local `skills/`
 and `.osac-ai-skills/` are bootstrap-managed and gitignored, as are the
@@ -102,6 +103,45 @@ E2E) lives in osac-ai-skills, not in this repo. After bootstrap, see
 `~/.osac-ai-skills/README.md` or `.osac-ai-skills/README.md` (section
 **Recommended Skill Sequence**), or the
 [upstream README](https://github.com/osac-project/osac-ai-skills#recommended-skill-sequence).
+
+## Enhancement Proposals
+
+OSAC uses the flightctl PRD and design skills with project-level template
+overrides. Both documents publish to the `enhancement-proposals` sibling
+cloned by bootstrap.
+
+### Docs repo and paths
+
+- Local path: `./enhancement-proposals/` — give this path when `/prd:publish`
+  or `/design:publish` asks for the docs repo
+- Skip the "release" question — use `enhancements` as the fixed directory prefix
+- Feature directory: `enhancements/<jira-key>-<feature-slug>/`, where
+  `<jira-key>` is the Jira **Feature**-level key exactly as it appears in Jira
+  (no zero-padding), e.g. `enhancements/OSAC-42-example-feature/`
+- PRD filename: `prd.md`; design (EP) filename: `design.md`; both in that
+  same directory
+
+### Feature dimensions and templates
+
+PRD and design ingest must read all files in `.design/context/`:
+
+- **`osac-dimensions.md`** — which cross-cutting dimensions apply; guides
+  clarifying questions, persona/user-story scope, and design coverage (see
+  also `osac-docs/personas.md`)
+- **`review-patterns.md`** — common design-reviewer themes and anti-patterns
+
+Templates live in the sibling clone; section guidance is vendored from
+osac-ai-skills (edit there, not the local copy):
+
+- Design: `enhancement-proposals/guidelines/design_template.md` and
+  `.design/templates/section-guidance.md`
+- PRD: `enhancement-proposals/guidelines/prd_template.md` and
+  `.prd/templates/section-guidance.md`
+
+Design and implement ingest must read the `AGENTS.md` of each affected
+component. For fulfillment-service API work (proto, services,
+request/response), [`fulfillment-service/docs/API.md`](fulfillment-service/docs/API.md)
+is canonical — see also [`fulfillment-service/AGENTS.md`](fulfillment-service/AGENTS.md).
 
 ## Git Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,11 @@ sibling checkouts listed under [External Repos](#external-repos). Bump
 `metadata.version` in any skill you change (see [Critical Rules](#critical-rules)).
 PRD/design ingest reads `.design/context/` (fan-out from osac-ai-skills).
 
+Recommended skill sequence (Feature → PRD → Design → Jira sync → Implement →
+E2E) lives in osac-ai-skills, not in this repo. After bootstrap, see
+`.osac-ai-skills/README.md` (section **Recommended Skill Sequence**), or the
+[upstream README](https://github.com/osac-project/osac-ai-skills#recommended-skill-sequence).
+
 ## Git Workflow
 
 Fork-based push rules, branch naming, DCO sign-off, AI attribution, and PR

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,7 +174,7 @@ is canonical — see also [`fulfillment-service/AGENTS.md`](fulfillment-service/
 
 `/e2e` writes pytest suites in [`tests/e2e/`](tests/e2e/) in this repo.
 Discover patterns from `tests/e2e/<suite>/` and
-`tests/core/`. Do not add, modify, or delete test suites in
+[`tests/e2e/core/`](tests/e2e/core/). Do not add, modify, or delete test suites in
 [osac-test-infra](https://github.com/osac-project/osac-test-infra) —
 osac-test-infra's `tests/` tree is a placeholder plus the infrastructure backend
 contract. `/debug-e2e` still lives there; clone that repo only when

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,8 @@ covers broader project-level architecture guides and diagrams).
 `tools/bootstrap.sh` clones these into gitignored directories at this repo
 root (skill-relative paths when this checkout is the project root). By
 default it also forks the writeable four to your GitHub account (`origin` =
-osac-project, `fork` = you) so `/create-pr` has a push remote. Never forked:
+osac-project, `fork` = you — the `$PUSH_REMOTE` that `resolve-remotes.sh`
+reports) so `/create-pr` has a push remote. Never forked:
 `osac-ux`, `.osac-ai-skills`, `.ai-workflows`. Pass `--no-fork` for
 read-only or CI clones (requires no `gh`). Default path requires
 authenticated `gh`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ covers broader project-level architecture guides and diagrams).
 
 `tools/bootstrap.sh` clones these into gitignored directories at this repo
 root (skill-relative paths when this checkout is the project root). By
-default it also forks the writeable four to your GitHub account (`origin` =
+default it also forks the writeable three to your GitHub account (`origin` =
 osac-project, `fork` = you — the `$PUSH_REMOTE` that `resolve-remotes.sh`
 reports) so `/create-pr` has a push remote. Never forked:
 `osac-ux`, `.osac-ai-skills`, `.ai-workflows`. Pass `--no-fork` for
@@ -70,11 +70,16 @@ authenticated `gh`.
 
 | Repo | Local path | Fork remote | Description |
 |------|------------|-------------|-------------|
-| [osac-test-infra](https://github.com/osac-project/osac-test-infra) | `osac-test-infra/` | yes | E2E pytest tests against the fulfillment-service gRPC API |
 | [osac-ui](https://github.com/osac-project/osac-ui) | `osac-ui/` | yes | Web console (React, PatternFly 6) |
 | [osac-ux](https://github.com/osac-project/osac-ux) | `osac-ux/` | no | Read-only UI reference (`@temp-api` types) |
 | [enhancement-proposals](https://github.com/osac-project/enhancement-proposals) | `enhancement-proposals/` | yes | PRDs and design documents (two-stage EP flow) |
 | [docs](https://github.com/osac-project/docs) | `osac-docs/` | yes | Architecture guides and personas |
+
+[osac-test-infra](https://github.com/osac-project/osac-test-infra) is **not**
+cloned. E2E pytest suites live in [`tests/e2e/`](tests/e2e/) (OSAC-3593). That
+repo keeps infrastructure backends, reusable e2e caller workflows, and a
+`tests/` placeholder — do not add or modify suites there. Clone it only for
+infra or `/debug-e2e` work.
 
 In-tree [`docs/`](docs/) (`ARCHITECTURE.md`, `CONVENTIONS.md`) is **not** that
 repo. Skills read `osac-docs/personas.md`.
@@ -164,6 +169,16 @@ component. For fulfillment-service API work (proto, services,
 request/response), [`fulfillment-service/docs/API.md`](fulfillment-service/docs/API.md)
 is canonical — see also [`fulfillment-service/AGENTS.md`](fulfillment-service/AGENTS.md).
 
+## E2E tests
+
+`/e2e` writes pytest suites in [`tests/e2e/`](tests/e2e/) in this repo
+(OSAC-3593). Discover patterns from `tests/e2e/<suite>/` and
+`tests/core/`. Do not add, modify, or delete test suites in
+[osac-test-infra](https://github.com/osac-project/osac-test-infra) — that
+repo's `tests/` tree is a placeholder plus the infrastructure backend
+contract. `/debug-e2e` still lives there; clone that repo only when
+debugging Prow or changing infra backends.
+
 ## Git Workflow
 
 Fork-based push rules, branch naming, DCO sign-off, AI attribution, and PR
@@ -204,7 +219,7 @@ osac/                              Mono-repo: fulfillment-service + osac-operato
   bare-metal-fulfillment-operator  Kubernetes operator for bare metal fulfillment
   osac-csi-driver                  CSI storage driver, routes to vendor backends via storage tiers
   osac-metering                    Metering pipeline for usage events and Kafka publishing
-osac-test-infra                    E2E test playbooks against fulfillment-service gRPC API
+  tests/e2e/                         E2E pytest suites (BMaaS, VMaaS, CaaS, catalog, storage, references)
 osac-ui                            Web console (React, PatternFly 6)
 osac-ux                            Read-only UI reference (@temp-api)
 enhancement-proposals              Design documents and RFCs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ authenticated `gh`.
 | [docs](https://github.com/osac-project/docs) | `osac-docs/` | yes | Architecture guides and personas |
 
 [osac-test-infra](https://github.com/osac-project/osac-test-infra) is **not**
-cloned. E2E pytest suites live in [`tests/e2e/`](tests/e2e/) (OSAC-3593). That
+cloned. E2E pytest suites live in [`tests/e2e/`](tests/e2e/). That
 repo keeps infrastructure backends, reusable e2e caller workflows, and a
 `tests/` placeholder — do not add or modify suites there. Clone it only for
 infra or `/debug-e2e` work.
@@ -171,8 +171,8 @@ is canonical — see also [`fulfillment-service/AGENTS.md`](fulfillment-service/
 
 ## E2E tests
 
-`/e2e` writes pytest suites in [`tests/e2e/`](tests/e2e/) in this repo
-(OSAC-3593). Discover patterns from `tests/e2e/<suite>/` and
+`/e2e` writes pytest suites in [`tests/e2e/`](tests/e2e/) in this repo.
+Discover patterns from `tests/e2e/<suite>/` and
 `tests/core/`. Do not add, modify, or delete test suites in
 [osac-test-infra](https://github.com/osac-project/osac-test-infra) — that
 repo's `tests/` tree is a placeholder plus the infrastructure backend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ After clone, run `tools/bootstrap.sh` to vendor AI skills and workflows (see [AI
 
 ### Parallel worktrees
 
-Source [`tools/osac-helpers.sh`](tools/osac-helpers.sh) and run `osac-new-worktree <branch>` from this repo. It adds a sibling worktree (`../osac-<branch-basename>`), runs `tools/bootstrap.sh` there, and appends Jira context to `.claude/CLAUDE.md` when the branch name contains `OSAC-NNNN`. Override the parent directory with `OSAC_WORKTREE_PARENT`. Clean up with `git worktree remove` on that path (default `../osac-<suffix>`; with `OSAC_WORKTREE_PARENT`, `$OSAC_WORKTREE_PARENT/osac-<suffix>`).
+Source [`tools/osac-helpers.sh`](tools/osac-helpers.sh) and run `osac-new-worktree <branch>` from this repo. It adds a sibling worktree (`../osac-<branch-basename>`), runs `tools/bootstrap.sh` there (extra args after the branch are forwarded, e.g. `--no-fork`), and appends Jira context to `.claude/CLAUDE.md` when the branch name contains `OSAC-NNNN`. Override the parent directory with `OSAC_WORKTREE_PARENT`. Clean up with `git worktree remove` on that path (default `../osac-<suffix>`; with `OSAC_WORKTREE_PARENT`, `$OSAC_WORKTREE_PARENT/osac-<suffix>`).
 
 ## Components
 

--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,4 @@ status: ## Show distrobox and image status
 	@$(CONTAINER_CMD) images --filter reference=$(IMAGE_NAME) --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}\t{{.Created}}"
 	@echo ""
 	@echo "=== Distrobox ==="
-	@distrobox list --no-color 2>/dev/null | head -1; distrobox list --no-color 2>/dev/null | awk -F'|' 'NR>1{gsub(/^ +| +$$/,"",$$2); if($$2=="$(DISTROBOX_NAME)") print}' || echo "  (not created)"
+	@distrobox list --no-color 2>/dev/null | head -1; distrobox list --no-color 2>/dev/null | awk -F'|' 'NR>1{gsub(/^ +| +$$/,"",$$2); if($$2=="$(DISTROBOX_NAME)") { print; found=1 }} END { if (!found) print "  (not created)" }'

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+IMAGE_NAME ?= osac-dev
+DISTROBOX_NAME ?= osac
+HOME_DIR ?= $(HOME)
+CONTAINER_CMD ?= $(shell command -v podman 2>/dev/null || echo docker)
+DISTROBOX_CONTEXT := tools/distrobox
+ARGS ?=
+
+.PHONY: image enter claude stop rm rebuild status help
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-12s\033[0m %s\n", $$1, $$2}'
+
+image: ## Build the distrobox image
+	$(CONTAINER_CMD) build -t $(IMAGE_NAME) -f $(DISTROBOX_CONTEXT)/Containerfile $(DISTROBOX_CONTEXT)
+
+enter: image ## Enter the distrobox (creates it on first run)
+	@if ! distrobox list --no-color 2>/dev/null | awk -F'|' 'NR>1{gsub(/^ +| +$$/,"",$$2); print $$2}' | grep -Fxq "$(DISTROBOX_NAME)"; then \
+		distrobox create --image $(IMAGE_NAME) --name $(DISTROBOX_NAME) --home $(HOME_DIR); \
+	fi
+	distrobox enter $(DISTROBOX_NAME)
+
+claude: image ## Run Claude Code inside distrobox (ARGS="--flag" to pass flags)
+	@if ! distrobox list --no-color 2>/dev/null | awk -F'|' 'NR>1{gsub(/^ +| +$$/,"",$$2); print $$2}' | grep -Fxq "$(DISTROBOX_NAME)"; then \
+		distrobox create --image $(IMAGE_NAME) --name $(DISTROBOX_NAME) --home $(HOME_DIR); \
+	fi
+	distrobox enter $(DISTROBOX_NAME) -- claude $(ARGS)
+
+stop: ## Stop the running distrobox container
+	@distrobox stop -Y $(DISTROBOX_NAME) 2>/dev/null || true
+
+rm: ## Remove the distrobox and its container
+	@distrobox rm --force $(DISTROBOX_NAME) 2>/dev/null || true
+
+rebuild: rm image enter ## Rebuild image from scratch and enter
+
+status: ## Show distrobox and image status
+	@echo "=== Images ==="
+	@$(CONTAINER_CMD) images --filter reference=$(IMAGE_NAME) --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}\t{{.Created}}"
+	@echo ""
+	@echo "=== Distrobox ==="
+	@distrobox list --no-color 2>/dev/null | head -1; distrobox list --no-color 2>/dev/null | awk -F'|' 'NR>1{gsub(/^ +| +$$/,"",$$2); if($$2=="$(DISTROBOX_NAME)") print}' || echo "  (not created)"

--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,13 @@ image: ## Build the distrobox image
 
 enter: image ## Enter the distrobox (creates it on first run)
 	@if ! distrobox list --no-color 2>/dev/null | awk -F'|' 'NR>1{gsub(/^ +| +$$/,"",$$2); print $$2}' | grep -Fxq "$(DISTROBOX_NAME)"; then \
-		distrobox create --image $(IMAGE_NAME) --name $(DISTROBOX_NAME) --home $(HOME_DIR); \
+		distrobox create --image $(IMAGE_NAME) --name $(DISTROBOX_NAME) --home "$(HOME_DIR)"; \
 	fi
 	distrobox enter $(DISTROBOX_NAME)
 
 claude: image ## Run Claude Code inside distrobox (ARGS="--flag" to pass flags)
 	@if ! distrobox list --no-color 2>/dev/null | awk -F'|' 'NR>1{gsub(/^ +| +$$/,"",$$2); print $$2}' | grep -Fxq "$(DISTROBOX_NAME)"; then \
-		distrobox create --image $(IMAGE_NAME) --name $(DISTROBOX_NAME) --home $(HOME_DIR); \
+		distrobox create --image $(IMAGE_NAME) --name $(DISTROBOX_NAME) --home "$(HOME_DIR)"; \
 	fi
 	distrobox enter $(DISTROBOX_NAME) -- claude $(ARGS)
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ source tools/osac-helpers.sh
 osac-new-worktree feat/OSAC-1234
 ```
 
-Creates `../osac-OSAC-1234`, checks out the new branch, and runs `tools/bootstrap.sh`. Remove with `git worktree remove ../osac-OSAC-1234` from the original clone.
+Creates `../osac-OSAC-1234` by default (or `$OSAC_WORKTREE_PARENT/osac-OSAC-1234`), checks out the new branch, and runs `tools/bootstrap.sh`. Remove with `git worktree remove` on that path from the original clone.
 
 > [!WARNING]
 > Be mindful of the content you commit to this repository. Do not commit any

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ skill-relative sibling repos (see `AGENTS.md`), and links Claude Code / Cursor /
 Gemini CLI skill discovery. Do not run it from an `osac/` nested inside
 `osac-workspace`.
 
-The Feature → PRD → Design → Implement sequence is documented in
+The Feature → PRD → Design → Jira sync → Implement → E2E sequence is documented in
 [osac-ai-skills](https://github.com/osac-project/osac-ai-skills#recommended-skill-sequence)
 (local after bootstrap: `~/.osac-ai-skills/README.md` or
 `.osac-ai-skills/README.md`). See [`AGENTS.md`](AGENTS.md)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Gemini CLI skill discovery. Do not run it from an `osac/` nested inside
 
 The Feature → PRD → Design → Implement sequence is documented in
 [osac-ai-skills](https://github.com/osac-project/osac-ai-skills#recommended-skill-sequence)
-(local after bootstrap: `.osac-ai-skills/README.md`). See [`AGENTS.md`](AGENTS.md)
+(local after bootstrap: `~/.osac-ai-skills/README.md` or
+`.osac-ai-skills/README.md`). See [`AGENTS.md`](AGENTS.md)
 for bootstrap details and component conventions.
 
 > [!WARNING]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,28 @@ The Feature → PRD → Design → Jira sync → Implement → E2E sequence is d
 `.osac-ai-skills/README.md`). See [`AGENTS.md`](AGENTS.md)
 for bootstrap details and component conventions.
 
+## Distrobox
+
+Requires [podman](https://podman.io/) and [distrobox](https://distrobox.it/). From this repo root:
+
+```bash
+make enter                     # Build image and enter
+make claude                    # Run Claude Code inside the distrobox
+make status
+make rebuild
+```
+
+The image lives in `tools/distrobox/`. It shares `$HOME` by default (`HOME_DIR` to override).
+
+## Parallel worktrees
+
+```bash
+source tools/osac-helpers.sh
+osac-new-worktree feat/OSAC-1234
+```
+
+Creates `../osac-OSAC-1234`, checks out the new branch, and runs `tools/bootstrap.sh`. Remove with `git worktree remove ../osac-OSAC-1234` from the original clone.
+
 > [!WARNING]
 > Be mindful of the content you commit to this repository. Do not commit any
 > material containing Red Hat confidential content, including information about

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ After clone, run `tools/bootstrap.sh` from this repo root. It vendors
 [flightctl/ai-workflows](https://github.com/flightctl/ai-workflows), clones
 skill-relative sibling repos (see `AGENTS.md`), forks the writeable siblings
 to your GitHub account, and links Claude Code / Cursor / Gemini CLI skill
-discovery. Requires authenticated `gh` unless you pass `--no-fork`. This
+discovery. Requires an authenticated `gh` session unless you pass `--no-fork`. This
 repo is the project root. A nested `osac-workspace/osac/` checkout aborts;
 use a standalone clone or worktree instead.
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ The Feature → PRD → Design → Jira sync → Implement → E2E sequence is d
 `.osac-ai-skills/README.md`). See [`AGENTS.md`](AGENTS.md)
 for bootstrap details and component conventions.
 
-## Distrobox
+## Distrobox (Linux/x86_64)
 
-Requires [podman](https://podman.io/) and [distrobox](https://distrobox.it/). From this repo root:
+Requires [podman](https://podman.io/) and [distrobox](https://distrobox.it/) on Linux. Image tool binaries are x86_64 only. From this repo root:
 
 ```bash
 make enter                     # Build image and enter

--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ cross-module changes can be built and tested locally without publishing intermed
 versions. Go tooling run from the repo root will automatically use the workspace; no
 extra flags are needed.
 
+## AI-assisted development
+
+After clone, run `tools/bootstrap.sh` from this repo root. It vendors
+[osac-ai-skills](https://github.com/osac-project/osac-ai-skills) and
+[flightctl/ai-workflows](https://github.com/flightctl/ai-workflows), clones
+skill-relative sibling repos (see `AGENTS.md`), and links Claude Code / Cursor /
+Gemini CLI skill discovery. Do not run it from an `osac/` nested inside
+`osac-workspace`.
+
+The Feature → PRD → Design → Implement sequence is documented in
+[osac-ai-skills](https://github.com/osac-project/osac-ai-skills#recommended-skill-sequence)
+(local after bootstrap: `.osac-ai-skills/README.md`). See [`AGENTS.md`](AGENTS.md)
+for bootstrap details and component conventions.
+
 > [!WARNING]
 > Be mindful of the content you commit to this repository. Do not commit any
 > material containing Red Hat confidential content, including information about

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ source tools/osac-helpers.sh
 osac-new-worktree feat/OSAC-1234
 ```
 
-Creates `../osac-OSAC-1234` by default (or `$OSAC_WORKTREE_PARENT/osac-OSAC-1234`), checks out the new branch, and runs `tools/bootstrap.sh`. Remove with `git worktree remove` on that path from the original clone.
+Creates `../osac-OSAC-1234` by default (or `$OSAC_WORKTREE_PARENT/osac-OSAC-1234`), checks out the new branch, and runs `tools/bootstrap.sh` (extra args after the branch are forwarded, e.g. `--no-fork`). Remove with `git worktree remove` on that path from the original clone.
 
 > [!WARNING]
 > Be mindful of the content you commit to this repository. Do not commit any

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ After clone, run `tools/bootstrap.sh` from this repo root. It vendors
 [flightctl/ai-workflows](https://github.com/flightctl/ai-workflows), clones
 skill-relative sibling repos (see `AGENTS.md`), forks the writeable siblings
 to your GitHub account, and links Claude Code / Cursor / Gemini CLI skill
-discovery. Requires authenticated `gh` unless you pass `--no-fork`. Do not
-run it from an `osac/` nested inside `osac-workspace`.
+discovery. Requires authenticated `gh` unless you pass `--no-fork`. This
+repo is the project root. A nested `osac-workspace/osac/` checkout aborts;
+use a standalone clone or worktree instead.
 
 The Feature → PRD → Design → Jira sync → Implement → E2E sequence is documented in
 [osac-ai-skills](https://github.com/osac-project/osac-ai-skills#recommended-skill-sequence)

--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ extra flags are needed.
 After clone, run `tools/bootstrap.sh` from this repo root. It vendors
 [osac-ai-skills](https://github.com/osac-project/osac-ai-skills) and
 [flightctl/ai-workflows](https://github.com/flightctl/ai-workflows), clones
-skill-relative sibling repos (see `AGENTS.md`), and links Claude Code / Cursor /
-Gemini CLI skill discovery. Do not run it from an `osac/` nested inside
-`osac-workspace`.
+skill-relative sibling repos (see `AGENTS.md`), forks the writeable siblings
+to your GitHub account, and links Claude Code / Cursor / Gemini CLI skill
+discovery. Requires authenticated `gh` unless you pass `--no-fork`. Do not
+run it from an `osac/` nested inside `osac-workspace`.
 
 The Feature → PRD → Design → Jira sync → Implement → E2E sequence is documented in
 [osac-ai-skills](https://github.com/osac-project/osac-ai-skills#recommended-skill-sequence)

--- a/osac-csi-driver/AGENTS.md
+++ b/osac-csi-driver/AGENTS.md
@@ -119,7 +119,7 @@ CLI flags are defined in `cmd/osac-csi-driver/main.go`. Run `go run ./cmd/osac-c
 
 - **Unit tests**: `pkg/driver/controller_test.go` — standard Go `testing` package with hand-written mocks; covers CreateVolume, DeleteVolume, Publish/Unpublish, polling, idempotency, error handling
 - **Sanity tests**: `test/sanity/` — kubernetes-csi/csi-test/v5 compliance suite against the real driver + a fake vendor backend
-- **E2E tests**: None in this component (E2E tests live in `osac-test-infra`)
+- **E2E tests**: None in this component (E2E tests live in `tests/e2e/`)
 - Run all: `make test`
 
 ## Helm Charts

--- a/osac-operator/AGENTS.md
+++ b/osac-operator/AGENTS.md
@@ -121,7 +121,7 @@ hack/sync-helm-crds.py     # Script invoked by `make helm-crds` to sync CRDs to 
 
 - **Unit tests**: Ginkgo + Gomega with `envtest` (real etcd + kube-apiserver)
 - **Integration**: `make -C ../osac-installer test PLATFORM=kind PROFILE=dev NS=osac SUITE=operator`
-- **E2E tests**: pytest-based, live in the separate `osac-test-infra` repo; triggered by the root-level `.github/workflows/e2e-vmaas-full-install.yml`
+- **E2E tests**: pytest-based, live in [`tests/e2e/`](../tests/e2e/) (OSAC-3593); triggered by the root-level `.github/workflows/e2e-vmaas-full-install.yml`
 - Kind cluster defaults to `osac-dev` (`KIND_CLUSTER_NAME` in Makefile)
 - Clean up: `kind delete cluster --name osac-dev`
 

--- a/osac-operator/AGENTS.md
+++ b/osac-operator/AGENTS.md
@@ -121,7 +121,7 @@ hack/sync-helm-crds.py     # Script invoked by `make helm-crds` to sync CRDs to 
 
 - **Unit tests**: Ginkgo + Gomega with `envtest` (real etcd + kube-apiserver)
 - **Integration**: `make -C ../osac-installer test PLATFORM=kind PROFILE=dev NS=osac SUITE=operator`
-- **E2E tests**: pytest-based, live in [`tests/e2e/`](../tests/e2e/) (OSAC-3593); triggered by the root-level `.github/workflows/e2e-vmaas-full-install.yml`
+- **E2E tests**: pytest-based, live in [`tests/e2e/`](../tests/e2e/); triggered by the root-level `.github/workflows/e2e-vmaas-full-install.yml`
 - Kind cluster defaults to `osac-dev` (`KIND_CLUSTER_NAME` in Makefile)
 - Clean up: `kind delete cluster --name osac-dev`
 

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -13,7 +13,7 @@
 #   5. Clones skill-relative sibling repos under this checkout
 #      (enhancement-proposals, osac-ux, osac-ui, osac-docs). osac-docs
 #      is osac-project/docs — not docs/. E2E suites live in-tree at
-#      tests/e2e/ (OSAC-3593); osac-test-infra is not cloned.
+#      tests/e2e/; osac-test-infra is not cloned.
 #      Writeable siblings get a `fork` remote (origin = osac-project).
 #      osac-ux and vendor clones are never forked.
 #

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -98,6 +98,10 @@ else
 fi
 
 OSAC_AI_SKILLS_REPO="osac-project/osac-ai-skills"
+HOME_OSAC_AI_SKILLS="${HOME}/.osac-ai-skills"
+REPO_OSAC_AI_SKILLS="${PROJECT_ROOT}/.osac-ai-skills"
+HOME_AI_WORKFLOWS="${HOME}/.ai-workflows"
+REPO_AI_WORKFLOWS="${PROJECT_ROOT}/.ai-workflows"
 
 # Git-capable check — gates the git fetch/rebase below. tools/link-agent-skills.sh's
 # resolve_osac_ai_skills_dir() intentionally uses a weaker, content-based check
@@ -141,24 +145,24 @@ update_git_repo() {
 
 # --- osac-ai-skills ---
 
-if [[ -d "${HOME}/.osac-ai-skills" ]] && osac_ai_skills_vendor_ok "${HOME}/.osac-ai-skills"; then
-  OSAC_AI_SKILLS_DIR="$(readlink -f "${HOME}/.osac-ai-skills")"
+if [[ -d "${HOME_OSAC_AI_SKILLS}" ]] && osac_ai_skills_vendor_ok "${HOME_OSAC_AI_SKILLS}"; then
+  OSAC_AI_SKILLS_DIR="$(readlink -f "${HOME_OSAC_AI_SKILLS}")"
   echo "Updating osac-ai-skills (${OSAC_AI_SKILLS_DIR})..."
   update_git_repo "${OSAC_AI_SKILLS_DIR}" "osac-ai-skills"
-elif [[ -d "${PROJECT_ROOT}/.osac-ai-skills" ]] && osac_ai_skills_vendor_ok "${PROJECT_ROOT}/.osac-ai-skills"; then
-  OSAC_AI_SKILLS_DIR="${PROJECT_ROOT}/.osac-ai-skills"
+elif [[ -d "${REPO_OSAC_AI_SKILLS}" ]] && osac_ai_skills_vendor_ok "${REPO_OSAC_AI_SKILLS}"; then
+  OSAC_AI_SKILLS_DIR="${REPO_OSAC_AI_SKILLS}"
   echo "Updating osac-ai-skills (.osac-ai-skills)..."
   update_git_repo "${OSAC_AI_SKILLS_DIR}" "osac-ai-skills"
-elif [[ -d "${PROJECT_ROOT}/.osac-ai-skills" ]]; then
-  echo "ERROR: ${PROJECT_ROOT}/.osac-ai-skills exists but is not a usable vendor checkout." >&2
+elif [[ -d "${REPO_OSAC_AI_SKILLS}" ]]; then
+  echo "ERROR: ${REPO_OSAC_AI_SKILLS} exists but is not a usable vendor checkout." >&2
   echo "Expected a git clone with skills/ and an executable tools/link-agent-skills.sh." >&2
   echo "Remove or rename that directory, then re-run tools/bootstrap.sh to clone a fresh copy." >&2
   exit 1
 else
-  if [[ -d "${HOME}/.osac-ai-skills" ]]; then
-    echo "  ${HOME}/.osac-ai-skills exists but is not a usable vendor checkout; using ${PROJECT_ROOT}/.osac-ai-skills"
+  if [[ -d "${HOME_OSAC_AI_SKILLS}" ]]; then
+    echo "  ${HOME_OSAC_AI_SKILLS} exists but is not a usable vendor checkout; using ${REPO_OSAC_AI_SKILLS}"
   fi
-  OSAC_AI_SKILLS_DIR="${PROJECT_ROOT}/.osac-ai-skills"
+  OSAC_AI_SKILLS_DIR="${REPO_OSAC_AI_SKILLS}"
   echo "Cloning osac-ai-skills..."
   git clone "https://github.com/${OSAC_AI_SKILLS_REPO}.git" "${OSAC_AI_SKILLS_DIR}"
 fi
@@ -168,16 +172,16 @@ AI_WORKFLOWS_DIR=""
 
 # --- ai-workflows (flightctl) ---
 
-if [[ -d "${HOME}/.ai-workflows" ]]; then
-  AI_WORKFLOWS_DIR="$(readlink -f "${HOME}/.ai-workflows")"
+if [[ -d "${HOME_AI_WORKFLOWS}" ]]; then
+  AI_WORKFLOWS_DIR="$(readlink -f "${HOME_AI_WORKFLOWS}")"
   echo "Updating ai-workflows (${AI_WORKFLOWS_DIR})..."
   update_git_repo "${AI_WORKFLOWS_DIR}" "ai-workflows"
-elif [[ -d "${PROJECT_ROOT}/.ai-workflows" ]]; then
-  AI_WORKFLOWS_DIR="${PROJECT_ROOT}/.ai-workflows"
+elif [[ -d "${REPO_AI_WORKFLOWS}" ]]; then
+  AI_WORKFLOWS_DIR="${REPO_AI_WORKFLOWS}"
   echo "Updating ai-workflows (.ai-workflows)..."
   update_git_repo "${AI_WORKFLOWS_DIR}" "ai-workflows"
 else
-  AI_WORKFLOWS_DIR="${PROJECT_ROOT}/.ai-workflows"
+  AI_WORKFLOWS_DIR="${REPO_AI_WORKFLOWS}"
   echo "Cloning ai-workflows..."
   git clone "https://github.com/${AI_WORKFLOWS_REPO}.git" "${AI_WORKFLOWS_DIR}"
 fi

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -108,7 +108,11 @@ OSAC_AI_SKILLS_REPO="osac-project/osac-ai-skills"
 # still has open (git subtree / copy-bot) for automated-framework consumption.
 osac_ai_skills_vendor_ok() {
   local dir="$1"
-  [[ -d "${dir}/.git" ]] \
+  # Linked worktrees store .git as a file; require a work-tree root so a
+  # leftover directory inside some other checkout does not count.
+  [[ -n "$dir" && -d "$dir" ]] \
+    && git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+    && [[ -z "$(git -C "$dir" rev-parse --show-prefix 2>/dev/null)" ]] \
     && [[ -d "${dir}/skills" ]] \
     && [[ -x "${dir}/tools/link-agent-skills.sh" ]]
 }

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -10,6 +10,9 @@
 #      (umbrella symlinks must exist before ai-workflows install.sh, which
 #      writes workflow links into those paths)
 #   4. Installs workflows (bugfix, implement, prd, design, e2e)
+#   5. Clones skill-relative sibling repos under this checkout
+#      (enhancement-proposals, osac-ux, osac-ui, osac-test-infra,
+#      osac-docs). osac-docs is osac-project/docs — not docs/.
 #
 # Re-run anytime to update to latest main.
 set -euo pipefail
@@ -120,6 +123,52 @@ OSAC_AI_SKILLS_VENDOR_DIR="${OSAC_AI_SKILLS_DIR}" "${PROJECT_ROOT}/tools/link-ag
 echo "Installing ai-workflows skills..."
 AI_WORKFLOWS="bugfix,implement,prd,design,e2e"
 "${AI_WORKFLOWS_DIR}/install.sh" all --project "${PROJECT_ROOT}" --workflows "${AI_WORKFLOWS}"
+
+# Skill-relative sibling checkouts (gitignored). Local dir name follows the
+# GitHub repo except docs → osac-docs (docs/ is in-tree conventions).
+SIBLINGS=(
+  "enhancement-proposals"
+  "osac-ux"
+  "osac-ui"
+  "osac-test-infra"
+  "docs:osac-docs"
+)
+
+is_expected_sibling() {
+  local dir="$1" repo="$2"
+  local expected_suffix="osac-project/${repo}"
+  local remote url
+  for remote in $(git -C "$dir" remote 2>/dev/null); do
+    url=$(git -C "$dir" remote get-url "$remote" 2>/dev/null) || continue
+    if [[ "${url%.git}" == *"$expected_suffix" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+ensure_sibling() {
+  local repo="$1" dir="$2"
+  local dest="${PROJECT_ROOT}/${dir}"
+  if [[ -d "${dest}" ]] && is_expected_sibling "${dest}" "${repo}"; then
+    echo "Updating ${dir}..."
+    update_git_repo "${dest}" "${dir}"
+  elif [[ -d "${dest}" ]]; then
+    echo "Skipping ${dir} — directory exists but is not a clone of osac-project/${repo}."
+  else
+    echo "Cloning ${repo} into ${dir}..."
+    if ! git clone "https://github.com/osac-project/${repo}.git" "${dest}"; then
+      echo "  Clone failed for ${repo}. Skipping."
+    fi
+  fi
+}
+
+echo "Cloning sibling repos..."
+for entry in "${SIBLINGS[@]}"; do
+  repo="${entry%%:*}"
+  dir="${entry#*:}"
+  ensure_sibling "${repo}" "${dir}"
+done
 
 echo ""
 echo "AI workflows and OSAC skills installed."

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -86,7 +86,7 @@ if [[ "$NO_FORK" == false ]]; then
     echo "Install it (https://cli.github.com/) or use --no-fork for read-only clone." >&2
     exit 1
   fi
-  if ! gh auth status; then
+  if ! gh auth status &>/dev/null; then
     echo "ERROR: gh CLI is not authenticated." >&2
     echo "Run 'gh auth login' or use --no-fork for read-only clone." >&2
     exit 1

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -332,7 +332,8 @@ ensure_sibling() {
   local repo="$1" dir="$2"
   local dest="${PROJECT_ROOT}/${dir}"
   dest="${dest%/}"
-  if [[ -z "$dir" || "$dir" == "." || "$dest" == "$PROJECT_ROOT" ]]; then
+  # Single child of PROJECT_ROOT — no empty, ., .., or slash (blocks ../victim).
+  if [[ -z "$dir" || "$dir" == "." || "$dir" == ".." || "$dir" == */* || "$dest" == "$PROJECT_ROOT" ]]; then
     echo "Skipping ${repo} — invalid sibling directory '${dir}'."
     return 0
   fi
@@ -346,7 +347,7 @@ ensure_sibling() {
     echo "Cloning ${repo} into ${dir}..."
     if ! git clone "https://github.com/${GITHUB_ORG}/${repo}.git" "${dest}"; then
       echo "  Clone failed for ${repo}. Skipping."
-      if [[ -n "$dir" && "$dest" != "$PROJECT_ROOT" ]]; then
+      if [[ "$dest" == "$PROJECT_ROOT"/* ]]; then
         rm -rf "${dest}" 2>/dev/null || true
       fi
       return 0

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -113,11 +113,18 @@ osac_ai_skills_vendor_ok() {
     && [[ -x "${dir}/tools/link-agent-skills.sh" ]]
 }
 
-# Fetch + rebase a vendored git checkout onto origin/main. Warns and continues
-# on failure rather than exiting — a stale vendor is recoverable manually, and
-# this runs before any skill-discovery step that depends on it.
+# Fetch + rebase a git checkout onto origin/main. Warns and continues on
+# failure rather than exiting — a stale checkout is recoverable manually.
+# Skip when HEAD is not main so a later bootstrap does not rebase a feature
+# branch (siblings now have a fork remote; developers will check those out).
 update_git_repo() {
   local dir="$1" label="$2"
+  local branch
+  branch=$(git -C "$dir" symbolic-ref --short HEAD 2>/dev/null || echo "")
+  if [[ "$branch" != "main" ]]; then
+    echo "  ${label} is on '${branch:-unknown}'. Skipping update to avoid rebasing your work."
+    return 0
+  fi
   if ! (cd "${dir}" && git fetch origin -q); then
     echo "  Fetch failed for ${label}. Skipping update."
   elif ! (cd "${dir}" && git rebase origin/main --autostash -q); then

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -92,6 +92,11 @@ if [[ "$NO_FORK" == false ]]; then
     exit 1
   fi
   GH_USER=$(gh api user -q .login)
+  if [[ -z "$GH_USER" ]]; then
+    echo "ERROR: gh API returned an empty GitHub username." >&2
+    echo "Cannot construct fork URLs. Run 'gh auth login' or use --no-fork for read-only clone." >&2
+    exit 1
+  fi
   GIT_PROTOCOL=$(gh config get git_protocol 2>/dev/null || echo "https")
   echo "Bootstrapping OSAC for GitHub user: ${GH_USER}"
 else

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -11,8 +11,9 @@
 #      writes workflow links into those paths)
 #   4. Installs workflows (bugfix, implement, prd, design, e2e)
 #   5. Clones skill-relative sibling repos under this checkout
-#      (enhancement-proposals, osac-ux, osac-ui, osac-test-infra,
-#      osac-docs). osac-docs is osac-project/docs — not docs/.
+#      (enhancement-proposals, osac-ux, osac-ui, osac-docs). osac-docs
+#      is osac-project/docs — not docs/. E2E suites live in-tree at
+#      tests/e2e/ (OSAC-3593); osac-test-infra is not cloned.
 #      Writeable siblings get a `fork` remote (origin = osac-project).
 #      osac-ux and vendor clones are never forked.
 #
@@ -233,7 +234,6 @@ SIBLINGS=(
   "enhancement-proposals"
   "osac-ux"
   "osac-ui"
-  "osac-test-infra"
   "docs:osac-docs"
 )
 

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Install AI workflow skills for this repo.
 #
-# Usage: tools/bootstrap.sh
+# Usage: tools/bootstrap.sh [--no-fork]
 #
 # This script:
 #   1. Clones or updates osac-project/osac-ai-skills (prefers ~/.osac-ai-skills)
@@ -13,12 +13,56 @@
 #   5. Clones skill-relative sibling repos under this checkout
 #      (enhancement-proposals, osac-ux, osac-ui, osac-test-infra,
 #      osac-docs). osac-docs is osac-project/docs — not docs/.
+#      Writeable siblings get a `fork` remote (origin = osac-project).
+#      osac-ux and vendor clones are never forked.
 #
 # Re-run anytime to update to latest main.
 set -euo pipefail
 
 SCRIPT_DIR="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 PROJECT_ROOT="$(realpath "${SCRIPT_DIR}/..")"
+
+GITHUB_ORG="osac-project"
+NO_FORK=false
+FORK_REMOTE_NAME="fork"
+GH_USER=""
+GIT_PROTOCOL="https"
+
+usage() {
+  cat <<'EOF'
+Usage: tools/bootstrap.sh [--no-fork]
+
+Vendors AI skills/workflows and clones skill-relative sibling repos under
+this checkout.
+
+By default, each writeable sibling is forked to your GitHub account:
+  origin     = osac-project/<repo>     (upstream source, PR target)
+  fork       = <your-username>/<repo>  (push target for feature branches)
+
+osac-ux is a reference clone (no fork). Vendor checkouts (.osac-ai-skills,
+.ai-workflows) are never forked.
+
+Options:
+  --no-fork   Clone siblings from osac-project without forking.
+              Useful for read-only access or CI environments.
+  --help      Show this help message.
+
+Prerequisites:
+  - gh CLI installed and authenticated (gh auth login), unless --no-fork
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-fork) NO_FORK=true; shift ;;
+    --help|-h) usage; exit 0 ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
 
 # Nested osac/ inside osac-workspace would install a second skill overlay
 # (two PROJECT_ROOTs). Workspace ./bootstrap.sh already covers this clone.
@@ -33,6 +77,24 @@ if [[ "${OSAC_ALLOW_NESTED_BOOTSTRAP:-}" != "1" ]] \
     echo "To force this script anyway: OSAC_ALLOW_NESTED_BOOTSTRAP=1 $0" >&2
     exit 1
   fi
+fi
+
+if [[ "$NO_FORK" == false ]]; then
+  if ! command -v gh &>/dev/null; then
+    echo "ERROR: gh CLI is not installed." >&2
+    echo "Install it (https://cli.github.com/) or use --no-fork for read-only clone." >&2
+    exit 1
+  fi
+  if ! gh auth status; then
+    echo "ERROR: gh CLI is not authenticated." >&2
+    echo "Run 'gh auth login' or use --no-fork for read-only clone." >&2
+    exit 1
+  fi
+  GH_USER=$(gh api user -q .login)
+  GIT_PROTOCOL=$(gh config get git_protocol 2>/dev/null || echo "https")
+  echo "Bootstrapping OSAC for GitHub user: ${GH_USER}"
+else
+  echo "Bootstrapping OSAC (read-only, no forks)..."
 fi
 
 OSAC_AI_SKILLS_REPO="osac-project/osac-ai-skills"
@@ -137,7 +199,7 @@ SIBLINGS=(
 
 is_expected_sibling() {
   local dir="$1" repo="$2"
-  local expected_suffix="osac-project/${repo}"
+  local expected_suffix="${GITHUB_ORG}/${repo}"
   local remote url
   for remote in $(git -C "$dir" remote 2>/dev/null); do
     url=$(git -C "$dir" remote get-url "$remote" 2>/dev/null) || continue
@@ -149,20 +211,89 @@ is_expected_sibling() {
   return 1
 }
 
+get_fork_url() {
+  local repo="$1"
+  if [[ "$GIT_PROTOCOL" == "ssh" ]]; then
+    echo "git@github.com:${GH_USER}/${repo}.git"
+  else
+    echo "https://github.com/${GH_USER}/${repo}.git"
+  fi
+}
+
+# Returns 0 if every push URL for $remote in $dir ends with $expected_suffix
+# (e.g. $GH_USER/$repo). Checks push URLs, not the fetch URL.
+fork_remote_push_matches() {
+  local dir="$1" remote="$2" expected_suffix="$3"
+  local push_urls
+  push_urls=$(git -C "$dir" remote get-url --push --all "$remote" 2>/dev/null) || return 1
+  [[ -n "$push_urls" ]] || return 1
+  local push_url
+  while IFS= read -r push_url; do
+    [[ "${push_url%.git}" == *"$expected_suffix" ]] || return 1
+  done <<< "$push_urls"
+  return 0
+}
+
+ensure_fork_remote() {
+  local repo="$1" dir="$2"
+  local url
+  if ! gh repo fork "${GITHUB_ORG}/${repo}" --clone=false --default-branch-only; then
+    if ! gh repo view "${GH_USER}/${repo}" >/dev/null; then
+      echo "  Failed to fork ${GITHUB_ORG}/${repo}. Skipping fork remote."
+      return 1
+    fi
+  fi
+  url=$(get_fork_url "$repo")
+  if git -C "$dir" remote get-url "$FORK_REMOTE_NAME" &>/dev/null; then
+    if fork_remote_push_matches "$dir" "$FORK_REMOTE_NAME" "${GH_USER}/${repo}"; then
+      return 0
+    fi
+    echo "  Remote '${FORK_REMOTE_NAME}' already exists with a different URL. Skipping."
+    return 1
+  fi
+  git -C "$dir" remote add "$FORK_REMOTE_NAME" "$url"
+  git -C "$dir" fetch "$FORK_REMOTE_NAME" || {
+    echo "  Fetch of ${FORK_REMOTE_NAME} failed for ${repo}. Remote was added."
+    return 0
+  }
+}
+
+# Writeable siblings get a fork remote. osac-ux is reference-only; vendors
+# never enter this loop.
+should_fork_sibling() {
+  local repo="$1"
+  [[ "$NO_FORK" == false ]] || return 1
+  [[ "$repo" != "osac-ux" ]] || return 1
+  return 0
+}
+
+maybe_fork_sibling() {
+  local repo="$1" dest="$2"
+  should_fork_sibling "$repo" || return 0
+  if fork_remote_push_matches "$dest" "$FORK_REMOTE_NAME" "${GH_USER}/${repo}"; then
+    return 0
+  fi
+  echo "Adding ${FORK_REMOTE_NAME} remote for ${repo}..."
+  ensure_fork_remote "$repo" "$dest" || echo "  Fork remote for ${repo} failed. Continuing."
+}
+
 ensure_sibling() {
   local repo="$1" dir="$2"
   local dest="${PROJECT_ROOT}/${dir}"
   if [[ -d "${dest}" ]] && is_expected_sibling "${dest}" "${repo}"; then
     echo "Updating ${dir}..."
     update_git_repo "${dest}" "${dir}"
+    maybe_fork_sibling "$repo" "$dest"
   elif [[ -d "${dest}" ]]; then
-    echo "Skipping ${dir} — directory exists but is not a clone of osac-project/${repo}."
+    echo "Skipping ${dir} — directory exists but is not a clone of ${GITHUB_ORG}/${repo}."
   else
     echo "Cloning ${repo} into ${dir}..."
-    if ! git clone "https://github.com/osac-project/${repo}.git" "${dest}"; then
+    if ! git clone "https://github.com/${GITHUB_ORG}/${repo}.git" "${dest}"; then
       echo "  Clone failed for ${repo}. Skipping."
       rm -rf "${dest}" 2>/dev/null || true
+      return 0
     fi
+    maybe_fork_sibling "$repo" "$dest"
   fi
 }
 

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -126,6 +126,7 @@ AI_WORKFLOWS="bugfix,implement,prd,design,e2e"
 
 # Skill-relative sibling checkouts (gitignored). Local dir name follows the
 # GitHub repo except docs → osac-docs (docs/ is in-tree conventions).
+# Format: "repo" or "repo:local-dir"
 SIBLINGS=(
   "enhancement-proposals"
   "osac-ux"
@@ -140,7 +141,8 @@ is_expected_sibling() {
   local remote url
   for remote in $(git -C "$dir" remote 2>/dev/null); do
     url=$(git -C "$dir" remote get-url "$remote" 2>/dev/null) || continue
-    if [[ "${url%.git}" == *"$expected_suffix" ]]; then
+    # Require a path or SSH separator so evil-osac-project/<repo> does not match.
+    if [[ "${url%.git}" == *"/${expected_suffix}" || "${url%.git}" == *":${expected_suffix}" ]]; then
       return 0
     fi
   done
@@ -159,11 +161,12 @@ ensure_sibling() {
     echo "Cloning ${repo} into ${dir}..."
     if ! git clone "https://github.com/osac-project/${repo}.git" "${dest}"; then
       echo "  Clone failed for ${repo}. Skipping."
+      rm -rf "${dest}" 2>/dev/null || true
     fi
   fi
 }
 
-echo "Cloning sibling repos..."
+echo "Ensuring sibling repos..."
 for entry in "${SIBLINGS[@]}"; do
   repo="${entry%%:*}"
   dir="${entry#*:}"

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -240,15 +240,11 @@ SIBLINGS=(
 is_expected_sibling() {
   local dir="$1" repo="$2"
   local expected_suffix="${GITHUB_ORG}/${repo}"
-  local remote url
-  for remote in $(git -C "$dir" remote 2>/dev/null); do
-    url=$(git -C "$dir" remote get-url "$remote" 2>/dev/null) || continue
-    # Require a path or SSH separator so evil-osac-project/<repo> does not match.
-    if [[ "${url%.git}" == *"/${expected_suffix}" || "${url%.git}" == *":${expected_suffix}" ]]; then
-      return 0
-    fi
-  done
-  return 1
+  local url
+  url=$(git -C "$dir" remote get-url origin 2>/dev/null) || return 1
+  # Require a path or SSH separator so evil-osac-project/<repo> does not match.
+  # origin only: update_git_repo rebases origin/main, so any other remote is irrelevant.
+  [[ "${url%.git}" == *"/${expected_suffix}" || "${url%.git}" == *":${expected_suffix}" ]]
 }
 
 get_fork_url() {

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -64,16 +64,17 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Nested osac/ inside osac-workspace would install a second skill overlay
-# (two PROJECT_ROOTs). Workspace ./bootstrap.sh already covers this clone.
-# Temporary until osac-workspace is decommissioned.
-# Override: OSAC_ALLOW_NESTED_BOOTSTRAP=1
+# Nested osac-workspace/osac would install a second skill overlay (two
+# PROJECT_ROOTs). This repo is the project root — abort that one path so
+# people use a standalone clone or worktree. Temporary until osac-workspace
+# is decommissioned. Override: OSAC_ALLOW_NESTED_BOOTSTRAP=1
 if [[ "${OSAC_ALLOW_NESTED_BOOTSTRAP:-}" != "1" ]] \
    && [[ -x "${PROJECT_ROOT}/../bootstrap.sh" ]]; then
   nested_osac="$(realpath "${PROJECT_ROOT}/../osac" 2>/dev/null || true)"
   if [[ -n "${nested_osac}" && "${nested_osac}" == "${PROJECT_ROOT}" ]]; then
     echo "ERROR: this osac/ checkout is inside osac-workspace." >&2
-    echo "Run the workspace ./bootstrap.sh instead (it already covers this clone)." >&2
+    echo "This repo is the project root — use a standalone clone or worktree," >&2
+    echo "then run tools/bootstrap.sh there (not from osac-workspace/osac)." >&2
     echo "To force this script anyway: OSAC_ALLOW_NESTED_BOOTSTRAP=1 $0" >&2
     exit 1
   fi
@@ -103,6 +104,16 @@ REPO_OSAC_AI_SKILLS="${PROJECT_ROOT}/.osac-ai-skills"
 HOME_AI_WORKFLOWS="${HOME}/.ai-workflows"
 REPO_AI_WORKFLOWS="${PROJECT_ROOT}/.ai-workflows"
 
+# Linked worktrees store .git as a file; require a work-tree root so a
+# leftover directory inside some other checkout does not inherit that parent
+# (git -C would otherwise fetch/rebase the enclosing repo).
+is_git_work_tree_root() {
+  local dir="$1"
+  [[ -n "$dir" && -d "$dir" ]] \
+    && git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+    && [[ -z "$(git -C "$dir" rev-parse --show-prefix 2>/dev/null)" ]]
+}
+
 # Git-capable check — gates the git fetch/rebase below. tools/link-agent-skills.sh's
 # resolve_osac_ai_skills_dir() intentionally uses a weaker, content-based check
 # instead (skills/ + executable fan-out, no .git): it never runs git against the
@@ -112,13 +123,14 @@ REPO_AI_WORKFLOWS="${PROJECT_ROOT}/.ai-workflows"
 # still has open (git subtree / copy-bot) for automated-framework consumption.
 osac_ai_skills_vendor_ok() {
   local dir="$1"
-  # Linked worktrees store .git as a file; require a work-tree root so a
-  # leftover directory inside some other checkout does not count.
-  [[ -n "$dir" && -d "$dir" ]] \
-    && git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
-    && [[ -z "$(git -C "$dir" rev-parse --show-prefix 2>/dev/null)" ]] \
+  is_git_work_tree_root "$dir" \
     && [[ -d "${dir}/skills" ]] \
     && [[ -x "${dir}/tools/link-agent-skills.sh" ]]
+}
+
+ai_workflows_checkout_ok() {
+  local dir="$1"
+  is_git_work_tree_root "$dir" && [[ -x "${dir}/install.sh" ]]
 }
 
 # Fetch + rebase a git checkout onto origin/main. Warns and continues on
@@ -172,15 +184,23 @@ AI_WORKFLOWS_DIR=""
 
 # --- ai-workflows (flightctl) ---
 
-if [[ -d "${HOME_AI_WORKFLOWS}" ]]; then
+if ai_workflows_checkout_ok "${HOME_AI_WORKFLOWS}"; then
   AI_WORKFLOWS_DIR="$(readlink -f "${HOME_AI_WORKFLOWS}")"
   echo "Updating ai-workflows (${AI_WORKFLOWS_DIR})..."
   update_git_repo "${AI_WORKFLOWS_DIR}" "ai-workflows"
-elif [[ -d "${REPO_AI_WORKFLOWS}" ]]; then
+elif ai_workflows_checkout_ok "${REPO_AI_WORKFLOWS}"; then
   AI_WORKFLOWS_DIR="${REPO_AI_WORKFLOWS}"
   echo "Updating ai-workflows (.ai-workflows)..."
   update_git_repo "${AI_WORKFLOWS_DIR}" "ai-workflows"
+elif [[ -d "${REPO_AI_WORKFLOWS}" ]]; then
+  echo "ERROR: ${REPO_AI_WORKFLOWS} exists but is not a usable ai-workflows checkout." >&2
+  echo "Expected a git clone with an executable install.sh." >&2
+  echo "Remove or rename that directory, then re-run tools/bootstrap.sh to clone a fresh copy." >&2
+  exit 1
 else
+  if [[ -d "${HOME_AI_WORKFLOWS}" ]]; then
+    echo "  ${HOME_AI_WORKFLOWS} exists but is not a usable ai-workflows checkout; using ${REPO_AI_WORKFLOWS}"
+  fi
   AI_WORKFLOWS_DIR="${REPO_AI_WORKFLOWS}"
   echo "Cloning ai-workflows..."
   git clone "https://github.com/${AI_WORKFLOWS_REPO}.git" "${AI_WORKFLOWS_DIR}"

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -92,7 +92,7 @@ if [[ "$NO_FORK" == false ]]; then
     exit 1
   fi
   GH_USER=$(gh api user -q .login)
-  if [[ -z "$GH_USER" ]]; then
+  if [[ -z "$GH_USER" || "$GH_USER" == "null" ]]; then
     echo "ERROR: gh API returned an empty GitHub username." >&2
     echo "Cannot construct fork URLs. Run 'gh auth login' or use --no-fork for read-only clone." >&2
     exit 1
@@ -331,6 +331,11 @@ maybe_fork_sibling() {
 ensure_sibling() {
   local repo="$1" dir="$2"
   local dest="${PROJECT_ROOT}/${dir}"
+  dest="${dest%/}"
+  if [[ -z "$dir" || "$dir" == "." || "$dest" == "$PROJECT_ROOT" ]]; then
+    echo "Skipping ${repo} — invalid sibling directory '${dir}'."
+    return 0
+  fi
   if [[ -d "${dest}" ]] && is_expected_sibling "${dest}" "${repo}"; then
     echo "Updating ${dir}..."
     update_git_repo "${dest}" "${dir}"
@@ -341,7 +346,9 @@ ensure_sibling() {
     echo "Cloning ${repo} into ${dir}..."
     if ! git clone "https://github.com/${GITHUB_ORG}/${repo}.git" "${dest}"; then
       echo "  Clone failed for ${repo}. Skipping."
-      rm -rf "${dest}" 2>/dev/null || true
+      if [[ -n "$dir" && "$dest" != "$PROJECT_ROOT" ]]; then
+        rm -rf "${dest}" 2>/dev/null || true
+      fi
       return 0
     fi
     maybe_fork_sibling "$repo" "$dest"

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -220,25 +220,36 @@ get_fork_url() {
   fi
 }
 
-# Returns 0 if every push URL for $remote in $dir ends with $expected_suffix
-# (e.g. $GH_USER/$repo). Checks push URLs, not the fetch URL.
+# Returns 0 if every push URL for $remote in $dir is a path/SSH match for
+# $expected_suffix (e.g. $GH_USER/$repo). Require / or : before the suffix
+# so user "ed" does not match github.com/fred/<repo>. Checks push URLs.
 fork_remote_push_matches() {
   local dir="$1" remote="$2" expected_suffix="$3"
   local push_urls
   push_urls=$(git -C "$dir" remote get-url --push --all "$remote" 2>/dev/null) || return 1
   [[ -n "$push_urls" ]] || return 1
-  local push_url
+  local push_url stripped
   while IFS= read -r push_url; do
-    [[ "${push_url%.git}" == *"$expected_suffix" ]] || return 1
+    stripped="${push_url%.git}"
+    [[ "$stripped" == *"/${expected_suffix}" || "$stripped" == *":${expected_suffix}" ]] || return 1
   done <<< "$push_urls"
   return 0
+}
+
+# True when $GH_USER/$repo is a GitHub fork of osac-project/$repo (not an
+# unrelated same-name repo — common for the docs sibling).
+is_github_fork_of_org_repo() {
+  local repo="$1"
+  local parent
+  parent=$(gh repo view "${GH_USER}/${repo}" --json parent -q '.parent.nameWithOwner // empty' 2>/dev/null) || return 1
+  [[ "$parent" == "${GITHUB_ORG}/${repo}" ]]
 }
 
 ensure_fork_remote() {
   local repo="$1" dir="$2"
   local url
   if ! gh repo fork "${GITHUB_ORG}/${repo}" --clone=false --default-branch-only; then
-    if ! gh repo view "${GH_USER}/${repo}" >/dev/null; then
+    if ! is_github_fork_of_org_repo "$repo"; then
       echo "  Failed to fork ${GITHUB_ORG}/${repo}. Skipping fork remote."
       return 1
     fi

--- a/tools/distrobox/Containerfile
+++ b/tools/distrobox/Containerfile
@@ -1,0 +1,101 @@
+# Distrobox-compatible development container for the osac mono-repo.
+# Usage (from repo root):
+#   make enter
+#   # or: podman build -t osac-dev -f tools/distrobox/Containerfile tools/distrobox
+#
+# Inside the container, Claude Code and all dev tools are available.
+#
+# Rootful podman (host socket for kind / nested containers):
+#   On the host, run once from the osac repo root:
+#     sudo install -d /etc/systemd/system/podman.socket.d
+#     sudo install -m 0644 tools/distrobox/podman-socket-rootful.conf \
+#       /etc/systemd/system/podman.socket.d/rootful-group.conf
+#     sudo chgrp wheel /run/podman && sudo chmod 710 /run/podman
+#     sudo systemctl daemon-reload && sudo systemctl restart podman.socket
+
+# Fedora 42 — pinned to digest; bump with: skopeo inspect docker://registry.fedoraproject.org/fedora:42
+FROM registry.fedoraproject.org/fedora@sha256:63773f454664cd77e239f8e0b13ae7f18effe9e3d6612a325b5646eb3bda11f1
+
+# --- DNF packages (distrobox compat + dev tools) ---
+RUN dnf install -y \
+    bash bc bzip2 curl diffutils dnf-plugins-core findutils git gnupg2 \
+    hostname iproute iputils keyutils less lsof man-db man-pages \
+    mesa-dri-drivers mesa-vulkan-drivers ncurses nss-mdns openssh-clients \
+    openssl passwd pinentry pigz procps-ng rsync shadow-utils sudo tar time \
+    tree unzip util-linux vte-profile wget which words xorg-x11-xauth xz \
+    zip zsh \
+    nodejs npm python3 python3-pip python3-pyyaml \
+    make gcc gcc-c++ jq ripgrep \
+    'dnf-command(config-manager)' \
+    && dnf config-manager addrepo --from-repofile=https://cli.github.com/packages/rpm/gh-cli.repo \
+    && dnf install -y gh \
+    && dnf clean all
+
+# --- Binary tools (Go, buf, kubectl, kind, jira, grpcurl, ginkgo) ---
+# NOTE: binary downloads target x86_64 only.
+# Each download is verified against the project's published checksum.
+ARG GO_VERSION=1.24.4
+ARG BUF_VERSION=1.50.0
+ARG KUBECTL_VERSION=1.33.1
+ARG KIND_VERSION=0.27.0
+ARG JIRA_VERSION=1.7.0
+ARG GRPCURL_VERSION=1.9.3
+ARG GINKGO_VERSION=2.23.4
+RUN set -e \
+    # -- Go --
+    && curl -fsSLo /tmp/go.tar.gz "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
+    && curl -fsSL "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz.sha256" \
+       | tr -d '[:space:]' > /tmp/go.sha256 \
+    && echo "  /tmp/go.tar.gz" >> /tmp/go.sha256 \
+    && sha256sum -c /tmp/go.sha256 \
+    && tar -C /usr/local -xzf /tmp/go.tar.gz \
+    && ln -s /usr/local/go/bin/go /usr/local/bin/go \
+    && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt \
+    && GOBIN=/usr/local/bin go install "github.com/onsi/ginkgo/v2/ginkgo@v${GINKGO_VERSION}" \
+    # -- buf --
+    && curl -fsSLo /tmp/buf.tar.gz "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/buf-Linux-x86_64.tar.gz" \
+    && curl -fsSL "https://github.com/bufbuild/buf/releases/download/v${BUF_VERSION}/sha256.txt" \
+       | grep 'buf-Linux-x86_64.tar.gz' | sed 's|buf-Linux-x86_64.tar.gz|/tmp/buf.tar.gz|' > /tmp/buf.sha256 \
+    && sha256sum -c /tmp/buf.sha256 \
+    && tar -C /usr/local -xzf /tmp/buf.tar.gz --strip-components=1 buf/bin/buf buf/bin/protoc-gen-buf-breaking buf/bin/protoc-gen-buf-lint \
+    # -- kubectl --
+    && curl -fsSLo /usr/local/bin/kubectl \
+       "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+    && curl -fsSL "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256" \
+       | tr -d '[:space:]' > /tmp/kubectl.sha256 \
+    && echo "  /usr/local/bin/kubectl" >> /tmp/kubectl.sha256 \
+    && sha256sum -c /tmp/kubectl.sha256 \
+    && chmod +x /usr/local/bin/kubectl \
+    # -- kind --
+    && curl -fsSLo /usr/local/bin/kind \
+       "https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64" \
+    && curl -fsSL "https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64.sha256sum" \
+       | sed 's|kind-linux-amd64|/usr/local/bin/kind|' > /tmp/kind.sha256 \
+    && sha256sum -c /tmp/kind.sha256 \
+    && chmod +x /usr/local/bin/kind \
+    # -- jira --
+    && curl -fsSLo /tmp/jira.tar.gz "https://github.com/ankitpokhrel/jira-cli/releases/download/v${JIRA_VERSION}/jira_${JIRA_VERSION}_linux_x86_64.tar.gz" \
+    && curl -fsSL "https://github.com/ankitpokhrel/jira-cli/releases/download/v${JIRA_VERSION}/checksums.txt" \
+       | grep "jira_${JIRA_VERSION}_linux_x86_64.tar.gz" | sed "s|jira_${JIRA_VERSION}_linux_x86_64.tar.gz|/tmp/jira.tar.gz|" > /tmp/jira.sha256 \
+    && sha256sum -c /tmp/jira.sha256 \
+    && tar -C /usr/local/bin -xzf /tmp/jira.tar.gz --strip-components=2 --wildcards '*/bin/jira' \
+    && chmod +x /usr/local/bin/jira \
+    # -- grpcurl --
+    && curl -fsSLo /tmp/grpcurl.tar.gz "https://github.com/fullstorydev/grpcurl/releases/download/v${GRPCURL_VERSION}/grpcurl_${GRPCURL_VERSION}_linux_x86_64.tar.gz" \
+    && curl -fsSL "https://github.com/fullstorydev/grpcurl/releases/download/v${GRPCURL_VERSION}/grpcurl_${GRPCURL_VERSION}_checksums.txt" \
+       | grep "grpcurl_${GRPCURL_VERSION}_linux_x86_64.tar.gz" | sed "s|grpcurl_${GRPCURL_VERSION}_linux_x86_64.tar.gz|/tmp/grpcurl.tar.gz|" > /tmp/grpcurl.sha256 \
+    && sha256sum -c /tmp/grpcurl.sha256 \
+    && tar -C /usr/local/bin --no-same-owner -xzf /tmp/grpcurl.tar.gz grpcurl \
+    && chmod +x /usr/local/bin/grpcurl \
+    # -- cleanup --
+    && rm -f /tmp/*.tar.gz /tmp/*.sha256
+
+# --- Language-level packages (pip, npm) ---
+RUN pip3 install --no-cache-dir pytest ansible \
+    && npm install -g @anthropic-ai/claude-code
+
+# --- podman wrapper (delegates to host via distrobox-host-exec) ---
+# Supports rootful mode: set PODMAN_ROOTFUL=1 to use the system podman socket.
+# Requires the host to have the socket group override installed (see header).
+COPY podman-wrapper.sh /usr/local/bin/podman
+RUN chmod +x /usr/local/bin/podman

--- a/tools/distrobox/podman-socket-rootful.conf
+++ b/tools/distrobox/podman-socket-rootful.conf
@@ -1,0 +1,12 @@
+# Systemd drop-in for podman.socket — allows wheel group members to use
+# the rootful podman socket without sudo.
+#
+# Install on the host (from the osac repo root):
+#   sudo install -d /etc/systemd/system/podman.socket.d
+#   sudo install -m 0644 tools/distrobox/podman-socket-rootful.conf \
+#     /etc/systemd/system/podman.socket.d/rootful-group.conf
+#   sudo chgrp wheel /run/podman && sudo chmod 710 /run/podman
+#   sudo systemctl daemon-reload && sudo systemctl restart podman.socket
+[Socket]
+SocketGroup=wheel
+DirectoryMode=0710

--- a/tools/distrobox/podman-wrapper.sh
+++ b/tools/distrobox/podman-wrapper.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Podman wrapper for distrobox — delegates to the host via distrobox-host-exec.
+# Set PODMAN_ROOTFUL=1 to use the system (rootful) podman socket.
+# The rootful socket requires a one-time host setup (see Containerfile header).
+ROOTFUL_SOCKET="/run/podman/podman.sock"
+
+if [ "${PODMAN_ROOTFUL:-0}" = "1" ]; then
+  exec distrobox-host-exec env CONTAINER_HOST="unix://${ROOTFUL_SOCKET}" podman "$@"
+else
+  exec distrobox-host-exec podman "$@"
+fi

--- a/tools/osac-helpers.sh
+++ b/tools/osac-helpers.sh
@@ -11,7 +11,7 @@
 
 # First OSAC-NNNN in a branch name; empty if none. POSIX so zsh nounset is fine.
 osac_jira_ticket_from_branch() {
-    printf '%s\n' "${1:-}" | sed -n 's/.*\(OSAC-[0-9][0-9]*\).*/\1/p'
+    printf '%s\n' "${1:-}" | awk 'match($0, /OSAC-[0-9]+/) { print substr($0, RSTART, RLENGTH); exit }'
 }
 
 osac-new-worktree() {
@@ -60,6 +60,8 @@ osac-new-worktree() {
 
     if ! ./tools/bootstrap.sh; then
         echo "Error: tools/bootstrap.sh failed." >&2
+        echo "  Worktree exists at ${target_dir}." >&2
+        echo "  Recovery: cd ${target_dir} && ./tools/bootstrap.sh --no-fork" >&2
         return 1
     fi
 
@@ -67,25 +69,30 @@ osac-new-worktree() {
     ticket=$(osac_jira_ticket_from_branch "$branch_name")
     if [[ -n "$ticket" ]]; then
         echo "Fetching Jira ticket ${ticket}..."
-        local raw summary issue_type
+        local timeout_bin="" raw="" summary issue_type
         if command -v timeout >/dev/null 2>&1; then
-            raw=$(timeout 15 jira issue view "$ticket" --raw 2>/dev/null) || raw=""
-        else
-            raw=$(jira issue view "$ticket" --raw 2>/dev/null) || raw=""
+            timeout_bin=timeout
+        elif command -v gtimeout >/dev/null 2>&1; then
+            timeout_bin=gtimeout
         fi
-        if [[ -n "$raw" ]]; then
-            summary=$(echo "$raw" | jq -r '.fields.summary // empty' 2>/dev/null)
-            issue_type=$(echo "$raw" | jq -r '.fields.issuetype.name // empty' 2>/dev/null)
-            if [[ -n "$summary" ]]; then
-                mkdir -p .claude
-                printf '\n## Current Work\n- **Jira:** [%s](https://redhat.atlassian.net/browse/%s)\n- **Summary:** %s\n- **Type:** %s\n' \
-                    "$ticket" "$ticket" "$summary" "${issue_type:-Unknown}" >> .claude/CLAUDE.md
-                echo "Appended Jira context to .claude/CLAUDE.md"
-            else
-                echo "Warning: Jira ticket ${ticket} has no summary field." >&2
-            fi
+        if [[ -z "$timeout_bin" ]]; then
+            echo "Warning: no timeout or gtimeout on PATH; skipping Jira fetch for ${ticket}." >&2
         else
-            echo "Warning: could not fetch Jira ticket ${ticket} (is jira CLI configured?)" >&2
+            raw=$("$timeout_bin" 15 jira issue view "$ticket" --raw 2>/dev/null) || raw=""
+            if [[ -n "$raw" ]]; then
+                summary=$(echo "$raw" | jq -r '.fields.summary // empty' 2>/dev/null)
+                issue_type=$(echo "$raw" | jq -r '.fields.issuetype.name // empty' 2>/dev/null)
+                if [[ -n "$summary" ]]; then
+                    mkdir -p .claude
+                    printf '\n## Current Work\n- **Jira:** [%s](https://redhat.atlassian.net/browse/%s)\n- **Summary:** %s\n- **Type:** %s\n' \
+                        "$ticket" "$ticket" "$summary" "${issue_type:-Unknown}" >> .claude/CLAUDE.md
+                    echo "Appended Jira context to .claude/CLAUDE.md"
+                else
+                    echo "Warning: Jira ticket ${ticket} has no summary field." >&2
+                fi
+            else
+                echo "Warning: could not fetch Jira ticket ${ticket} (is jira CLI configured?)" >&2
+            fi
         fi
     fi
 

--- a/tools/osac-helpers.sh
+++ b/tools/osac-helpers.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# shellcheck shell=bash
+#
+# osac-helpers.sh — source this file to get OSAC developer workflow utilities.
+#
+# Usage:
+#   source tools/osac-helpers.sh
+#   osac-new-worktree feat/my-feature
+
+osac-new-worktree() {
+    if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "Error: not inside a Git repository." >&2
+        return 1
+    fi
+
+    local repo_root
+    repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+    if [[ ! -x "${repo_root}/tools/bootstrap.sh" ]]; then
+        echo "Error: this command must be run from an osac clone (missing tools/bootstrap.sh)." >&2
+        echo "  Current repository root: ${repo_root}" >&2
+        return 1
+    fi
+
+    if [[ -z "${1:-}" ]]; then
+        echo "Error: please provide a branch name." >&2
+        echo "Usage: osac-new-worktree <branch-name>" >&2
+        return 1
+    fi
+
+    local branch_name=$1
+    if [[ "$branch_name" =~ [[:space:]] || "$branch_name" == *..* || "$branch_name" == /* ]]; then
+        echo "Error: branch name must not contain spaces, '..', or start with '/'." >&2
+        return 1
+    fi
+
+    local worktree_suffix target_dir worktree_parent
+    worktree_suffix=$(basename "$branch_name")
+    worktree_parent="${OSAC_WORKTREE_PARENT:-$(dirname "$repo_root")}"
+    target_dir="${worktree_parent}/osac-${worktree_suffix}"
+
+    echo "Creating worktree for branch '${branch_name}' at '${target_dir}'..."
+    if ! git -C "$repo_root" worktree add -b "$branch_name" "$target_dir"; then
+        echo "Error: failed to create worktree." >&2
+        echo "  Possible causes:" >&2
+        echo "  - Branch '${branch_name}' already exists (use: git branch -d ${branch_name})" >&2
+        echo "  - Worktree path conflicts with an existing directory" >&2
+        echo "  To list existing worktrees: git worktree list" >&2
+        return 1
+    fi
+
+    cd "$target_dir" || return 1
+    echo "Switched to worktree: $(pwd)"
+
+    if ! ./tools/bootstrap.sh; then
+        echo "Error: tools/bootstrap.sh failed." >&2
+        return 1
+    fi
+
+    local ticket=""
+    if [[ "$branch_name" =~ (OSAC-[0-9]+) ]]; then
+        ticket="${BASH_REMATCH[1]}"
+        echo "Fetching Jira ticket ${ticket}..."
+        local raw summary issue_type
+        raw=$(timeout 15 jira issue view "$ticket" --raw 2>/dev/null)
+        if [[ -n "$raw" ]]; then
+            summary=$(echo "$raw" | jq -r '.fields.summary // empty' 2>/dev/null)
+            issue_type=$(echo "$raw" | jq -r '.fields.issuetype.name // empty' 2>/dev/null)
+            if [[ -n "$summary" ]]; then
+                mkdir -p .claude
+                printf '\n## Current Work\n- **Jira:** [%s](https://redhat.atlassian.net/browse/%s)\n- **Summary:** %s\n- **Type:** %s\n' \
+                    "$ticket" "$ticket" "$summary" "${issue_type:-Unknown}" >> .claude/CLAUDE.md
+                echo "Appended Jira context to .claude/CLAUDE.md"
+            else
+                echo "Warning: Jira ticket ${ticket} has no summary field." >&2
+            fi
+        else
+            echo "Warning: could not fetch Jira ticket ${ticket} (is jira CLI configured?)" >&2
+        fi
+    fi
+
+    echo ""
+    echo "Worktree ready at: ${target_dir}"
+    echo "  Branch: ${branch_name}"
+    echo "  To return: cd ${repo_root}"
+}

--- a/tools/osac-helpers.sh
+++ b/tools/osac-helpers.sh
@@ -61,6 +61,7 @@ osac-new-worktree() {
     if ! ./tools/bootstrap.sh; then
         echo "Error: tools/bootstrap.sh failed." >&2
         echo "  Worktree exists at ${target_dir}." >&2
+        echo "  Current directory is already ${target_dir}." >&2
         echo "  Recovery: cd ${target_dir} && ./tools/bootstrap.sh --no-fork" >&2
         return 1
     fi

--- a/tools/osac-helpers.sh
+++ b/tools/osac-helpers.sh
@@ -5,7 +5,7 @@
 #
 # Usage:
 #   source tools/osac-helpers.sh
-#   osac-new-worktree feat/my-feature
+#   osac-new-worktree feat/my-feature [-- bootstrap args...]
 #
 # Safe to source from bash or zsh (macOS default). Do not use BASH_REMATCH.
 
@@ -58,7 +58,7 @@ osac-new-worktree() {
     cd "$target_dir" || return 1
     echo "Switched to worktree: $(pwd)"
 
-    if ! ./tools/bootstrap.sh; then
+    if ! ./tools/bootstrap.sh "${@:2}"; then
         echo "Error: tools/bootstrap.sh failed." >&2
         echo "  Worktree exists at ${target_dir}." >&2
         echo "  Current directory is already ${target_dir}." >&2

--- a/tools/osac-helpers.sh
+++ b/tools/osac-helpers.sh
@@ -5,7 +5,7 @@
 #
 # Usage:
 #   source tools/osac-helpers.sh
-#   osac-new-worktree feat/my-feature [-- bootstrap args...]
+#   osac-new-worktree feat/my-feature [bootstrap args...]
 #
 # Safe to source from bash or zsh (macOS default). Do not use BASH_REMATCH.
 

--- a/tools/osac-helpers.sh
+++ b/tools/osac-helpers.sh
@@ -6,6 +6,13 @@
 # Usage:
 #   source tools/osac-helpers.sh
 #   osac-new-worktree feat/my-feature
+#
+# Safe to source from bash or zsh (macOS default). Do not use BASH_REMATCH.
+
+# First OSAC-NNNN in a branch name; empty if none. POSIX so zsh nounset is fine.
+osac_jira_ticket_from_branch() {
+    printf '%s\n' "${1:-}" | sed -n 's/.*\(OSAC-[0-9][0-9]*\).*/\1/p'
+}
 
 osac-new-worktree() {
     if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
@@ -57,8 +64,8 @@ osac-new-worktree() {
     fi
 
     local ticket=""
-    if [[ "$branch_name" =~ (OSAC-[0-9]+) ]]; then
-        ticket="${BASH_REMATCH[1]}"
+    ticket=$(osac_jira_ticket_from_branch "$branch_name")
+    if [[ -n "$ticket" ]]; then
         echo "Fetching Jira ticket ${ticket}..."
         local raw summary issue_type
         raw=$(timeout 15 jira issue view "$ticket" --raw 2>/dev/null)

--- a/tools/osac-helpers.sh
+++ b/tools/osac-helpers.sh
@@ -68,7 +68,11 @@ osac-new-worktree() {
     if [[ -n "$ticket" ]]; then
         echo "Fetching Jira ticket ${ticket}..."
         local raw summary issue_type
-        raw=$(timeout 15 jira issue view "$ticket" --raw 2>/dev/null)
+        if command -v timeout >/dev/null 2>&1; then
+            raw=$(timeout 15 jira issue view "$ticket" --raw 2>/dev/null) || raw=""
+        else
+            raw=$(jira issue view "$ticket" --raw 2>/dev/null) || raw=""
+        fi
         if [[ -n "$raw" ]]; then
             summary=$(echo "$raw" | jq -r '.fields.summary // empty' 2>/dev/null)
             issue_type=$(echo "$raw" | jq -r '.fields.issuetype.name // empty' 2>/dev/null)

--- a/tools/osac-helpers.sh
+++ b/tools/osac-helpers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck shell=bash
 #
 # osac-helpers.sh — source this file to get OSAC developer workflow utilities.
@@ -80,8 +80,8 @@ osac-new-worktree() {
         else
             raw=$("$timeout_bin" 15 jira issue view "$ticket" --raw 2>/dev/null) || raw=""
             if [[ -n "$raw" ]]; then
-                summary=$(echo "$raw" | jq -r '.fields.summary // empty' 2>/dev/null)
-                issue_type=$(echo "$raw" | jq -r '.fields.issuetype.name // empty' 2>/dev/null)
+                summary=$(echo "$raw" | jq -r '.fields.summary // empty' 2>/dev/null | tr -d '\n\r')
+                issue_type=$(echo "$raw" | jq -r '.fields.issuetype.name // empty' 2>/dev/null | tr -d '\n\r')
                 if [[ -n "$summary" ]]; then
                     mkdir -p .claude
                     printf '\n## Current Work\n- **Jira:** [%s](https://redhat.atlassian.net/browse/%s)\n- **Summary:** %s\n- **Type:** %s\n' \

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -68,6 +68,7 @@ EOF
 seed_vendor_ok() {
   local dir="$1"
   mkdir -p "${dir}/skills" "${dir}/tools"
+  printf '#\n' > "${dir}/skills/.keep"
   printf '#!/bin/sh\nexit 0\n' > "${dir}/tools/link-agent-skills.sh"
   chmod +x "${dir}/tools/link-agent-skills.sh"
   "$REAL_GIT" init -q "$dir"
@@ -504,6 +505,31 @@ test_unrelated_same_name_github_repo_is_not_used_as_fork() {
   pass "does not point fork at an unrelated same-name GitHub repo"
 }
 
+test_home_worktree_vendor_is_updated_not_recloned() {
+  local home="${TMPDIR_ROOT}/home-vendor-wt"
+  local root="${TMPDIR_ROOT}/osac-vendor-wt"
+  local bin="${TMPDIR_ROOT}/bin-vendor-wt"
+  local source="${TMPDIR_ROOT}/skills-vendor-src"
+  mkdir -p "$home" "$bin"
+  write_git_wrapper "${bin}/git"
+  seed_vendor_ok "$source"
+  seed_ai_workflows "${home}/.ai-workflows"
+  prepare_osac "$root"
+  "$REAL_GIT" -C "$source" checkout -q --detach
+  "$REAL_GIT" -C "$source" worktree add -q "${home}/.osac-ai-skills" main
+  [[ -f "${home}/.osac-ai-skills/.git" ]] || fail "expected HOME vendor worktree"
+
+  local out
+  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
+  echo "$out" | grep -q "Updating osac-ai-skills" \
+    || fail "HOME worktree vendor should be updated: $out"
+  echo "$out" | grep -q "Cloning osac-ai-skills" \
+    && fail "must not clone a second vendor over a HOME worktree: $out"
+  [[ ! -e "${root}/.osac-ai-skills" ]] \
+    || fail "must not create project-local vendor when HOME worktree is usable"
+  pass "HOME linked worktree vendor is updated, not re-cloned"
+}
+
 test_skips_update_when_sibling_not_on_main() {
   local home="${TMPDIR_ROOT}/home-skip-rebase"
   local root="${TMPDIR_ROOT}/osac-skip-rebase"
@@ -572,6 +598,7 @@ test_no_fork_leaves_writeable_without_fork_remote
 test_forks_writeable_siblings_not_osac_ux_or_vendors
 test_rerun_adds_fork_remote_to_existing_clone
 test_unrelated_same_name_github_repo_is_not_used_as_fork
+test_home_worktree_vendor_is_updated_not_recloned
 test_skips_update_when_sibling_not_on_main
 test_fork_remote_match_requires_user_boundary
 

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -22,7 +22,6 @@ EXPECTED_DIRS=(
   enhancement-proposals
   osac-ux
   osac-ui
-  osac-test-infra
   osac-docs
 )
 
@@ -221,7 +220,9 @@ assert_expected_clones() {
   grep -q 'osac-project/osac-ux' "$log" || fail "clone log missing osac-ux: $(cat "$log")"
   grep -q 'osac-project/osac-ui' "$log" || fail "clone log missing osac-ui: $(cat "$log")"
   grep -q 'osac-project/osac-test-infra' "$log" \
-    || fail "clone log missing osac-test-infra: $(cat "$log")"
+    && fail "osac-test-infra must not be cloned (e2e is tests/e2e/): $(cat "$log")"
+  [[ ! -d "${root}/osac-test-infra" ]] \
+    || fail "osac-test-infra/ must not exist after bootstrap"
   grep -q 'osac-project/docs' "$log" || fail "clone log missing osac-project/docs: $(cat "$log")"
   grep -q "${root}/osac-docs" "$log" || fail "docs repo dest must be osac-docs: $(cat "$log")"
   if grep -F "osac-project/docs.git ${root}/docs" "$log"; then
@@ -229,13 +230,13 @@ assert_expected_clones() {
   fi
 }
 
-test_clones_all_five_into_project_root() {
+test_clones_all_four_into_project_root() {
   local home root bin home_skills home_workflows repo_skills clone_log out
-  prepare_fixture five
+  prepare_fixture four
 
   out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
   assert_expected_clones "$root" "$clone_log"
-  pass "clones all five sibling repos under PROJECT_ROOT, not into docs/"
+  pass "clones all four sibling repos under PROJECT_ROOT, not into docs/"
 }
 
 test_rerun_updates_expected_clone() {
@@ -508,7 +509,6 @@ test_no_fork_leaves_writeable_without_fork_remote() {
   assert_expected_clones "$root" "$clone_log"
   assert_no_fork_remote "${root}/enhancement-proposals" "enhancement-proposals"
   assert_no_fork_remote "${root}/osac-ui" "osac-ui"
-  assert_no_fork_remote "${root}/osac-test-infra" "osac-test-infra"
   assert_no_fork_remote "${root}/osac-docs" "osac-docs"
   assert_no_fork_remote "${root}/osac-ux" "osac-ux"
   [[ ! -s "${home}/gh.log" ]] || fail "--no-fork must not invoke gh: $(cat "${home}/gh.log")"
@@ -527,7 +527,6 @@ test_forks_writeable_siblings_not_osac_ux_or_vendors() {
   assert_expected_clones "$root" "$clone_log"
   assert_fork_remote "${root}/enhancement-proposals" "enhancement-proposals"
   assert_fork_remote "${root}/osac-ui" "osac-ui"
-  assert_fork_remote "${root}/osac-test-infra" "osac-test-infra"
   assert_fork_remote "${root}/osac-docs" "docs"
   assert_no_fork_remote "${root}/osac-ux" "osac-ux"
   assert_no_fork_remote "$home_skills" "osac-ai-skills vendor"
@@ -538,6 +537,9 @@ test_forks_writeable_siblings_not_osac_ux_or_vendors() {
     || fail "docs fork must use GitHub repo name docs: $(cat "$gh_log")"
   if grep -q 'repo fork osac-project/osac-ux' "$gh_log"; then
     fail "must not gh fork osac-ux: $(cat "$gh_log")"
+  fi
+  if grep -q 'repo fork osac-project/osac-test-infra' "$gh_log"; then
+    fail "must not gh fork osac-test-infra: $(cat "$gh_log")"
   fi
   if grep -q 'repo fork osac-project/osac-ai-skills' "$gh_log"; then
     fail "must not gh fork osac-ai-skills: $(cat "$gh_log")"
@@ -739,7 +741,7 @@ test_home_git_subdir_ai_workflows_falls_back_to_repo_local() {
   pass "HOME git checkout with plain .ai-workflows subdir falls back to repo-local"
 }
 
-test_clones_all_five_into_project_root
+test_clones_all_four_into_project_root
 test_rerun_updates_expected_clone
 test_skips_unrelated_existing_dir
 test_extra_list_entry_clones_without_other_edits

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# Smoke test: tools/bootstrap.sh declarative sibling clones (under PROJECT_ROOT).
+# Run from osac/: bash tools/test/bootstrap-sibling-clone-smoke.sh
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+BOOTSTRAP="${REPO_ROOT}/tools/bootstrap.sh"
+REAL_GIT=$(command -v git)
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "PASS: $*"; }
+
+[[ -f "$BOOTSTRAP" ]] || fail "missing $BOOTSTRAP"
+[[ -x "$BOOTSTRAP" ]] || fail "$BOOTSTRAP is not executable"
+[[ -n "$REAL_GIT" ]] || fail "git not on PATH"
+
+TMPDIR_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+EXPECTED_DIRS=(
+  enhancement-proposals
+  osac-ux
+  osac-ui
+  osac-test-infra
+  osac-docs
+)
+
+write_git_wrapper() {
+  local dest="$1"
+  cat >"$dest" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+REAL="${REAL_GIT}"
+LOG="\${OSAC_SMOKE_CLONE_LOG}"
+if [[ " \$* " == *" clone "* ]]; then
+  dest="\${!#}"
+  url=""
+  prev=""
+  for a in "\$@"; do
+    if [[ "\$prev" == "clone" ]]; then
+      url="\$a"
+    fi
+    prev="\$a"
+  done
+  printf '%s %s\\n' "\$url" "\$dest" >> "\$LOG"
+  mkdir -p "\$dest"
+  "\$REAL" init -q "\$dest"
+  "\$REAL" -C "\$dest" checkout -q -b main
+  "\$REAL" -C "\$dest" remote add origin "\$url"
+  exit 0
+fi
+exec "\$REAL" "\$@"
+EOF
+  chmod +x "$dest"
+}
+
+seed_vendor_ok() {
+  local dir="$1"
+  mkdir -p "${dir}/skills" "${dir}/tools"
+  printf '#!/bin/sh\nexit 0\n' > "${dir}/tools/link-agent-skills.sh"
+  chmod +x "${dir}/tools/link-agent-skills.sh"
+  "$REAL_GIT" init -q "$dir"
+  "$REAL_GIT" -C "$dir" checkout -q -b main
+  "$REAL_GIT" -C "$dir" add skills tools
+  "$REAL_GIT" -C "$dir" -c user.email=smoke@test -c user.name=smoke \
+    commit -q --allow-empty -m seed
+  "$REAL_GIT" -C "$dir" remote add origin "$dir"
+}
+
+seed_ai_workflows() {
+  local dir="$1"
+  mkdir -p "$dir"
+  printf '#!/bin/sh\necho stub-install\nexit 0\n' > "${dir}/install.sh"
+  chmod +x "${dir}/install.sh"
+  "$REAL_GIT" init -q "$dir"
+  "$REAL_GIT" -C "$dir" checkout -q -b main
+  "$REAL_GIT" -C "$dir" remote add origin "$dir"
+}
+
+prepare_osac() {
+  local root="$1"
+  mkdir -p "${root}/tools" "${root}/docs"
+  cp "$BOOTSTRAP" "${root}/tools/bootstrap.sh"
+  chmod +x "${root}/tools/bootstrap.sh"
+  printf '#!/bin/sh\necho stub-link\nexit 0\n' > "${root}/tools/link-agent-skills.sh"
+  chmod +x "${root}/tools/link-agent-skills.sh"
+  echo "in-tree" > "${root}/docs/ARCHITECTURE.md"
+}
+
+run_bootstrap() {
+  local root="$1" home="$2" bin="$3"
+  HOME="$home" PATH="${bin}:${PATH}" \
+    OSAC_SMOKE_CLONE_LOG="${home}/clone.log" \
+    bash "${root}/tools/bootstrap.sh"
+}
+
+assert_expected_clones() {
+  local root="$1" log="$2"
+  local dir
+  for dir in "${EXPECTED_DIRS[@]}"; do
+    [[ -d "${root}/${dir}/.git" ]] || fail "missing sibling checkout ${root}/${dir}"
+  done
+  [[ -f "${root}/docs/ARCHITECTURE.md" ]] || fail "tracked docs/ARCHITECTURE.md was removed"
+  grep -q 'in-tree' "${root}/docs/ARCHITECTURE.md" \
+    || fail "tracked docs/ARCHITECTURE.md was overwritten"
+  [[ ! -d "${root}/docs/.git" ]] || fail "docs repo must not land in docs/"
+
+  grep -q 'osac-project/enhancement-proposals' "$log" \
+    || fail "clone log missing enhancement-proposals: $(cat "$log")"
+  grep -q 'osac-project/osac-ux' "$log" || fail "clone log missing osac-ux: $(cat "$log")"
+  grep -q 'osac-project/osac-ui' "$log" || fail "clone log missing osac-ui: $(cat "$log")"
+  grep -q 'osac-project/osac-test-infra' "$log" \
+    || fail "clone log missing osac-test-infra: $(cat "$log")"
+  grep -q 'osac-project/docs' "$log" || fail "clone log missing osac-project/docs: $(cat "$log")"
+  grep -q "${root}/osac-docs" "$log" || fail "docs repo dest must be osac-docs: $(cat "$log")"
+  if grep -E 'osac-project/docs .*/docs$' "$log" | grep -vq osac-docs; then
+    fail "docs repo cloned to docs/ rather than osac-docs/: $(cat "$log")"
+  fi
+}
+
+test_clones_all_five_into_project_root() {
+  local home="${TMPDIR_ROOT}/home-five"
+  local root="${TMPDIR_ROOT}/osac-five"
+  local bin="${TMPDIR_ROOT}/bin-five"
+  mkdir -p "$home" "$bin"
+  write_git_wrapper "${bin}/git"
+  seed_vendor_ok "${home}/.osac-ai-skills"
+  seed_ai_workflows "${home}/.ai-workflows"
+  prepare_osac "$root"
+
+  local out
+  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
+  assert_expected_clones "$root" "${home}/clone.log"
+  pass "clones all five sibling repos under PROJECT_ROOT, not into docs/"
+}
+
+test_rerun_updates_expected_clone() {
+  local home="${TMPDIR_ROOT}/home-update"
+  local root="${TMPDIR_ROOT}/osac-update"
+  local bin="${TMPDIR_ROOT}/bin-update"
+  mkdir -p "$home" "$bin"
+  write_git_wrapper "${bin}/git"
+  seed_vendor_ok "${home}/.osac-ai-skills"
+  seed_ai_workflows "${home}/.ai-workflows"
+  prepare_osac "$root"
+
+  run_bootstrap "$root" "$home" "$bin" >/dev/null
+  echo marker > "${root}/enhancement-proposals/keep-me"
+  : > "${home}/clone.log"
+  local out
+  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap re-run failed: $out"
+  [[ -f "${root}/enhancement-proposals/keep-me" ]] \
+    || fail "re-run deleted an expected clone"
+  [[ ! -s "${home}/clone.log" ]] \
+    || fail "re-run should not git clone again: $(cat "${home}/clone.log")"
+  echo "$out" | grep -q 'enhancement-proposals' \
+    || fail "re-run should mention enhancement-proposals update: $out"
+  pass "re-run updates an expected clone and does not delete it"
+}
+
+test_skips_unrelated_existing_dir() {
+  local home="${TMPDIR_ROOT}/home-skip"
+  local root="${TMPDIR_ROOT}/osac-skip"
+  local bin="${TMPDIR_ROOT}/bin-skip"
+  mkdir -p "$home" "$bin"
+  write_git_wrapper "${bin}/git"
+  seed_vendor_ok "${home}/.osac-ai-skills"
+  seed_ai_workflows "${home}/.ai-workflows"
+  prepare_osac "$root"
+  mkdir -p "${root}/osac-ux"
+  echo leftover > "${root}/osac-ux/not-the-repo"
+
+  local out
+  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
+  grep -q leftover "${root}/osac-ux/not-the-repo" \
+    || fail "unrelated osac-ux/ dir was overwritten"
+  echo "$out" | grep -qi 'skip' \
+    || fail "expected skip warning for unrelated osac-ux/: $out"
+  [[ ! -d "${root}/osac-ux/.git" ]] || fail "skip path must not init a git repo"
+  pass "skips an existing dir that is not the expected clone"
+}
+
+test_extra_list_entry_clones_without_other_edits() {
+  local home="${TMPDIR_ROOT}/home-extra"
+  local root="${TMPDIR_ROOT}/osac-extra"
+  local bin="${TMPDIR_ROOT}/bin-extra"
+  mkdir -p "$home" "$bin"
+  write_git_wrapper "${bin}/git"
+  seed_vendor_ok "${home}/.osac-ai-skills"
+  seed_ai_workflows "${home}/.ai-workflows"
+  prepare_osac "$root"
+
+  grep -q 'SIBLINGS=(' "${root}/tools/bootstrap.sh" \
+    || fail "bootstrap.sh has no SIBLINGS=( list"
+  # Insert one extra entry after the opening SIBLINGS=( line only.
+  local tmp="${root}/tools/bootstrap.sh.new"
+  awk '
+    { print }
+    /SIBLINGS=\(/ && !done { print "  \"fixture-sibling\""; done=1 }
+  ' "${root}/tools/bootstrap.sh" >"$tmp"
+  mv "$tmp" "${root}/tools/bootstrap.sh"
+  chmod +x "${root}/tools/bootstrap.sh"
+
+  local out
+  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
+  assert_expected_clones "$root" "${home}/clone.log"
+  [[ -d "${root}/fixture-sibling/.git" ]] \
+    || fail "extra SIBLINGS entry was not cloned"
+  grep -q 'osac-project/fixture-sibling' "${home}/clone.log" \
+    || fail "extra entry clone URL missing: $(cat "${home}/clone.log")"
+  pass "adding a SIBLINGS list entry clones an extra dest with no other code edits"
+}
+
+test_nested_abort_skips_sibling_clones() {
+  local nest="${TMPDIR_ROOT}/nested-ws"
+  local empty_home="${TMPDIR_ROOT}/nested-ws-home"
+  mkdir -p "${nest}/osac/tools" "${nest}/osac/docs" "${empty_home}"
+  printf '#!/bin/sh\necho workspace-bootstrap\n' > "${nest}/bootstrap.sh"
+  chmod +x "${nest}/bootstrap.sh"
+  cp "$BOOTSTRAP" "${nest}/osac/tools/bootstrap.sh"
+  chmod +x "${nest}/osac/tools/bootstrap.sh"
+  echo "in-tree" > "${nest}/osac/docs/ARCHITECTURE.md"
+
+  local out rc=0
+  out=$(HOME="${empty_home}" bash "${nest}/osac/tools/bootstrap.sh" 2>&1) || rc=$?
+  [[ "$rc" -eq 1 ]] || fail "nested bootstrap expected exit 1, got $rc: $out"
+  [[ ! -d "${nest}/osac/osac-docs" ]] \
+    || fail "nested abort must not clone osac-docs"
+  [[ ! -d "${nest}/osac/enhancement-proposals" ]] \
+    || fail "nested abort must not clone enhancement-proposals"
+  pass "nested workspace abort happens before sibling clones"
+}
+
+test_clones_all_five_into_project_root
+test_rerun_updates_expected_clone
+test_skips_unrelated_existing_dir
+test_extra_list_entry_clones_without_other_edits
+test_nested_abort_skips_sibling_clones
+
+echo "All bootstrap sibling-clone smoke tests passed."

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -117,6 +117,9 @@ case "${1:-}" in
   auth) exit 0 ;;
   api)
     if [[ "${2:-}" == "user" ]]; then
+      if [[ -n "${OSAC_SMOKE_EMPTY_LOGIN:-}" ]]; then
+        exit 0
+      fi
       echo smokeuser
       exit 0
     fi
@@ -374,6 +377,26 @@ test_missing_gh_without_no_fork_exits() {
   pass "missing gh without --no-fork exits before sibling clones"
 }
 
+test_empty_gh_user_without_no_fork_exits() {
+  local home root bin home_skills home_workflows repo_skills clone_log out rc=0
+  prepare_fixture empty-gh-user
+  write_gh_wrapper "${bin}/gh"
+
+  out=$(HOME="$home" PATH="${bin}:${PATH}" \
+    OSAC_SMOKE_CLONE_LOG="$clone_log" \
+    OSAC_SMOKE_GH_LOG="${home}/gh.log" \
+    OSAC_SMOKE_EMPTY_LOGIN=1 \
+    bash "${root}/tools/bootstrap.sh" 2>&1) || rc=$?
+  [[ "$rc" -eq 1 ]] || fail "empty GH_USER expected exit 1, got $rc: $out"
+  echo "$out" | grep -qi 'empty GitHub username' \
+    || fail "expected empty-username error: $out"
+  [[ ! -d "${root}/enhancement-proposals" ]] \
+    || fail "must not clone siblings when GH_USER is empty"
+  grep -q 'api user' "${home}/gh.log" \
+    || fail "expected gh api user invocation: $(cat "${home}/gh.log" 2>/dev/null || true)"
+  pass "empty GH_USER without --no-fork exits before sibling clones"
+}
+
 test_no_fork_leaves_writeable_without_fork_remote() {
   local home root bin home_skills home_workflows repo_skills clone_log out
   prepare_fixture nofork
@@ -624,6 +647,7 @@ test_nested_abort_skips_sibling_clones
 test_failed_clone_cleans_dest
 test_expected_sibling_requires_org_boundary
 test_missing_gh_without_no_fork_exits
+test_empty_gh_user_without_no_fork_exits
 test_no_fork_leaves_writeable_without_fork_remote
 test_forks_writeable_siblings_not_osac_ux_or_vendors
 test_rerun_adds_fork_remote_to_existing_clone

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -414,6 +414,28 @@ test_expected_sibling_requires_org_boundary() {
   pass "expected-clone match requires / or : before osac-project"
 }
 
+test_expected_sibling_requires_origin_remote() {
+  local home root bin home_skills home_workflows repo_skills clone_log out ep
+  prepare_fixture origin-only
+  ep="${root}/enhancement-proposals"
+
+  run_bootstrap "$root" "$home" "$bin" >/dev/null
+  "$REAL_GIT" -C "$ep" remote set-url origin \
+    "https://github.com/unrelated/enhancement-proposals.git"
+  "$REAL_GIT" -C "$ep" remote add extra \
+    "https://github.com/osac-project/enhancement-proposals.git"
+  echo keep > "${ep}/keep-me"
+
+  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
+  echo "$out" | grep -qi 'skip' \
+    || fail "non-origin osac-project remote must not count as expected clone: $out"
+  echo "$out" | grep -q 'Updating enhancement-proposals' \
+    && fail "must not update when origin is unrelated: $out"
+  grep -q keep "${ep}/keep-me" \
+    || fail "dir with unrelated origin was overwritten"
+  pass "expected-clone match uses origin only, not other remotes"
+}
+
 test_missing_gh_without_no_fork_exits() {
   local home root bin home_skills home_workflows repo_skills clone_log out rc=0
   prepare_fixture no-gh
@@ -726,6 +748,7 @@ test_parent_dir_sibling_does_not_rm_external
 test_nested_abort_skips_sibling_clones
 test_failed_clone_cleans_dest
 test_expected_sibling_requires_org_boundary
+test_expected_sibling_requires_origin_remote
 test_missing_gh_without_no_fork_exits
 test_empty_gh_user_without_no_fork_exits
 test_null_gh_user_without_no_fork_exits

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -96,11 +96,63 @@ prepare_osac() {
   echo "in-tree" > "${root}/docs/ARCHITECTURE.md"
 }
 
+write_gh_wrapper() {
+  local dest="$1"
+  cat >"$dest" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+LOG="${OSAC_SMOKE_GH_LOG:-/dev/null}"
+printf 'gh %s\n' "$*" >> "$LOG"
+case "${1:-}" in
+  auth) exit 0 ;;
+  api)
+    if [[ "${2:-}" == "user" ]]; then
+      echo smokeuser
+      exit 0
+    fi
+    ;;
+  config)
+    echo https
+    exit 0
+    ;;
+  repo) exit 0 ;;
+esac
+exit 0
+EOF
+  chmod +x "$dest"
+}
+
 run_bootstrap() {
+  local root="$1" home="$2" bin="$3"
+  shift 3
+  HOME="$home" PATH="${bin}:${PATH}" \
+    OSAC_SMOKE_CLONE_LOG="${home}/clone.log" \
+    OSAC_SMOKE_GH_LOG="${home}/gh.log" \
+    bash "${root}/tools/bootstrap.sh" --no-fork "$@"
+}
+
+run_bootstrap_fork() {
   local root="$1" home="$2" bin="$3"
   HOME="$home" PATH="${bin}:${PATH}" \
     OSAC_SMOKE_CLONE_LOG="${home}/clone.log" \
+    OSAC_SMOKE_GH_LOG="${home}/gh.log" \
     bash "${root}/tools/bootstrap.sh"
+}
+
+assert_no_fork_remote() {
+  local dest="$1" label="$2"
+  if git -C "$dest" remote get-url fork >/dev/null 2>&1; then
+    fail "$label must not have a fork remote: $(git -C "$dest" remote -v)"
+  fi
+}
+
+assert_fork_remote() {
+  local dest="$1" repo="$2"
+  local url
+  url=$(git -C "$dest" remote get-url fork 2>/dev/null) \
+    || fail "missing fork remote on ${dest}: $(git -C "$dest" remote -v 2>/dev/null || true)"
+  [[ "${url%.git}" == *"smokeuser/${repo}" ]] \
+    || fail "fork remote on ${dest} expected smokeuser/${repo}, got: $url"
 }
 
 assert_expected_clones() {
@@ -301,6 +353,113 @@ test_expected_sibling_requires_org_boundary() {
   pass "expected-clone match requires / or : before osac-project"
 }
 
+test_missing_gh_without_no_fork_exits() {
+  local home="${TMPDIR_ROOT}/home-no-gh"
+  local root="${TMPDIR_ROOT}/osac-no-gh"
+  local bin="${TMPDIR_ROOT}/bin-no-gh"
+  mkdir -p "$home" "$bin"
+  write_git_wrapper "${bin}/git"
+  seed_vendor_ok "${home}/.osac-ai-skills"
+  seed_ai_workflows "${home}/.ai-workflows"
+  prepare_osac "$root"
+
+  local out rc=0
+  out=$(HOME="$home" PATH="${bin}:/usr/bin:/bin" \
+    OSAC_SMOKE_CLONE_LOG="${home}/clone.log" \
+    bash "${root}/tools/bootstrap.sh" 2>&1) || rc=$?
+  [[ "$rc" -eq 1 ]] || fail "missing gh expected exit 1, got $rc: $out"
+  echo "$out" | grep -qi 'gh CLI is not installed' \
+    || fail "expected gh-missing error: $out"
+  [[ ! -d "${root}/enhancement-proposals" ]] \
+    || fail "must not clone siblings when gh is missing"
+  pass "missing gh without --no-fork exits before sibling clones"
+}
+
+test_no_fork_leaves_writeable_without_fork_remote() {
+  local home="${TMPDIR_ROOT}/home-nofork"
+  local root="${TMPDIR_ROOT}/osac-nofork"
+  local bin="${TMPDIR_ROOT}/bin-nofork"
+  mkdir -p "$home" "$bin"
+  write_git_wrapper "${bin}/git"
+  write_gh_wrapper "${bin}/gh"
+  seed_vendor_ok "${home}/.osac-ai-skills"
+  seed_ai_workflows "${home}/.ai-workflows"
+  prepare_osac "$root"
+
+  local out
+  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap --no-fork failed: $out"
+  echo "$out" | grep -q 'read-only, no forks' \
+    || fail "expected read-only banner: $out"
+  assert_expected_clones "$root" "${home}/clone.log"
+  assert_no_fork_remote "${root}/enhancement-proposals" "enhancement-proposals"
+  assert_no_fork_remote "${root}/osac-ui" "osac-ui"
+  assert_no_fork_remote "${root}/osac-test-infra" "osac-test-infra"
+  assert_no_fork_remote "${root}/osac-docs" "osac-docs"
+  assert_no_fork_remote "${root}/osac-ux" "osac-ux"
+  [[ ! -s "${home}/gh.log" ]] || fail "--no-fork must not invoke gh: $(cat "${home}/gh.log")"
+  pass "--no-fork clones siblings without fork remotes even if gh is on PATH"
+}
+
+test_forks_writeable_siblings_not_osac_ux_or_vendors() {
+  local home="${TMPDIR_ROOT}/home-fork"
+  local root="${TMPDIR_ROOT}/osac-fork"
+  local bin="${TMPDIR_ROOT}/bin-fork"
+  mkdir -p "$home" "$bin"
+  write_git_wrapper "${bin}/git"
+  write_gh_wrapper "${bin}/gh"
+  seed_vendor_ok "${home}/.osac-ai-skills"
+  seed_ai_workflows "${home}/.ai-workflows"
+  prepare_osac "$root"
+
+  local out
+  out=$(run_bootstrap_fork "$root" "$home" "$bin" 2>&1) || fail "bootstrap fork path failed: $out"
+  echo "$out" | grep -q 'GitHub user: smokeuser' \
+    || fail "expected GitHub user banner: $out"
+  assert_expected_clones "$root" "${home}/clone.log"
+  assert_fork_remote "${root}/enhancement-proposals" "enhancement-proposals"
+  assert_fork_remote "${root}/osac-ui" "osac-ui"
+  assert_fork_remote "${root}/osac-test-infra" "osac-test-infra"
+  assert_fork_remote "${root}/osac-docs" "docs"
+  assert_no_fork_remote "${root}/osac-ux" "osac-ux"
+  assert_no_fork_remote "${home}/.osac-ai-skills" "osac-ai-skills vendor"
+  assert_no_fork_remote "${home}/.ai-workflows" "ai-workflows vendor"
+  grep -q 'repo fork osac-project/enhancement-proposals' "${home}/gh.log" \
+    || fail "expected gh repo fork for enhancement-proposals: $(cat "${home}/gh.log")"
+  grep -q 'repo fork osac-project/docs' "${home}/gh.log" \
+    || fail "docs fork must use GitHub repo name docs: $(cat "${home}/gh.log")"
+  if grep -q 'repo fork osac-project/osac-ux' "${home}/gh.log"; then
+    fail "must not gh fork osac-ux: $(cat "${home}/gh.log")"
+  fi
+  if grep -q 'repo fork osac-project/osac-ai-skills' "${home}/gh.log"; then
+    fail "must not gh fork osac-ai-skills: $(cat "${home}/gh.log")"
+  fi
+  pass "forks writeable siblings; skips osac-ux and vendors"
+}
+
+test_rerun_adds_fork_remote_to_existing_clone() {
+  local home="${TMPDIR_ROOT}/home-fork-rerun"
+  local root="${TMPDIR_ROOT}/osac-fork-rerun"
+  local bin="${TMPDIR_ROOT}/bin-fork-rerun"
+  mkdir -p "$home" "$bin"
+  write_git_wrapper "${bin}/git"
+  write_gh_wrapper "${bin}/gh"
+  seed_vendor_ok "${home}/.osac-ai-skills"
+  seed_ai_workflows "${home}/.ai-workflows"
+  prepare_osac "$root"
+
+  run_bootstrap "$root" "$home" "$bin" >/dev/null
+  assert_no_fork_remote "${root}/enhancement-proposals" "enhancement-proposals after --no-fork"
+  : > "${home}/gh.log"
+  local out
+  out=$(run_bootstrap_fork "$root" "$home" "$bin" 2>&1) || fail "fork re-run failed: $out"
+  assert_fork_remote "${root}/enhancement-proposals" "enhancement-proposals"
+  assert_fork_remote "${root}/osac-docs" "docs"
+  assert_no_fork_remote "${root}/osac-ux" "osac-ux"
+  echo "$out" | grep -q 'Adding fork remote for enhancement-proposals' \
+    || fail "re-run should add missing fork remotes: $out"
+  pass "re-run adds fork remotes to existing origin-only clones"
+}
+
 test_clones_all_five_into_project_root
 test_rerun_updates_expected_clone
 test_skips_unrelated_existing_dir
@@ -308,5 +467,9 @@ test_extra_list_entry_clones_without_other_edits
 test_nested_abort_skips_sibling_clones
 test_failed_clone_cleans_dest
 test_expected_sibling_requires_org_boundary
+test_missing_gh_without_no_fork_exits
+test_no_fork_leaves_writeable_without_fork_remote
+test_forks_writeable_siblings_not_osac_ux_or_vendors
+test_rerun_adds_fork_remote_to_existing_clone
 
 echo "All bootstrap sibling-clone smoke tests passed."

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -26,6 +26,9 @@ EXPECTED_DIRS=(
   osac-docs
 )
 
+OSAC_AI_SKILLS_NAME=".osac-ai-skills"
+AI_WORKFLOWS_NAME=".ai-workflows"
+
 write_git_wrapper() {
   local dest="$1"
   cat >"$dest" <<EOF
@@ -142,6 +145,22 @@ EOF
   chmod +x "$dest"
 }
 
+# Sets caller's home, root, bin, home_skills, home_workflows, repo_skills, clone_log.
+prepare_fixture() {
+  home="${TMPDIR_ROOT}/home-$1"
+  root="${TMPDIR_ROOT}/osac-$1"
+  bin="${TMPDIR_ROOT}/bin-$1"
+  home_skills="${home}/${OSAC_AI_SKILLS_NAME}"
+  home_workflows="${home}/${AI_WORKFLOWS_NAME}"
+  repo_skills="${root}/${OSAC_AI_SKILLS_NAME}"
+  clone_log="${home}/clone.log"
+  mkdir -p "$home" "$bin"
+  write_git_wrapper "${bin}/git"
+  seed_vendor_ok "$home_skills"
+  seed_ai_workflows "$home_workflows"
+  prepare_osac "$root"
+}
+
 run_bootstrap() {
   local root="$1" home="$2" bin="$3"
   shift 3
@@ -200,64 +219,42 @@ assert_expected_clones() {
 }
 
 test_clones_all_five_into_project_root() {
-  local home="${TMPDIR_ROOT}/home-five"
-  local root="${TMPDIR_ROOT}/osac-five"
-  local bin="${TMPDIR_ROOT}/bin-five"
-  mkdir -p "$home" "$bin"
-  write_git_wrapper "${bin}/git"
-  seed_vendor_ok "${home}/.osac-ai-skills"
-  seed_ai_workflows "${home}/.ai-workflows"
-  prepare_osac "$root"
+  local home root bin home_skills home_workflows repo_skills clone_log out
+  prepare_fixture five
 
-  local out
   out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
-  assert_expected_clones "$root" "${home}/clone.log"
+  assert_expected_clones "$root" "$clone_log"
   pass "clones all five sibling repos under PROJECT_ROOT, not into docs/"
 }
 
 test_rerun_updates_expected_clone() {
-  local home="${TMPDIR_ROOT}/home-update"
-  local root="${TMPDIR_ROOT}/osac-update"
-  local bin="${TMPDIR_ROOT}/bin-update"
-  mkdir -p "$home" "$bin"
-  write_git_wrapper "${bin}/git"
-  seed_vendor_ok "${home}/.osac-ai-skills"
-  seed_ai_workflows "${home}/.ai-workflows"
-  prepare_osac "$root"
+  local home root bin home_skills home_workflows repo_skills clone_log out ep
+  prepare_fixture update
+  ep="${root}/enhancement-proposals"
 
   run_bootstrap "$root" "$home" "$bin" >/dev/null
-  echo marker > "${root}/enhancement-proposals/keep-me"
-  : > "${home}/clone.log"
-  local out
+  echo marker > "${ep}/keep-me"
+  : > "$clone_log"
   out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap re-run failed: $out"
-  [[ -f "${root}/enhancement-proposals/keep-me" ]] \
-    || fail "re-run deleted an expected clone"
-  [[ ! -s "${home}/clone.log" ]] \
-    || fail "re-run should not git clone again: $(cat "${home}/clone.log")"
+  [[ -f "${ep}/keep-me" ]] || fail "re-run deleted an expected clone"
+  [[ ! -s "$clone_log" ]] || fail "re-run should not git clone again: $(cat "$clone_log")"
   echo "$out" | grep -q 'enhancement-proposals' \
     || fail "re-run should mention enhancement-proposals update: $out"
   pass "re-run updates an expected clone and does not delete it"
 }
 
 test_skips_unrelated_existing_dir() {
-  local home="${TMPDIR_ROOT}/home-skip"
-  local root="${TMPDIR_ROOT}/osac-skip"
-  local bin="${TMPDIR_ROOT}/bin-skip"
-  mkdir -p "$home" "$bin"
-  write_git_wrapper "${bin}/git"
-  seed_vendor_ok "${home}/.osac-ai-skills"
-  seed_ai_workflows "${home}/.ai-workflows"
-  prepare_osac "$root"
-  mkdir -p "${root}/osac-ux"
-  echo leftover > "${root}/osac-ux/not-the-repo"
+  local home root bin home_skills home_workflows repo_skills clone_log out ux
+  prepare_fixture skip
+  ux="${root}/osac-ux"
+  mkdir -p "$ux"
+  echo leftover > "${ux}/not-the-repo"
 
-  local out
   out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
-  grep -q leftover "${root}/osac-ux/not-the-repo" \
-    || fail "unrelated osac-ux/ dir was overwritten"
+  grep -q leftover "${ux}/not-the-repo" || fail "unrelated osac-ux/ dir was overwritten"
   echo "$out" | grep -qi 'skip' \
     || fail "expected skip warning for unrelated osac-ux/: $out"
-  [[ ! -d "${root}/osac-ux/.git" ]] || fail "skip path must not init a git repo"
+  [[ ! -d "${ux}/.git" ]] || fail "skip path must not init a git repo"
   [[ -d "${root}/osac-ui/.git" ]] \
     || fail "skip of osac-ux must still clone later siblings (osac-ui)"
   [[ -d "${root}/osac-docs/.git" ]] \
@@ -266,19 +263,12 @@ test_skips_unrelated_existing_dir() {
 }
 
 test_extra_list_entry_clones_without_other_edits() {
-  local home="${TMPDIR_ROOT}/home-extra"
-  local root="${TMPDIR_ROOT}/osac-extra"
-  local bin="${TMPDIR_ROOT}/bin-extra"
-  mkdir -p "$home" "$bin"
-  write_git_wrapper "${bin}/git"
-  seed_vendor_ok "${home}/.osac-ai-skills"
-  seed_ai_workflows "${home}/.ai-workflows"
-  prepare_osac "$root"
+  local home root bin home_skills home_workflows repo_skills clone_log out tmp
+  prepare_fixture extra
 
   grep -q 'SIBLINGS=(' "${root}/tools/bootstrap.sh" \
     || fail "bootstrap.sh has no SIBLINGS=( list"
-  # Insert one extra entry after the opening SIBLINGS=( line only.
-  local tmp="${root}/tools/bootstrap.sh.new"
+  tmp="${root}/tools/bootstrap.sh.new"
   awk '
     { print }
     /SIBLINGS=\(/ && !done { print "  \"fixture-sibling\""; done=1 }
@@ -286,13 +276,12 @@ test_extra_list_entry_clones_without_other_edits() {
   mv "$tmp" "${root}/tools/bootstrap.sh"
   chmod +x "${root}/tools/bootstrap.sh"
 
-  local out
   out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
-  assert_expected_clones "$root" "${home}/clone.log"
+  assert_expected_clones "$root" "$clone_log"
   [[ -d "${root}/fixture-sibling/.git" ]] \
     || fail "extra SIBLINGS entry was not cloned"
-  grep -q 'osac-project/fixture-sibling' "${home}/clone.log" \
-    || fail "extra entry clone URL missing: $(cat "${home}/clone.log")"
+  grep -q 'osac-project/fixture-sibling' "$clone_log" \
+    || fail "extra entry clone URL missing: $(cat "$clone_log")"
   pass "adding a SIBLINGS list entry clones an extra dest with no other code edits"
 }
 
@@ -317,55 +306,44 @@ test_nested_abort_skips_sibling_clones() {
 }
 
 test_failed_clone_cleans_dest() {
-  local home="${TMPDIR_ROOT}/home-fail"
-  local root="${TMPDIR_ROOT}/osac-fail"
-  local bin="${TMPDIR_ROOT}/bin-fail"
-  mkdir -p "$home" "$bin"
-  write_git_wrapper "${bin}/git"
-  seed_vendor_ok "${home}/.osac-ai-skills"
-  seed_ai_workflows "${home}/.ai-workflows"
-  prepare_osac "$root"
+  local home root bin home_skills home_workflows repo_skills clone_log out ux
+  prepare_fixture fail
+  ux="${root}/osac-ux"
 
-  local out
   out=$(OSAC_SMOKE_FAIL_CLONE=osac-ux run_bootstrap "$root" "$home" "$bin" 2>&1) \
     || fail "bootstrap should continue after a sibling clone failure: $out"
   echo "$out" | grep -qi 'Clone failed for osac-ux' \
     || fail "expected clone-failed message for osac-ux: $out"
-  [[ ! -e "${root}/osac-ux" ]] \
-    || fail "failed clone must not leave dest behind: $(ls -la "${root}/osac-ux" 2>/dev/null || true)"
+  [[ ! -e "$ux" ]] \
+    || fail "failed clone must not leave dest behind: $(ls -la "$ux" 2>/dev/null || true)"
   [[ -d "${root}/osac-ui/.git" ]] \
     || fail "clone failure of osac-ux must still clone later siblings"
   [[ -d "${root}/enhancement-proposals/.git" ]] \
     || fail "clone failure of osac-ux must still clone earlier siblings"
 
   out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "retry after failed clone failed: $out"
-  [[ -d "${root}/osac-ux/.git" ]] || fail "retry did not clone osac-ux after cleanup"
+  [[ -d "${ux}/.git" ]] || fail "retry did not clone osac-ux after cleanup"
   pass "failed clone removes dest so a later run can retry"
 }
 
 test_expected_sibling_requires_org_boundary() {
-  local home="${TMPDIR_ROOT}/home-boundary"
-  local root="${TMPDIR_ROOT}/osac-boundary"
-  local bin="${TMPDIR_ROOT}/bin-boundary"
-  mkdir -p "$home" "$bin"
-  write_git_wrapper "${bin}/git"
-  seed_vendor_ok "${home}/.osac-ai-skills"
-  seed_ai_workflows "${home}/.ai-workflows"
-  prepare_osac "$root"
+  local home root bin home_skills home_workflows repo_skills clone_log out docs_dest ep
+  prepare_fixture boundary
+  docs_dest="${root}/osac-docs"
+  ep="${root}/enhancement-proposals"
 
   run_bootstrap "$root" "$home" "$bin" >/dev/null
-  "$REAL_GIT" -C "${root}/osac-docs" remote set-url origin \
+  "$REAL_GIT" -C "$docs_dest" remote set-url origin \
     "https://github.com/evil-osac-project/docs.git"
-  echo keep > "${root}/osac-docs/keep-me"
+  echo keep > "${docs_dest}/keep-me"
 
-  local out
   out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
   echo "$out" | grep -qi 'skip' \
     || fail "evil-osac-project/docs must not count as osac-project/docs: $out"
-  grep -q keep "${root}/osac-docs/keep-me" \
+  grep -q keep "${docs_dest}/keep-me" \
     || fail "unrelated osac-docs/ dir was overwritten"
 
-  "$REAL_GIT" -C "${root}/enhancement-proposals" remote set-url origin \
+  "$REAL_GIT" -C "$ep" remote set-url origin \
     "git@github.com:osac-project/enhancement-proposals.git"
   out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed on SSH remote: $out"
   echo "$out" | grep -q 'Updating enhancement-proposals' \
@@ -374,22 +352,15 @@ test_expected_sibling_requires_org_boundary() {
 }
 
 test_missing_gh_without_no_fork_exits() {
-  local home="${TMPDIR_ROOT}/home-no-gh"
-  local root="${TMPDIR_ROOT}/osac-no-gh"
-  local bin="${TMPDIR_ROOT}/bin-no-gh"
-  mkdir -p "$home" "$bin"
-  write_git_wrapper "${bin}/git"
-  seed_vendor_ok "${home}/.osac-ai-skills"
-  seed_ai_workflows "${home}/.ai-workflows"
-  prepare_osac "$root"
+  local home root bin home_skills home_workflows repo_skills clone_log out rc=0
+  prepare_fixture no-gh
 
   ln -sf "$(command -v realpath)" "${bin}/realpath"
   ln -sf "$(command -v dirname)" "${bin}/dirname"
-  local out rc=0
   # PATH is $bin only so a host /usr/bin/gh cannot satisfy command -v gh.
   # Invoke bash by absolute path so PATH isolation does not hide the interpreter.
   out=$(HOME="$home" PATH="$bin" \
-    OSAC_SMOKE_CLONE_LOG="${home}/clone.log" \
+    OSAC_SMOKE_CLONE_LOG="$clone_log" \
     /bin/bash "${root}/tools/bootstrap.sh" 2>&1) || rc=$?
   [[ "$rc" -eq 1 ]] || fail "missing gh expected exit 1, got $rc: $out"
   echo "$out" | grep -qi 'gh CLI is not installed' \
@@ -400,21 +371,14 @@ test_missing_gh_without_no_fork_exits() {
 }
 
 test_no_fork_leaves_writeable_without_fork_remote() {
-  local home="${TMPDIR_ROOT}/home-nofork"
-  local root="${TMPDIR_ROOT}/osac-nofork"
-  local bin="${TMPDIR_ROOT}/bin-nofork"
-  mkdir -p "$home" "$bin"
-  write_git_wrapper "${bin}/git"
+  local home root bin home_skills home_workflows repo_skills clone_log out
+  prepare_fixture nofork
   write_gh_wrapper "${bin}/gh"
-  seed_vendor_ok "${home}/.osac-ai-skills"
-  seed_ai_workflows "${home}/.ai-workflows"
-  prepare_osac "$root"
 
-  local out
   out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap --no-fork failed: $out"
   echo "$out" | grep -q 'read-only, no forks' \
     || fail "expected read-only banner: $out"
-  assert_expected_clones "$root" "${home}/clone.log"
+  assert_expected_clones "$root" "$clone_log"
   assert_no_fork_remote "${root}/enhancement-proposals" "enhancement-proposals"
   assert_no_fork_remote "${root}/osac-ui" "osac-ui"
   assert_no_fork_remote "${root}/osac-test-infra" "osac-test-infra"
@@ -425,58 +389,46 @@ test_no_fork_leaves_writeable_without_fork_remote() {
 }
 
 test_forks_writeable_siblings_not_osac_ux_or_vendors() {
-  local home="${TMPDIR_ROOT}/home-fork"
-  local root="${TMPDIR_ROOT}/osac-fork"
-  local bin="${TMPDIR_ROOT}/bin-fork"
-  mkdir -p "$home" "$bin"
-  write_git_wrapper "${bin}/git"
+  local home root bin home_skills home_workflows repo_skills clone_log out gh_log
+  prepare_fixture fork
   write_gh_wrapper "${bin}/gh"
-  seed_vendor_ok "${home}/.osac-ai-skills"
-  seed_ai_workflows "${home}/.ai-workflows"
-  prepare_osac "$root"
+  gh_log="${home}/gh.log"
 
-  local out
   out=$(run_bootstrap_fork "$root" "$home" "$bin" 2>&1) || fail "bootstrap fork path failed: $out"
   echo "$out" | grep -q 'GitHub user: smokeuser' \
     || fail "expected GitHub user banner: $out"
-  assert_expected_clones "$root" "${home}/clone.log"
+  assert_expected_clones "$root" "$clone_log"
   assert_fork_remote "${root}/enhancement-proposals" "enhancement-proposals"
   assert_fork_remote "${root}/osac-ui" "osac-ui"
   assert_fork_remote "${root}/osac-test-infra" "osac-test-infra"
   assert_fork_remote "${root}/osac-docs" "docs"
   assert_no_fork_remote "${root}/osac-ux" "osac-ux"
-  assert_no_fork_remote "${home}/.osac-ai-skills" "osac-ai-skills vendor"
-  assert_no_fork_remote "${home}/.ai-workflows" "ai-workflows vendor"
-  grep -q 'repo fork osac-project/enhancement-proposals' "${home}/gh.log" \
-    || fail "expected gh repo fork for enhancement-proposals: $(cat "${home}/gh.log")"
-  grep -q 'repo fork osac-project/docs' "${home}/gh.log" \
-    || fail "docs fork must use GitHub repo name docs: $(cat "${home}/gh.log")"
-  if grep -q 'repo fork osac-project/osac-ux' "${home}/gh.log"; then
-    fail "must not gh fork osac-ux: $(cat "${home}/gh.log")"
+  assert_no_fork_remote "$home_skills" "osac-ai-skills vendor"
+  assert_no_fork_remote "$home_workflows" "ai-workflows vendor"
+  grep -q 'repo fork osac-project/enhancement-proposals' "$gh_log" \
+    || fail "expected gh repo fork for enhancement-proposals: $(cat "$gh_log")"
+  grep -q 'repo fork osac-project/docs' "$gh_log" \
+    || fail "docs fork must use GitHub repo name docs: $(cat "$gh_log")"
+  if grep -q 'repo fork osac-project/osac-ux' "$gh_log"; then
+    fail "must not gh fork osac-ux: $(cat "$gh_log")"
   fi
-  if grep -q 'repo fork osac-project/osac-ai-skills' "${home}/gh.log"; then
-    fail "must not gh fork osac-ai-skills: $(cat "${home}/gh.log")"
+  if grep -q 'repo fork osac-project/osac-ai-skills' "$gh_log"; then
+    fail "must not gh fork osac-ai-skills: $(cat "$gh_log")"
   fi
   pass "forks writeable siblings; skips osac-ux and vendors"
 }
 
 test_rerun_adds_fork_remote_to_existing_clone() {
-  local home="${TMPDIR_ROOT}/home-fork-rerun"
-  local root="${TMPDIR_ROOT}/osac-fork-rerun"
-  local bin="${TMPDIR_ROOT}/bin-fork-rerun"
-  mkdir -p "$home" "$bin"
-  write_git_wrapper "${bin}/git"
+  local home root bin home_skills home_workflows repo_skills clone_log out ep
+  prepare_fixture fork-rerun
   write_gh_wrapper "${bin}/gh"
-  seed_vendor_ok "${home}/.osac-ai-skills"
-  seed_ai_workflows "${home}/.ai-workflows"
-  prepare_osac "$root"
+  ep="${root}/enhancement-proposals"
 
   run_bootstrap "$root" "$home" "$bin" >/dev/null
-  assert_no_fork_remote "${root}/enhancement-proposals" "enhancement-proposals after --no-fork"
+  assert_no_fork_remote "$ep" "enhancement-proposals after --no-fork"
   : > "${home}/gh.log"
-  local out
   out=$(run_bootstrap_fork "$root" "$home" "$bin" 2>&1) || fail "fork re-run failed: $out"
-  assert_fork_remote "${root}/enhancement-proposals" "enhancement-proposals"
+  assert_fork_remote "$ep" "enhancement-proposals"
   assert_fork_remote "${root}/osac-docs" "docs"
   assert_no_fork_remote "${root}/osac-ux" "osac-ux"
   echo "$out" | grep -q 'Adding fork remote for enhancement-proposals' \
@@ -485,17 +437,10 @@ test_rerun_adds_fork_remote_to_existing_clone() {
 }
 
 test_unrelated_same_name_github_repo_is_not_used_as_fork() {
-  local home="${TMPDIR_ROOT}/home-fork-collision"
-  local root="${TMPDIR_ROOT}/osac-fork-collision"
-  local bin="${TMPDIR_ROOT}/bin-fork-collision"
-  mkdir -p "$home" "$bin"
-  write_git_wrapper "${bin}/git"
+  local home root bin home_skills home_workflows repo_skills clone_log out
+  prepare_fixture fork-collision
   write_gh_wrapper "${bin}/gh"
-  seed_vendor_ok "${home}/.osac-ai-skills"
-  seed_ai_workflows "${home}/.ai-workflows"
-  prepare_osac "$root"
 
-  local out
   out=$(OSAC_SMOKE_FORK_COLLISION=docs run_bootstrap_fork "$root" "$home" "$bin" 2>&1) \
     || fail "bootstrap should continue when docs fork collides: $out"
   echo "$out" | grep -qi 'Failed to fork osac-project/docs' \
@@ -506,81 +451,64 @@ test_unrelated_same_name_github_repo_is_not_used_as_fork() {
 }
 
 test_home_worktree_vendor_is_updated_not_recloned() {
-  local home="${TMPDIR_ROOT}/home-vendor-wt"
-  local root="${TMPDIR_ROOT}/osac-vendor-wt"
-  local bin="${TMPDIR_ROOT}/bin-vendor-wt"
-  local source="${TMPDIR_ROOT}/skills-vendor-src"
-  mkdir -p "$home" "$bin"
-  write_git_wrapper "${bin}/git"
+  local home root bin home_skills home_workflows repo_skills clone_log source out
+  prepare_fixture vendor-wt
+  source="${TMPDIR_ROOT}/skills-vendor-src"
+  rm -rf "$home_skills"
   seed_vendor_ok "$source"
-  seed_ai_workflows "${home}/.ai-workflows"
-  prepare_osac "$root"
   "$REAL_GIT" -C "$source" checkout -q --detach
-  "$REAL_GIT" -C "$source" worktree add -q "${home}/.osac-ai-skills" main
-  [[ -f "${home}/.osac-ai-skills/.git" ]] || fail "expected HOME vendor worktree"
+  "$REAL_GIT" -C "$source" worktree add -q "$home_skills" main
+  [[ -f "${home_skills}/.git" ]] || fail "expected HOME vendor worktree"
 
-  local out
   out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
   echo "$out" | grep -q "Updating osac-ai-skills" \
     || fail "HOME worktree vendor should be updated: $out"
   echo "$out" | grep -q "Cloning osac-ai-skills" \
     && fail "must not clone a second vendor over a HOME worktree: $out"
-  [[ ! -e "${root}/.osac-ai-skills" ]] \
+  [[ ! -e "$repo_skills" ]] \
     || fail "must not create project-local vendor when HOME worktree is usable"
   pass "HOME linked worktree vendor is updated, not re-cloned"
 }
 
 test_skips_update_when_sibling_not_on_main() {
-  local home="${TMPDIR_ROOT}/home-skip-rebase"
-  local root="${TMPDIR_ROOT}/osac-skip-rebase"
-  local bin="${TMPDIR_ROOT}/bin-skip-rebase"
-  mkdir -p "$home" "$bin"
-  write_git_wrapper "${bin}/git"
+  local home root bin home_skills home_workflows repo_skills clone_log out branch ep
+  prepare_fixture skip-rebase
   write_gh_wrapper "${bin}/gh"
-  seed_vendor_ok "${home}/.osac-ai-skills"
-  seed_ai_workflows "${home}/.ai-workflows"
-  prepare_osac "$root"
+  ep="${root}/enhancement-proposals"
 
   run_bootstrap "$root" "$home" "$bin" >/dev/null
-  "$REAL_GIT" -C "${root}/enhancement-proposals" checkout -q -b feat/keep-me
-  echo keep > "${root}/enhancement-proposals/keep-me"
+  "$REAL_GIT" -C "$ep" checkout -q -b feat/keep-me
+  echo keep > "${ep}/keep-me"
 
-  local out branch
   out=$(run_bootstrap_fork "$root" "$home" "$bin" 2>&1) \
     || fail "bootstrap failed: $out"
   echo "$out" | grep -q "enhancement-proposals is on 'feat/keep-me'" \
     || fail "should skip rebase when sibling is not on main: $out"
   echo "$out" | grep -q "enhancement-proposals up to date" \
     && fail "must not claim a feature branch was rebased: $out"
-  branch=$("$REAL_GIT" -C "${root}/enhancement-proposals" symbolic-ref --short HEAD)
+  branch=$("$REAL_GIT" -C "$ep" symbolic-ref --short HEAD)
   [[ "$branch" == "feat/keep-me" ]] \
     || fail "must stay on feat/keep-me, got: $branch"
-  [[ -f "${root}/enhancement-proposals/keep-me" ]] \
+  [[ -f "${ep}/keep-me" ]] \
     || fail "must not drop uncommitted work on a feature branch"
-  assert_fork_remote "${root}/enhancement-proposals" "enhancement-proposals"
+  assert_fork_remote "$ep" "enhancement-proposals"
   pass "skips rebase on a feature branch and still adds the fork remote"
 }
 
 test_fork_remote_match_requires_user_boundary() {
-  local home="${TMPDIR_ROOT}/home-fork-boundary"
-  local root="${TMPDIR_ROOT}/osac-fork-boundary"
-  local bin="${TMPDIR_ROOT}/bin-fork-boundary"
-  mkdir -p "$home" "$bin"
-  write_git_wrapper "${bin}/git"
+  local home root bin home_skills home_workflows repo_skills clone_log out url docs_dest
+  prepare_fixture fork-boundary
   write_gh_wrapper "${bin}/gh"
-  seed_vendor_ok "${home}/.osac-ai-skills"
-  seed_ai_workflows "${home}/.ai-workflows"
-  prepare_osac "$root"
+  docs_dest="${root}/osac-docs"
 
   run_bootstrap "$root" "$home" "$bin" >/dev/null
-  "$REAL_GIT" -C "${root}/osac-docs" remote add fork \
+  "$REAL_GIT" -C "$docs_dest" remote add fork \
     "https://github.com/evilsmokeuser/docs.git"
 
-  local out
   out=$(run_bootstrap_fork "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
   echo "$out" | grep -q 'already exists with a different URL' \
     || fail "evilsmokeuser/docs must not count as smokeuser/docs: $out"
-  url=$(git -C "${root}/osac-docs" remote get-url fork)
+  url=$(git -C "$docs_dest" remote get-url fork)
   [[ "$url" == *evilsmokeuser/docs* ]] \
     || fail "must not overwrite an existing mismatched fork remote: $url"
   pass "fork-remote match requires / or : before \$GH_USER/repo"

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -117,7 +117,7 @@ assert_expected_clones() {
     || fail "clone log missing osac-test-infra: $(cat "$log")"
   grep -q 'osac-project/docs' "$log" || fail "clone log missing osac-project/docs: $(cat "$log")"
   grep -q "${root}/osac-docs" "$log" || fail "docs repo dest must be osac-docs: $(cat "$log")"
-  if grep -E 'osac-project/docs .*/docs$' "$log" | grep -vq osac-docs; then
+  if grep -F "osac-project/docs.git ${root}/docs" "$log"; then
     fail "docs repo cloned to docs/ rather than osac-docs/: $(cat "$log")"
   fi
 }
@@ -181,6 +181,10 @@ test_skips_unrelated_existing_dir() {
   echo "$out" | grep -qi 'skip' \
     || fail "expected skip warning for unrelated osac-ux/: $out"
   [[ ! -d "${root}/osac-ux/.git" ]] || fail "skip path must not init a git repo"
+  [[ -d "${root}/osac-ui/.git" ]] \
+    || fail "skip of osac-ux must still clone later siblings (osac-ui)"
+  [[ -d "${root}/osac-docs/.git" ]] \
+    || fail "skip of osac-ux must still clone later siblings (osac-docs)"
   pass "skips an existing dir that is not the expected clone"
 }
 

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -120,6 +120,10 @@ case "${1:-}" in
       if [[ -n "${OSAC_SMOKE_EMPTY_LOGIN:-}" ]]; then
         exit 0
       fi
+      if [[ -n "${OSAC_SMOKE_NULL_LOGIN:-}" ]]; then
+        echo null
+        exit 0
+      fi
       echo smokeuser
       exit 0
     fi
@@ -292,6 +296,31 @@ test_extra_list_entry_clones_without_other_edits() {
   pass "adding a SIBLINGS list entry clones an extra dest with no other code edits"
 }
 
+test_dot_sibling_dir_does_not_rm_project_root() {
+  local home root bin home_skills home_workflows repo_skills clone_log out tmp
+  prepare_fixture dot-dir
+
+  grep -q 'SIBLINGS=(' "${root}/tools/bootstrap.sh" \
+    || fail "bootstrap.sh has no SIBLINGS=( list"
+  tmp="${root}/tools/bootstrap.sh.new"
+  awk '
+    { print }
+    /SIBLINGS=\(/ && !done { print "  \"bogus:.\""; done=1 }
+  ' "${root}/tools/bootstrap.sh" >"$tmp"
+  mv "$tmp" "${root}/tools/bootstrap.sh"
+  chmod +x "${root}/tools/bootstrap.sh"
+
+  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
+  echo "$out" | grep -q "invalid sibling directory" \
+    || fail "expected invalid dest skip: $out"
+  [[ -f "${root}/docs/ARCHITECTURE.md" ]] \
+    || fail "PROJECT_ROOT must not be removed for dir=."
+  grep -q in-tree "${root}/docs/ARCHITECTURE.md" \
+    || fail "tracked docs/ARCHITECTURE.md was overwritten"
+  assert_expected_clones "$root" "$clone_log"
+  pass "malformed sibling dir=. does not rm PROJECT_ROOT"
+}
+
 test_nested_abort_skips_sibling_clones() {
   local nest="${TMPDIR_ROOT}/nested-ws"
   local empty_home="${TMPDIR_ROOT}/nested-ws-home"
@@ -374,6 +403,8 @@ test_missing_gh_without_no_fork_exits() {
     || fail "expected gh-missing error: $out"
   [[ ! -d "${root}/enhancement-proposals" ]] \
     || fail "must not clone siblings when gh is missing"
+  [[ ! -s "$clone_log" ]] \
+    || fail "must not clone when gh is missing: $(cat "$clone_log")"
   pass "missing gh without --no-fork exits before sibling clones"
 }
 
@@ -392,9 +423,29 @@ test_empty_gh_user_without_no_fork_exits() {
     || fail "expected empty-username error: $out"
   [[ ! -d "${root}/enhancement-proposals" ]] \
     || fail "must not clone siblings when GH_USER is empty"
+  [[ ! -s "$clone_log" ]] \
+    || fail "must not clone when GH_USER is empty: $(cat "$clone_log")"
   grep -q 'api user' "${home}/gh.log" \
     || fail "expected gh api user invocation: $(cat "${home}/gh.log" 2>/dev/null || true)"
   pass "empty GH_USER without --no-fork exits before sibling clones"
+}
+
+test_null_gh_user_without_no_fork_exits() {
+  local home root bin home_skills home_workflows repo_skills clone_log out rc=0
+  prepare_fixture null-gh-user
+  write_gh_wrapper "${bin}/gh"
+
+  out=$(HOME="$home" PATH="${bin}:${PATH}" \
+    OSAC_SMOKE_CLONE_LOG="$clone_log" \
+    OSAC_SMOKE_GH_LOG="${home}/gh.log" \
+    OSAC_SMOKE_NULL_LOGIN=1 \
+    bash "${root}/tools/bootstrap.sh" 2>&1) || rc=$?
+  [[ "$rc" -eq 1 ]] || fail "null GH_USER expected exit 1, got $rc: $out"
+  echo "$out" | grep -qi 'empty GitHub username' \
+    || fail "expected empty-username error: $out"
+  [[ ! -s "$clone_log" ]] \
+    || fail "must not clone when GH_USER is null: $(cat "$clone_log")"
+  pass "null GH_USER without --no-fork exits before sibling clones"
 }
 
 test_no_fork_leaves_writeable_without_fork_remote() {
@@ -643,11 +694,13 @@ test_clones_all_five_into_project_root
 test_rerun_updates_expected_clone
 test_skips_unrelated_existing_dir
 test_extra_list_entry_clones_without_other_edits
+test_dot_sibling_dir_does_not_rm_project_root
 test_nested_abort_skips_sibling_clones
 test_failed_clone_cleans_dest
 test_expected_sibling_requires_org_boundary
 test_missing_gh_without_no_fork_exits
 test_empty_gh_user_without_no_fork_exits
+test_null_gh_user_without_no_fork_exits
 test_no_fork_leaves_writeable_without_fork_remote
 test_forks_writeable_siblings_not_osac_ux_or_vendors
 test_rerun_adds_fork_remote_to_existing_clone

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -566,6 +566,29 @@ test_repo_local_leftover_ai_workflows_errors_without_updating() {
   pass "repo-local leftover .ai-workflows errors without fetch/rebase of osac"
 }
 
+test_repo_local_leftover_osac_ai_skills_errors_without_updating() {
+  local home root bin home_skills home_workflows repo_skills clone_log out leftover rc=0
+  prepare_fixture leftover-repo-skills
+  rm -rf "$home_skills"
+  leftover="${root}/${OSAC_AI_SKILLS_NAME}"
+  "$REAL_GIT" init -q "$root"
+  "$REAL_GIT" -C "$root" checkout -q -b main
+  "$REAL_GIT" -C "$root" -c user.email=smoke@test -c user.name=smoke \
+    commit -q --allow-empty -m osac
+  mkdir -p "$leftover"
+  echo leftover > "${leftover}/not-a-clone"
+
+  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || rc=$?
+  [[ "$rc" -eq 1 ]] || fail "leftover .osac-ai-skills expected exit 1, got $rc: $out"
+  echo "$out" | grep -q "not a usable vendor checkout" \
+    || fail "expected leftover vendor error: $out"
+  echo "$out" | grep -q "Updating osac-ai-skills" \
+    && fail "must not update leftover .osac-ai-skills (would git the enclosing repo): $out"
+  grep -q leftover "${leftover}/not-a-clone" \
+    || fail "must not overwrite leftover .osac-ai-skills"
+  pass "repo-local leftover .osac-ai-skills errors without fetch/rebase of osac"
+}
+
 test_home_git_subdir_ai_workflows_falls_back_to_repo_local() {
   local home root bin home_skills home_workflows repo_skills clone_log out repo_wf
   prepare_fixture leftover-home-wf
@@ -610,6 +633,7 @@ test_skips_update_when_sibling_not_on_main
 test_fork_remote_match_requires_user_boundary
 test_home_git_subdir_skills_falls_back_to_repo_local
 test_repo_local_leftover_ai_workflows_errors_without_updating
+test_repo_local_leftover_osac_ai_skills_errors_without_updating
 test_home_git_subdir_ai_workflows_falls_back_to_repo_local
 
 echo "All bootstrap sibling-clone smoke tests passed."

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -58,6 +58,10 @@ if [[ " \$* " == *" clone "* ]]; then
   "\$REAL" -C "\$dest" -c user.email=smoke@test -c user.name=smoke \
     commit -q --allow-empty -m seed
   "\$REAL" -C "\$dest" remote add origin "\$url"
+  if [[ "\$(basename "\$dest")" == "${AI_WORKFLOWS_NAME}" ]]; then
+    printf '#!/bin/sh\\necho stub-install\\nexit 0\\n' > "\$dest/install.sh"
+    chmod +x "\$dest/install.sh"
+  fi
   exit 0
 fi
 if [[ " \$* " == *" fetch "* ]] || [[ " \$* " == *" rebase "* ]]; then
@@ -514,6 +518,81 @@ test_fork_remote_match_requires_user_boundary() {
   pass "fork-remote match requires / or : before \$GH_USER/repo"
 }
 
+test_home_git_subdir_skills_falls_back_to_repo_local() {
+  local home root bin home_skills home_workflows repo_skills clone_log out
+  prepare_fixture leftover-home-skills
+  rm -rf "$home_skills"
+  "$REAL_GIT" init -q "$home"
+  "$REAL_GIT" -C "$home" checkout -q -b main
+  mkdir -p "$home_skills/skills" "$home_skills/tools"
+  printf '#!/bin/sh\nexit 0\n' > "${home_skills}/tools/link-agent-skills.sh"
+  chmod +x "${home_skills}/tools/link-agent-skills.sh"
+
+  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
+  echo "$out" | grep -q "not a usable vendor checkout; using" \
+    || fail "HOME leftover subdir should fall back to repo-local: $out"
+  echo "$out" | grep -q "Cloning osac-ai-skills" \
+    || fail "should clone repo-local vendor: $out"
+  echo "$out" | grep -q "Updating osac-ai-skills" \
+    && fail "must not treat HOME leftover subdir as the vendor: $out"
+  grep -q "osac-project/osac-ai-skills" "$clone_log" \
+    && grep -q "${OSAC_AI_SKILLS_NAME}" "$clone_log" \
+    || fail "clone log should target repo-local vendor: $(cat "$clone_log")"
+  [[ -d "${repo_skills}/.git" ]] \
+    || fail "expected cloned repo-local vendor at ${repo_skills}"
+  pass "HOME git checkout with plain .osac-ai-skills subdir falls back to repo-local"
+}
+
+test_repo_local_leftover_ai_workflows_errors_without_updating() {
+  local home root bin home_skills home_workflows repo_skills clone_log out leftover rc=0
+  prepare_fixture leftover-repo-wf
+  rm -rf "$home_workflows"
+  leftover="${root}/${AI_WORKFLOWS_NAME}"
+  "$REAL_GIT" init -q "$root"
+  "$REAL_GIT" -C "$root" checkout -q -b main
+  "$REAL_GIT" -C "$root" -c user.email=smoke@test -c user.name=smoke \
+    commit -q --allow-empty -m osac
+  mkdir -p "$leftover"
+  echo leftover > "${leftover}/not-a-clone"
+
+  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || rc=$?
+  [[ "$rc" -eq 1 ]] || fail "leftover .ai-workflows expected exit 1, got $rc: $out"
+  echo "$out" | grep -q "not a usable ai-workflows checkout" \
+    || fail "expected leftover error: $out"
+  echo "$out" | grep -q "Updating ai-workflows" \
+    && fail "must not update leftover .ai-workflows (would git the enclosing repo): $out"
+  grep -q leftover "${leftover}/not-a-clone" \
+    || fail "must not overwrite leftover .ai-workflows"
+  pass "repo-local leftover .ai-workflows errors without fetch/rebase of osac"
+}
+
+test_home_git_subdir_ai_workflows_falls_back_to_repo_local() {
+  local home root bin home_skills home_workflows repo_skills clone_log out repo_wf
+  prepare_fixture leftover-home-wf
+  rm -rf "$home_workflows"
+  repo_wf="${root}/${AI_WORKFLOWS_NAME}"
+  "$REAL_GIT" init -q "$home"
+  "$REAL_GIT" -C "$home" checkout -q -b main
+  mkdir -p "$home_workflows"
+  echo leftover > "${home_workflows}/not-a-clone"
+
+  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
+  echo "$out" | grep -q "not a usable ai-workflows checkout; using" \
+    || fail "HOME leftover subdir should fall back to repo-local: $out"
+  echo "$out" | grep -q "Cloning ai-workflows" \
+    || fail "should clone repo-local ai-workflows: $out"
+  echo "$out" | grep -q "Updating ai-workflows" \
+    && fail "must not treat HOME leftover subdir as ai-workflows: $out"
+  grep -q leftover "${home_workflows}/not-a-clone" \
+    || fail "must not overwrite HOME leftover .ai-workflows"
+  grep -q "flightctl/ai-workflows" "$clone_log" \
+    && grep -q "${AI_WORKFLOWS_NAME}" "$clone_log" \
+    || fail "clone log should target repo-local ai-workflows: $(cat "$clone_log")"
+  [[ -d "${repo_wf}/.git" ]] \
+    || fail "expected cloned repo-local ai-workflows at ${repo_wf}"
+  pass "HOME git checkout with plain .ai-workflows subdir falls back to repo-local"
+}
+
 test_clones_all_five_into_project_root
 test_rerun_updates_expected_clone
 test_skips_unrelated_existing_dir
@@ -529,5 +608,8 @@ test_unrelated_same_name_github_repo_is_not_used_as_fork
 test_home_worktree_vendor_is_updated_not_recloned
 test_skips_update_when_sibling_not_on_main
 test_fork_remote_match_requires_user_boundary
+test_home_git_subdir_skills_falls_back_to_repo_local
+test_repo_local_leftover_ai_workflows_errors_without_updating
+test_home_git_subdir_ai_workflows_falls_back_to_repo_local
 
 echo "All bootstrap sibling-clone smoke tests passed."

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -115,7 +115,24 @@ case "${1:-}" in
     echo https
     exit 0
     ;;
-  repo) exit 0 ;;
+  repo)
+    if [[ "${2:-}" == "fork" ]]; then
+      for a in "$@"; do
+        if [[ -n "${OSAC_SMOKE_FORK_COLLISION:-}" && "$a" == "osac-project/${OSAC_SMOKE_FORK_COLLISION}" ]]; then
+          exit 1
+        fi
+      done
+      exit 0
+    fi
+    if [[ "${2:-}" == "view" ]]; then
+      if [[ " $* " == *" --json "* && " $* " == *" parent "* ]]; then
+        echo ""
+        exit 0
+      fi
+      exit 0
+    fi
+    exit 0
+    ;;
 esac
 exit 0
 EOF
@@ -363,10 +380,14 @@ test_missing_gh_without_no_fork_exits() {
   seed_ai_workflows "${home}/.ai-workflows"
   prepare_osac "$root"
 
+  ln -sf "$(command -v realpath)" "${bin}/realpath"
+  ln -sf "$(command -v dirname)" "${bin}/dirname"
   local out rc=0
-  out=$(HOME="$home" PATH="${bin}:/usr/bin:/bin" \
+  # PATH is $bin only so a host /usr/bin/gh cannot satisfy command -v gh.
+  # Invoke bash by absolute path so PATH isolation does not hide the interpreter.
+  out=$(HOME="$home" PATH="$bin" \
     OSAC_SMOKE_CLONE_LOG="${home}/clone.log" \
-    bash "${root}/tools/bootstrap.sh" 2>&1) || rc=$?
+    /bin/bash "${root}/tools/bootstrap.sh" 2>&1) || rc=$?
   [[ "$rc" -eq 1 ]] || fail "missing gh expected exit 1, got $rc: $out"
   echo "$out" | grep -qi 'gh CLI is not installed' \
     || fail "expected gh-missing error: $out"
@@ -460,6 +481,52 @@ test_rerun_adds_fork_remote_to_existing_clone() {
   pass "re-run adds fork remotes to existing origin-only clones"
 }
 
+test_unrelated_same_name_github_repo_is_not_used_as_fork() {
+  local home="${TMPDIR_ROOT}/home-fork-collision"
+  local root="${TMPDIR_ROOT}/osac-fork-collision"
+  local bin="${TMPDIR_ROOT}/bin-fork-collision"
+  mkdir -p "$home" "$bin"
+  write_git_wrapper "${bin}/git"
+  write_gh_wrapper "${bin}/gh"
+  seed_vendor_ok "${home}/.osac-ai-skills"
+  seed_ai_workflows "${home}/.ai-workflows"
+  prepare_osac "$root"
+
+  local out
+  out=$(OSAC_SMOKE_FORK_COLLISION=docs run_bootstrap_fork "$root" "$home" "$bin" 2>&1) \
+    || fail "bootstrap should continue when docs fork collides: $out"
+  echo "$out" | grep -qi 'Failed to fork osac-project/docs' \
+    || fail "expected skip for unrelated github.com/smokeuser/docs: $out"
+  assert_no_fork_remote "${root}/osac-docs" "osac-docs after docs name collision"
+  assert_fork_remote "${root}/enhancement-proposals" "enhancement-proposals"
+  pass "does not point fork at an unrelated same-name GitHub repo"
+}
+
+test_fork_remote_match_requires_user_boundary() {
+  local home="${TMPDIR_ROOT}/home-fork-boundary"
+  local root="${TMPDIR_ROOT}/osac-fork-boundary"
+  local bin="${TMPDIR_ROOT}/bin-fork-boundary"
+  mkdir -p "$home" "$bin"
+  write_git_wrapper "${bin}/git"
+  write_gh_wrapper "${bin}/gh"
+  seed_vendor_ok "${home}/.osac-ai-skills"
+  seed_ai_workflows "${home}/.ai-workflows"
+  prepare_osac "$root"
+
+  run_bootstrap "$root" "$home" "$bin" >/dev/null
+  "$REAL_GIT" -C "${root}/osac-docs" remote add fork \
+    "https://github.com/evilsmokeuser/docs.git"
+
+  local out
+  out=$(run_bootstrap_fork "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
+  echo "$out" | grep -q 'already exists with a different URL' \
+    || fail "evilsmokeuser/docs must not count as smokeuser/docs: $out"
+  url=$(git -C "${root}/osac-docs" remote get-url fork)
+  [[ "$url" == *evilsmokeuser/docs* ]] \
+    || fail "must not overwrite an existing mismatched fork remote: $url"
+  pass "fork-remote match requires / or : before \$GH_USER/repo"
+}
+
 test_clones_all_five_into_project_root
 test_rerun_updates_expected_clone
 test_skips_unrelated_existing_dir
@@ -471,5 +538,7 @@ test_missing_gh_without_no_fork_exits
 test_no_fork_leaves_writeable_without_fork_remote
 test_forks_writeable_siblings_not_osac_ux_or_vendors
 test_rerun_adds_fork_remote_to_existing_clone
+test_unrelated_same_name_github_repo_is_not_used_as_fork
+test_fork_remote_match_requires_user_boundary
 
 echo "All bootstrap sibling-clone smoke tests passed."

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -321,6 +321,33 @@ test_dot_sibling_dir_does_not_rm_project_root() {
   pass "malformed sibling dir=. does not rm PROJECT_ROOT"
 }
 
+test_parent_dir_sibling_does_not_rm_external() {
+  local home root bin home_skills home_workflows repo_skills clone_log out tmp victim
+  prepare_fixture parent-dir
+  victim="${root}/../victim"
+  echo keep > "$victim"
+
+  grep -q 'SIBLINGS=(' "${root}/tools/bootstrap.sh" \
+    || fail "bootstrap.sh has no SIBLINGS=( list"
+  tmp="${root}/tools/bootstrap.sh.new"
+  awk '
+    { print }
+    /SIBLINGS=\(/ && !done { print "  \"bogus:../victim\""; done=1 }
+  ' "${root}/tools/bootstrap.sh" >"$tmp"
+  mv "$tmp" "${root}/tools/bootstrap.sh"
+  chmod +x "${root}/tools/bootstrap.sh"
+
+  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
+  echo "$out" | grep -q "invalid sibling directory" \
+    || fail "expected invalid dest skip for ../victim: $out"
+  grep -q keep "$victim" \
+    || fail "must not rm path outside PROJECT_ROOT: ${victim}"
+  grep -q 'osac-project/bogus' "$clone_log" \
+    && fail "must not clone bogus:../victim: $(cat "$clone_log")"
+  assert_expected_clones "$root" "$clone_log"
+  pass "malformed sibling dir=../victim does not rm an external path"
+}
+
 test_nested_abort_skips_sibling_clones() {
   local nest="${TMPDIR_ROOT}/nested-ws"
   local empty_home="${TMPDIR_ROOT}/nested-ws-home"
@@ -695,6 +722,7 @@ test_rerun_updates_expected_clone
 test_skips_unrelated_existing_dir
 test_extra_list_entry_clones_without_other_edits
 test_dot_sibling_dir_does_not_rm_project_root
+test_parent_dir_sibling_does_not_rm_external
 test_nested_abort_skips_sibling_clones
 test_failed_clone_cleans_dest
 test_expected_sibling_requires_org_boundary

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -43,6 +43,11 @@ if [[ " \$* " == *" clone "* ]]; then
     fi
     prev="\$a"
   done
+  if [[ -n "\${OSAC_SMOKE_FAIL_CLONE:-}" && "\$dest" == *"\${OSAC_SMOKE_FAIL_CLONE}" ]]; then
+    mkdir -p "\$dest"
+    echo partial > "\$dest/partial"
+    exit 1
+  fi
   printf '%s %s\\n' "\$url" "\$dest" >> "\$LOG"
   mkdir -p "\$dest"
   "\$REAL" init -q "\$dest"
@@ -239,10 +244,69 @@ test_nested_abort_skips_sibling_clones() {
   pass "nested workspace abort happens before sibling clones"
 }
 
+test_failed_clone_cleans_dest() {
+  local home="${TMPDIR_ROOT}/home-fail"
+  local root="${TMPDIR_ROOT}/osac-fail"
+  local bin="${TMPDIR_ROOT}/bin-fail"
+  mkdir -p "$home" "$bin"
+  write_git_wrapper "${bin}/git"
+  seed_vendor_ok "${home}/.osac-ai-skills"
+  seed_ai_workflows "${home}/.ai-workflows"
+  prepare_osac "$root"
+
+  local out
+  out=$(OSAC_SMOKE_FAIL_CLONE=osac-ux run_bootstrap "$root" "$home" "$bin" 2>&1) \
+    || fail "bootstrap should continue after a sibling clone failure: $out"
+  echo "$out" | grep -qi 'Clone failed for osac-ux' \
+    || fail "expected clone-failed message for osac-ux: $out"
+  [[ ! -e "${root}/osac-ux" ]] \
+    || fail "failed clone must not leave dest behind: $(ls -la "${root}/osac-ux" 2>/dev/null || true)"
+  [[ -d "${root}/osac-ui/.git" ]] \
+    || fail "clone failure of osac-ux must still clone later siblings"
+  [[ -d "${root}/enhancement-proposals/.git" ]] \
+    || fail "clone failure of osac-ux must still clone earlier siblings"
+
+  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "retry after failed clone failed: $out"
+  [[ -d "${root}/osac-ux/.git" ]] || fail "retry did not clone osac-ux after cleanup"
+  pass "failed clone removes dest so a later run can retry"
+}
+
+test_expected_sibling_requires_org_boundary() {
+  local home="${TMPDIR_ROOT}/home-boundary"
+  local root="${TMPDIR_ROOT}/osac-boundary"
+  local bin="${TMPDIR_ROOT}/bin-boundary"
+  mkdir -p "$home" "$bin"
+  write_git_wrapper "${bin}/git"
+  seed_vendor_ok "${home}/.osac-ai-skills"
+  seed_ai_workflows "${home}/.ai-workflows"
+  prepare_osac "$root"
+
+  run_bootstrap "$root" "$home" "$bin" >/dev/null
+  "$REAL_GIT" -C "${root}/osac-docs" remote set-url origin \
+    "https://github.com/evil-osac-project/docs.git"
+  echo keep > "${root}/osac-docs/keep-me"
+
+  local out
+  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
+  echo "$out" | grep -qi 'skip' \
+    || fail "evil-osac-project/docs must not count as osac-project/docs: $out"
+  grep -q keep "${root}/osac-docs/keep-me" \
+    || fail "unrelated osac-docs/ dir was overwritten"
+
+  "$REAL_GIT" -C "${root}/enhancement-proposals" remote set-url origin \
+    "git@github.com:osac-project/enhancement-proposals.git"
+  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed on SSH remote: $out"
+  echo "$out" | grep -q 'Updating enhancement-proposals' \
+    || fail "SSH osac-project remote should still update: $out"
+  pass "expected-clone match requires / or : before osac-project"
+}
+
 test_clones_all_five_into_project_root
 test_rerun_updates_expected_clone
 test_skips_unrelated_existing_dir
 test_extra_list_entry_clones_without_other_edits
 test_nested_abort_skips_sibling_clones
+test_failed_clone_cleans_dest
+test_expected_sibling_requires_org_boundary
 
 echo "All bootstrap sibling-clone smoke tests passed."

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -52,6 +52,8 @@ if [[ " \$* " == *" clone "* ]]; then
   mkdir -p "\$dest"
   "\$REAL" init -q "\$dest"
   "\$REAL" -C "\$dest" checkout -q -b main
+  "\$REAL" -C "\$dest" -c user.email=smoke@test -c user.name=smoke \
+    commit -q --allow-empty -m seed
   "\$REAL" -C "\$dest" remote add origin "\$url"
   exit 0
 fi
@@ -168,7 +170,7 @@ assert_fork_remote() {
   local url
   url=$(git -C "$dest" remote get-url fork 2>/dev/null) \
     || fail "missing fork remote on ${dest}: $(git -C "$dest" remote -v 2>/dev/null || true)"
-  [[ "${url%.git}" == *"smokeuser/${repo}" ]] \
+  [[ "${url%.git}" == *"/smokeuser/${repo}" || "${url%.git}" == *":smokeuser/${repo}" ]] \
     || fail "fork remote on ${dest} expected smokeuser/${repo}, got: $url"
 }
 
@@ -502,6 +504,37 @@ test_unrelated_same_name_github_repo_is_not_used_as_fork() {
   pass "does not point fork at an unrelated same-name GitHub repo"
 }
 
+test_skips_update_when_sibling_not_on_main() {
+  local home="${TMPDIR_ROOT}/home-skip-rebase"
+  local root="${TMPDIR_ROOT}/osac-skip-rebase"
+  local bin="${TMPDIR_ROOT}/bin-skip-rebase"
+  mkdir -p "$home" "$bin"
+  write_git_wrapper "${bin}/git"
+  write_gh_wrapper "${bin}/gh"
+  seed_vendor_ok "${home}/.osac-ai-skills"
+  seed_ai_workflows "${home}/.ai-workflows"
+  prepare_osac "$root"
+
+  run_bootstrap "$root" "$home" "$bin" >/dev/null
+  "$REAL_GIT" -C "${root}/enhancement-proposals" checkout -q -b feat/keep-me
+  echo keep > "${root}/enhancement-proposals/keep-me"
+
+  local out branch
+  out=$(run_bootstrap_fork "$root" "$home" "$bin" 2>&1) \
+    || fail "bootstrap failed: $out"
+  echo "$out" | grep -q "enhancement-proposals is on 'feat/keep-me'" \
+    || fail "should skip rebase when sibling is not on main: $out"
+  echo "$out" | grep -q "enhancement-proposals up to date" \
+    && fail "must not claim a feature branch was rebased: $out"
+  branch=$("$REAL_GIT" -C "${root}/enhancement-proposals" symbolic-ref --short HEAD)
+  [[ "$branch" == "feat/keep-me" ]] \
+    || fail "must stay on feat/keep-me, got: $branch"
+  [[ -f "${root}/enhancement-proposals/keep-me" ]] \
+    || fail "must not drop uncommitted work on a feature branch"
+  assert_fork_remote "${root}/enhancement-proposals" "enhancement-proposals"
+  pass "skips rebase on a feature branch and still adds the fork remote"
+}
+
 test_fork_remote_match_requires_user_boundary() {
   local home="${TMPDIR_ROOT}/home-fork-boundary"
   local root="${TMPDIR_ROOT}/osac-fork-boundary"
@@ -539,6 +572,7 @@ test_no_fork_leaves_writeable_without_fork_remote
 test_forks_writeable_siblings_not_osac_ux_or_vendors
 test_rerun_adds_fork_remote_to_existing_clone
 test_unrelated_same_name_github_repo_is_not_used_as_fork
+test_skips_update_when_sibling_not_on_main
 test_fork_remote_match_requires_user_boundary
 
 echo "All bootstrap sibling-clone smoke tests passed."

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -50,6 +50,9 @@ if [[ " \$* " == *" clone "* ]]; then
   "\$REAL" -C "\$dest" remote add origin "\$url"
   exit 0
 fi
+if [[ " \$* " == *" fetch "* ]] || [[ " \$* " == *" rebase "* ]]; then
+  exit 0
+fi
 exec "\$REAL" "\$@"
 EOF
   chmod +x "$dest"

--- a/tools/test/link-agent-skills-consumer-smoke.sh
+++ b/tools/test/link-agent-skills-consumer-smoke.sh
@@ -505,7 +505,7 @@ test_bootstrap_aborts_when_nested_in_workspace() {
 
   rc=0
   out=$(HOME="${empty_home}" PATH="${nest}/bin:${PATH}" \
-    OSAC_ALLOW_NESTED_BOOTSTRAP=1 bash "${nest}/osac/tools/bootstrap.sh" 2>&1) || rc=$?
+    OSAC_ALLOW_NESTED_BOOTSTRAP=1 bash "${nest}/osac/tools/bootstrap.sh" --no-fork 2>&1) || rc=$?
   echo "$out" | grep -q "inside osac-workspace" \
     && fail "override must skip the nested abort: $out"
   echo "$out" | grep -q "stub-git" \

--- a/tools/test/osac-new-worktree-smoke.sh
+++ b/tools/test/osac-new-worktree-smoke.sh
@@ -147,7 +147,7 @@ test_zsh_nounset_jira_ticket() {
 # PATH with only this bin (no host timeout/gtimeout). Requires git wrapper already in $bin.
 isolated_core_path() {
   local bin="$1" c src
-  for c in awk jq basename dirname mkdir chmod cat cp bash; do
+  for c in awk jq basename dirname mkdir chmod cat cp bash tr; do
     src=$(command -v "$c") || fail "need $c for isolated PATH"
     ln -sf "$src" "${bin}/$c"
   done
@@ -291,11 +291,57 @@ EOF
   pass "gtimeout is used when timeout is missing"
 }
 
+test_jira_summary_strips_newlines() {
+  local parent repo dest bin log
+  parent="${TMPDIR_ROOT}/wt-nl-parent"
+  repo="${parent}/osac"
+  dest="${parent}/osac-OSAC-1234"
+  bin="${TMPDIR_ROOT}/wt-nl-bin"
+  log="${TMPDIR_ROOT}/wt-nl.log"
+  mkdir -p "${repo}/tools" "$bin"
+  printf '#!/bin/sh\nprintf "bootstrap %%s\\n" "$0" >> "%s"\nexit 0\n' "$log" \
+    > "${repo}/tools/bootstrap.sh"
+  chmod +x "${repo}/tools/bootstrap.sh"
+  "$REAL_GIT" init -q "$repo"
+  "$REAL_GIT" -C "$repo" checkout -q -b main
+  "$REAL_GIT" -C "$repo" -c user.email=smoke@test -c user.name=smoke \
+    commit -q --allow-empty -m seed
+  write_git_worktree_stub "$bin" "$repo" "$log"
+  cat > "${bin}/timeout" <<'EOF'
+#!/bin/sh
+shift
+exec "$@"
+EOF
+  chmod +x "${bin}/timeout"
+  cat > "${bin}/jira" <<'EOF'
+#!/bin/sh
+printf '%s\n' '{"fields":{"summary":"dogfood\n## Injected","issuetype":{"name":"Task\nBad"}}}'
+EOF
+  chmod +x "${bin}/jira"
+
+  (
+    cd "$repo"
+    # shellcheck source=../osac-helpers.sh
+    source "$HELPERS"
+    export PATH="${bin}:${PATH}"
+    export OSAC_WORKTREE_PARENT="$parent"
+    osac-new-worktree feat/OSAC-1234 >/dev/null
+  )
+  grep -q 'dogfood## Injected' "${dest}/.claude/CLAUDE.md" \
+    || fail "expected stripped summary, got: $(cat "${dest}/.claude/CLAUDE.md")"
+  grep -q 'TaskBad' "${dest}/.claude/CLAUDE.md" \
+    || fail "expected stripped type, got: $(cat "${dest}/.claude/CLAUDE.md")"
+  grep -q '^## Injected' "${dest}/.claude/CLAUDE.md" \
+    && fail "newline in summary must not become a markdown heading"
+  pass "Jira summary and type strip CR/LF before append"
+}
+
 test_dest_basename_and_repo_bootstrap
 test_jira_ticket_from_branch
 test_zsh_nounset_jira_ticket
 test_bootstrap_fail_prints_recovery
 test_no_timeout_skips_jira
 test_gtimeout_used_when_timeout_missing
+test_jira_summary_strips_newlines
 
 echo "All osac-new-worktree smoke tests passed."

--- a/tools/test/osac-new-worktree-smoke.sh
+++ b/tools/test/osac-new-worktree-smoke.sh
@@ -202,6 +202,8 @@ test_bootstrap_fail_prints_recovery() {
       || fail "expected worktree path in recovery: $out"
     echo "$out" | grep -Fq "Recovery: cd ${dest} && ./tools/bootstrap.sh --no-fork" \
       || fail "expected --no-fork recovery: $out"
+    echo "$out" | grep -q "Current directory is already ${dest}" \
+      || fail "expected cwd hint on bootstrap failure: $out"
   )
   pass "bootstrap failure prints --no-fork recovery"
 }
@@ -266,10 +268,11 @@ test_gtimeout_used_when_timeout_missing() {
     commit -q --allow-empty -m seed
   write_git_worktree_stub "$bin" "$repo" "$log"
   isolated_core_path "$bin" >/dev/null
-  cat > "${bin}/gtimeout" <<'EOF'
+  cat > "${bin}/gtimeout" <<EOF
 #!/bin/sh
+printf 'gtimeout %s\\n' "\$*" >> "${log}"
 shift
-exec "$@"
+exec "\$@"
 EOF
   chmod +x "${bin}/gtimeout"
   cat > "${bin}/jira" <<'EOF'
@@ -288,6 +291,8 @@ EOF
   )
   grep -q 'gtimeout ticket' "${dest}/.claude/CLAUDE.md" \
     || fail "expected gtimeout-backed Jira context in ${dest}/.claude/CLAUDE.md"
+  grep -q '^gtimeout 15 jira issue view OSAC-1234 --raw$' "$log" \
+    || fail "expected Jira to run through gtimeout: $(cat "$log")"
   pass "gtimeout is used when timeout is missing"
 }
 

--- a/tools/test/osac-new-worktree-smoke.sh
+++ b/tools/test/osac-new-worktree-smoke.sh
@@ -6,11 +6,13 @@ set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
 HELPERS="${REPO_ROOT}/tools/osac-helpers.sh"
+REAL_GIT=$(command -v git)
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 pass() { echo "PASS: $*"; }
 
 [[ -f "$HELPERS" ]] || fail "missing $HELPERS"
+[[ -n "$REAL_GIT" ]] || fail "git not on PATH"
 
 TMPDIR_ROOT=$(mktemp -d)
 trap 'rm -rf "$TMPDIR_ROOT"' EXIT
@@ -48,5 +50,58 @@ git -C "$not_osac" -c user.email=smoke@test -c user.name=smoke \
     || fail "expected osac-clone guard: $out"
 )
 pass "rejects a git repo that is not an osac clone"
+
+test_dest_basename_and_repo_bootstrap() {
+  local parent repo dest bin log
+  parent="${TMPDIR_ROOT}/wt-parent"
+  repo="${parent}/osac"
+  dest="${parent}/osac-OSAC-1234"
+  bin="${TMPDIR_ROOT}/wt-bin"
+  log="${TMPDIR_ROOT}/wt.log"
+  mkdir -p "${repo}/tools" "$bin"
+  printf '#!/bin/sh\nprintf "bootstrap %%s\\n" "$0" >> "%s"\nexit 0\n' "$log" \
+    > "${repo}/tools/bootstrap.sh"
+  chmod +x "${repo}/tools/bootstrap.sh"
+  "$REAL_GIT" init -q "$repo"
+  "$REAL_GIT" -C "$repo" checkout -q -b main
+  "$REAL_GIT" -C "$repo" -c user.email=smoke@test -c user.name=smoke \
+    commit -q --allow-empty -m seed
+
+  cat > "${bin}/git" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ " \$* " == *" worktree "* && " \$* " == *" add "* ]]; then
+  dest="\${!#}"
+  mkdir -p "\$dest/tools"
+  cp "${repo}/tools/bootstrap.sh" "\$dest/tools/bootstrap.sh"
+  chmod +x "\$dest/tools/bootstrap.sh"
+  echo "worktree-add \$dest" >> "${log}"
+  exit 0
+fi
+exec "${REAL_GIT}" "\$@"
+EOF
+  chmod +x "${bin}/git"
+
+  (
+    cd "$repo"
+    # shellcheck source=../osac-helpers.sh
+    source "$HELPERS"
+    export PATH="${bin}:${PATH}"
+    export OSAC_WORKTREE_PARENT="$parent"
+    osac-new-worktree feat/OSAC-1234 >/dev/null
+    [[ "$(pwd)" == "$dest" ]] || fail "sourced call should cd into ${dest}, got $(pwd)"
+  )
+  grep -q "worktree-add ${dest}" "$log" \
+    || fail "expected worktree dest ${dest}: $(cat "$log")"
+  grep -q "tools/bootstrap.sh" "$log" \
+    || fail "expected tools/bootstrap.sh: $(cat "$log")"
+  grep -q "bootstrap.sh" "$log" \
+    || fail "bootstrap was not invoked: $(cat "$log")"
+  [[ -x "${dest}/tools/bootstrap.sh" ]] \
+    || fail "dest should contain tools/bootstrap.sh"
+  pass "worktree dest is osac-<basename> and runs tools/bootstrap.sh"
+}
+
+test_dest_basename_and_repo_bootstrap
 
 echo "All osac-new-worktree smoke tests passed."

--- a/tools/test/osac-new-worktree-smoke.sh
+++ b/tools/test/osac-new-worktree-smoke.sh
@@ -121,9 +121,11 @@ test_jira_ticket_from_branch() {
   local got
   got=$(osac_jira_ticket_from_branch "feat/OSAC-4040-wt-dogfood")
   [[ "$got" == "OSAC-4040" ]] || fail "expected OSAC-4040, got ${got}"
+  got=$(osac_jira_ticket_from_branch "feat/OSAC-1234-follow-up-OSAC-5678")
+  [[ "$got" == "OSAC-1234" ]] || fail "expected first key OSAC-1234, got ${got}"
   got=$(osac_jira_ticket_from_branch "feat/no-ticket")
   [[ -z "$got" ]] || fail "expected empty ticket, got ${got}"
-  pass "osac_jira_ticket_from_branch extracts OSAC-NNNN"
+  pass "osac_jira_ticket_from_branch extracts the first OSAC-NNNN"
 }
 
 test_zsh_nounset_jira_ticket() {
@@ -136,12 +138,164 @@ test_zsh_nounset_jira_ticket() {
     source "$1"
     got=$(osac_jira_ticket_from_branch "feat/OSAC-4040-wt-dogfood")
     [[ "$got" == "OSAC-4040" ]]
-  ' zsh "$HELPERS" || fail "zsh nounset failed to parse OSAC-4040 from branch"
+    got=$(osac_jira_ticket_from_branch "feat/OSAC-1234-follow-up-OSAC-5678")
+    [[ "$got" == "OSAC-1234" ]]
+  ' zsh "$HELPERS" || fail "zsh nounset failed to parse first OSAC-NNNN from branch"
   pass "osac_jira_ticket_from_branch works under zsh nounset"
+}
+
+# PATH with only this bin (no host timeout/gtimeout). Requires git wrapper already in $bin.
+isolated_core_path() {
+  local bin="$1" c src
+  for c in awk jq basename dirname mkdir chmod cat cp bash; do
+    src=$(command -v "$c") || fail "need $c for isolated PATH"
+    ln -sf "$src" "${bin}/$c"
+  done
+  printf '%s' "$bin"
+}
+
+write_git_worktree_stub() {
+  local bin="$1" repo="$2" log="$3"
+  cat > "${bin}/git" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ " \$* " == *" worktree "* && " \$* " == *" add "* ]]; then
+  dest="\${!#}"
+  mkdir -p "\$dest/tools"
+  cp "${repo}/tools/bootstrap.sh" "\$dest/tools/bootstrap.sh"
+  chmod +x "\$dest/tools/bootstrap.sh"
+  echo "worktree-add \$dest" >> "${log}"
+  exit 0
+fi
+exec "${REAL_GIT}" "\$@"
+EOF
+  chmod +x "${bin}/git"
+}
+
+test_bootstrap_fail_prints_recovery() {
+  local parent repo dest bin log out
+  parent="${TMPDIR_ROOT}/wt-fail-parent"
+  repo="${parent}/osac"
+  dest="${parent}/osac-OSAC-3958"
+  bin="${TMPDIR_ROOT}/wt-fail-bin"
+  log="${TMPDIR_ROOT}/wt-fail.log"
+  mkdir -p "${repo}/tools" "$bin"
+  printf '#!/bin/sh\necho bootstrap-fail >> "%s"\nexit 1\n' "$log" \
+    > "${repo}/tools/bootstrap.sh"
+  chmod +x "${repo}/tools/bootstrap.sh"
+  "$REAL_GIT" init -q "$repo"
+  "$REAL_GIT" -C "$repo" checkout -q -b main
+  "$REAL_GIT" -C "$repo" -c user.email=smoke@test -c user.name=smoke \
+    commit -q --allow-empty -m seed
+  write_git_worktree_stub "$bin" "$repo" "$log"
+
+  (
+    cd "$repo"
+    # shellcheck source=../osac-helpers.sh
+    source "$HELPERS"
+    export PATH="${bin}:${PATH}"
+    export OSAC_WORKTREE_PARENT="$parent"
+    out=$(osac-new-worktree feat/OSAC-3958 2>&1) && fail "bootstrap fail should fail: $out" || true
+    echo "$out" | grep -q "tools/bootstrap.sh failed" \
+      || fail "expected bootstrap failure: $out"
+    echo "$out" | grep -q "Worktree exists at ${dest}" \
+      || fail "expected worktree path in recovery: $out"
+    echo "$out" | grep -Fq "Recovery: cd ${dest} && ./tools/bootstrap.sh --no-fork" \
+      || fail "expected --no-fork recovery: $out"
+  )
+  pass "bootstrap failure prints --no-fork recovery"
+}
+
+test_no_timeout_skips_jira() {
+  local parent repo dest bin log jira_log out
+  parent="${TMPDIR_ROOT}/wt-skip-parent"
+  repo="${parent}/osac"
+  dest="${parent}/osac-OSAC-1234"
+  bin="${TMPDIR_ROOT}/wt-skip-bin"
+  log="${TMPDIR_ROOT}/wt-skip.log"
+  jira_log="${TMPDIR_ROOT}/wt-skip-jira.log"
+  mkdir -p "${repo}/tools" "$bin"
+  printf '#!/bin/sh\nprintf "bootstrap %%s\\n" "$0" >> "%s"\nexit 0\n' "$log" \
+    > "${repo}/tools/bootstrap.sh"
+  chmod +x "${repo}/tools/bootstrap.sh"
+  "$REAL_GIT" init -q "$repo"
+  "$REAL_GIT" -C "$repo" checkout -q -b main
+  "$REAL_GIT" -C "$repo" -c user.email=smoke@test -c user.name=smoke \
+    commit -q --allow-empty -m seed
+  write_git_worktree_stub "$bin" "$repo" "$log"
+  isolated_core_path "$bin" >/dev/null
+  cat > "${bin}/jira" <<EOF
+#!/bin/sh
+echo jira-called >> "${jira_log}"
+printf '%s\\n' '{"fields":{"summary":"should-not-run","issuetype":{"name":"Task"}}}'
+EOF
+  chmod +x "${bin}/jira"
+
+  out=$(
+    cd "$repo"
+    # shellcheck source=../osac-helpers.sh
+    source "$HELPERS"
+    export PATH="$bin"
+    export OSAC_WORKTREE_PARENT="$parent"
+    osac-new-worktree feat/OSAC-1234 2>&1
+  ) || fail "skip-jira path should succeed: $out"
+  echo "$out" | grep -q "no timeout or gtimeout on PATH" \
+    || fail "expected timeout skip warning: $out"
+  echo "$out" | grep -q "could not fetch Jira ticket" \
+    && fail "skip path must not also warn about fetch: $out"
+  [[ -f "$jira_log" ]] && fail "jira must not be invoked without timeout: $(cat "$jira_log")"
+  [[ -f "${dest}/.claude/CLAUDE.md" ]] \
+    && fail "skip path must not write Jira context"
+  pass "missing timeout/gtimeout skips Jira fetch"
+}
+
+test_gtimeout_used_when_timeout_missing() {
+  local parent repo dest bin log
+  parent="${TMPDIR_ROOT}/wt-gto-parent"
+  repo="${parent}/osac"
+  dest="${parent}/osac-OSAC-1234"
+  bin="${TMPDIR_ROOT}/wt-gto-bin"
+  log="${TMPDIR_ROOT}/wt-gto.log"
+  mkdir -p "${repo}/tools" "$bin"
+  printf '#!/bin/sh\nprintf "bootstrap %%s\\n" "$0" >> "%s"\nexit 0\n' "$log" \
+    > "${repo}/tools/bootstrap.sh"
+  chmod +x "${repo}/tools/bootstrap.sh"
+  "$REAL_GIT" init -q "$repo"
+  "$REAL_GIT" -C "$repo" checkout -q -b main
+  "$REAL_GIT" -C "$repo" -c user.email=smoke@test -c user.name=smoke \
+    commit -q --allow-empty -m seed
+  write_git_worktree_stub "$bin" "$repo" "$log"
+  isolated_core_path "$bin" >/dev/null
+  cat > "${bin}/gtimeout" <<'EOF'
+#!/bin/sh
+shift
+exec "$@"
+EOF
+  chmod +x "${bin}/gtimeout"
+  cat > "${bin}/jira" <<'EOF'
+#!/bin/sh
+printf '%s\n' '{"fields":{"summary":"gtimeout ticket","issuetype":{"name":"Task"}}}'
+EOF
+  chmod +x "${bin}/jira"
+
+  (
+    cd "$repo"
+    # shellcheck source=../osac-helpers.sh
+    source "$HELPERS"
+    export PATH="$bin"
+    export OSAC_WORKTREE_PARENT="$parent"
+    osac-new-worktree feat/OSAC-1234 >/dev/null
+  )
+  grep -q 'gtimeout ticket' "${dest}/.claude/CLAUDE.md" \
+    || fail "expected gtimeout-backed Jira context in ${dest}/.claude/CLAUDE.md"
+  pass "gtimeout is used when timeout is missing"
 }
 
 test_dest_basename_and_repo_bootstrap
 test_jira_ticket_from_branch
 test_zsh_nounset_jira_ticket
+test_bootstrap_fail_prints_recovery
+test_no_timeout_skips_jira
+test_gtimeout_used_when_timeout_missing
 
 echo "All osac-new-worktree smoke tests passed."

--- a/tools/test/osac-new-worktree-smoke.sh
+++ b/tools/test/osac-new-worktree-smoke.sh
@@ -82,6 +82,19 @@ exec "${REAL_GIT}" "\$@"
 EOF
   chmod +x "${bin}/git"
 
+  cat > "${bin}/timeout" <<'EOF'
+#!/bin/sh
+shift
+exec "$@"
+EOF
+  chmod +x "${bin}/timeout"
+
+  cat > "${bin}/jira" <<'EOF'
+#!/bin/sh
+printf '%s\n' '{"fields":{"summary":"dogfood ticket","issuetype":{"name":"Task"}}}'
+EOF
+  chmod +x "${bin}/jira"
+
   (
     cd "$repo"
     # shellcheck source=../osac-helpers.sh
@@ -99,9 +112,36 @@ EOF
     || fail "bootstrap was not invoked: $(cat "$log")"
   [[ -x "${dest}/tools/bootstrap.sh" ]] \
     || fail "dest should contain tools/bootstrap.sh"
+  grep -q 'redhat.atlassian.net/browse/OSAC-1234' "${dest}/.claude/CLAUDE.md" \
+    || fail "expected Jira context in ${dest}/.claude/CLAUDE.md"
   pass "worktree dest is osac-<basename> and runs tools/bootstrap.sh"
 }
 
+test_jira_ticket_from_branch() {
+  local got
+  got=$(osac_jira_ticket_from_branch "feat/OSAC-4040-wt-dogfood")
+  [[ "$got" == "OSAC-4040" ]] || fail "expected OSAC-4040, got ${got}"
+  got=$(osac_jira_ticket_from_branch "feat/no-ticket")
+  [[ -z "$got" ]] || fail "expected empty ticket, got ${got}"
+  pass "osac_jira_ticket_from_branch extracts OSAC-NNNN"
+}
+
+test_zsh_nounset_jira_ticket() {
+  if ! command -v zsh >/dev/null 2>&1; then
+    echo "SKIP: zsh not on PATH (Jira ticket parse under nounset)"
+    return 0
+  fi
+  zsh -c '
+    set -eu
+    source "$1"
+    got=$(osac_jira_ticket_from_branch "feat/OSAC-4040-wt-dogfood")
+    [[ "$got" == "OSAC-4040" ]]
+  ' zsh "$HELPERS" || fail "zsh nounset failed to parse OSAC-4040 from branch"
+  pass "osac_jira_ticket_from_branch works under zsh nounset"
+}
+
 test_dest_basename_and_repo_bootstrap
+test_jira_ticket_from_branch
+test_zsh_nounset_jira_ticket
 
 echo "All osac-new-worktree smoke tests passed."

--- a/tools/test/osac-new-worktree-smoke.sh
+++ b/tools/test/osac-new-worktree-smoke.sh
@@ -341,6 +341,36 @@ EOF
   pass "Jira summary and type strip CR/LF before append"
 }
 
+test_forwards_bootstrap_args() {
+  local parent repo dest bin log
+  parent="${TMPDIR_ROOT}/wt-args-parent"
+  repo="${parent}/osac"
+  dest="${parent}/osac-extra-args"
+  bin="${TMPDIR_ROOT}/wt-args-bin"
+  log="${TMPDIR_ROOT}/wt-args.log"
+  mkdir -p "${repo}/tools" "$bin"
+  printf '#!/bin/sh\nprintf "bootstrap %%s\\n" "$*" >> "%s"\nexit 0\n' "$log" \
+    > "${repo}/tools/bootstrap.sh"
+  chmod +x "${repo}/tools/bootstrap.sh"
+  "$REAL_GIT" init -q "$repo"
+  "$REAL_GIT" -C "$repo" checkout -q -b main
+  "$REAL_GIT" -C "$repo" -c user.email=smoke@test -c user.name=smoke \
+    commit -q --allow-empty -m seed
+  write_git_worktree_stub "$bin" "$repo" "$log"
+
+  (
+    cd "$repo"
+    # shellcheck source=../osac-helpers.sh
+    source "$HELPERS"
+    export PATH="${bin}:${PATH}"
+    export OSAC_WORKTREE_PARENT="$parent"
+    osac-new-worktree feat/extra-args --no-fork >/dev/null
+  )
+  grep -q -- '--no-fork' "$log" \
+    || fail "expected bootstrap --no-fork: $(cat "$log")"
+  pass "forwards extra args to tools/bootstrap.sh"
+}
+
 test_dest_basename_and_repo_bootstrap
 test_jira_ticket_from_branch
 test_zsh_nounset_jira_ticket
@@ -348,5 +378,6 @@ test_bootstrap_fail_prints_recovery
 test_no_timeout_skips_jira
 test_gtimeout_used_when_timeout_missing
 test_jira_summary_strips_newlines
+test_forwards_bootstrap_args
 
 echo "All osac-new-worktree smoke tests passed."

--- a/tools/test/osac-new-worktree-smoke.sh
+++ b/tools/test/osac-new-worktree-smoke.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Smoke test: tools/osac-helpers.sh osac-new-worktree guards.
+# Run from osac/: bash tools/test/osac-new-worktree-smoke.sh
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+HELPERS="${REPO_ROOT}/tools/osac-helpers.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "PASS: $*"; }
+
+[[ -f "$HELPERS" ]] || fail "missing $HELPERS"
+
+TMPDIR_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+# shellcheck source=../osac-helpers.sh
+source "$HELPERS"
+
+out=$(osac-new-worktree 2>&1) && fail "empty branch should fail: $out" || true
+echo "$out" | grep -q "please provide a branch name" \
+  || fail "expected missing-branch error: $out"
+pass "rejects a missing branch name"
+
+out=$(osac-new-worktree "feat/has space" 2>&1) && fail "spaced branch should fail: $out" || true
+echo "$out" | grep -q "must not contain spaces" \
+  || fail "expected invalid-branch error: $out"
+pass "rejects a branch name with spaces"
+
+out=$(osac-new-worktree "feat/../escape" 2>&1) && fail ".. branch should fail: $out" || true
+echo "$out" | grep -q "must not contain spaces" \
+  || fail "expected invalid-branch error for ..: $out"
+pass "rejects a branch name containing .."
+
+not_osac="${TMPDIR_ROOT}/other-repo"
+mkdir -p "$not_osac"
+git -C "$not_osac" init -q
+git -C "$not_osac" checkout -q -b main
+git -C "$not_osac" -c user.email=smoke@test -c user.name=smoke \
+  commit -q --allow-empty -m seed
+(
+  cd "$not_osac"
+  # shellcheck source=../osac-helpers.sh
+  source "$HELPERS"
+  out=$(osac-new-worktree feat/nope 2>&1) && fail "non-osac repo should fail: $out" || true
+  echo "$out" | grep -q "must be run from an osac clone" \
+    || fail "expected osac-clone guard: $out"
+)
+pass "rejects a git repo that is not an osac clone"
+
+echo "All osac-new-worktree smoke tests passed."

--- a/tools/test/statusline-osac-ai-skills-smoke.sh
+++ b/tools/test/statusline-osac-ai-skills-smoke.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Smoke test: Claude statusline flags missing/stale osac-ai-skills.
+# Run from osac/: bash tools/test/statusline-osac-ai-skills-smoke.sh
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+STATUSLINE="${REPO_ROOT}/.claude/hooks/statusline.sh"
+REAL_GIT=$(command -v git)
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "PASS: $*"; }
+
+[[ -x "$STATUSLINE" ]] || fail "missing executable $STATUSLINE"
+[[ -n "$REAL_GIT" ]] || fail "git not on PATH"
+
+TMPDIR_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+init_repo() {
+  local dir="$1"
+  mkdir -p "$dir"
+  "$REAL_GIT" init -q "$dir"
+  "$REAL_GIT" -C "$dir" checkout -q -b main
+  "$REAL_GIT" -C "$dir" -c user.email=smoke@test -c user.name=smoke \
+    commit -q --allow-empty -m seed
+  "$REAL_GIT" -C "$dir" remote add origin "$dir"
+  "$REAL_GIT" -C "$dir" update-ref refs/remotes/origin/main HEAD
+}
+
+make_behind() {
+  local dir="$1" n="$2"
+  local i
+  for i in $(seq 1 "$n"); do
+    "$REAL_GIT" -C "$dir" -c user.email=smoke@test -c user.name=smoke \
+      commit -q --allow-empty -m "ahead-$i"
+  done
+  "$REAL_GIT" -C "$dir" update-ref refs/remotes/origin/main HEAD
+  "$REAL_GIT" -C "$dir" reset -q --hard "HEAD~${n}"
+}
+
+run_statusline() {
+  local home="$1" project="$2"
+  printf '%s' '{}' | HOME="$home" bash "$STATUSLINE" "$project"
+}
+
+test_missing_vendor_is_muted_not_found() {
+  local home="${TMPDIR_ROOT}/home-missing"
+  local project="${TMPDIR_ROOT}/proj-missing"
+  mkdir -p "$home"
+  init_repo "$project"
+  local out
+  out=$(run_statusline "$home" "$project")
+  echo "$out" | grep -q 'osac-ai-skills: not found' \
+    || fail "expected muted osac-ai-skills: not found, got: $out"
+  pass "missing vendor → osac-ai-skills: not found"
+}
+
+test_repo_local_up_to_date() {
+  local home="${TMPDIR_ROOT}/home-local"
+  local project="${TMPDIR_ROOT}/proj-local"
+  mkdir -p "$home"
+  init_repo "$project"
+  init_repo "${project}/.osac-ai-skills"
+  local out
+  out=$(run_statusline "$home" "$project")
+  echo "$out" | grep -q 'osac-ai-skills: main ✓' \
+    || fail "expected repo-local ✓, got: $out"
+  pass "repo-local .osac-ai-skills at origin/main → ✓"
+}
+
+test_repo_local_behind() {
+  local home="${TMPDIR_ROOT}/home-behind"
+  local project="${TMPDIR_ROOT}/proj-behind"
+  mkdir -p "$home"
+  init_repo "$project"
+  init_repo "${project}/.osac-ai-skills"
+  make_behind "${project}/.osac-ai-skills" 3
+  local out
+  out=$(run_statusline "$home" "$project")
+  echo "$out" | grep -q 'osac-ai-skills: main ↓3 behind' \
+    || fail "expected ↓3 behind, got: $out"
+  pass "repo-local N behind origin/main → ↓N"
+}
+
+test_home_git_wins_over_repo_local() {
+  local home="${TMPDIR_ROOT}/home-pref"
+  local project="${TMPDIR_ROOT}/proj-pref"
+  mkdir -p "$home"
+  init_repo "$project"
+  init_repo "${project}/.osac-ai-skills"
+  make_behind "${project}/.osac-ai-skills" 2
+  init_repo "${home}/.osac-ai-skills"
+  local out
+  out=$(run_statusline "$home" "$project")
+  echo "$out" | grep -q 'osac-ai-skills: main ✓' \
+    || fail "HOME git checkout should win (✓), got: $out"
+  echo "$out" | grep -q '↓2' \
+    && fail "should not report repo-local behind when HOME wins: $out"
+  pass "~/.osac-ai-skills/.git wins over repo-local"
+}
+
+test_home_without_git_falls_back_to_repo_local() {
+  local home="${TMPDIR_ROOT}/home-nongit"
+  local project="${TMPDIR_ROOT}/proj-nongit"
+  mkdir -p "${home}/.osac-ai-skills"
+  init_repo "$project"
+  init_repo "${project}/.osac-ai-skills"
+  local out
+  out=$(run_statusline "$home" "$project")
+  echo "$out" | grep -q 'osac-ai-skills: not found' \
+    && fail "HOME dir without .git must not hide repo-local: $out"
+  echo "$out" | grep -q 'osac-ai-skills: main ✓' \
+    || fail "expected fallback to repo-local ✓, got: $out"
+  pass "HOME without .git falls back to repo-local"
+}
+
+test_missing_vendor_is_muted_not_found
+test_repo_local_up_to_date
+test_repo_local_behind
+test_home_git_wins_over_repo_local
+test_home_without_git_falls_back_to_repo_local
+
+echo "All statusline osac-ai-skills smoke tests passed."

--- a/tools/test/statusline-osac-ai-skills-smoke.sh
+++ b/tools/test/statusline-osac-ai-skills-smoke.sh
@@ -138,11 +138,46 @@ test_home_worktree_wins_over_repo_local() {
   pass "HOME linked worktree wins over repo-local"
 }
 
+test_repo_local_nongit_dir_is_not_found() {
+  local home="${TMPDIR_ROOT}/home-leftover"
+  local project="${TMPDIR_ROOT}/proj-leftover"
+  mkdir -p "$home"
+  init_repo "$project"
+  mkdir -p "${project}/.osac-ai-skills"
+  local out
+  out=$(run_statusline "$home" "$project")
+  echo "$out" | grep -q 'osac-ai-skills: not found' \
+    || fail "leftover non-git dir must not inherit osac's branch: $out"
+  echo "$out" | grep -q 'osac-ai-skills: main ✓' \
+    && fail "false green for leftover .osac-ai-skills: $out"
+  pass "repo-local leftover dir → osac-ai-skills: not found"
+}
+
+test_home_git_subdir_falls_back_to_repo_local() {
+  local home="${TMPDIR_ROOT}/home-dotfiles"
+  local project="${TMPDIR_ROOT}/proj-dotfiles"
+  mkdir -p "$home"
+  init_repo "$home"
+  make_behind "$home" 5
+  mkdir -p "${home}/.osac-ai-skills"
+  init_repo "$project"
+  init_repo "${project}/.osac-ai-skills"
+  local out
+  out=$(run_statusline "$home" "$project")
+  echo "$out" | grep -q 'osac-ai-skills: main ✓' \
+    || fail "HOME git with plain .osac-ai-skills subdir must fall back: $out"
+  echo "$out" | grep -q '↓5' \
+    && fail "must not report HOME's behind-count as osac-ai-skills: $out"
+  pass "HOME git checkout with plain subdir falls back to repo-local"
+}
+
 test_missing_vendor_is_muted_not_found
 test_repo_local_up_to_date
 test_repo_local_behind
 test_home_git_wins_over_repo_local
 test_home_without_git_falls_back_to_repo_local
 test_home_worktree_wins_over_repo_local
+test_repo_local_nongit_dir_is_not_found
+test_home_git_subdir_falls_back_to_repo_local
 
 echo "All statusline osac-ai-skills smoke tests passed."

--- a/tools/test/statusline-osac-ai-skills-smoke.sh
+++ b/tools/test/statusline-osac-ai-skills-smoke.sh
@@ -172,6 +172,23 @@ test_home_git_subdir_falls_back_to_repo_local() {
   pass "HOME git checkout with plain subdir falls back to repo-local"
 }
 
+test_leftover_home_ai_workflows_falls_back_to_repo_local() {
+  local home project out
+  home="${TMPDIR_ROOT}/home-ai-leftover"
+  project="${TMPDIR_ROOT}/proj-ai-leftover"
+  mkdir -p "$home"
+  init_repo "$home"
+  mkdir -p "${home}/.ai-workflows"
+  init_repo "$project"
+  init_repo "${project}/.ai-workflows"
+  out=$(run_statusline "$home" "$project")
+  echo "$out" | grep -q 'ai-workflows: main ✓' \
+    || fail "leftover HOME dest must fall back to repo-local ai-workflows: $out"
+  echo "$out" | grep -q 'ai-workflows: not found' \
+    && fail "must not mute ai-workflows when repo-local exists: $out"
+  pass "leftover ~/.ai-workflows falls back to repo-local"
+}
+
 test_missing_vendor_is_muted_not_found
 test_repo_local_up_to_date
 test_repo_local_behind
@@ -180,5 +197,6 @@ test_home_without_git_falls_back_to_repo_local
 test_home_worktree_wins_over_repo_local
 test_repo_local_nongit_dir_is_not_found
 test_home_git_subdir_falls_back_to_repo_local
+test_leftover_home_ai_workflows_falls_back_to_repo_local
 
 echo "All statusline osac-ai-skills smoke tests passed."

--- a/tools/test/statusline-osac-ai-skills-smoke.sh
+++ b/tools/test/statusline-osac-ai-skills-smoke.sh
@@ -115,10 +115,34 @@ test_home_without_git_falls_back_to_repo_local() {
   pass "HOME without .git falls back to repo-local"
 }
 
+test_home_worktree_wins_over_repo_local() {
+  local home="${TMPDIR_ROOT}/home-wt"
+  local project="${TMPDIR_ROOT}/proj-wt"
+  local source="${TMPDIR_ROOT}/skills-src"
+  mkdir -p "$home"
+  init_repo "$source"
+  init_repo "$project"
+  init_repo "${project}/.osac-ai-skills"
+  make_behind "${project}/.osac-ai-skills" 2
+  # Free `main` in the source checkout so the linked worktree can occupy it.
+  "$REAL_GIT" -C "$source" checkout -q --detach
+  "$REAL_GIT" -C "$source" worktree add -q "${home}/.osac-ai-skills" main
+  [[ -f "${home}/.osac-ai-skills/.git" ]] || fail "expected linked worktree .git file"
+  [[ ! -d "${home}/.osac-ai-skills/.git" ]] || fail "worktree .git should not be a directory"
+  local out
+  out=$(run_statusline "$home" "$project")
+  echo "$out" | grep -q 'osac-ai-skills: main ✓' \
+    || fail "HOME worktree should win (✓), got: $out"
+  echo "$out" | grep -q '↓2' \
+    && fail "should not report repo-local behind when HOME worktree wins: $out"
+  pass "HOME linked worktree wins over repo-local"
+}
+
 test_missing_vendor_is_muted_not_found
 test_repo_local_up_to_date
 test_repo_local_behind
 test_home_git_wins_over_repo_local
 test_home_without_git_falls_back_to_repo_local
+test_home_worktree_wins_over_repo_local
 
 echo "All statusline osac-ai-skills smoke tests passed."

--- a/tools/test/statusline-osac-ai-skills-smoke.sh
+++ b/tools/test/statusline-osac-ai-skills-smoke.sh
@@ -7,6 +7,7 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
 STATUSLINE="${REPO_ROOT}/.claude/hooks/statusline.sh"
 REAL_GIT=$(command -v git)
+OSAC_AI_SKILLS_NAME=".osac-ai-skills"
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 pass() { echo "PASS: $*"; }
@@ -44,12 +45,19 @@ run_statusline() {
   printf '%s' '{}' | HOME="$home" bash "$STATUSLINE" "$project"
 }
 
+# Sets caller's home, project, home_skills, repo_skills.
+fixture() {
+  home="${TMPDIR_ROOT}/home-$1"
+  project="${TMPDIR_ROOT}/proj-$1"
+  home_skills="${home}/${OSAC_AI_SKILLS_NAME}"
+  repo_skills="${project}/${OSAC_AI_SKILLS_NAME}"
+}
+
 test_missing_vendor_is_muted_not_found() {
-  local home="${TMPDIR_ROOT}/home-missing"
-  local project="${TMPDIR_ROOT}/proj-missing"
+  local home project home_skills repo_skills out
+  fixture missing
   mkdir -p "$home"
   init_repo "$project"
-  local out
   out=$(run_statusline "$home" "$project")
   echo "$out" | grep -q 'osac-ai-skills: not found' \
     || fail "expected muted osac-ai-skills: not found, got: $out"
@@ -57,26 +65,24 @@ test_missing_vendor_is_muted_not_found() {
 }
 
 test_repo_local_up_to_date() {
-  local home="${TMPDIR_ROOT}/home-local"
-  local project="${TMPDIR_ROOT}/proj-local"
+  local home project home_skills repo_skills out
+  fixture local
   mkdir -p "$home"
   init_repo "$project"
-  init_repo "${project}/.osac-ai-skills"
-  local out
+  init_repo "$repo_skills"
   out=$(run_statusline "$home" "$project")
   echo "$out" | grep -q 'osac-ai-skills: main ✓' \
     || fail "expected repo-local ✓, got: $out"
-  pass "repo-local .osac-ai-skills at origin/main → ✓"
+  pass "repo-local ${OSAC_AI_SKILLS_NAME} at origin/main → ✓"
 }
 
 test_repo_local_behind() {
-  local home="${TMPDIR_ROOT}/home-behind"
-  local project="${TMPDIR_ROOT}/proj-behind"
+  local home project home_skills repo_skills out
+  fixture behind
   mkdir -p "$home"
   init_repo "$project"
-  init_repo "${project}/.osac-ai-skills"
-  make_behind "${project}/.osac-ai-skills" 3
-  local out
+  init_repo "$repo_skills"
+  make_behind "$repo_skills" 3
   out=$(run_statusline "$home" "$project")
   echo "$out" | grep -q 'osac-ai-skills: main ↓3 behind' \
     || fail "expected ↓3 behind, got: $out"
@@ -84,29 +90,27 @@ test_repo_local_behind() {
 }
 
 test_home_git_wins_over_repo_local() {
-  local home="${TMPDIR_ROOT}/home-pref"
-  local project="${TMPDIR_ROOT}/proj-pref"
+  local home project home_skills repo_skills out
+  fixture pref
   mkdir -p "$home"
   init_repo "$project"
-  init_repo "${project}/.osac-ai-skills"
-  make_behind "${project}/.osac-ai-skills" 2
-  init_repo "${home}/.osac-ai-skills"
-  local out
+  init_repo "$repo_skills"
+  make_behind "$repo_skills" 2
+  init_repo "$home_skills"
   out=$(run_statusline "$home" "$project")
   echo "$out" | grep -q 'osac-ai-skills: main ✓' \
     || fail "HOME git checkout should win (✓), got: $out"
   echo "$out" | grep -q '↓2' \
     && fail "should not report repo-local behind when HOME wins: $out"
-  pass "~/.osac-ai-skills/.git wins over repo-local"
+  pass "~/${OSAC_AI_SKILLS_NAME}/.git wins over repo-local"
 }
 
 test_home_without_git_falls_back_to_repo_local() {
-  local home="${TMPDIR_ROOT}/home-nongit"
-  local project="${TMPDIR_ROOT}/proj-nongit"
-  mkdir -p "${home}/.osac-ai-skills"
+  local home project home_skills repo_skills out
+  fixture nongit
+  mkdir -p "$home_skills"
   init_repo "$project"
-  init_repo "${project}/.osac-ai-skills"
-  local out
+  init_repo "$repo_skills"
   out=$(run_statusline "$home" "$project")
   echo "$out" | grep -q 'osac-ai-skills: not found' \
     && fail "HOME dir without .git must not hide repo-local: $out"
@@ -116,20 +120,19 @@ test_home_without_git_falls_back_to_repo_local() {
 }
 
 test_home_worktree_wins_over_repo_local() {
-  local home="${TMPDIR_ROOT}/home-wt"
-  local project="${TMPDIR_ROOT}/proj-wt"
-  local source="${TMPDIR_ROOT}/skills-src"
+  local home project home_skills repo_skills source out
+  fixture wt
+  source="${TMPDIR_ROOT}/skills-src"
   mkdir -p "$home"
   init_repo "$source"
   init_repo "$project"
-  init_repo "${project}/.osac-ai-skills"
-  make_behind "${project}/.osac-ai-skills" 2
+  init_repo "$repo_skills"
+  make_behind "$repo_skills" 2
   # Free `main` in the source checkout so the linked worktree can occupy it.
   "$REAL_GIT" -C "$source" checkout -q --detach
-  "$REAL_GIT" -C "$source" worktree add -q "${home}/.osac-ai-skills" main
-  [[ -f "${home}/.osac-ai-skills/.git" ]] || fail "expected linked worktree .git file"
-  [[ ! -d "${home}/.osac-ai-skills/.git" ]] || fail "worktree .git should not be a directory"
-  local out
+  "$REAL_GIT" -C "$source" worktree add -q "$home_skills" main
+  [[ -f "${home_skills}/.git" ]] || fail "expected linked worktree .git file"
+  [[ ! -d "${home_skills}/.git" ]] || fail "worktree .git should not be a directory"
   out=$(run_statusline "$home" "$project")
   echo "$out" | grep -q 'osac-ai-skills: main ✓' \
     || fail "HOME worktree should win (✓), got: $out"
@@ -139,33 +142,31 @@ test_home_worktree_wins_over_repo_local() {
 }
 
 test_repo_local_nongit_dir_is_not_found() {
-  local home="${TMPDIR_ROOT}/home-leftover"
-  local project="${TMPDIR_ROOT}/proj-leftover"
+  local home project home_skills repo_skills out
+  fixture leftover
   mkdir -p "$home"
   init_repo "$project"
-  mkdir -p "${project}/.osac-ai-skills"
-  local out
+  mkdir -p "$repo_skills"
   out=$(run_statusline "$home" "$project")
   echo "$out" | grep -q 'osac-ai-skills: not found' \
     || fail "leftover non-git dir must not inherit osac's branch: $out"
   echo "$out" | grep -q 'osac-ai-skills: main ✓' \
-    && fail "false green for leftover .osac-ai-skills: $out"
+    && fail "false green for leftover ${OSAC_AI_SKILLS_NAME}: $out"
   pass "repo-local leftover dir → osac-ai-skills: not found"
 }
 
 test_home_git_subdir_falls_back_to_repo_local() {
-  local home="${TMPDIR_ROOT}/home-dotfiles"
-  local project="${TMPDIR_ROOT}/proj-dotfiles"
+  local home project home_skills repo_skills out
+  fixture dotfiles
   mkdir -p "$home"
   init_repo "$home"
   make_behind "$home" 5
-  mkdir -p "${home}/.osac-ai-skills"
+  mkdir -p "$home_skills"
   init_repo "$project"
-  init_repo "${project}/.osac-ai-skills"
-  local out
+  init_repo "$repo_skills"
   out=$(run_statusline "$home" "$project")
   echo "$out" | grep -q 'osac-ai-skills: main ✓' \
-    || fail "HOME git with plain .osac-ai-skills subdir must fall back: $out"
+    || fail "HOME git with plain ${OSAC_AI_SKILLS_NAME} subdir must fall back: $out"
   echo "$out" | grep -q '↓5' \
     && fail "must not report HOME's behind-count as osac-ai-skills: $out"
   pass "HOME git checkout with plain subdir falls back to repo-local"

--- a/tools/test/update-ai-context-smoke.sh
+++ b/tools/test/update-ai-context-smoke.sh
@@ -76,8 +76,23 @@ test_skip_rebase_off_main() {
   pass "skips rebase when ~/.ai-workflows is not on main"
 }
 
+test_empty_claude_project_dir_skips_repo_local() {
+  local home project out
+  home="${TMPDIR_ROOT}/empty-proj-home"
+  project="${TMPDIR_ROOT}/empty-proj-proj"
+  mkdir -p "$home" "$project"
+  init_repo "$home"
+  mkdir -p "${home}/.ai-workflows"
+  init_repo "${project}/.ai-workflows"
+  out=$(HOME="$home" CLAUDE_PROJECT_DIR="" bash "$HOOK")
+  echo "$out" | grep -q 'ai-workflows:' \
+    && fail "empty CLAUDE_PROJECT_DIR must not update repo-local: $out"
+  pass "empty CLAUDE_PROJECT_DIR does not fall back to repo-local"
+}
+
 test_leftover_home_dir_does_not_rebase_enclosing_repo
 test_leftover_home_falls_back_to_repo_local
 test_skip_rebase_off_main
+test_empty_claude_project_dir_skips_repo_local
 
 echo "All update-ai-context smoke tests passed."

--- a/tools/test/update-ai-context-smoke.sh
+++ b/tools/test/update-ai-context-smoke.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Smoke test: SessionStart update-ai-context.sh leftover dest and skip-off-main.
+# Run from osac/: bash tools/test/update-ai-context-smoke.sh
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+HOOK="${REPO_ROOT}/.claude/hooks/update-ai-context.sh"
+REAL_GIT=$(command -v git)
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "PASS: $*"; }
+
+[[ -x "$HOOK" ]] || fail "missing executable $HOOK"
+[[ -n "$REAL_GIT" ]] || fail "git not on PATH"
+
+TMPDIR_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+init_repo() {
+  local dir="$1"
+  mkdir -p "$dir"
+  "$REAL_GIT" init -q "$dir"
+  "$REAL_GIT" -C "$dir" checkout -q -b main
+  "$REAL_GIT" -C "$dir" -c user.email=smoke@test -c user.name=smoke \
+    commit -q --allow-empty -m seed
+  "$REAL_GIT" -C "$dir" remote add origin "$dir"
+  "$REAL_GIT" -C "$dir" update-ref refs/remotes/origin/main HEAD
+}
+
+run_hook() {
+  local home="$1" project="$2"
+  HOME="$home" CLAUDE_PROJECT_DIR="$project" bash "$HOOK"
+}
+
+test_leftover_home_dir_does_not_rebase_enclosing_repo() {
+  local home project before after out
+  home="${TMPDIR_ROOT}/dotfiles-home"
+  project="${TMPDIR_ROOT}/dotfiles-proj"
+  mkdir -p "$home" "$project"
+  init_repo "$home"
+  mkdir -p "${home}/.ai-workflows"
+  before=$("$REAL_GIT" -C "$home" rev-parse HEAD)
+  out=$(run_hook "$home" "$project")
+  after=$("$REAL_GIT" -C "$home" rev-parse HEAD)
+  [[ "$before" == "$after" ]] || fail "leftover ~/.ai-workflows rebased HOME: $before -> $after"
+  echo "$out" | grep -q 'ai-workflows:' \
+    && fail "leftover dest must not report ai-workflows status: $out"
+  pass "leftover ~/.ai-workflows does not fetch/rebase enclosing HOME"
+}
+
+test_leftover_home_falls_back_to_repo_local() {
+  local home project out
+  home="${TMPDIR_ROOT}/fallback-home"
+  project="${TMPDIR_ROOT}/fallback-proj"
+  mkdir -p "$home" "$project"
+  init_repo "$home"
+  mkdir -p "${home}/.ai-workflows"
+  init_repo "${project}/.ai-workflows"
+  out=$(run_hook "$home" "$project")
+  echo "$out" | grep -q 'ai-workflows: up to date' \
+    || fail "expected repo-local update, got: $out"
+  pass "leftover HOME dest falls back to repo-local .ai-workflows"
+}
+
+test_skip_rebase_off_main() {
+  local home project out
+  home="${TMPDIR_ROOT}/feat-home"
+  project="${TMPDIR_ROOT}/feat-proj"
+  mkdir -p "$home" "$project"
+  init_repo "${home}/.ai-workflows"
+  "$REAL_GIT" -C "${home}/.ai-workflows" checkout -q -b feat/not-main
+  out=$(run_hook "$home" "$project")
+  echo "$out" | grep -q 'ai-workflows: on feat/not-main, skipped' \
+    || fail "expected skip off main, got: $out"
+  pass "skips rebase when ~/.ai-workflows is not on main"
+}
+
+test_leftover_home_dir_does_not_rebase_enclosing_repo
+test_leftover_home_falls_back_to_repo_local
+test_skip_rebase_off_main
+
+echo "All update-ai-context smoke tests passed."


### PR DESCRIPTION
## [OSAC-3958](https://redhat.atlassian.net/browse/OSAC-3958): Clone skill-relative sibling repos on bootstrap

**Jira:** [OSAC-3958](https://redhat.atlassian.net/browse/OSAC-3958), [OSAC-4483](https://redhat.atlassian.net/browse/OSAC-4483), [OSAC-4011](https://redhat.atlassian.net/browse/OSAC-4011) (osac pointer only), [OSAC-4010](https://redhat.atlassian.net/browse/OSAC-4010), [OSAC-4040](https://redhat.atlassian.net/browse/OSAC-4040)
**Story type:** Task

Depends on osac-project/osac#307 (merged). Workspace 4011 stub already landed as osac-project/osac-workspace#225.

### Summary

Standalone `osac/` bootstrap now clones the skill-relative sibling repos this checkout still needs (PRD/design, UI, docs) into gitignored dirs so those paths survive `osac-workspace` cutover. `/e2e` writes [`tests/e2e/`](tests/e2e/) in this repo ([OSAC-3593](https://redhat.atlassian.net/browse/OSAC-3593)); `osac-test-infra` is **not** cloned. Writeable siblings get a `fork` remote (workspace-shaped: `origin` = osac-project, `fork` = you). The Claude status line shows `osac-ai-skills` the same way it shows `ai-workflows`. `AGENTS.md` points at the canonical Feature → PRD → Design sequence in osac-ai-skills (canonical copy: [osac-ai-skills#25](https://github.com/osac-project/osac-ai-skills/pull/25)). Distrobox (`make enter`) and `osac-new-worktree` are ported here so they are not workspace-only.

### Siblings cloned by `tools/bootstrap.sh`

Default: `gh` fork of the writeable three. `--no-fork` for CI/read-only. Clone/fork failures warn-and-continue so skill install still runs. Nested `osac/` inside `osac-workspace` still aborts (use a standalone clone or worktree). Never forked: `osac-ux`, `.osac-ai-skills`, `.ai-workflows`.

| GitHub repo | Local path (gitignored) | Fork remote | Why |
|-------------|-------------------------|-------------|-----|
| [enhancement-proposals](https://github.com/osac-project/enhancement-proposals) | `enhancement-proposals/` | yes | PRD/design `/publish` + `/respond` |
| [osac-ux](https://github.com/osac-project/osac-ux) | `osac-ux/` | no | `/design:research`, `/implement:ingest` `@temp-api` (not osac-ui) |
| [osac-ui](https://github.com/osac-project/osac-ui) | `osac-ui/` | yes | production console; `/osac-release` |
| [docs](https://github.com/osac-project/docs) | `osac-docs/` | yes | personas / architecture guides. **Not** in-tree `docs/` (`ARCHITECTURE.md`, `CONVENTIONS.md`) |

Not in this list: `osac-ai-skills` and `ai-workflows` (already vendored by #307). Mono-repo components and E2E suites (`tests/e2e/`, [OSAC-3593](https://redhat.atlassian.net/browse/OSAC-3593)) are already in-tree. [osac-test-infra](https://github.com/osac-project/osac-test-infra) is not cloned — infra backends / `/debug-e2e` only; do not add test suites there.

### Changes

- **`tools/bootstrap.sh`:** declarative `SIBLINGS` list (`"repo"` or `"repo:local-dir"`) after skill install. Never clones into tracked `docs/`. Default `gh` forks on writeable siblings; `--no-fork` for clone-only. Empty `GH_USER` from `gh api user` fails before fork URLs are built. Leftover `.ai-workflows` / `.osac-ai-skills` dirs must be git work-tree roots before fetch/rebase.
- **`.claude/hooks/update-ai-context.sh`:** same leftover-dest guard on SessionStart (do not `git -C` a leftover `~/.ai-workflows`); skip rebase off `main`; fall back to repo-local.
- **`Makefile` + `tools/distrobox/`:** Distrobox image (`make enter` / `make claude`). Tool binaries in the image are x86_64 only (see `tools/distrobox/Containerfile`). Podman wrapper lives here (`kind-dev` was removed in [OSAC-3752](https://redhat.atlassian.net/browse/OSAC-3752)).
- **`tools/osac-helpers.sh`:** `osac-new-worktree` for this repo (`../osac-<branch-basename>`, then `tools/bootstrap.sh`). Jira keys in the branch name use `awk` for the leftmost `OSAC-NNNN` so sourcing from zsh works. Jira fetch uses `timeout` then `gtimeout`, or skips if neither is present. Bootstrap failure prints that cwd is already the worktree plus a `--no-fork` recovery command.
- **`AGENTS.md` / `README.md`:** External Repos, EP publish paths, Distrobox (Linux/x86_64), worktrees, 4011 skill-sequence pointer. `/e2e` → `tests/e2e/` ([OSAC-3593](https://redhat.atlassian.net/browse/OSAC-3593)); `osac-test-infra` is not a bootstrap sibling.

### Testing

- **Unit tests:** `tools/test/bootstrap-sibling-clone-smoke.sh` (including empty `GH_USER`), `tools/test/statusline-osac-ai-skills-smoke.sh`, `tools/test/osac-new-worktree-smoke.sh` (guards, dest/bootstrap, first Jira key, timeout/`gtimeout`/skip, cwd hint, zsh nounset), `tools/test/update-ai-context-smoke.sh` (leftover HOME dest, repo-local fallback, skip off `main`). Existing `link-agent-skills-consumer-smoke.sh` still passes.
- **Integration tests:** N/A (bootstrap/statusline/helpers). Distrobox image build is not CI-smoked.
- **Coverage:** smokes cover `--no-fork` and stubbed `gh` fork remotes. Live bootstrap without `--no-fork` will create GitHub forks.

### Acceptance Criteria

- [x] AC-1 (3958): `enhancement-proposals` clones as a sibling on `bootstrap.sh` run
- [x] AC-2 (3958): adding a future sibling requires only a list entry
- [x] AC-1 (4483): resolve `~/.osac-ai-skills` else `$REPO/.osac-ai-skills`
- [x] AC-2 (4483): missing → muted `osac-ai-skills: not found`
- [x] AC-3 (4483): present → branch + `✓` / `↓N`
- [x] AC-4 (4483): recovery remains `tools/bootstrap.sh`; no extra symlink-health widget
- [x] (4010): `Makefile` + `tools/distrobox/` on `osac/`; `make help` lists targets. Image build is Linux/x86_64 and is not CI-smoked (`make enter` not claimed on macOS).
- [x] (4040): `tools/osac-helpers.sh` `osac-new-worktree` documented in `AGENTS.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable Distrobox development environment with build, entry, status, cleanup, and toolchain support.
  - Added guided worktree creation with optional Jira context.
  - Bootstrap now supports no-fork setup, related repository management, and fork remotes.
  - Status and setup workflows now recognize `osac-ai-skills`.

- **Bug Fixes**
  - Improved repository validation prevents nested or invalid checkouts from being updated.
  - Updates skip repositories that are not on `main`.

- **Documentation**
  - Expanded setup guidance for Linux, worktrees, bootstrapping, enhancement proposals, and architecture.
  - Clarified GitHub CLI authentication requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


