### PR TITLE
feat: add Cost Management provider adapter

### DIFF
--- a/.github/workflows/build-metering-cost-management-adapter-image.yaml
+++ b/.github/workflows/build-metering-cost-management-adapter-image.yaml
@@ -1,0 +1,74 @@
+name: Build metering-cost-management-adapter image
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'osac-metering/adapters/**'
+      - 'osac-metering/schema/**'
+      - '!osac-metering/adapters/**/*.md'
+      - '!osac-metering/schema/**/*.md'
+  push:
+    branches:
+    - main
+    tags:
+    - 'osac-metering/v*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: osac-project/metering-cost-management-adapter
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compute release version
+        if: startsWith(github.ref, 'refs/tags/osac-metering/')
+        run: |
+          version="${GITHUB_REF_NAME#osac-metering/}"
+          semver_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?$'
+          if ! [[ "${version}" =~ ${semver_re} ]]; then
+            echo "::error::Tag '${GITHUB_REF_NAME}' is not a valid semver release tag"
+            exit 1
+          fi
+          core="${version%%-*}"
+          echo "RELEASE_VERSION=${version}" >> "$GITHUB_ENV"
+          echo "RELEASE_MAJOR_MINOR=${core%.*}" >> "$GITHUB_ENV"
+          echo "RELEASE_MAJOR=${core%%.*}" >> "$GITHUB_ENV"
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ env.RELEASE_VERSION }},enable=${{ env.RELEASE_VERSION != '' }}
+            type=raw,value=${{ env.RELEASE_MAJOR_MINOR }},enable=${{ env.RELEASE_VERSION != '' }}
+            type=raw,value=${{ env.RELEASE_MAJOR }},enable=${{ env.RELEASE_VERSION != '' }}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: osac-metering
+          file: osac-metering/adapters/Containerfile.cost-management-adapter
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/osac-metering/adapters/Containerfile.cost-management-adapter
+++ b/osac-metering/adapters/Containerfile.cost-management-adapter
@@ -1,0 +1,18 @@
+FROM registry.access.redhat.com/ubi10/go-toolset:1.26 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /opt/app-root/src
+COPY --chown=1001:0 schema/ schema/
+COPY --chown=1001:0 adapters/go.mod adapters/go.sum adapters/
+RUN cd adapters && go mod download
+
+COPY --chown=1001:0 adapters/ adapters/
+
+RUN cd adapters && CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -buildvcs=false -a -o /opt/app-root/src/cost-management-adapter ./cmd/cost-management-adapter
+
+FROM registry.access.redhat.com/ubi10-minimal:10.2
+WORKDIR /
+COPY --from=builder /opt/app-root/src/cost-management-adapter .
+USER 65532:65532
+ENTRYPOINT ["/cost-management-adapter"]

--- a/osac-metering/adapters/Makefile
+++ b/osac-metering/adapters/Makefile
@@ -11,9 +11,9 @@ GINKGO ?= go run github.com/onsi/ginkgo/v2/ginkgo
 
 include $(shell git rev-parse --show-toplevel)/tools/golangci-lint.mk
 
-.PHONY: all build-echo-adapter build-m360-adapter test lint clean
+.PHONY: all build-echo-adapter build-m360-adapter build-cost-management-adapter test lint clean
 
-all: build-echo-adapter build-m360-adapter
+all: build-echo-adapter build-m360-adapter build-cost-management-adapter
 
 build-echo-adapter:
 	@mkdir -p bin
@@ -22,6 +22,10 @@ build-echo-adapter:
 build-m360-adapter:
 	@mkdir -p bin
 	go build -o bin/m360-adapter ./cmd/m360-adapter
+
+build-cost-management-adapter:
+	@mkdir -p bin
+	go build -o bin/cost-management-adapter ./cmd/cost-management-adapter
 
 test:
 	$(GINKGO) run -r .

