### PR TITLE
OSAC-2988: Deprecate --pull-secret-file inline arg

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -15,6 +15,6 @@ When changing one repo, check all dependent repos in this table before submittin
 |-----------|-----------|-----|
 | `osac-operator` CRD types | `fulfillment-service` reconciler registration | New CRD types must be registered in the fulfillment-service reconciler (in-repo change, same PR) |
 | `osac-operator` CRD spec changes | `osac-aap` roles that read CRD fields | Adding a field to `ClusterOrderSpec` requires the AAP playbook to extract and use it |
-| `fulfillment-service` CLI flag changes | `osac-test-infra` test helpers | Adding `--pull-secret-file` required updating `OsacCLI.create_cluster` in the test infra (separate repo, separate PR) |
+| `fulfillment-service` CLI flag changes | `tests/core/osac_cli.py` | Keep the shared E2E CLI helper aligned with tenant-facing flags |
 
 Evidence: MGMT-24226 eval scored 3/5 because the agent fixed `fulfillment-service` and `osac-aap` but missed updating `osac-installer`'s pinned image version — this was pre-mono-repo-merge (OSAC-1739), when these were still separate repos and image tags were pinned per-commit. That specific mechanism (a separate pinned tag needing a manual re-sync via `sync-image-tags.sh`) no longer exists post-mono-repo — `osac/osac-installer/scripts/sync-image-tags.sh` was removed upstream (`OSAC-3367`) and `osac/osac-installer/values/*/values.yaml` now leaves mono-repo-resident components' image tags unpinned. See the CRD-registration and CLI-flag rows above for what still needs a cross-file check today.

--- a/fulfillment-service/docs/CATALOG_ITEMS.md
+++ b/fulfillment-service/docs/CATALOG_ITEMS.md
@@ -322,9 +322,12 @@ osac create cluster --catalog-item dev-sandbox
 Users can provide spec fields via CLI flags and `--set`:
 
 ```bash
+osac create secret --name cluster-pull-secret \
+  --from-file=.dockerconfigjson=pull-secret.json
+
 osac create cluster --catalog-item dev-sandbox \
   --name my-cluster \
-  --pull-secret "$(cat pull-secret.json)" \
+  --pull-secret cluster-pull-secret \
   --ssh-public-key "$(cat ~/.ssh/id_ed25519.pub)" \
   --version "4-17-0" \
   --pod-cidr "10.128.0.0/14"
@@ -337,7 +340,7 @@ single `KEY=VALUE` pair (split on the first `=`):
 osac create cluster --catalog-item rhel-ai-small \
   --set template_parameters.vpc_id=vpc-staging-02 \
   --set template_parameters.ip_block_id=block-789 \
-  --pull-secret-file pull-secret.json
+  --pull-secret cluster-pull-secret
 ```
 
 Non-editable parameters are rejected by the server:

--- a/fulfillment-service/internal/cmd/cli/create/cluster/create_cluster_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/cluster/create_cluster_cmd.go
@@ -99,12 +99,6 @@ func Cmd() *cobra.Command {
 		pullSecretFlagHelp,
 	)
 	flags.StringVar(
-		&runner.args.pullSecretFile,
-		"pull-secret-file",
-		"",
-		pullSecretFileFlagHelp,
-	)
-	flags.StringVar(
 		&runner.args.sshPublicKey,
 		"ssh-public-key",
 		"",
@@ -154,7 +148,6 @@ func Cmd() *cobra.Command {
 	)
 	result.MarkFlagsMutuallyExclusive("catalog-item", "template")
 	result.MarkFlagsOneRequired("catalog-item", "template")
-	result.MarkFlagsMutuallyExclusive("pull-secret", "pull-secret-file")
 	return result
 }
 
