### PR TITLE
NO-ISSUE: Fix Slack chart table misalignment by wrapping it in a code fence

### DIFF
--- a/osac-installer/scripts/nightly-charts.sh
+++ b/osac-installer/scripts/nightly-charts.sh
@@ -534,8 +534,16 @@ build_slack_charts_published_summary() {
 
     table=$(_build_slack_charts_table "${manifest_file}" true "${repo_owner}")
 
-    # Plain mrkdwn (no code fence): linked version cells use <url|text> markup.
-    printf '*Charts published:*\n%s' "${table}"
+    # Wrapped in a triple-backtick code fence to keep the box-drawing table
+    # monospace-aligned -- unfenced, Slack renders it in a proportional font
+    # and the columns don't line up (confirmed live: a real posted message
+    # without the fence showed a jagged, misaligned table). The fence does
+    # NOT break the <url|text> link markup used for the per-chart GHCR links
+    # -- also confirmed live: an earlier fenced message still rendered the
+    # linked version cell as a real, clickable, underlined link with a
+    # working preview tooltip. Slack supports both at once; the previous
+    # comment here assumed otherwise, which was the actual bug.
+    printf '*Charts published:*\n```\n%s\n```' "${table}"
 
     ui_source=$(_osac_ui_source_from_manifest "${manifest_file}") || true
     if [[ -n "${ui_source}" ]]; then


### PR DESCRIPTION
## Problem

`build_slack_charts_published_summary()` posts the nightly chart-version table to Slack without a triple-backtick code fence, on the assumption (stated in the old comment) that fencing would break the `<url|text>` link markup used for the per-chart GHCR links. **That assumption is wrong**, confirmed directly via real Slack screenshots from a real posted message: unfenced, Slack renders the box-drawing table in a proportional font and the columns don't line up — that's the actual regression. A separate, earlier message that *was* fenced still rendered the linked version cell as a real, clickable, underlined link with a working preview tooltip pointing at the correct GHCR URL. Slack supports both at once.

## Fix

Wrap `${table}` in a triple-backtick fence in the `printf` call, and correct the now-inaccurate comment. `_build_slack_charts_table()` and its `linked=true` call are untouched — only the missing fence in the caller needed fixing.

### Before

```
*Charts published:*
┌─────────────────────┬─────────┐
│ Chart               │ Version │
├─────────────────────┼─────────┤
│ osac-operator       │ <https://.../osac-operator/0.0.17|0.0.17>  │
│ fulfillment-service │ <https://.../fulfillment-service/0.0.42|0.0.42>  │
└─────────────────────┴─────────┘
```
(posted as plain mrkdwn — Slack renders this in a proportional font, columns misaligned)

### After

```
*Charts published:*
```
┌─────────────────────┬─────────┐
│ Chart               │ Version │
├─────────────────────┼─────────┤
│ osac-operator       │ <https://.../osac-operator/0.0.17|0.0.17>  │
│ fulfillment-service │ <https://.../fulfillment-service/0.0.42|0.0.42>  │
└─────────────────────┴─────────┘
```
```
(the inner ` ``` ` pair is now literal output of the script — Slack renders this monospace-aligned, with the `<url|text>` cells still rendering as real clickable links, per direct user verification with screenshots)

## Verification

No existing test file or `--dry-run` mechanism exists for this script (checked first, per instruction) — built a synthetic local test instead:

- [x] Sourced the script, stubbed `chart_version_url()` to avoid a real GitHub Packages API call, ran `build_slack_charts_published_summary()` against a synthetic 3-row manifest
- [x] Confirmed via `xxd`/hexdump that the fence lines are three literal `0x60` backtick bytes each, on their own line — not a shell command-substitution artifact (the format string is single-quoted, so no escaping was needed)
- [x] `bash -n` syntax check passes
- [x] `shellcheck` output is byte-identical before/after (same 3 pre-existing info-level notes only — `SC2034`, `SC1091`, `SC2016` — no new warnings introduced)

This is confirmed against **real observed Slack rendering behavior** (screenshots of both an unfenced/misaligned message and an earlier fenced/still-linked message), not a guess about Slack's mrkdwn spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Slack chart summaries with clearer table formatting.
  * Retained clickable links for chart version details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->