--- a/osac-metering/adapters/cmd/cost-management-adapter/adapter.go
+++ b/osac-metering/adapters/cmd/cost-management-adapter/adapter.go
@@ -1,0 +1,192 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+
+	"github.com/osac-project/osac-metering/adapters"
+	"github.com/osac-project/osac-metering/schema"
+)
+
+const (
+	maxBatchEvents            = 100
+	maxBatchBytes             = 1 << 20
+	resourceTypeMaaSInference = "maas_inference"
+)
+
+type bufferedEvent struct {
+	encoded json.RawMessage
+}
+
+type costManagementAdapter struct {
+	client *costManagementClient
+
+	mu      sync.Mutex
+	flushMu sync.Mutex
+	pending []bufferedEvent
+}
+
+func newCostManagementAdapter(client *costManagementClient) *costManagementAdapter {
+	return &costManagementAdapter{client: client}
+}
+
+func (a *costManagementAdapter) Name() string { return "cost-management" }
+
+// Submit performs deterministic validation before retaining the structured
+// CloudEvent. A validation error is deliberately non-retryable: the Runner
+// can route exactly that Kafka record to its DLQ.
+func (a *costManagementAdapter) Submit(_ context.Context, event adapters.MeteringEvent) error {
+	if err := validateCloudEvent(event.CloudEvent); err != nil {
+		return &adapters.NonRetryableError{Err: err}
+	}
+	encoded, err := json.Marshal(event.CloudEvent)
+	if err != nil {
+		return &adapters.NonRetryableError{Err: fmt.Errorf("marshal CloudEvent: %w", err)}
+	}
+	// A valid single event must fit inside the Cost contract once JSON envelope
+	// bytes are included. It could never be delivered in a valid batch.
+	if len(encoded)+len(`{"events":[]}`) > maxBatchBytes {
+		return &adapters.NonRetryableError{Err: fmt.Errorf("CloudEvent exceeds %d-byte batch limit", maxBatchBytes)}
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.pending = append(a.pending, bufferedEvent{encoded: encoded})
+	return nil
+}
+
+func (a *costManagementAdapter) Flush(ctx context.Context) (adapters.SubmitResult, error) {
+	a.flushMu.Lock()
+	defer a.flushMu.Unlock()
+
+	for {
+		a.mu.Lock()
+		batch := nextBatch(a.pending)
+		a.mu.Unlock()
+		if len(batch) == 0 {
+			return adapters.SubmitResult{Idempotent: true}, nil
+		}
+
+		payload, err := marshalBatch(batch)
+		if err != nil {
+			return adapters.SubmitResult{}, fmt.Errorf("marshal Cost Management batch: %w", err)
+		}
+		if err := a.client.postBatch(ctx, payload); err != nil {
+			// Keep every buffered record. The receiver's receipt ledger makes a
+			// replay after a partial network failure safe.
+			return adapters.SubmitResult{}, err
+		}
+
+		a.mu.Lock()
+		// Flush is serialized and Submit appends only, so the accepted batch is
+		// always the current prefix even while new events arrive.
+		a.pending = a.pending[len(batch):]
+		a.mu.Unlock()
+	}
+}
+
+func (a *costManagementAdapter) HealthCheck(ctx context.Context) error {
+	return a.client.healthCheck(ctx)
+}
+
+func (a *costManagementAdapter) Close() error { return nil }
+
+func (a *costManagementAdapter) pendingCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.pending)
+}
+
+func nextBatch(pending []bufferedEvent) []bufferedEvent {
+	if len(pending) == 0 {
+		return nil
+	}
+	// The empty batch is {"events":[]}; each member contributes its encoded
+	// bytes plus a comma except the first member.
+	size := len(`{"events":[]}`)
+	batch := make([]bufferedEvent, 0, min(len(pending), maxBatchEvents))
+	for _, event := range pending {
+		additional := len(event.encoded)
+		if len(batch) > 0 {
+			additional++
+		}
+		if len(batch) == maxBatchEvents || size+additional > maxBatchBytes {
+			break
+		}
+		size += additional
+		batch = append(batch, event)
+	}
+	return batch
+}
+
+func validateCloudEvent(ce cloudevents.Event) error {
+	if ce.SpecVersion() != "1.0" {
+		return fmt.Errorf("CloudEvent must use specversion 1.0")
+	}
+	if ce.ID() == "" || ce.Type() == "" || ce.Source() == "" || ce.Time().IsZero() {
+		return errors.New("CloudEvent must include id, type, source, and time")
+	}
+	if ce.DataContentType() != "application/json" {
+		return fmt.Errorf("CloudEvent datacontenttype must be application/json")
+	}
+
+	var data struct {
+		ResourceID     string `json:"resource_id"`
+		ResourceType   string `json:"resource_type"`
+		TenantID       string `json:"tenant_id"`
+		TransitionTime string `json:"transition_time"`
+		SchemaVersion  string `json:"schema_version"`
+	}
+	if err := json.Unmarshal(ce.Data(), &data); err != nil {
+		return fmt.Errorf("CloudEvent data must be JSON: %w", err)
+	}
+	if data.ResourceID == "" || data.ResourceType == "" || data.TenantID == "" ||
+		data.TransitionTime == "" || data.SchemaVersion == "" {
+		return errors.New("CloudEvent data is missing required canonical identity or lifecycle fields")
+	}
+	if _, err := time.Parse(time.RFC3339, data.TransitionTime); err != nil {
+		return fmt.Errorf("CloudEvent transition_time must be RFC3339: %w", err)
+	}
+	if data.SchemaVersion != schema.SchemaVersion {
+		return fmt.Errorf("unsupported schema_version %q", data.SchemaVersion)
+	}
+	if !isSupportedResourceType(data.ResourceType) {
+		return fmt.Errorf("unsupported resource_type %q", data.ResourceType)
+	}
+	if extensionString(ce, schema.ExtResourceID) != data.ResourceID ||
+		extensionString(ce, schema.ExtResourceType) != data.ResourceType ||
+		extensionString(ce, schema.ExtTenant) != data.TenantID {
+		return errors.New("CloudEvent OSAC identity extensions must match payload identity")
+	}
+	return nil
+}
+
+func extensionString(ce cloudevents.Event, key string) string {
+	value, ok := ce.Extensions()[key]
+	if !ok {
+		return ""
+	}
+	valueString, _ := value.(string)
+	return valueString
+}
+
+func isSupportedResourceType(resourceType string) bool {
+	return resourceType == schema.ResourceTypeComputeInstance ||
+		resourceType == schema.ResourceTypeClusterOrder ||
+		resourceType == resourceTypeMaaSInference
+}

