### PR TITLE
NO-ISSUE: Add openbao to kind dev deployment by default

### DIFF
--- a/osac-installer/charts/osac/templates/bundled-openbao.yaml
+++ b/osac-installer/charts/osac/templates/bundled-openbao.yaml
@@ -164,6 +164,9 @@ spec:
       automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
+        runAsUser: 100
+        runAsGroup: 1000
+        fsGroup: 1000
       volumes:
       - name: server-cert
         secret:

--- a/osac-installer/docs/helm-deployment-guide.md
+++ b/osac-installer/docs/helm-deployment-guide.md
@@ -115,6 +115,7 @@ These are top-level values, disabled by default. Enable only in CI/dev:
 |-------|-------------|
 | `hubAccess.enabled` | Creates hub-access SA/RBAC and registers local cluster as a hub. Only for environments where fulfillment-service and hub are the same cluster. |
 | `bundledPostgres.enabled` | Deploys a single-pod ephemeral PostgreSQL. Uses `fsync=off` and `emptyDir` — data lost on restart. Not for production. |
+| `bundledVault.enabled` | Deploys a single-pod ephemeral OpenBao (Vault-compatible) secret store for testing. Dev mode — data is lost on restart. Not for production. |
 
 ## Infrastructure Configuration
 

--- a/osac-installer/values/dev/kind-instance.yaml
+++ b/osac-installer/values/dev/kind-instance.yaml
@@ -88,7 +88,22 @@ service:
   log:
     level: debug
   vault:
-    endpoint: ""
+    endpoint: "https://openbao.osac.svc.cluster.local:8200"
+    namespace: osac
+    kvMountPath: secret
+    lifecycleRole: lifecycle
+    lifecycleMountPath: jwt
+    keycloakClientId: osac-controller
+    keycloakIssuerUrl: "https://keycloak.keycloak.svc.cluster.local:8443/realms/osac"
+    keycloakAudience: osac-api
+    caBundle:
+      configMap: ca-bundle
+    credentials:
+      - secret:
+          name: fulfillment-controller-credentials
+          items:
+            - key: client-secret
+              param: client-secret
 
 # --- AAP (disabled for kind) ---
 aap:
@@ -151,3 +166,8 @@ capiProvider:
 
 kafka:
   enabled: false
+
+# --- Vault compatible secret store (OpenBao) ---
+bundledVault:
+  enabled: true
+  devRootToken: "dev-root-token"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled the bundled OpenBao service for Kind development environments.
  * Added development configuration for OpenBao connectivity, storage paths, lifecycle settings, Keycloak integration, certificates, and controller credentials.
  * Added a development root token for local OpenBao access.

* **Bug Fixes**
  * Ensured the OpenBao deployment runs with explicit non-root security settings.

* **Documentation**
  * Documented the bundled OpenBao option as an ephemeral, non-production feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->