### PR TITLE
OSAC-4633: fix osac-installer integration test silently failing on helm install/upgrade

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -292,65 +292,48 @@ jobs:
       with:
         version: v3.17.0
 
-    - name: Create Kind cluster
+    - name: Install Kind
       uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc  # v1
       with:
-        cluster_name: osac-integration
-
-    - name: Install cert-manager
-      run: |
-        kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.1/cert-manager.yaml
-        kubectl wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=120s
-        kubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s
-        kubectl wait --for=condition=Available deployment/cert-manager-cainjector -n cert-manager --timeout=120s
-
-    - name: Build chart dependencies
-      working-directory: osac-installer
-      run: helm dependency build charts/osac/
+        install_only: true
 
     - name: Lint charts
       working-directory: osac-installer
       run: |
+        helm dependency build charts/osac/
         helm lint charts/osac-deps/
         helm lint charts/osac-infra/ --values values/dev/infra.yaml
-        helm lint charts/osac/ --values values/dev/instance.yaml \
-          --set service.externalHostname=fulfillment-api.osac.svc.cluster.local \
-          --set service.internalHostname=fulfillment-internal-api.osac.svc.cluster.local
+        helm lint charts/osac/ --values values/dev/kind-instance.yaml
 
     - name: Template charts (dry-run validation)
       working-directory: osac-installer
       run: |
         helm template osac-deps charts/osac-deps/ --values values/dev/infra.yaml
-        helm template osac-infra charts/osac-infra/ --values values/dev/infra.yaml
-        helm template osac charts/osac/ --values values/dev/instance.yaml \
-          --set service.externalHostname=fulfillment-api.osac.svc.cluster.local \
-          --set service.internalHostname=fulfillment-internal-api.osac.svc.cluster.local
+        helm template osac-infra charts/osac-infra/ --values values/dev/infra.yaml \
+          --set trustManager.upstream.enabled=true
+        helm template osac charts/osac/ --values values/dev/kind-instance.yaml
+
+    # Same real command (and cluster: `make install-infra` creates its own
+    # Kind cluster, config, cert-manager/trust-manager/envoy-gateway/osac-infra
+    # install in one shot) fulfillment-service's and osac-operator's jobs in
+    # this same file already use successfully -- rather than hand-reimplementing
+    # the same sequence in workflow YAML, which is exactly how this job drifted
+    # out of sync with the real deployment path in the first place (missing
+    # trust-manager/envoy-gateway installs, wrong values file).
+    - name: Install infrastructure on Kind
+      env:
+        CONTAINER_TOOL: docker
+      run: make -C osac-installer install-infra PLATFORM=kind PROFILE=dev NS=osac
 
     - name: Deploy charts
-      continue-on-error: true
-      working-directory: osac-installer
-      run: |
-        helm install osac-infra charts/osac-infra/ \
-          --namespace osac \
-          --create-namespace \
-          --values values/dev/infra.yaml \
-          --timeout 5m \
-          --wait
-        helm install osac charts/osac/ \
-          --namespace osac \
-          --values values/dev/instance.yaml \
-          --set service.externalHostname=fulfillment-api.osac.svc.cluster.local \
-          --set service.internalHostname=fulfillment-internal-api.osac.svc.cluster.local \
-          --set validation.enabled=false \
-          --set aap.bootstrap.enabled=false \
-          --set aap.aap.instance.enabled=false \
-          --set dbMigrate.enabled=false \
-          --timeout 10m \
-          --wait
+      env:
+        CONTAINER_TOOL: docker
+      run: make -C osac-installer install-osac PLATFORM=kind PROFILE=dev NS=osac
 
     - name: Check deployed resources
       if: always()
       run: |
+        export KUBECONFIG="$HOME/.kube/osac-dev-kind.kubeconfig"
         echo "=== Pods ==="
         kubectl get pods -n osac
         echo "=== Deployments ==="
@@ -360,18 +343,11 @@ jobs:
         echo "=== Helm releases ==="
         helm list -n osac
 
+    # make install-osac is `helm upgrade --install` -- invoking it again
+    # against an unchanged values file/chart IS the real idempotency test,
+    # using the same real command as the initial deploy above rather than a
+    # hand-copied `helm upgrade` invocation that could drift from it.
     - name: Test idempotency (helm upgrade with no changes)