--- a/osac-metering/adapters/cmd/cost-management-adapter/adapter_test.go
+++ b/osac-metering/adapters/cmd/cost-management-adapter/adapter_test.go
@@ -1,0 +1,249 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/osac-project/osac-metering/adapters"
+	"github.com/osac-project/osac-metering/schema"
+)
+
+func canonicalEvent(id, resourceID, resourceType string) cloudevents.Event {
+	ce := cloudevents.NewEvent()
+	ce.SetSpecVersion("1.0")
+	ce.SetID(id)
+	ce.SetType("osac.resource.lifecycle.v1")
+	ce.SetSource("osac-metering-service")
+	ce.SetSubject(resourceType + "/" + resourceID)
+	ce.SetTime(time.Date(2026, 8, 28, 10, 0, 0, 0, time.UTC))
+	ce.SetDataContentType(cloudevents.ApplicationJSON)
+	ce.SetExtension(schema.ExtResourceID, resourceID)
+	ce.SetExtension(schema.ExtResourceType, resourceType)
+	ce.SetExtension(schema.ExtTenant, "tenant-acme")
+	ExpectWithOffset(1, ce.SetData(cloudevents.ApplicationJSON, map[string]any{
+		"resource_id":     resourceID,
+		"resource_type":   resourceType,
+		"tenant_id":       "tenant-acme",
+		"current_state":   "running",
+		"transition_time": "2026-08-28T10:00:00Z",
+		"schema_version":  "v1",
+	})).To(Succeed())
+	return ce
+}
+
+func adapterEvent(id, resourceID, resourceType string) adapters.MeteringEvent {
+	return adapters.MeteringEvent{CloudEvent: canonicalEvent(id, resourceID, resourceType)}
+}
+
+var _ = Describe("costManagementAdapter", func() {
+	Describe("configuration", func() {
+		It("accepts absolute HTTP(S) endpoint URLs and rejects unsafe values", func() {
+			Expect(validateCostManagementURL("https://cost.example.test")).To(Succeed())
+			Expect(validateCostManagementURL("http://cost.example.test/api")).To(Succeed())
+			Expect(validateCostManagementURL("cost.example.test")).NotTo(Succeed())
+			Expect(validateCostManagementURL("ftp://cost.example.test")).NotTo(Succeed())
+		})
+	})
+
+	Describe("Submit", func() {
+		It("buffers canonical VMaaS, CaaS, and MaaS CloudEvents unchanged", func() {
+			adapter := newCostManagementAdapter(newCostManagementClient("https://cost.example.test", "token"))
+			for _, event := range []adapters.MeteringEvent{
+				adapterEvent("vm-1", "vm-1", schema.ResourceTypeComputeInstance),
+				adapterEvent("cluster-1", "cluster-1", schema.ResourceTypeClusterOrder),
+				adapterEvent("inference-1", "request-1", resourceTypeMaaSInference),
+			} {
+				Expect(adapter.Submit(context.Background(), event)).To(Succeed())
+			}
+
+			Expect(adapter.pendingCount()).To(Equal(3))
+		})
+
+		It("returns a non-retryable error for a malformed CloudEvent before buffering", func() {
+			adapter := newCostManagementAdapter(newCostManagementClient("https://cost.example.test", "token"))
+			event := adapterEvent("bad-1", "vm-1", schema.ResourceTypeComputeInstance)
+			event.CloudEvent.SetExtension(schema.ExtResourceID, "other-resource")
+
+			err := adapter.Submit(context.Background(), event)
+
+			var nonRetryable *adapters.NonRetryableError
+			Expect(errors.As(err, &nonRetryable)).To(BeTrue())
+			Expect(adapter.pendingCount()).To(BeZero())
+		})
+
+		It("returns a non-retryable error when one event cannot fit in a Cost batch", func() {
+			adapter := newCostManagementAdapter(newCostManagementClient("https://cost.example.test", "token"))
+			event := adapterEvent("too-large", "vm-1", schema.ResourceTypeComputeInstance)
+			Expect(event.CloudEvent.SetData(cloudevents.ApplicationJSON, map[string]any{
+				"resource_id":     "vm-1",
+				"resource_type":   schema.ResourceTypeComputeInstance,
+				"tenant_id":       "tenant-acme",
+				"current_state":   "running",
+				"transition_time": "2026-08-28T10:00:00Z",
+				"schema_version":  "v1",
+				"padding":         strings.Repeat("x", maxBatchBytes),
+			})).To(Succeed())
+
+			err := adapter.Submit(context.Background(), event)
+
+			var nonRetryable *adapters.NonRetryableError
+			Expect(errors.As(err, &nonRetryable)).To(BeTrue())
+			Expect(adapter.pendingCount()).To(BeZero())
+		})
+	})
+
+	Describe("Flush", func() {
+		var (
+			server       *httptest.Server
+			adapter      *costManagementAdapter
+			capturedBody []byte
+			capturedAuth string
+			mu           sync.Mutex
+		)
+
+		AfterEach(func() {
+			if server != nil {
+				server.Close()
+			}
+		})
+
+		It("posts a batch to the Cost endpoint with bearer authentication and preserves structured CloudEvents", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.Method).To(Equal(http.MethodPost))
+				Expect(r.URL.Path).To(Equal(costBatchPath))
+				mu.Lock()
+				capturedAuth = r.Header.Get("Authorization")
+				capturedBody, _ = io.ReadAll(r.Body)
+				mu.Unlock()
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			adapter = newCostManagementAdapter(newCostManagementClient(server.URL, "cost-token"))
+			for _, event := range []adapters.MeteringEvent{
+				adapterEvent("vm-1", "vm-1", schema.ResourceTypeComputeInstance),
+				adapterEvent("cluster-1", "cluster-1", schema.ResourceTypeClusterOrder),
+				adapterEvent("inference-1", "request-1", resourceTypeMaaSInference),
+			} {
+				Expect(adapter.Submit(context.Background(), event)).To(Succeed())
+			}
+
+			_, err := adapter.Flush(context.Background())
+
+			Expect(err).NotTo(HaveOccurred())
+			mu.Lock()
+			defer mu.Unlock()
+			Expect(capturedAuth).To(Equal("Bearer cost-token"))
+			var batch batchRequest
+			Expect(json.Unmarshal(capturedBody, &batch)).To(Succeed())
+			Expect(batch.Events).To(HaveLen(3))
+			Expect(batch.Events[0].ID()).To(Equal("vm-1"))
+			Expect(batch.Events[1].Extensions()[schema.ExtResourceType]).To(Equal(schema.ResourceTypeClusterOrder))
+			Expect(batch.Events[2].Extensions()[schema.ExtResourceType]).To(Equal(resourceTypeMaaSInference))
+			Expect(adapter.pendingCount()).To(BeZero())
+		})
+
+		It("retains its batch after retryable receiver failures", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+			}))
+			adapter = newCostManagementAdapter(newCostManagementClient(server.URL, "cost-token"))
+			Expect(adapter.Submit(context.Background(), adapterEvent("vm-1", "vm-1", schema.ResourceTypeComputeInstance))).To(Succeed())
+
+			_, err := adapter.Flush(context.Background())
+
+			Expect(err).To(HaveOccurred())
+			Expect(adapter.pendingCount()).To(Equal(1))
+		})
+
+		It("retains its batch after 429", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusTooManyRequests)
+			}))
+			adapter = newCostManagementAdapter(newCostManagementClient(server.URL, "cost-token"))
+			Expect(adapter.Submit(context.Background(), adapterEvent("vm-1", "vm-1", schema.ResourceTypeComputeInstance))).To(Succeed())
+
+			_, err := adapter.Flush(context.Background())
+
+			Expect(err).To(HaveOccurred())
+			Expect(adapter.pendingCount()).To(Equal(1))
+		})
+
+		It("retains its batch for receiver 4xx because a batch response cannot identify a poison event", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+			}))
+			adapter = newCostManagementAdapter(newCostManagementClient(server.URL, "cost-token"))
+			Expect(adapter.Submit(context.Background(), adapterEvent("vm-1", "vm-1", schema.ResourceTypeComputeInstance))).To(Succeed())
+
+			_, err := adapter.Flush(context.Background())
+
+			Expect(err).To(HaveOccurred())
+			Expect(adapter.pendingCount()).To(Equal(1))
+		})
+
+		It("splits batches at 100 events", func() {
+			var requests int
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requests++
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			adapter = newCostManagementAdapter(newCostManagementClient(server.URL, "cost-token"))
+			for i := range maxBatchEvents + 1 {
+				Expect(adapter.Submit(context.Background(), adapterEvent(fmt.Sprintf("event-%d", i), fmt.Sprintf("vm-%d", i), schema.ResourceTypeComputeInstance))).To(Succeed())
+			}
+
+			_, err := adapter.Flush(context.Background())
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(requests).To(Equal(2))
+			Expect(adapter.pendingCount()).To(BeZero())
+		})
+
+		It("splits batches before the one-mebibyte request limit", func() {
+			var requests int
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requests++
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			adapter = newCostManagementAdapter(newCostManagementClient(server.URL, "cost-token"))
+			for i := range 2 {
+				event := adapterEvent(fmt.Sprintf("large-%d", i), fmt.Sprintf("vm-%d", i), schema.ResourceTypeComputeInstance)
+				Expect(event.CloudEvent.SetData(cloudevents.ApplicationJSON, map[string]any{
+					"resource_id":     fmt.Sprintf("vm-%d", i),
+					"resource_type":   schema.ResourceTypeComputeInstance,
+					"tenant_id":       "tenant-acme",
+					"current_state":   "running",
+					"transition_time": "2026-08-28T10:00:00Z",
+					"schema_version":  "v1",
+					"padding":         strings.Repeat("x", maxBatchBytes/2),
+				})).To(Succeed())
+				Expect(adapter.Submit(context.Background(), event)).To(Succeed())
+			}
+
+			_, err := adapter.Flush(context.Background())
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(requests).To(Equal(2))
+		})
+	})
+})