@@ -167,7 +160,6 @@ type runnerContext struct {
 		templateParameterFiles  []string
 		setFields               []string
 		pullSecret              string
-		pullSecretFile          string
 		sshPublicKey            string
 		sshPublicKeyFile        string
 		version                 string
@@ -249,8 +241,8 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	c.clustersClient = publicv1.NewClustersClient(conn)
 	c.clusterVersionsClient = publicv1.NewClusterVersionsClient(conn)
 
-	// Resolve credentials before branching (used in both catalog-item and template paths):
-	pullSecret, sshPublicKey, err := c.resolveCredentials()
+	// Resolve the SSH public key before branching (used in both catalog-item and template paths):
+	sshPublicKey, err := c.resolveSSHPublicKey()
 	if err != nil {
 		return err
 	}
@@ -269,7 +261,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		specBuilder := publicv1.ClusterSpec_builder{
 			CatalogItem: &publicv1.ClusterCatalogItemReference{Name: c.args.catalogItem},
 		}
-		c.applyOptionalSpecFields(&specBuilder, pullSecret, sshPublicKey)
+		c.applyOptionalSpecFields(&specBuilder, sshPublicKey)
 		if err := c.applyNetworkingFlags(&specBuilder); err != nil {
 			return err
 		}
@@ -308,23 +300,15 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		Template:           &publicv1.ClusterTemplateReference{Id: template.GetId()},
 		TemplateParameters: templateParameterValues,
 	}
-	c.applyOptionalSpecFields(&specBuilder, pullSecret, sshPublicKey)
+	c.applyOptionalSpecFields(&specBuilder, sshPublicKey)
 	if err := c.applyNetworkingFlags(&specBuilder); err != nil {
 		return err
 	}
 	return c.createCluster(ctx, specBuilder.Build())
 }
 
