### PR TITLE
OSAC-4573: Fix osac-metering release race between service and m360-adapter builds

### DIFF
--- a/.github/scripts/wait-for-ghcr-image.sh
+++ b/.github/scripts/wait-for-ghcr-image.sh
@@ -14,14 +14,33 @@ IMAGE_REPO="$1"
 TAG="$2"
 MAX_ATTEMPTS="${3:-30}"
 SLEEP_SECONDS="${4:-20}"
+
+# Reject values that could break or inject a workflow command into any echo
+# below -- every line in this script's output starts with one of these two
+# caller-controlled values, and GitHub Actions treats any log line starting
+# with "::" as a workflow command, not just ones this script intends as such.
+# Current callers only pass hardcoded repos and semver-validated tags, but
+# this script is written to be reusable.
+for value in "${IMAGE_REPO}" "${TAG}"; do
+  if [[ "${value}" == *$'\n'* || "${value}" == *$'\r'* || "${value}" == *"::"* ]]; then
+    echo "::error::Invalid argument '${value//$'\n'/\\n}' -- must not contain newlines or '::'"
+    exit 1
+  fi
+done
+
 REPO_PATH="${IMAGE_REPO#ghcr.io/}"
 
 for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
-  token="$(curl -sf "https://ghcr.io/token?scope=repository:${REPO_PATH}:pull" | jq -r '.token // empty')"
-  if [[ -n "${token}" ]] && curl -sf -o /dev/null \
-      -H "Authorization: Bearer ${token}" \
-      -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json" \
-      "https://ghcr.io/v2/${REPO_PATH}/manifests/${TAG}"; then
+  # Token fetch is inside the if condition (not a separate `token=$(...)`
+  # assignment) so a transient failure here is caught by the retry loop
+  # instead of tripping `set -e` and aborting the whole script on attempt 1.
+  if token="$(curl -sf --connect-timeout 5 --max-time 15 \
+        "https://ghcr.io/token?scope=repository:${REPO_PATH}:pull" | jq -r '.token // empty')" \
+      && [[ -n "${token}" ]] \
+      && curl -sf --connect-timeout 5 --max-time 15 -o /dev/null \
+        -H "Authorization: Bearer ${token}" \
+        -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json" \
+        "https://ghcr.io/v2/${REPO_PATH}/manifests/${TAG}"; then
     echo "Found ${IMAGE_REPO}:${TAG} (attempt ${attempt}/${MAX_ATTEMPTS})"
     exit 0
   fi
@@ -29,5 +48,5 @@ for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
   sleep "${SLEEP_SECONDS}"
 done
 
-echo "::error::${IMAGE_REPO}:${TAG} did not appear in GHCR within $((MAX_ATTEMPTS * SLEEP_SECONDS))s -- its build may have failed or is taking unusually long"
+echo "::error::${IMAGE_REPO}:${TAG} did not appear in GHCR within $((MAX_ATTEMPTS * SLEEP_SECONDS))s -- its build may have failed, the package may not be public (anonymous pull token would come back empty), or it's taking unusually long"
 exit 1

--- a/.github/scripts/wait-for-ghcr-image.sh
+++ b/.github/scripts/wait-for-ghcr-image.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Polls a GHCR image manifest until it exists (bounded retries). Used by
+# chart-publish jobs that depend on more than one sibling tag-triggered
+# image-build workflow completing for the same release tag -- those builds
+# run as fully independent GitHub Actions workflows with no cross-workflow
+# ordering, so whichever one finishes first must wait for the others rather
+# than assume they're already done.
+#
+# Usage: wait-for-ghcr-image.sh <image_repo> <tag> [max_attempts] [sleep_seconds]
+#   image_repo: e.g. ghcr.io/osac-project/metering-m360-adapter
+set -euo pipefail
+
+IMAGE_REPO="$1"
+TAG="$2"
+MAX_ATTEMPTS="${3:-30}"
+SLEEP_SECONDS="${4:-20}"
+REPO_PATH="${IMAGE_REPO#ghcr.io/}"
+
+for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
+  token="$(curl -sf "https://ghcr.io/token?scope=repository:${REPO_PATH}:pull" | jq -r '.token // empty')"
+  if [[ -n "${token}" ]] && curl -sf -o /dev/null \
+      -H "Authorization: Bearer ${token}" \
+      -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json" \
+      "https://ghcr.io/v2/${REPO_PATH}/manifests/${TAG}"; then
+    echo "Found ${IMAGE_REPO}:${TAG} (attempt ${attempt}/${MAX_ATTEMPTS})"
+    exit 0
+  fi
+  echo "Waiting for ${IMAGE_REPO}:${TAG} (attempt ${attempt}/${MAX_ATTEMPTS})..."
+  sleep "${SLEEP_SECONDS}"
+done
+
+echo "::error::${IMAGE_REPO}:${TAG} did not appear in GHCR within $((MAX_ATTEMPTS * SLEEP_SECONDS))s -- its build may have failed or is taking unusually long"
+exit 1

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -725,6 +725,14 @@ jobs:
       success() &&
       (github.event.workflow_run.name == 'Build metering-service image' ||
        github.event.workflow_run.name == 'Build metering-m360-adapter image')