-      continue-on-error: true
-      working-directory: osac-installer
-      run: |
-        helm upgrade osac charts/osac/ \
-          --namespace osac \
-          --values values/dev/instance.yaml \
-          --set service.externalHostname=fulfillment-api.osac.svc.cluster.local \
-          --set service.internalHostname=fulfillment-internal-api.osac.svc.cluster.local \
-          --set validation.enabled=false \
-          --set aap.bootstrap.enabled=false \
-          --set aap.aap.instance.enabled=false \
-          --set dbMigrate.enabled=false \
-          --timeout 10m \
-          --wait
+      env:
+        CONTAINER_TOOL: docker
+      run: make -C osac-installer install-osac PLATFORM=kind PROFILE=dev NS=osac


### PR DESCRIPTION
## Summary
The `osac-installer` job in `integration-tests.yml` silently failed on every run: `helm install osac-infra` failed with `no matches for kind "Bundle" in version "trust.cert-manager.io/v1alpha1"`, masked by `continue-on-error: true` on both the deploy and idempotency steps.

Root cause: the job hand-reimplemented the deploy sequence in workflow YAML instead of using the project's own real deployment automation (the root `Makefile`), and had drifted from it in multiple ways:
- trust-manager (and its `Bundle` CRD) was never installed
- envoy-gateway (and its Gateway API CRDs, e.g. `TLSRoute`) was never installed
- the job used `values/dev/instance.yaml` (OpenShift-oriented) instead of the Kind-specific `values/dev/kind-instance.yaml` the Makefile actually uses for `PLATFORM=kind`, causing an unconditional OpenShift `Route` creation to fail

## Fix
- Removed `continue-on-error: true` from "Deploy charts" and "Test idempotency" -- real failures here should fail the job loudly, not report false-green.
- Refactored the job to call `make -C osac-installer install-infra` / `install-osac PLATFORM=kind PROFILE=dev NS=osac` directly -- the same real commands `fulfillment-service`'s and `osac-operator`'s jobs in this same workflow file already use successfully -- instead of a second, drift-prone reimplementation. Idempotency now re-invokes `install-osac` (a real `helm upgrade --install`) rather than a separately hand-copied command.

**Scope note:** an earlier version of this PR also included two chart-level fixes (an `osac-infra` trust-manager resource collision, and an `osac-aap` unconditional OpenShift-only Helm `lookup`) found while debugging intermediate states of this issue. Both were real bugs, but neither is actually required once the real root cause above is fixed: `values/dev/kind-infra.yaml` sets `trustManager.enabled=false` (so the colliding template never renders) and `values/dev/kind-instance.yaml`'s effective `clusterFulfillment.enabled` is `false` (matching `osac-aap`'s own chart default, so the `lookup` is never reached). Removed them from this PR to keep it scoped to what's actually needed -- confirmed via a real GitHub Actions run that the job still passes fully without them. The `osac-aap` lookup bug is still real and tracked separately as **OSAC-4637** for whoever wants to fix it independently.

## Verification
Verified via multiple real GitHub Actions runs on this branch (no local Kind/Docker/Helm available in my environment). Final run (workflow-only fix, no chart changes): https://github.com/osac-project/osac/actions/runs/33141777830
- cert-manager, trust-manager, envoy-gateway, osac-infra, and osac all show `STATUS: deployed` (genuine first installs: `Release "X" does not exist. Installing it now.`)
- the idempotency upgrade succeeds (`Release "osac" has been upgraded. Happy Helming!`)
- all 6 real pods come up `1/1 Running`, 0 restarts (confirmed via `kubectl get pods`, not just Helm's own report)
- zero `##[error]` lines in the job log

## Test plan
- [x] `helm install osac-infra` succeeds for real (Bundle CRD present, no resource collisions)
- [x] `continue-on-error: true` removed -- confirmed the job fails loudly when a real bug exists (observed across several intermediate runs on this branch)
- [x] `helm install osac` succeeds for real
- [x] `helm upgrade osac` (idempotency) succeeds for real
- [x] Full real GitHub Actions run passing end to end, pod-health verified, with no chart-level changes needed