-// resolveCredentials reads pull secret and SSH public key from file flags when specified.
-func (c *runnerContext) resolveCredentials() (pullSecret, sshPublicKey string, err error) {
-	if c.args.pullSecretFile != "" {
-		data, readErr := os.ReadFile(c.args.pullSecretFile)
-		if readErr != nil {
-			err = fmt.Errorf("failed to read pull secret file '%s': %w", c.args.pullSecretFile, readErr)
-			return
-		}
-		pullSecret = strings.TrimSpace(string(data))
-	}
+// resolveSSHPublicKey reads the SSH public key from a file when specified.
+func (c *runnerContext) resolveSSHPublicKey() (sshPublicKey string, err error) {
 	sshPublicKey = c.args.sshPublicKey
 	if c.args.sshPublicKeyFile != "" {
 		data, readErr := os.ReadFile(c.args.sshPublicKeyFile)
@@ -340,11 +324,8 @@ func (c *runnerContext) resolveCredentials() (pullSecret, sshPublicKey string, e
 // applyOptionalSpecFields sets pull secret, SSH public key, version, and network CIDRs
 // on the spec builder when their corresponding flags are provided.
 func (c *runnerContext) applyOptionalSpecFields(
-	specBuilder *publicv1.ClusterSpec_builder, pullSecret, sshPublicKey string,
+	specBuilder *publicv1.ClusterSpec_builder, sshPublicKey string,
 ) {
-	if pullSecret != "" {
-		specBuilder.PullSecret = &pullSecret
-	}
 	if c.args.pullSecret != "" {
 		specBuilder.PullSecretSecret = publicv1.SecretLocalReference_builder{
 			Name: c.args.pullSecret,
@@ -968,13 +949,8 @@ times.
 
 const pullSecretFlagHelp = `
 _NAME_ - Name of a Secret resource containing pull secret credentials.
-Mutually exclusive with {{ bt }}--pull-secret-file{{ bt }}. The secret must
-exist in the same tenant. See also {{ bt }}osac create secret{{ bt }}.
-`
-
-const pullSecretFileFlagHelp = `
-_FILE_ - Path to a file containing the pull secret, provided as inline
-credentials. Mutually exclusive with {{ bt }}--pull-secret{{ bt }}.
+The secret must exist in the same tenant. See also
+{{ bt }}osac create secret{{ bt }}.
 `
 
 const sshPublicKeyFlagHelp = `

--- a/fulfillment-service/internal/cmd/cli/create/cluster/create_cluster_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/create/cluster/create_cluster_cmd_test.go
@@ -258,25 +258,6 @@ var _ = Describe("Create cluster pull secret flags", func() {
 		Expect(flag.DefValue).To(Equal(""))
 	})
 
-	It("should register --pull-secret-file flag", func() {
-		cmd := Cmd()
-		cmd.SetOut(GinkgoWriter)
-		cmd.SetErr(GinkgoWriter)
-		flag := cmd.Flags().Lookup("pull-secret-file")
-		Expect(flag).NotTo(BeNil())
-		Expect(flag.DefValue).To(Equal(""))
-	})
-
-	It("should reject both --pull-secret and --pull-secret-file", func() {
-		cmd := Cmd()
-		cmd.SetOut(GinkgoWriter)
-		cmd.SetErr(GinkgoWriter)
-		cmd.SetArgs([]string{"--catalog-item", "cat-001", "--name", "test", "--pull-secret", "my-secret", "--pull-secret-file", "/tmp/secret"})
-		err := cmd.Execute()
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("if any flags in the group"))
-		Expect(err.Error()).To(ContainSubstring("pull-secret"))
-	})
 })
 
 var _ = Describe("Create cluster networking flags", func() {

--- a/osac-aap/collections/ansible_collections/osac/service/roles/cluster_settings/tasks/main.yml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/cluster_settings/tasks/main.yml
@@ -74,8 +74,8 @@
       (spec.pullSecret, templateParameters, and the provider default Secret
       '{{ cluster_settings_default_credentials_secret_name }}'
       in namespace '{{ cluster_settings_default_credentials_secret_namespace }}').
-      Supply a pull secret via --pull-secret-file, spec.pullSecret, or configure
-      the provider default Secret.
+      Supply a pull secret via an OSAC Secret referenced by --pull-secret, or
+      configure the provider default Secret.
   when: not cluster_settings_pull_secret
 
 # Write resolved values back into template_parameters for backward compatibility

--- a/tests/core/osac_cli.py
+++ b/tests/core/osac_cli.py
@@ -177,7 +177,7 @@ class OsacCLI:
         *,
         template: str,
         name: str | None = None,
-        pull_secret_file: str | None = None,
+        pull_secret: str | None = None,
         ssh_public_key_file: str | None = None,
         version: str | None = None,
         template_parameters: dict[str, str] | None = None,
@@ -186,8 +186,8 @@ class OsacCLI:
         args: list[str] = ["create", "cluster", "--template", template]
         if name is not None:
             args.extend(["--name", name])
-        if pull_secret_file is not None:
-            args.extend(["--pull-secret-file", pull_secret_file])
+        if pull_secret is not None:
+            args.extend(["--pull-secret", pull_secret])
         if ssh_public_key_file is not None:
             args.extend(["--ssh-public-key-file", ssh_public_key_file])
         if version is not None:
@@ -200,6 +200,12 @@ class OsacCLI:
                 args.extend(["-f", f"{key}={path}"])
 
         return self._parse_uuid(self._run(*args))
+
+    def create_secret(self, *, name: str, from_files: dict[str, str]) -> None:
+        args: list[str] = ["create", "secret", "--name", name]
+        for key, path in from_files.items():
+            args.extend(["--from-file", f"{key}={path}"])
+        self._run(*args)
 
     def get(self, resource: str, *, output: str | None = None) -> str:
         args: list[str] = ["get", resource]


### PR DESCRIPTION
Removes the --pull-secret-file argument that places file contents inline for a given cluster.

I had thought this would need to be a back and forth updating e2e then the cli, but it turns out now e2e tests have moved into the monorepo as well as nothing in the e2e actually using the pull-secret-file arg.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cluster creation now references pull secrets by Kubernetes Secret name.
  * Added support for creating secrets from one or more named files.

* **Bug Fixes**
  * Updated guidance and validation messages to reflect Secret-based pull-secret configuration.

* **Documentation**
  * Updated catalog creation examples and dependency guidance for the revised pull-secret workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->