+    # Both triggering workflows completing for the same tag queues two runs
+    # of this job. The steps below are idempotent either way (OCI pushes,
+    # gh release create/edit), but serialize them (don't cancel, just queue)
+    # so the second run isn't wastefully polling/packaging/pushing in
+    # parallel with the first.
+    concurrency:
+      group: publish-metering-chart-${{ github.event.workflow_run.head_branch }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -820,6 +828,10 @@ jobs:
       success() &&
       (github.event.workflow_run.name == 'Build metering-service image' ||
        github.event.workflow_run.name == 'Build metering-m360-adapter image')
+    # Same reasoning as publish-metering-chart's concurrency group above.
+    concurrency:
+      group: create-metering-release-${{ github.event.workflow_run.head_branch }}
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -21,7 +21,7 @@ on:
     # this workflow at all without each component's build workflow name also
     # present in this list (missed once for osac-aap, see OSAC-3511/#49 --
     # don't repeat that).
-    workflows: ["Container image", "Build container image", "Build execution environment", "Build bare-metal-fulfillment-operator image", "Build osac-csi-driver image", "Build metering-service image"]
+    workflows: ["Container image", "Build container image", "Build execution environment", "Build bare-metal-fulfillment-operator image", "Build osac-csi-driver image", "Build metering-service image", "Build metering-m360-adapter image"]
     types: [completed]
 
 env:
@@ -712,7 +712,19 @@ jobs:
   publish-metering-chart:
     name: Publish metering chart
     needs: guard
-    if: success() && github.event.workflow_run.name == 'Build metering-service image'
+    # osac-metering is the only component with more than one tag-triggered
+    # image-build workflow (metering-service, m360-adapter, echo-adapter --
+    # see build-metering-*-image.yaml, all on the same osac-metering/v* tag).
+    # They're fully independent workflows with no ordering between them, so
+    # this job can be triggered by either the service or the m360-adapter
+    # build completing -- whichever fires first waits for the other via the
+    # "Wait for sibling image builds" step below rather than assuming it's
+    # already done. echo-adapter's image isn't pinned at release time (its
+    # values.yaml block is commented out by default), so it doesn't gate this.
+    if: >
+      success() &&
+      (github.event.workflow_run.name == 'Build metering-service image' ||
+       github.event.workflow_run.name == 'Build metering-m360-adapter image')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -757,6 +769,18 @@ jobs:
           exit 1
         fi
 
+    - name: Wait for sibling image builds
+      # This job only got triggered by ONE of the two builds that matter for
+      # this chart's release completing -- wait for the other one's image to
+      # actually land in GHCR too before pinning both tags into values.yaml
+      # and packaging. 30 attempts * 20s = up to 10m, generous relative to a
+      # typical container build.
+      run: |
+        set -euo pipefail
+        VERSION="v${{ steps.version.outputs.version }}"
+        .github/scripts/wait-for-ghcr-image.sh "${REGISTRY}/osac-project/metering-service" "${VERSION}" 30 20
+        .github/scripts/wait-for-ghcr-image.sh "${REGISTRY}/osac-project/metering-m360-adapter" "${VERSION}" 30 20
+
     - name: Update image tags in values.yaml
       working-directory: osac-metering
       # sed exits 0 even when a pattern matches zero lines, so a future values.yaml
@@ -791,7 +815,11 @@ jobs:
     name: Create GitHub Release (osac-metering)
     runs-on: ubuntu-latest
     needs: [guard, publish-metering-chart]
-    if: success() && github.event.workflow_run.name == 'Build metering-service image'
+    # Same either/or gate as publish-metering-chart above -- see its comment.
+    if: >
+      success() &&
+      (github.event.workflow_run.name == 'Build metering-service image' ||
+       github.event.workflow_run.name == 'Build metering-m360-adapter image')
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary

`osac-metering` is the only component with more than one tag-triggered image-build workflow — `Build metering-service image`, `Build metering-m360-adapter image`, and `Build metering-echo-adapter image` all trigger independently on the same `osac-metering/v*` tag push.

`publish-charts.yaml`'s guard-job pattern (one `publish-*-chart` job per component, gated on that component's single build workflow completing) works for every other component because each has exactly one such build. It silently breaks for `osac-metering` (introduced in #596): `publish-metering-chart` only reacted to `Build metering-service image` completing, so it could package and push the chart pinning `m360Adapter.image.tag` to a version whose image hadn't been pushed to GHCR yet (or never would, if that independent build failed) — a race with no ordering guarantee between the two workflows.

## Fix

- Also trigger on `Build metering-m360-adapter image` completing — either workflow can now kick off the release.
- Add a "Wait for sibling image builds" step (new script `wait-for-ghcr-image.sh`, polls GHCR with retries) that confirms **both** `metering-service` and `metering-m360-adapter` images exist at the release tag before pinning either into `values.yaml` or packaging the chart.
- `echo-adapter` isn't included in the wait — its `values.yaml` image block is commented out by default and isn't pinned at release time.

Whichever build's completion triggers this job first now waits for the other rather than assuming it's already done. `create-metering-release`'s existing `gh release create || gh release edit` fallback already makes it safe for this job to potentially run twice (once per triggering workflow) — the second run just finds the chart already published.

## Test plan

- [x] `actionlint`/YAML validation on `publish-charts.yaml` — clean
- [x] `bash -n` on every modified `run:` block — clean
- [x] Ran `wait-for-ghcr-image.sh` locally against the real, already-published `ghcr.io/osac-project/metering-service:latest` and `ghcr.io/osac-project/metering-m360-adapter:latest` — both found successfully
- [x] Ran it against a nonexistent tag with a short retry window — correctly fails with a clear error after exhausting retries
- [ ] Exercise a real `osac-metering/vX.Y.Z` tag push to confirm both build-completion events correctly trigger the release and the chart ends up with both images pinned

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved chart release automation to support builds from multiple metering components.
  * Chart publishing now waits for all required container images before packaging and releasing charts.
  * Added automated verification for tagged container images with configurable retries, delays, and request timeouts.
  * Improved validation and failure reporting when image details are invalid or required images remain unavailable.
  * Same-tag chart releases are now serialized to prevent conflicting publishing runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->