--- a/osac-metering/adapters/cmd/cost-management-adapter/client.go
+++ b/osac-metering/adapters/cmd/cost-management-adapter/client.go
@@ -1,0 +1,116 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+)
+
+const (
+	costBatchPath    = "/api/v1/events/batch"
+	costHTTPTimeout  = 30 * time.Second
+	maxResponseBytes = 256
+)
+
+// batchRequest is the Cost Management batch ingestion contract. Events stay
+// in CloudEvents structured form; no provider-specific mapping is performed.
+type batchRequest struct {
+	Events []cloudevents.Event `json:"events"`
+}
+
+type costManagementClient struct {
+	httpClient *http.Client
+	batchURL   string
+	token      string
+	baseURL    string
+}
+
+func newCostManagementClient(baseURL, token string) *costManagementClient {
+	return &costManagementClient{
+		httpClient: &http.Client{Timeout: costHTTPTimeout},
+		batchURL:   strings.TrimRight(baseURL, "/") + costBatchPath,
+		token:      token,
+		baseURL:    strings.TrimRight(baseURL, "/"),
+	}
+}
+
+func validateCostManagementURL(rawURL string) error {
+	parsed, err := url.ParseRequestURI(rawURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("COST_MANAGEMENT_API_URL must be an absolute HTTP(S) URL")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("COST_MANAGEMENT_API_URL must use http or https")
+	}
+	return nil
+}
+
+// postBatch returns only retryable errors. Receiver 4xx values are retained
+// for operator correction because a batch response has no per-event attribution
+// that would make DLQ routing safe.
+func (c *costManagementClient) postBatch(ctx context.Context, payload []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.batchURL, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("create Cost Management batch request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("cost management batch request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if readErr != nil {
+		body = []byte("[response body unreadable]")
+	}
+	return fmt.Errorf("cost management batch endpoint returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+}
+
+func (c *costManagementClient) healthCheck(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, c.baseURL, nil)
+	if err != nil {
+		return fmt.Errorf("create Cost Management health check request: %w", err)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("cost management health check: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return nil
+}
+
+func marshalBatch(events []bufferedEvent) ([]byte, error) {
+	rawEvents := make([]json.RawMessage, len(events))
+	for i := range events {
+		rawEvents[i] = events[i].encoded
+	}
+	return json.Marshal(struct {
+		Events []json.RawMessage `json:"events"`
+	}{Events: rawEvents})
+}

--- a/osac-metering/adapters/cmd/cost-management-adapter/cost_management_adapter_suite_test.go
+++ b/osac-metering/adapters/cmd/cost-management-adapter/cost_management_adapter_suite_test.go
@@ -1,0 +1,22 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCostManagementAdapter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cost Management Adapter Suite")
+}

--- a/osac-metering/adapters/cmd/cost-management-adapter/main.go
+++ b/osac-metering/adapters/cmd/cost-management-adapter/main.go
@@ -1,0 +1,119 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+// cost-management-adapter consumes canonical OSAC CloudEvents from Kafka and
+// batches them to Cost Management's durable ingress endpoint.
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/go-logr/stdr"
+	"github.com/osac-project/osac-metering/adapters"
+	"github.com/osac-project/osac-metering/adapters/envutil"
+)
+
+func main() {
+	brokers := envutil.RequireEnv("KAFKA_BROKERS")
+	costURL := envutil.RequireEnv("COST_MANAGEMENT_API_URL")
+	if err := validateCostManagementURL(costURL); err != nil {
+		log.Fatal(err)
+	}
+	tokenFile := envutil.RequireEnv("COST_MANAGEMENT_API_TOKEN_FILE")
+	token := envutil.ReadFileOrFatal(tokenFile)
+
+	topics := adapters.AllTopics
+	if v := os.Getenv("KAFKA_TOPICS"); v != "" {
+		topics = envutil.SplitAndTrim(v, ",")
+		if len(topics) == 0 {
+			log.Fatal("KAFKA_TOPICS must contain at least one topic")
+		}
+	}
+	group := envutil.EnvOrDefault("KAFKA_CONSUMER_GROUP", "cost-management-adapter")
+	metricsAddr := envutil.EnvOrDefault("METRICS_ADDR", ":2112")
+
+	var flushInterval time.Duration
+	if v := os.Getenv("FLUSH_INTERVAL"); v != "" {
+		var err error
+		flushInterval, err = time.ParseDuration(v)
+		if err != nil || flushInterval < 0 {
+			log.Fatalf("invalid FLUSH_INTERVAL %q", v)
+		}
+	}
+
+	logger := stdr.New(log.New(os.Stderr, "", log.LstdFlags))
+	kafkaCfg := adapters.KafkaConfigFromEnv()
+	dlqOpt, dlqClose, err := adapters.DLQOptionFromEnv(brokers, kafkaCfg)
+	if err != nil {
+		log.Fatalf("setting up DLQ: %v", err)
+	}
+	defer func() {
+		if err := dlqClose(); err != nil {
+			log.Printf("DLQ producer close failed: %v", err)
+		}
+	}()
+
+	var opts []adapters.RunnerOption
+	if dlqOpt != nil {
+		opts = append(opts, dlqOpt)
+	}
+	adapter := newCostManagementAdapter(newCostManagementClient(costURL, token))
+	runner := adapters.NewRunner(adapter, adapters.RunnerConfig{
+		Brokers:       brokers,
+		ConsumerGroup: group,
+		Topics:        topics,
+		FlushInterval: flushInterval,
+		Kafka:         kafkaCfg,
+	}, logger, opts...)
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", runner.MetricsHandler())
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		if err := adapter.HealthCheck(r.Context()); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	server := &http.Server{
+		Addr:              metricsAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+	go func() {
+		log.Print("HTTP server listening")
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("metrics server error: %v", err)
+		}
+	}()
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+	log.Printf("starting Cost Management adapter: topics=%v group=%s flush=%s", topics, group, flushInterval)
+	runErr := runner.Run(ctx)
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer shutdownCancel()
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		log.Printf("metrics server shutdown error: %v", err)
+	}
+	if runErr != nil {
+		log.Fatalf("runner error: %v", runErr)
+	}
+}

--- a/osac-metering/adapters/docs/cost-management-adapter.md
+++ b/osac-metering/adapters/docs/cost-management-adapter.md
@@ -1,0 +1,45 @@
+# Cost Management adapter contract
+
+## Purpose
+
+The Cost Management adapter is the only Cost-side Kafka consumer. The
+`adapters.Runner` owns consumer-group offsets, retry, ordering checks, and DLQ
+publishing. The adapter only validates canonical structured CloudEvents, buffers
+them, and sends them to Cost Management.
+
+## Ingress contract
+
+`Flush` POSTs JSON to `COST_MANAGEMENT_API_URL/api/v1/events/batch`:
+
+```json
+{"events":[{"specversion":"1.0","id":"...","type":"...","source":"...","data":{...}}]}
+```
+
+Events remain canonical CloudEvents; there is no M360-style translation. Each
+request contains at most 100 events and is no larger than 1 MiB. Cost returns
+`204 No Content` only after the whole batch is durably and atomically processed.
+Cost's receipt ledger makes a replay of an accepted batch a no-op.
+
+The adapter needs `COST_MANAGEMENT_API_TOKEN_FILE`, a mounted Secret file. It
+sets a bearer authorization header and neither logs the token nor puts it in a
+Kubernetes environment value.
+
+## Failure semantics
+
+Before buffering, `Submit` requires CloudEvents 1.0 with `id`, `type`,
+`source`, `time`, JSON data, supported VMaaS/CaaS/MaaS resource types, and
+matching `osacresourceid`, `osacresourcetype`, and `osactenant` extensions.
+These deterministic malformed records return `NonRetryableError`, so the Runner
+routes their original Kafka records to DLQ.
+
+Timeouts, 429, 5xx, 401/403, and unexpected 400/413 leave the entire batch in
+memory and return an error. The Runner consequently does not commit offsets;
+the next delivery is safe because Cost's receipt ledger is idempotent. A batch
+response cannot safely attribute a 4xx to one record, so this increment never
+DLQs an entire failed batch. Contract-valid input should not receive a 400.
+
+Known framework limitation: the Runner currently adds its short-lived dedup
+entry after `Submit`, before a buffered `Flush` reaches durable Cost storage.
+This adapter therefore depends on no consumer-session rebalance between a failed
+flush and redelivery; the framework must move dedup acknowledgement to durable
+flush success before this can be treated as a complete delivery guarantee.

--- a/osac-metering/adapters/docs/runner-preflush-dedup-follow-up.md
+++ b/osac-metering/adapters/docs/runner-preflush-dedup-follow-up.md
@@ -1,0 +1,68 @@
+# Provider Adapter Runner: pre-flush deduplication follow-up
+
+## Scope
+
+This is a follow-up for the shared Provider Adapter `Runner`, not part of the
+Cost Management adapter implementation. Any adapter that buffers events in
+`Submit` and acknowledges them later from `Flush` can encounter this issue.
+
+## Current behaviour
+
+For a successfully submitted Kafka message, the Runner currently:
+
+1. adds the CloudEvent ID to its in-memory deduplication cache;
+2. records the Kafka offset as eligible to commit; and
+3. defers the actual Kafka commit until a later successful `Flush`.
+
+The completed-deduplication state is therefore recorded before the provider
+has acknowledged durable receipt.
+
+## Failure sequence
+
+1. Event `E` is accepted by `Submit` and buffered by an adapter.
+2. The Runner adds `E` to the completed deduplication cache.
+3. The provider call from `Flush` fails, so no offset is committed.
+4. A consumer-group rebalance redelivers `E` to the same long-running Runner.
+5. The Runner finds `E` in the cache, suppresses it, and records its offset.
+6. A later successful flush commits the offset even though `E` was never
+   acknowledged by the provider.
+
+This is a potential event loss / under-billing failure. A full process restart
+usually masks it because the in-memory cache is cleared; a rebalance without a
+process restart does not.
+
+## Required framework change
+
+Model delivery state explicitly:
+
+```text
+received -> pending delivery -> provider acknowledged -> deduplicated and offset-committable
+```
+
+- Only mark an event completed in the deduplication cache after its provider
+  delivery succeeds.
+- Retain failed-flush events as pending. A redelivery while an event is pending
+  must not be mistaken for a successfully delivered duplicate.
+- Track acknowledgement per topic/partition and commit only the contiguous
+  prefix of successfully delivered offsets.
+- Extend the flush acknowledgement contract if needed so a batching adapter can
+  report the exact successfully delivered event set; a multi-chunk flush may
+  partially succeed.
+
+## Cost adapter implications
+
+The Cost adapter intentionally retains its unchanged batch for retry after
+timeouts, `429`, `5xx`, and unexpected batch-level `4xx` responses. The Cost
+receiver's durable receipt ledger makes retry after an ambiguous request safe.
+It cannot prevent the Runner from suppressing a Kafka redelivery before any
+successful `Flush`, so this shared framework follow-up is required before
+production billing use.
+
+## Suggested tests
+
+- Buffered event, failed flush, same-process rebalance/redelivery, later flush:
+  verify the original event is delivered and its offset is not skipped.
+- Mixed partitions: verify an unresolved earlier offset prevents committing a
+  later offset in the same partition.
+- Multi-chunk flush with one successful and one failed chunk: verify only
+  durably acknowledged events become deduplicated/committable.

--- a/osac-metering/adapters/scripts/cost-management-adapter-gauntlet.sh
+++ b/osac-metering/adapters/scripts/cost-management-adapter-gauntlet.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Exercising the Cost adapter's delivery boundary: unit contract, race safety,
+# build, and enabled Helm render. Run from any directory in the repository.
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+adapters_dir="$(cd -- "${script_dir}/.." && pwd)"
+metering_dir="$(cd -- "${adapters_dir}/.." && pwd)"
+
+cd "${adapters_dir}"
+go test ./cmd/cost-management-adapter
+go test -race ./cmd/cost-management-adapter
+make build-cost-management-adapter
+
+cd "${metering_dir}"
+make helm-lint
+helm template osac-metering charts/osac-metering \
+  --set costManagementAdapter.enabled=true \
+  --set costManagementAdapter.costManagement.apiUrl=https://cost.example.test \
+  --set costManagementAdapter.costManagement.apiTokenSecret=cost-api-token \
+  >/dev/null

--- a/osac-metering/charts/osac-metering/templates/cost-management-adapter-deployment.yaml
+++ b/osac-metering/charts/osac-metering/templates/cost-management-adapter-deployment.yaml
@@ -1,0 +1,155 @@
+{{- if .Values.costManagementAdapter.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "osac-metering.fullname" . }}-cost-management-adapter
+  labels:
+    {{- include "osac-metering.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cost-management-adapter
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "osac-metering.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: cost-management-adapter
+  template:
+    metadata:
+      labels:
+        {{- include "osac-metering.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: cost-management-adapter
+    spec:
+      serviceAccountName: {{ include "osac-metering.fullname" . }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: kafka-secrets
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Mi
+        - name: cost-management-api-token
+          secret:
+            secretName: {{ required "costManagementAdapter.costManagement.apiTokenSecret is required when costManagementAdapter is enabled" .Values.costManagementAdapter.costManagement.apiTokenSecret }}
+        - name: tmp
+          emptyDir:
+            sizeLimit: 10Mi
+      initContainers:
+        - name: fetch-kafka-secrets
+          image: {{ .Values.cliImage | default "quay.io/openshift/origin-cli:4.20.0" }}
+          env:
+            - name: HOME
+              value: /tmp
+            - name: SOURCE_NS
+              value: {{ include "osac-metering.kafkaClusterNamespace" . }}
+            - name: SASL_SECRET
+              value: osac-metering-cost-management-adapter
+            - name: CA_SECRET
+              value: {{ include "osac-metering.kafkaCaSecret" . }}
+          volumeMounts:
+            - name: kafka-secrets
+              mountPath: /etc/kafka-secrets
+            - name: tmp
+              mountPath: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          command:
+            - /bin/bash
+            - -euo
+            - pipefail
+            - -c
+            - |
+              DEADLINE=$((SECONDS + 300))
+              wait_for_secret() {
+                local name=$1 ns=$2
+                echo "Waiting for secret ${name} in ${ns} (timeout 5m)..."
+                until oc get secret "${name}" -n "${ns}" > /dev/null 2>&1; do
+                  if [ $SECONDS -ge $DEADLINE ]; then
+                    echo "Timed out waiting for secret ${name} in ${ns}"
+                    exit 1
+                  fi
+                  sleep 5
+                done
+              }
+              wait_for_secret "${SASL_SECRET}" "${SOURCE_NS}"
+              wait_for_secret "${CA_SECRET}" "${SOURCE_NS}"
+              oc get secret "${SASL_SECRET}" -n "${SOURCE_NS}" -o jsonpath='{.data.password}' | base64 -d > /etc/kafka-secrets/password
+              oc get secret "${CA_SECRET}" -n "${SOURCE_NS}" -o jsonpath='{.data.ca\.crt}' | base64 -d > /etc/kafka-secrets/ca.crt
+      containers:
+        - name: cost-management-adapter
+          image: "{{ required "costManagementAdapter.image.repository is required when costManagementAdapter is enabled" .Values.costManagementAdapter.image.repository }}:{{ required "costManagementAdapter.image.tag is required when costManagementAdapter is enabled" .Values.costManagementAdapter.image.tag }}"
+          imagePullPolicy: {{ .Values.costManagementAdapter.image.pullPolicy | default "Always" }}
+          env:
+            - name: KAFKA_BROKERS
+              value: {{ include "osac-metering.kafkaBrokers" . | quote }}
+            - name: KAFKA_TLS_ENABLED
+              value: "true"
+            - name: KAFKA_TLS_CA_CERT
+              value: /etc/kafka-secrets/ca.crt
+            - name: KAFKA_SASL_USERNAME
+              value: osac-metering-cost-management-adapter
+            - name: KAFKA_CONSUMER_GROUP
+              value: osac-metering-cost-management-adapter
+            - name: KAFKA_SASL_PASSWORD_FILE
+              value: /etc/kafka-secrets/password
+            - name: COST_MANAGEMENT_API_URL
+              value: {{ required "costManagementAdapter.costManagement.apiUrl is required when costManagementAdapter is enabled" .Values.costManagementAdapter.costManagement.apiUrl | quote }}
+            - name: COST_MANAGEMENT_API_TOKEN_FILE
+              value: /etc/cost-management/api-token
+            - name: DLQ_TOPIC
+              value: "osac.metering.dlq"
+            - name: DLQ_ENABLED
+              value: "true"
+            - name: METRICS_ADDR
+              value: ":8080"
+          volumeMounts:
+            - name: kafka-secrets
+              mountPath: /etc/kafka-secrets
+              readOnly: true
+            - name: cost-management-api-token
+              mountPath: /etc/cost-management
+              readOnly: true
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+{{- end }}

--- a/osac-metering/charts/osac-metering/templates/cost-management-adapter-kafka-user.yaml
+++ b/osac-metering/charts/osac-metering/templates/cost-management-adapter-kafka-user.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.costManagementAdapter.enabled }}
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaUser
+metadata:
+  name: osac-metering-cost-management-adapter
+  namespace: {{ include "osac-metering.kafkaClusterNamespace" . }}
+  labels:
+    strimzi.io/cluster: {{ include "osac-metering.kafkaClusterName" . }}
+spec:
+  authentication:
+    type: scram-sha-512
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: osac.metering.
+          patternType: prefix
+        operations:
+          - Read
+          - Describe
+        host: "*"
+      - resource:
+          type: topic
+          name: osac.metering.dlq
+          patternType: literal
+        operations:
+          - Write
+        host: "*"
+      - resource:
+          type: cluster
+          name: kafka-cluster
+          patternType: literal
+        operations:
+          - IdempotentWrite
+        host: "*"
+      - resource:
+          type: group
+          name: osac-metering-cost-management-adapter
+          patternType: literal
+        operations:
+          - Read
+        host: "*"
+{{- end }}

--- a/osac-metering/charts/osac-metering/templates/cost-management-adapter-service.yaml
+++ b/osac-metering/charts/osac-metering/templates/cost-management-adapter-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.costManagementAdapter.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "osac-metering.fullname" . }}-cost-management-adapter
+  labels:
+    {{- include "osac-metering.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cost-management-adapter
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "osac-metering.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: cost-management-adapter
+{{- end }}

--- a/osac-metering/charts/osac-metering/templates/kafka-secrets-rbac.yaml
+++ b/osac-metering/charts/osac-metering/templates/kafka-secrets-rbac.yaml
@@ -20,6 +20,9 @@ rules:
       {{- if .Values.m360Adapter.enabled }}
       - osac-metering-m360-adapter
       {{- end }}
+      {{- if .Values.costManagementAdapter.enabled }}
+      - osac-metering-cost-management-adapter
+      {{- end }}
     verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/osac-metering/charts/osac-metering/values.yaml
+++ b/osac-metering/charts/osac-metering/values.yaml
@@ -58,3 +58,15 @@ m360Adapter:
     apiUrl: ""
     apiKeySecret: ""     # name of K8s Secret with key "api-key"
     apiVersion: "v1"
+
+## Cost Management adapter — batches canonical CloudEvents into Cost's
+## durable ingress endpoint. The API token is mounted from a Secret.
+costManagementAdapter:
+  enabled: false
+  image:
+    repository: ghcr.io/osac-project/metering-cost-management-adapter
+    tag: latest
+    pullPolicy: Always
+  costManagement:
+    apiUrl: ""
+    apiTokenSecret: "" # name of a K8s Secret with key "api-token"


### PR DESCRIPTION
## Summary

- add a buffered Cost Management Provider Adapter that forwards unchanged canonical OSAC CloudEvents to the Cost batch ingestion endpoint
- add bounded batches, bearer-token file authentication, image build workflow, and Helm deployment, service, KafkaUser, and RBAC wiring
- validate malformed CloudEvents before buffering so existing Runner DLQ behaviour handles event-level poison records

## Validation

- full adapters module suite: 178 specs
- focused race tests and lint
- Helm lint, enabled template render, adapter gauntlet, and diff check

## Dependency

Cost receiver draft: https://github.com/myersCody/cost_ai_grid_poc/pull/123

## Framework follow-up

Unexpected receiver batch-level 4xx responses retain the batch and leave offsets uncommitted; they are not blanket-DLQed because the endpoint cannot attribute the bad member. The shared Runner also marks deduplication before a successful flush, which needs a framework-level durability fix before production billing use. See `osac-metering/adapters/docs/runner-preflush-dedup-follow-up.md`.