### PR TITLE
OSAC-4191: Introduce github action to check generated public proto files

### DIFF
--- a/.github/workflows/check-generated-code.yaml
+++ b/.github/workflows/check-generated-code.yaml
@@ -93,8 +93,34 @@ jobs:
       with:
         version: '1.50.0'
         setup_only: true
+    - if: steps.should-run.outputs.run && matrix.component == 'fulfillment-service'
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      with:
+        enable-cache: auto
+        version: "latest-known"
+    - if: steps.should-run.outputs.run && matrix.component == 'fulfillment-service'
+      name: Install protoc
+      run: |
+        # Install protoc for the public proto generation step
+        sudo apt-get update
+        sudo apt-get install -y protobuf-compiler
+    - if: steps.should-run.outputs.run && matrix.component == 'fulfillment-service'
+      name: Generate public protos from private
+      working-directory: fulfillment-service
+      run: uv run dev.py build protos
     - if: steps.should-run.outputs.run
+      name: Generate Go code from protos
+      working-directory: ${{ matrix.component }}
+      run: buf generate
+    - if: steps.should-run.outputs.run
+      name: Check for uncommitted changes
       working-directory: ${{ matrix.component }}
       run: |
-        buf generate
-        git diff --exit-code -- .
+        if ! git diff --exit-code -- .; then
+          if [ "${{ matrix.component }}" = "fulfillment-service" ]; then
+            echo "::error::Generated code is out of date. Run 'uv run dev.py build protos && buf generate' in fulfillment-service/ and commit the changes."
+          else
+            echo "::error::Generated code is out of date. Run 'buf generate' in ${{ matrix.component }}/ and commit the changes."
+          fi
+          exit 1
+        fi

--- a/.github/workflows/check-generated-code.yaml
+++ b/.github/workflows/check-generated-code.yaml
@@ -53,12 +53,13 @@ jobs:
               - '!osac-operator/.claude/**'
               - 'fulfillment-service/proto/private/**'
             osac-metering/metering-service:
-              - 'osac-metering/metering-service/**'
+              - '{osac-metering/metering-service,fulfillment-service/proto/private}/**'
               - '!osac-metering/metering-service/OWNERS'
               - '!osac-metering/metering-service/LICENSE'
               - '!osac-metering/metering-service/**/*.md'
               - '!osac-metering/metering-service/docs/**'
               - '!osac-metering/metering-service/.claude/**'
+              - 'fulfillment-service/proto/private/**'
 
   check-generated-code:
     name: Check generated code (${{ matrix.component }})
@@ -77,6 +78,7 @@ jobs:
         component:
           - fulfillment-service
           - osac-operator
+          - osac-metering/metering-service
     steps:
     - name: Fail if path filter failed
       if: needs.changes.result != 'success'
@@ -94,6 +96,7 @@ jobs:
         version: '1.50.0'
         setup_only: true
     - if: steps.should-run.outputs.run && matrix.component == 'fulfillment-service'
+      name: Install uv
       uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
         enable-cache: auto
@@ -102,8 +105,8 @@ jobs:
       name: Install protoc
       run: |
         # Install protoc for the public proto generation step
-        sudo apt-get update
-        sudo apt-get install -y protobuf-compiler
+        sudo apt-get update -qq
+        sudo apt-get install -qq -y protobuf-compiler
     - if: steps.should-run.outputs.run && matrix.component == 'fulfillment-service'
       name: Generate public protos from private
       working-directory: fulfillment-service
@@ -116,7 +119,7 @@ jobs:
       name: Check for uncommitted changes
       working-directory: ${{ matrix.component }}
       run: |
-        if ! git diff --exit-code -- .; then
+        if ! git diff --exit-code -- . || [ -n "$(git ls-files --others --exclude-standard -- .)" ]; then
           if [ "${{ matrix.component }}" = "fulfillment-service" ]; then
             echo "::error::Generated code is out of date. Run 'uv run dev.py build protos && buf generate' in fulfillment-service/ and commit the changes."
           else

--- a/fulfillment-service/dev/tools.py
+++ b/fulfillment-service/dev/tools.py
@@ -42,6 +42,7 @@ class Tool:
         extracted_name: str = "",
         checksums_url: str = "",
         artifact_url: str = "",
+        arch_override: dict[str, str] | None = None,
     ):
         """
         Initialize a Tool definition.
@@ -57,11 +58,12 @@ class Tool:
             raise ValueError(f"Tool checksums are required for '{name}'")
 
         # Get normalized architecture name
-        arch_name = _ARCH_MAP.get(_SYSTEM_ARCH)
+        arch_map = arch_override if arch_override is not None else _ARCH_MAP
+        arch_name = arch_map.get(_SYSTEM_ARCH)
         if arch_name is None:
             raise ValueError(
                 f"Unsupported architecture '{_SYSTEM_ARCH}' for tool '{name}'. "
-                f"Supported architectures: {', '.join(_ARCH_MAP.keys())}"
+                f"Supported architectures: {', '.join(arch_map.keys())}"
             )
 
         # Save basic metadata
@@ -146,4 +148,13 @@ PROTOC_GEN_CLEANAPI = Tool(
     checksums_artifact="protoc-gen-cleanapi_{version}_checksums.txt",
     compressed_artifact_name="protoc-gen-cleanapi_{sys_os}_{sys_arch}.tar.gz",
     extracted_name="protoc-gen-cleanapi",  # Binary extracted directly, not in versioned dir
+    # This tool uses x86_64/i386 instead of amd64/386
+    arch_override={
+        "x86_64": "x86_64",
+        "aarch64": "arm64",
+        "arm64": "arm64",
+        "amd64": "x86_64",
+        "i386": "i386",
+        "i686": "i386",
+    },
 )


### PR DESCRIPTION
Now that public proto files are auto-generated from private proto files, the check-generated-code workflow should run the generation command and error out if there are any diffs to prevent merging public proto files that are not auto-generated from the private proto files.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated generated-code checks to include the metering service.
  * Improved protocol generation and validation for the fulfillment service.
  * Added clearer component-specific messages when generated code is out of date.

* **Bug Fixes**
  * Improved architecture handling for protocol compiler tooling across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->