### PR TITLE
OSAC-3370: Fix fork e2e replay PR lookup

### DIFF
--- a/.github/workflows/e2e-on-approval-fork.yml
+++ b/.github/workflows/e2e-on-approval-fork.yml
@@ -29,8 +29,7 @@ jobs:
       pull-requests: write
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request_review' &&
-      github.event.workflow_run.head_repository.full_name != github.repository
+      github.event.workflow_run.event == 'pull_request_review'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -39,14 +38,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           EVENT_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
           REVIEWER: coderabbitai[bot]
         run: |
           set -euo pipefail
 
-          if [[ -z "${EVENT_HEAD_SHA}" || -z "${HEAD_REPO}" ]]; then
-            echo "workflow_run missing head_sha or head_repository; skipping."
+          if [[ -z "${EVENT_HEAD_SHA}" ]]; then
+            echo "workflow_run missing head_sha; skipping."
             exit 0
           fi
 
@@ -60,27 +58,37 @@ jobs:
             exit 0
           fi
 
-          if ! prs_json=$(gh api "repos/${REPO}/commits/${EVENT_HEAD_SHA}/pulls"); then
-            echo "Failed to list PRs for ${HEAD_REPO}@${EVENT_HEAD_SHA:0:7}; skipping."
+          # commits/{sha}/pulls is empty for unmerged fork SHAs.
+          # List open main PRs and match head.sha; take head.repo from the PR.
+          if ! prs_json=$(gh api --paginate \
+            "repos/${REPO}/pulls?state=open&base=main&per_page=100" \
+            --jq '.[]' | jq -s '.'); then
+            echo "Failed to list open PRs for ${EVENT_HEAD_SHA:0:7}; skipping."
             exit 0
           fi
-          pr_json=$(jq -c --arg sha "${EVENT_HEAD_SHA}" --arg repo "${HEAD_REPO}" '
+          pr_json=$(jq -c --arg sha "${EVENT_HEAD_SHA}" --arg base "${REPO}" '
             [.[]
               | select(.state == "open")
               | select(.base.ref == "main")
               | select(.head.sha == $sha)
-              | select((.head.repo.full_name // "") == $repo)
+              | select((.head.repo.full_name // "") != "")
+              | select((.head.repo.full_name // "") != $base)
             ]
             | if length == 1 then .[0] else empty end
           ' <<<"${prs_json}")
           if [[ -z "${pr_json}" || "${pr_json}" == "null" ]]; then
-            echo "No unique open main PR for ${HEAD_REPO}@${EVENT_HEAD_SHA:0:7}; skipping."
+            echo "No unique open fork PR targeting main at ${EVENT_HEAD_SHA:0:7}; skipping."
             exit 0
           fi
 
           PR_NUMBER=$(jq -r '.number' <<<"${pr_json}")
           HEAD_SHA=$(jq -r '.head.sha' <<<"${pr_json}")
           HEAD_REF=$(jq -r '.head.ref // empty' <<<"${pr_json}")
+          HEAD_REPO=$(jq -r '.head.repo.full_name // empty' <<<"${pr_json}")
+          if [[ -z "${HEAD_REPO}" ]]; then
+            echo "PR #${PR_NUMBER} has empty head.repo; skipping."
+            exit 0
+          fi
 
           pr_is_open() {
             [[ "$(jq -r '.state' <<<"${pr_json}")" == "open" ]]


### PR DESCRIPTION
## Summary
- Fork CodeRabbit approval never started expensive e2e: `workflow_run.head_repository` is the base repo even for fork PRs, so the replay job `if` never ran.
- Drop that comparison. Keep `fork-handoff` as the trust gate. Resolve the fork from the open `main` PR that matches `head.sha` (`commits/{sha}/pulls` is empty for unmerged fork SHAs).
- Live-checked: unique fork PR resolved, all three failed `pull_request` e2e runs found via `head.repo`. After merge, a new successful `fork-handoff` (CR re-approve or re-run of that producer) is needed to fire replay.

## Jira
https://redhat.atlassian.net/browse/OSAC-3370

## Test plan
- [x] Dry-run new lookup against live GitHub (SHA → unique fork PR, CR APPROVED on exact HEAD)
- [x] Confirm `commits/{sha}/pulls` still empty for that unmerged fork SHA
- [x] Confirm `find_pr_run` matches all three e2e workflows with fork `head.repo` and misses when `HEAD_REPO` is the base
- [x] YAML parses
- [ ] After merge: CodeRabbit re-approve (or re-run the successful `fork-handoff` producer) starts expensive e2e on a fork PR

---

_This PR description was drafted with AI assistance ([create-pr](https://github.com/osac-project/osac-workspace/tree/main/skills/create-pr) v0.1.3). Review for accuracy_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved reliability of end-to-end test workflows for fork-based pull requests.
  - Workflows now more accurately identify the corresponding open pull request before running.
  - Added safeguards to skip runs when required pull request information is unavailable or ambiguous.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->