### PR TITLE
OSAC-1772: Add --password-file, --client-secret-file, --user-file, --client-id-file flags

### DIFF
--- a/fulfillment-service/docs/AUTH.md
+++ b/fulfillment-service/docs/AUTH.md
@@ -954,9 +954,17 @@ osac login https://fulfillment-api.osac.svc.cluster.local:8000
 osac login https://fulfillment-api.osac.svc.cluster.local:8000 \
   --user USERNAME --password PASSWORD
 
+# Login using password flow with credentials read from files (avoids shell history exposure)
+osac login https://fulfillment-api.osac.svc.cluster.local:8000 \
+  --user-file /run/secrets/username --password-file /run/secrets/password
+
 # Login using client credentials flow (for service accounts)
 osac login https://fulfillment-api.osac.svc.cluster.local:8000 \
   --client-id my-service --client-secret MY_SECRET
+
+# Login using client credentials with credentials read from files
+osac login https://fulfillment-api.osac.svc.cluster.local:8000 \
+  --client-id-file /run/secrets/client-id --client-secret-file /run/secrets/client-secret
 
 # Login with a custom CA certificate
 osac login https://fulfillment-api.osac.svc.cluster.local:8000 \
@@ -966,6 +974,11 @@ osac login https://fulfillment-api.osac.svc.cluster.local:8000 \
 osac login https://fulfillment-api.osac.svc.cluster.local:8000 \
   --token-script 'kubectl create token -n osac client --duration 1h'
 ```
+
+> **Note — file-based credential flags**: `--password-file`, `--client-secret-file`, `--user-file`,
+> and `--client-id-file` read the respective value from a file and trim surrounding whitespace.
+> Each is mutually exclusive with its direct counterpart flag. This avoids exposing secrets in
+> shell history, `ps` output, and CI logs.
 
 After login, the configuration is saved to `~/.config/osac/` and subsequent `osac` commands use the
 stored credentials automatically.

--- a/fulfillment-service/internal/cmd/cli/login/login_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/login/login_cmd.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -145,6 +146,30 @@ func Cmd() *cobra.Command {
 		"",
 		passwordFlagHelp,
 	)
+	flags.StringVar(
+		&runner.args.passwordFile,
+		"password-file",
+		"",
+		passwordFileFlagHelp,
+	)
+	flags.StringVar(
+		&runner.args.clientSecretFile,
+		"client-secret-file",
+		"",
+		clientSecretFileFlagHelp,
+	)
+	flags.StringVar(
+		&runner.args.userFile,
+		"user-file",
+		"",
+		userFileFlagHelp,
+	)
+	flags.StringVar(
+		&runner.args.clientIdFile,
+		"client-id-file",
+		"",
+		clientIdFileFlagHelp,
+	)
 
 	// Define the depreacated alternatives for the OAuth flags:
 	flags.StringVar(
@@ -235,9 +260,24 @@ type runnerContext struct {
 		clientSecret string
 		scopes       []string
 		redirectUri  string
-		user         string
-		password     string
+		user             string
+		password         string
+		passwordFile     string
+		clientSecretFile string
+		userFile         string
+		clientIdFile     string
 	}
+}
+
+// readTrimmedFile reads the content of the given file and returns it with all leading and
+// trailing whitespace removed.
+func (c *runnerContext) readTrimmedFile(file string) (result string, err error) {
+	data, err := os.ReadFile(filepath.Clean(file))
+	if err != nil {
+		return
+	}
+	result = strings.TrimSpace(string(data))
+	return
 }
 
 func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
@@ -255,6 +295,12 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	err = c.console.AddTemplates(templatesFS, "templates")
 	if err != nil {
 		return fmt.Errorf("failed to load templates: %w", err)
+	}
+
+	// Resolve *-file flags, populating the underlying fields before flow inference.
+	err = c.resolveFileFlags()
+	if err != nil {
+		return err
 	}
 
 	// Infer the OAuth flow from other flags when it hasn't been explicitly set:
@@ -564,6 +610,54 @@ func (c *runnerContext) createTokenSource(ctx context.Context, tokenIssuer strin
 	return
 }
 
+// resolveFileFlags reads each *-file flag and populates the corresponding plain field. It returns
+// an error if a *-file flag and its direct counterpart are both set, or if the file cannot be read.
+// It must be called before inferFlow so that Changed() checks on the *-file flags are still
+// effective for flow inference.
+func (c *runnerContext) resolveFileFlags() error {
+	if c.flags.Changed("password-file") {
+		if c.flags.Changed("password") {
+			return fmt.Errorf("flags '--password' and '--password-file' are mutually exclusive")
+		}
+		secret, err := c.readTrimmedFile(c.args.passwordFile)
+		if err != nil {
+			return fmt.Errorf("failed to read password file '%s': %w", c.args.passwordFile, err)
+		}
+		c.args.password = secret
+	}
+	if c.flags.Changed("client-secret-file") {
+		if c.flags.Changed("client-secret") {
+			return fmt.Errorf("flags '--client-secret' and '--client-secret-file' are mutually exclusive")
+		}
+		secret, err := c.readTrimmedFile(c.args.clientSecretFile)
+		if err != nil {
+			return fmt.Errorf("failed to read client secret file '%s': %w", c.args.clientSecretFile, err)
+		}
+		c.args.clientSecret = secret
+	}
+	if c.flags.Changed("user-file") {
+		if c.flags.Changed("user") {
+			return fmt.Errorf("flags '--user' and '--user-file' are mutually exclusive")
+		}
+		user, err := c.readTrimmedFile(c.args.userFile)
+		if err != nil {
+			return fmt.Errorf("failed to read user file '%s': %w", c.args.userFile, err)
+		}
+		c.args.user = user
+	}
+	if c.flags.Changed("client-id-file") {
+		if c.flags.Changed("client-id") {
+			return fmt.Errorf("flags '--client-id' and '--client-id-file' are mutually exclusive")
+		}
+		clientId, err := c.readTrimmedFile(c.args.clientIdFile)
+		if err != nil {
+			return fmt.Errorf("failed to read client ID file '%s': %w", c.args.clientIdFile, err)
+		}
+		c.args.clientId = clientId
+	}
+	return nil
+}
+
 // inferFlow infers the OAuth flow from other command line flags when the user hasn't explicitly set the '--flow' flag.
 // If '--client-secret' is provided, the flow is inferred to be 'credentials'. If '--user' or '--password' is provided,
 // the flow is inferred to be 'password'. If both sets of flags are present without an explicit '--flow', an error is
@@ -572,9 +666,10 @@ func (c *runnerContext) inferFlow(ctx context.Context) error {
 	if c.flags.Changed("flow") || c.flags.Changed("oauth-flow") {
 		return nil
 	}
-	credentialsHint := c.flags.Changed("client-secret") || c.flags.Changed("oauth-client-secret")
+	credentialsHint := c.flags.Changed("client-secret") || c.flags.Changed("oauth-client-secret") ||
+		c.flags.Changed("client-secret-file") || c.flags.Changed("client-id-file")
 	passwordHint := c.flags.Changed("user") || c.flags.Changed("oauth-user") || c.flags.Changed("password") ||
-		c.flags.Changed("oauth-password")
+		c.flags.Changed("oauth-password") || c.flags.Changed("user-file") || c.flags.Changed("password-file")
 	if credentialsHint && passwordHint {
 		c.console.Render(ctx, "ambiguous_flow.txt", nil)
 		return exit.Error(1)
@@ -759,4 +854,20 @@ _USER_ - OAuth user name. Required when using the {{ bt }}password{{ bt }} flow,
 const passwordFlagHelp = `
 _PASSWORD_ - OAuth password. Required when using the {{ bt }}password{{ bt }} flow, along with the
 {{ bt }}--user{{ bt }} flag.
+`
+
+const passwordFileFlagHelp = `
+_FILE_ - File containing the OAuth password. Mutually exclusive with {{ bt }}--password{{ bt }}.
+`
+
+const clientSecretFileFlagHelp = `
+_FILE_ - File containing the OAuth client secret. Mutually exclusive with {{ bt }}--client-secret{{ bt }}.
+`
+
+const userFileFlagHelp = `
+_FILE_ - File containing the OAuth user name. Mutually exclusive with {{ bt }}--user{{ bt }}.
+`
+
+const clientIdFileFlagHelp = `
+_FILE_ - File containing the OAuth client identifier. Mutually exclusive with {{ bt }}--client-id{{ bt }}.
 `

--- a/fulfillment-service/internal/cmd/cli/login/login_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/login/login_cmd.go
@@ -247,19 +247,19 @@ type runnerContext struct {
 	caPool     *x509.CertPool
 	tokenStore auth.TokenStore
 	args       struct {
-		plaintext    bool
-		insecure     bool
-		caFiles      []string
-		address      string
-		private      bool
-		token        string
-		tokenScript  string
-		issuer       string
-		flow         string
-		clientId     string
-		clientSecret string
-		scopes       []string
-		redirectUri  string
+		plaintext        bool
+		insecure         bool
+		caFiles          []string
+		address          string
+		private          bool
+		token            string
+		tokenScript      string
+		issuer           string
+		flow             string
+		clientId         string
+		clientSecret     string
+		scopes           []string
+		redirectUri      string
 		user             string
 		password         string
 		passwordFile     string

--- a/fulfillment-service/internal/cmd/cli/login/login_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/login/login_cmd.go
@@ -269,9 +269,13 @@ type runnerContext struct {
 	}
 }
 
+// maxCredentialFileSize is the upper bound for credential files read by readTrimmedFile.
+// Passwords and secrets are never this large; anything bigger is almost certainly a mistake.
+const maxCredentialFileSize = 1 << 20 // 1 MiB
+
 // readTrimmedFile reads the content of the given file and returns it with all leading and
 // trailing whitespace removed. It rejects non-regular files (directories, FIFOs, devices)
-// to prevent blocking reads from special files.
+// to prevent blocking reads from special files, and files larger than maxCredentialFileSize.
 func (c *runnerContext) readTrimmedFile(file string) (result string, err error) {
 	cleanPath := filepath.Clean(file)
 	info, err := os.Stat(cleanPath)
@@ -280,6 +284,10 @@ func (c *runnerContext) readTrimmedFile(file string) (result string, err error) 
 	}
 	if !info.Mode().IsRegular() {
 		err = fmt.Errorf("'%s' is not a regular file", file)
+		return
+	}
+	if info.Size() > maxCredentialFileSize {
+		err = fmt.Errorf("'%s' exceeds the maximum credential file size (%d bytes)", file, maxCredentialFileSize)
 		return
 	}
 	data, err := os.ReadFile(cleanPath)
@@ -834,10 +842,11 @@ const flowFlagHelp = `
 _FLOW_ - OAuth flow to use. Must be one of {{ bt }}code{{ bt }}, {{ bt }}device{{ bt }}, {{ bt }}credentials{{ bt }} or
 {{ bt }}password{{ bt }}.
 
-When this flag is omitted, the flow is inferred from other flags. If {{ bt }}--client-secret{{ bt }} is provided, the
-flow is set to {{ bt }}credentials{{ bt }}. If {{ bt }}--user{{ bt }} or {{ bt }}--password{{ bt }} is provided, the
-flow is set to {{ bt }}password{{ bt }}. If both {{ bt }}--client-secret{{ bt }} and {{ bt }}--user{{ bt }} or {{ bt
-}}--password{{ bt }} are provided, the flow cannot be inferred and this flag must be set explicitly.
+When this flag is omitted, the flow is inferred from other flags. If {{ bt }}--client-secret{{ bt }} or {{ bt
+}}--client-secret-file{{ bt }} is provided, the flow is set to {{ bt }}credentials{{ bt }}. If {{ bt }}--user{{ bt }},
+{{ bt }}--user-file{{ bt }}, {{ bt }}--password{{ bt }}, or {{ bt }}--password-file{{ bt }} is provided, the flow is
+set to {{ bt }}password{{ bt }}. If both credential and password hints are present, the flow cannot be inferred and
+this flag must be set explicitly.
 `
 
 const clientIdFlagHelp = `

--- a/fulfillment-service/internal/cmd/cli/login/login_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/login/login_cmd.go
@@ -270,9 +270,19 @@ type runnerContext struct {
 }
 
 // readTrimmedFile reads the content of the given file and returns it with all leading and
-// trailing whitespace removed.
+// trailing whitespace removed. It rejects non-regular files (directories, FIFOs, devices)
+// to prevent blocking reads from special files.
 func (c *runnerContext) readTrimmedFile(file string) (result string, err error) {
-	data, err := os.ReadFile(filepath.Clean(file))
+	cleanPath := filepath.Clean(file)
+	info, err := os.Stat(cleanPath)
+	if err != nil {
+		return
+	}
+	if !info.Mode().IsRegular() {
+		err = fmt.Errorf("'%s' is not a regular file", file)
+		return
+	}
+	data, err := os.ReadFile(cleanPath)
 	if err != nil {
 		return
 	}
@@ -297,14 +307,8 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load templates: %w", err)
 	}
 
-	// Resolve *-file flags, populating the underlying fields before flow inference.
-	err = c.resolveFileFlags()
-	if err != nil {
-		return err
-	}
-
-	// Infer the OAuth flow from other flags when it hasn't been explicitly set:
-	err = c.inferFlow(ctx)
+	// Resolve *-file flags and infer the OAuth flow in one combined step:
+	err = c.resolveAndInferFlow(ctx)
 	if err != nil {
 		return err
 	}
@@ -610,14 +614,24 @@ func (c *runnerContext) createTokenSource(ctx context.Context, tokenIssuer strin
 	return
 }
 
+// resolveAndInferFlow resolves *-file flags and then infers the OAuth flow. Combining the two
+// steps into one call keeps run() under the cyclomatic-complexity limit while preserving the
+// required ordering: file flags must be resolved before the Changed() checks in inferFlow.
+func (c *runnerContext) resolveAndInferFlow(ctx context.Context) error {
+	if err := c.resolveFileFlags(); err != nil {
+		return err
+	}
+	return c.inferFlow(ctx)
+}
+
 // resolveFileFlags reads each *-file flag and populates the corresponding plain field. It returns
-// an error if a *-file flag and its direct counterpart are both set, or if the file cannot be read.
-// It must be called before inferFlow so that Changed() checks on the *-file flags are still
-// effective for flow inference.
+// an error if a *-file flag and its direct counterpart (or its deprecated oauth-* alias) are both
+// set, or if the file cannot be read. It must be called before inferFlow so that Changed() checks
+// on the *-file flags are still effective for flow inference.
 func (c *runnerContext) resolveFileFlags() error {
 	if c.flags.Changed("password-file") {
-		if c.flags.Changed("password") {
-			return fmt.Errorf("flags '--password' and '--password-file' are mutually exclusive")
+		if c.flags.Changed("password") || c.flags.Changed("oauth-password") {
+			return fmt.Errorf("flags '--password'/'--oauth-password' and '--password-file' are mutually exclusive")
 		}
 		secret, err := c.readTrimmedFile(c.args.passwordFile)
 		if err != nil {
@@ -626,8 +640,8 @@ func (c *runnerContext) resolveFileFlags() error {
 		c.args.password = secret
 	}
 	if c.flags.Changed("client-secret-file") {
-		if c.flags.Changed("client-secret") {
-			return fmt.Errorf("flags '--client-secret' and '--client-secret-file' are mutually exclusive")
+		if c.flags.Changed("client-secret") || c.flags.Changed("oauth-client-secret") {
+			return fmt.Errorf("flags '--client-secret'/'--oauth-client-secret' and '--client-secret-file' are mutually exclusive")
 		}
 		secret, err := c.readTrimmedFile(c.args.clientSecretFile)
 		if err != nil {
@@ -636,8 +650,8 @@ func (c *runnerContext) resolveFileFlags() error {
 		c.args.clientSecret = secret
 	}
 	if c.flags.Changed("user-file") {
-		if c.flags.Changed("user") {
-			return fmt.Errorf("flags '--user' and '--user-file' are mutually exclusive")
+		if c.flags.Changed("user") || c.flags.Changed("oauth-user") {
+			return fmt.Errorf("flags '--user'/'--oauth-user' and '--user-file' are mutually exclusive")
 		}
 		user, err := c.readTrimmedFile(c.args.userFile)
 		if err != nil {
@@ -646,8 +660,8 @@ func (c *runnerContext) resolveFileFlags() error {
 		c.args.user = user
 	}
 	if c.flags.Changed("client-id-file") {
-		if c.flags.Changed("client-id") {
-			return fmt.Errorf("flags '--client-id' and '--client-id-file' are mutually exclusive")
+		if c.flags.Changed("client-id") || c.flags.Changed("oauth-client-id") {
+			return fmt.Errorf("flags '--client-id'/'--oauth-client-id' and '--client-id-file' are mutually exclusive")
 		}
 		clientId, err := c.readTrimmedFile(c.args.clientIdFile)
 		if err != nil {

--- a/fulfillment-service/internal/cmd/cli/login/login_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/login/login_cmd.go
@@ -117,10 +117,22 @@ func Cmd() *cobra.Command {
 		clientIdFlagHelp,
 	)
 	flags.StringVar(
+		&runner.args.clientIdFile,
+		"client-id-file",
+		"",
+		clientIdFileFlagHelp,
+	)
+	flags.StringVar(
 		&runner.args.clientSecret,
 		"client-secret",
 		"",
 		clientSecretFlagHelp,
+	)
+	flags.StringVar(
+		&runner.args.clientSecretFile,
+		"client-secret-file",
+		"",
+		clientSecretFileFlagHelp,
 	)
 	flags.StringSliceVar(
 		&runner.args.scopes,
@@ -141,6 +153,12 @@ func Cmd() *cobra.Command {
 		userFlagHelp,
 	)
 	flags.StringVar(
+		&runner.args.userFile,
+		"user-file",
+		"",
+		userFileFlagHelp,
+	)
+	flags.StringVar(
 		&runner.args.password,
 		"password",
 		"",
@@ -151,24 +169,6 @@ func Cmd() *cobra.Command {
 		"password-file",
 		"",
 		passwordFileFlagHelp,
-	)
-	flags.StringVar(
-		&runner.args.clientSecretFile,
-		"client-secret-file",
-		"",
-		clientSecretFileFlagHelp,
-	)
-	flags.StringVar(
-		&runner.args.userFile,
-		"user-file",
-		"",
-		userFileFlagHelp,
-	)
-	flags.StringVar(
-		&runner.args.clientIdFile,
-		"client-id-file",
-		"",
-		clientIdFileFlagHelp,
 	)
 
 	// Define the depreacated alternatives for the OAuth flags:
@@ -257,15 +257,15 @@ type runnerContext struct {
 		issuer           string
 		flow             string
 		clientId         string
+		clientIdFile     string
 		clientSecret     string
+		clientSecretFile string
 		scopes           []string
 		redirectUri      string
 		user             string
+		userFile         string
 		password         string
 		passwordFile     string
-		clientSecretFile string
-		userFile         string
-		clientIdFile     string
 	}
 }
 
@@ -681,7 +681,7 @@ func (c *runnerContext) inferFlow(ctx context.Context) error {
 		return nil
 	}
 	credentialsHint := c.flags.Changed("client-secret") || c.flags.Changed("oauth-client-secret") ||
-		c.flags.Changed("client-secret-file") || c.flags.Changed("client-id-file")
+		c.flags.Changed("client-secret-file")
 	passwordHint := c.flags.Changed("user") || c.flags.Changed("oauth-user") || c.flags.Changed("password") ||
 		c.flags.Changed("oauth-password") || c.flags.Changed("user-file") || c.flags.Changed("password-file")
 	if credentialsHint && passwordHint {

--- a/fulfillment-service/internal/cmd/cli/login/login_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/login/login_cmd_test.go
@@ -41,19 +41,21 @@ var _ = Describe("readTrimmedFile", func() {
 	})
 
 	It("reads a file and trims a trailing newline", func() {
+		testValue := "test-fixture-value"
 		f := filepath.Join(tmpDir, "secret.txt")
-		Expect(os.WriteFile(f, []byte("mysecret\n"), 0600)).To(Succeed())
+		Expect(os.WriteFile(f, []byte(testValue+"\n"), 0600)).To(Succeed())
 		result, err := runner.readTrimmedFile(f)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal("mysecret"))
+		Expect(result).To(Equal(testValue))
 	})
 
 	It("reads a file and trims surrounding whitespace", func() {
+		testValue := "test-fixture-value"
 		f := filepath.Join(tmpDir, "secret.txt")
-		Expect(os.WriteFile(f, []byte("  mysecret  \n"), 0600)).To(Succeed())
+		Expect(os.WriteFile(f, []byte("  "+testValue+"  \n"), 0600)).To(Succeed())
 		result, err := runner.readTrimmedFile(f)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(result).To(Equal("mysecret"))
+		Expect(result).To(Equal(testValue))
 	})
 
 	It("reads an empty file and returns an empty string", func() {
@@ -121,15 +123,16 @@ var _ = Describe("resolveFileFlags", func() {
 
 	Describe("--password-file", func() {
 		It("reads password from file and trims whitespace", func() {
-			path := writeFile("pw.txt", "mypassword\n")
+			testPassword := "test-pw-fixture"
+			path := writeFile("pw.txt", testPassword+"\n")
 			Expect(runner.flags.Parse([]string{"--password-file=" + path})).To(Succeed())
 			Expect(runner.resolveFileFlags()).To(Succeed())
-			Expect(runner.args.password).To(Equal("mypassword"))
+			Expect(runner.args.password).To(Equal(testPassword))
 		})
 
 		It("returns an error when both --password and --password-file are provided", func() {
-			path := writeFile("pw.txt", "mypassword\n")
-			Expect(runner.flags.Parse([]string{"--password=direct", "--password-file=" + path})).To(Succeed())
+			path := writeFile("pw.txt", "test-pw-fixture\n")
+			Expect(runner.flags.Parse([]string{"--password=test-direct", "--password-file=" + path})).To(Succeed())
 			Expect(runner.resolveFileFlags()).To(MatchError(ContainSubstring("mutually exclusive")))
 		})
 
@@ -141,71 +144,74 @@ var _ = Describe("resolveFileFlags", func() {
 
 	Describe("--client-secret-file", func() {
 		It("reads client secret from file and trims whitespace", func() {
-			path := writeFile("secret.txt", "tok123\n")
+			testSecret := "test-secret-fixture"
+			path := writeFile("secret.txt", testSecret+"\n")
 			Expect(runner.flags.Parse([]string{"--client-secret-file=" + path})).To(Succeed())
 			Expect(runner.resolveFileFlags()).To(Succeed())
-			Expect(runner.args.clientSecret).To(Equal("tok123"))
+			Expect(runner.args.clientSecret).To(Equal(testSecret))
 		})
 
 		It("returns an error when both --client-secret and --client-secret-file are provided", func() {
-			path := writeFile("secret.txt", "tok123\n")
-			Expect(runner.flags.Parse([]string{"--client-secret=direct", "--client-secret-file=" + path})).To(Succeed())
+			path := writeFile("secret.txt", "test-secret-fixture\n")
+			Expect(runner.flags.Parse([]string{"--client-secret=test-direct", "--client-secret-file=" + path})).To(Succeed())
 			Expect(runner.resolveFileFlags()).To(MatchError(ContainSubstring("mutually exclusive")))
 		})
 	})
 
 	Describe("--user-file", func() {
 		It("reads user from file and trims whitespace", func() {
-			path := writeFile("user.txt", "alice\n")
+			testUser := "test-user-fixture"
+			path := writeFile("user.txt", testUser+"\n")
 			Expect(runner.flags.Parse([]string{"--user-file=" + path})).To(Succeed())
 			Expect(runner.resolveFileFlags()).To(Succeed())
-			Expect(runner.args.user).To(Equal("alice"))
+			Expect(runner.args.user).To(Equal(testUser))
 		})
 
 		It("returns an error when both --user and --user-file are provided", func() {
-			path := writeFile("user.txt", "alice\n")
-			Expect(runner.flags.Parse([]string{"--user=bob", "--user-file=" + path})).To(Succeed())
+			path := writeFile("user.txt", "test-user-fixture\n")
+			Expect(runner.flags.Parse([]string{"--user=test-other", "--user-file=" + path})).To(Succeed())
 			Expect(runner.resolveFileFlags()).To(MatchError(ContainSubstring("mutually exclusive")))
 		})
 	})
 
 	Describe("--client-id-file", func() {
 		It("reads client ID from file and trims whitespace", func() {
-			path := writeFile("id.txt", "my-client\n")
+			testClientId := "test-client-fixture"
+			path := writeFile("id.txt", testClientId+"\n")
 			Expect(runner.flags.Parse([]string{"--client-id-file=" + path})).To(Succeed())
 			Expect(runner.resolveFileFlags()).To(Succeed())
-			Expect(runner.args.clientId).To(Equal("my-client"))
+			Expect(runner.args.clientId).To(Equal(testClientId))
 		})
 
 		It("returns an error when both --client-id and --client-id-file are provided", func() {
-			path := writeFile("id.txt", "my-client\n")
-			Expect(runner.flags.Parse([]string{"--client-id=other", "--client-id-file=" + path})).To(Succeed())
+			path := writeFile("id.txt", "test-client-fixture\n")
+			Expect(runner.flags.Parse([]string{"--client-id=test-other", "--client-id-file=" + path})).To(Succeed())
 			Expect(runner.resolveFileFlags()).To(MatchError(ContainSubstring("mutually exclusive")))
 		})
 	})
 
 	Describe("deprecated oauth-* alias conflicts", func() {
 		It("returns an error when --oauth-password and --password-file are both provided", func() {
-			path := writeFile("pw.txt", "secret\n")
-			Expect(runner.flags.Parse([]string{"--oauth-password=direct", "--password-file=" + path})).To(Succeed())
+			path := writeFile("pw.txt", "test-fixture\n")
+			Expect(runner.flags.Parse([]string{"--oauth-password=test-direct", "--password-file=" + path})).To(Succeed())
 			Expect(runner.resolveFileFlags()).To(MatchError(ContainSubstring("mutually exclusive")))
 		})
 
 		It("returns an error when --oauth-client-secret and --client-secret-file are both provided", func() {
-			path := writeFile("secret.txt", "tok\n")
-			Expect(runner.flags.Parse([]string{"--oauth-client-secret=direct", "--client-secret-file=" + path})).To(Succeed())
+			path := writeFile("secret.txt", "test-fixture\n")
+			Expect(runner.flags.Parse([]string{"--oauth-client-secret=test-direct", "--client-secret-file=" + path})).To(Succeed())
 			Expect(runner.resolveFileFlags()).To(MatchError(ContainSubstring("mutually exclusive")))
 		})
 
 		It("returns an error when --oauth-user and --user-file are both provided", func() {
-			path := writeFile("user.txt", "alice\n")
-			Expect(runner.flags.Parse([]string{"--oauth-user=bob", "--user-file=" + path})).To(Succeed())
+			path := writeFile("user.txt", "test-user-fixture\n")
+			Expect(runner.flags.Parse([]string{"--oauth-user=test-other", "--user-file=" + path})).To(Succeed())
 			Expect(runner.resolveFileFlags()).To(MatchError(ContainSubstring("mutually exclusive")))
 		})
 
 		It("returns an error when --oauth-client-id and --client-id-file are both provided", func() {
-			path := writeFile("id.txt", "my-client\n")
-			Expect(runner.flags.Parse([]string{"--oauth-client-id=other", "--client-id-file=" + path})).To(Succeed())
+			path := writeFile("id.txt", "test-client-fixture\n")
+			Expect(runner.flags.Parse([]string{"--oauth-client-id=test-other", "--client-id-file=" + path})).To(Succeed())
 			Expect(runner.resolveFileFlags()).To(MatchError(ContainSubstring("mutually exclusive")))
 		})
 	})

--- a/fulfillment-service/internal/cmd/cli/login/login_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/login/login_cmd_test.go
@@ -226,10 +226,10 @@ var _ = Describe("inferFlow", func() {
 		Expect(runner.args.flow).To(Equal(string(oauth.CredentialsFlow)))
 	})
 
-	It("sets credentials flow when --client-id-file is provided", func() {
+	It("does not infer flow when only --client-id-file is provided (client ID alone is insufficient)", func() {
 		Expect(runner.flags.Parse([]string{"--client-id-file=foo"})).To(Succeed())
 		Expect(runner.inferFlow(context.Background())).To(Succeed())
-		Expect(runner.args.flow).To(Equal(string(oauth.CredentialsFlow)))
+		Expect(runner.args.flow).To(Equal(defaultFlow))
 	})
 
 	It("sets password flow when --user-file is provided", func() {

--- a/fulfillment-service/internal/cmd/cli/login/login_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/login/login_cmd_test.go
@@ -1,0 +1,233 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package login
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/pflag"
+
+	"github.com/osac-project/osac/fulfillment-service/internal/oauth"
+)
+
+var _ = Describe("readTrimmedFile", func() {
+	var runner *runnerContext
+	var tmpDir string
+
+	BeforeEach(func() {
+		runner = &runnerContext{}
+		var err error
+		tmpDir, err = os.MkdirTemp("", "login-test-*")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	It("reads a file and trims a trailing newline", func() {
+		f := filepath.Join(tmpDir, "secret.txt")
+		Expect(os.WriteFile(f, []byte("mysecret\n"), 0600)).To(Succeed())
+		result, err := runner.readTrimmedFile(f)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal("mysecret"))
+	})
+
+	It("reads a file and trims surrounding whitespace", func() {
+		f := filepath.Join(tmpDir, "secret.txt")
+		Expect(os.WriteFile(f, []byte("  mysecret  \n"), 0600)).To(Succeed())
+		result, err := runner.readTrimmedFile(f)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal("mysecret"))
+	})
+
+	It("reads an empty file and returns an empty string", func() {
+		f := filepath.Join(tmpDir, "empty.txt")
+		Expect(os.WriteFile(f, []byte(""), 0600)).To(Succeed())
+		result, err := runner.readTrimmedFile(f)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(""))
+	})
+
+	It("returns an error when the file does not exist", func() {
+		_, err := runner.readTrimmedFile(filepath.Join(tmpDir, "nonexistent.txt"))
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+// newFileFlagSet creates a minimal pflag.FlagSet that covers all flags read by
+// resolveFileFlags and inferFlow, bound to the given runnerContext.
+func newFileFlagSet(r *runnerContext) *pflag.FlagSet {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.StringVar(&r.args.password, "password", "", "")
+	fs.StringVar(&r.args.passwordFile, "password-file", "", "")
+	fs.StringVar(&r.args.clientSecret, "client-secret", "", "")
+	fs.StringVar(&r.args.clientSecretFile, "client-secret-file", "", "")
+	fs.StringVar(&r.args.user, "user", "", "")
+	fs.StringVar(&r.args.userFile, "user-file", "", "")
+	fs.StringVar(&r.args.clientId, "client-id", "", "")
+	fs.StringVar(&r.args.clientIdFile, "client-id-file", "", "")
+	// inferFlow also checks these:
+	fs.StringVar(&r.args.flow, "flow", defaultFlow, "")
+	fs.StringVar(&r.args.flow, "oauth-flow", defaultFlow, "")
+	var dummy string
+	fs.StringVar(&dummy, "oauth-client-secret", "", "")
+	fs.StringVar(&dummy, "oauth-user", "", "")
+	fs.StringVar(&dummy, "oauth-password", "", "")
+	return fs
+}
+
+var _ = Describe("resolveFileFlags", func() {
+	var runner *runnerContext
+	var tmpDir string
+
+	BeforeEach(func() {
+		runner = &runnerContext{}
+		runner.flags = newFileFlagSet(runner)
+		var err error
+		tmpDir, err = os.MkdirTemp("", "login-test-*")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	writeFile := func(name, content string) string {
+		path := filepath.Join(tmpDir, name)
+		ExpectWithOffset(1, os.WriteFile(path, []byte(content), 0600)).To(Succeed())
+		return path
+	}
+
+	Describe("--password-file", func() {
+		It("reads password from file and trims whitespace", func() {
+			path := writeFile("pw.txt", "mypassword\n")
+			Expect(runner.flags.Parse([]string{"--password-file=" + path})).To(Succeed())
+			Expect(runner.resolveFileFlags()).To(Succeed())
+			Expect(runner.args.password).To(Equal("mypassword"))
+		})
+
+		It("returns an error when both --password and --password-file are provided", func() {
+			path := writeFile("pw.txt", "mypassword\n")
+			Expect(runner.flags.Parse([]string{"--password=direct", "--password-file=" + path})).To(Succeed())
+			Expect(runner.resolveFileFlags()).To(MatchError(ContainSubstring("mutually exclusive")))
+		})
+
+		It("returns an error when the file does not exist", func() {
+			Expect(runner.flags.Parse([]string{"--password-file=" + filepath.Join(tmpDir, "missing.txt")})).To(Succeed())
+			Expect(runner.resolveFileFlags()).To(HaveOccurred())
+		})
+	})
+
+	Describe("--client-secret-file", func() {
+		It("reads client secret from file and trims whitespace", func() {
+			path := writeFile("secret.txt", "tok123\n")
+			Expect(runner.flags.Parse([]string{"--client-secret-file=" + path})).To(Succeed())
+			Expect(runner.resolveFileFlags()).To(Succeed())
+			Expect(runner.args.clientSecret).To(Equal("tok123"))
+		})
+
+		It("returns an error when both --client-secret and --client-secret-file are provided", func() {
+			path := writeFile("secret.txt", "tok123\n")
+			Expect(runner.flags.Parse([]string{"--client-secret=direct", "--client-secret-file=" + path})).To(Succeed())
+			Expect(runner.resolveFileFlags()).To(MatchError(ContainSubstring("mutually exclusive")))
+		})
+	})
+
+	Describe("--user-file", func() {
+		It("reads user from file and trims whitespace", func() {
+			path := writeFile("user.txt", "alice\n")
+			Expect(runner.flags.Parse([]string{"--user-file=" + path})).To(Succeed())
+			Expect(runner.resolveFileFlags()).To(Succeed())
+			Expect(runner.args.user).To(Equal("alice"))
+		})
+
+		It("returns an error when both --user and --user-file are provided", func() {
+			path := writeFile("user.txt", "alice\n")
+			Expect(runner.flags.Parse([]string{"--user=bob", "--user-file=" + path})).To(Succeed())
+			Expect(runner.resolveFileFlags()).To(MatchError(ContainSubstring("mutually exclusive")))
+		})
+	})
+
+	Describe("--client-id-file", func() {
+		It("reads client ID from file and trims whitespace", func() {
+			path := writeFile("id.txt", "my-client\n")
+			Expect(runner.flags.Parse([]string{"--client-id-file=" + path})).To(Succeed())
+			Expect(runner.resolveFileFlags()).To(Succeed())
+			Expect(runner.args.clientId).To(Equal("my-client"))
+		})
+
+		It("returns an error when both --client-id and --client-id-file are provided", func() {
+			path := writeFile("id.txt", "my-client\n")
+			Expect(runner.flags.Parse([]string{"--client-id=other", "--client-id-file=" + path})).To(Succeed())
+			Expect(runner.resolveFileFlags()).To(MatchError(ContainSubstring("mutually exclusive")))
+		})
+	})
+})
+
+var _ = Describe("inferFlow", func() {
+	var runner *runnerContext
+
+	BeforeEach(func() {
+		runner = &runnerContext{}
+		runner.args.flow = defaultFlow
+		runner.flags = newFileFlagSet(runner)
+	})
+
+	It("sets credentials flow when --client-secret-file is provided", func() {
+		Expect(runner.flags.Parse([]string{"--client-secret-file=foo"})).To(Succeed())
+		Expect(runner.inferFlow(context.Background())).To(Succeed())
+		Expect(runner.args.flow).To(Equal(string(oauth.CredentialsFlow)))
+	})
+
+	It("sets credentials flow when --client-id-file is provided", func() {
+		Expect(runner.flags.Parse([]string{"--client-id-file=foo"})).To(Succeed())
+		Expect(runner.inferFlow(context.Background())).To(Succeed())
+		Expect(runner.args.flow).To(Equal(string(oauth.CredentialsFlow)))
+	})
+
+	It("sets password flow when --user-file is provided", func() {
+		Expect(runner.flags.Parse([]string{"--user-file=foo"})).To(Succeed())
+		Expect(runner.inferFlow(context.Background())).To(Succeed())
+		Expect(runner.args.flow).To(Equal(string(oauth.PasswordFlow)))
+	})
+
+	It("sets password flow when --password-file is provided", func() {
+		Expect(runner.flags.Parse([]string{"--password-file=foo"})).To(Succeed())
+		Expect(runner.inferFlow(context.Background())).To(Succeed())
+		Expect(runner.args.flow).To(Equal(string(oauth.PasswordFlow)))
+	})
+
+	It("existing --client-secret still triggers credentials flow (backwards compat)", func() {
+		Expect(runner.flags.Parse([]string{"--client-secret=foo"})).To(Succeed())
+		Expect(runner.inferFlow(context.Background())).To(Succeed())
+		Expect(runner.args.flow).To(Equal(string(oauth.CredentialsFlow)))
+	})
+
+	It("existing --password still triggers password flow (backwards compat)", func() {
+		Expect(runner.flags.Parse([]string{"--password=foo"})).To(Succeed())
+		Expect(runner.inferFlow(context.Background())).To(Succeed())
+		Expect(runner.args.flow).To(Equal(string(oauth.PasswordFlow)))
+	})
+
+	It("does not change flow when --flow is explicitly set", func() {
+		Expect(runner.flags.Parse([]string{"--flow=code", "--client-secret-file=foo"})).To(Succeed())
+		Expect(runner.inferFlow(context.Background())).To(Succeed())
+		Expect(runner.args.flow).To(Equal("code"))
+	})
+})

--- a/fulfillment-service/internal/cmd/cli/login/login_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/login/login_cmd_test.go
@@ -37,7 +37,7 @@ var _ = Describe("readTrimmedFile", func() {
 	})
 
 	AfterEach(func() {
-		os.RemoveAll(tmpDir)
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
 	})
 
 	It("reads a file and trims a trailing newline", func() {
@@ -68,6 +68,11 @@ var _ = Describe("readTrimmedFile", func() {
 		_, err := runner.readTrimmedFile(filepath.Join(tmpDir, "nonexistent.txt"))
 		Expect(err).To(HaveOccurred())
 	})
+
+	It("returns an error when the path is a directory", func() {
+		_, err := runner.readTrimmedFile(tmpDir)
+		Expect(err).To(MatchError(ContainSubstring("not a regular file")))
+	})
 })
 
 // newFileFlagSet creates a minimal pflag.FlagSet that covers all flags read by
@@ -82,13 +87,13 @@ func newFileFlagSet(r *runnerContext) *pflag.FlagSet {
 	fs.StringVar(&r.args.userFile, "user-file", "", "")
 	fs.StringVar(&r.args.clientId, "client-id", "", "")
 	fs.StringVar(&r.args.clientIdFile, "client-id-file", "", "")
-	// inferFlow also checks these:
+	// inferFlow and resolveFileFlags also check these deprecated aliases:
 	fs.StringVar(&r.args.flow, "flow", defaultFlow, "")
 	fs.StringVar(&r.args.flow, "oauth-flow", defaultFlow, "")
-	var dummy string
-	fs.StringVar(&dummy, "oauth-client-secret", "", "")
-	fs.StringVar(&dummy, "oauth-user", "", "")
-	fs.StringVar(&dummy, "oauth-password", "", "")
+	fs.StringVar(&r.args.clientSecret, "oauth-client-secret", "", "")
+	fs.StringVar(&r.args.user, "oauth-user", "", "")
+	fs.StringVar(&r.args.password, "oauth-password", "", "")
+	fs.StringVar(&r.args.clientId, "oauth-client-id", "", "")
 	return fs
 }
 
@@ -105,7 +110,7 @@ var _ = Describe("resolveFileFlags", func() {
 	})
 
 	AfterEach(func() {
-		os.RemoveAll(tmpDir)
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
 	})
 
 	writeFile := func(name, content string) string {
@@ -175,6 +180,32 @@ var _ = Describe("resolveFileFlags", func() {
 		It("returns an error when both --client-id and --client-id-file are provided", func() {
 			path := writeFile("id.txt", "my-client\n")
 			Expect(runner.flags.Parse([]string{"--client-id=other", "--client-id-file=" + path})).To(Succeed())
+			Expect(runner.resolveFileFlags()).To(MatchError(ContainSubstring("mutually exclusive")))
+		})
+	})
+
+	Describe("deprecated oauth-* alias conflicts", func() {
+		It("returns an error when --oauth-password and --password-file are both provided", func() {
+			path := writeFile("pw.txt", "secret\n")
+			Expect(runner.flags.Parse([]string{"--oauth-password=direct", "--password-file=" + path})).To(Succeed())
+			Expect(runner.resolveFileFlags()).To(MatchError(ContainSubstring("mutually exclusive")))
+		})
+
+		It("returns an error when --oauth-client-secret and --client-secret-file are both provided", func() {
+			path := writeFile("secret.txt", "tok\n")
+			Expect(runner.flags.Parse([]string{"--oauth-client-secret=direct", "--client-secret-file=" + path})).To(Succeed())
+			Expect(runner.resolveFileFlags()).To(MatchError(ContainSubstring("mutually exclusive")))
+		})
+
+		It("returns an error when --oauth-user and --user-file are both provided", func() {
+			path := writeFile("user.txt", "alice\n")
+			Expect(runner.flags.Parse([]string{"--oauth-user=bob", "--user-file=" + path})).To(Succeed())
+			Expect(runner.resolveFileFlags()).To(MatchError(ContainSubstring("mutually exclusive")))
+		})
+
+		It("returns an error when --oauth-client-id and --client-id-file are both provided", func() {
+			path := writeFile("id.txt", "my-client\n")
+			Expect(runner.flags.Parse([]string{"--oauth-client-id=other", "--client-id-file=" + path})).To(Succeed())
 			Expect(runner.resolveFileFlags()).To(MatchError(ContainSubstring("mutually exclusive")))
 		})
 	})

--- a/fulfillment-service/internal/cmd/cli/login/login_suite_test.go
+++ b/fulfillment-service/internal/cmd/cli/login/login_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package login
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestLogin(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Login command")
+}


### PR DESCRIPTION
## Summary

- Add four `*-file` flags to `osac login` so secrets can be read from files instead of passed as plain CLI arguments, avoiding exposure in shell history, `ps` output, and CI logs
- `--password-file`, `--client-secret-file`, `--user-file`, `--client-id-file` — each mutually exclusive with its direct counterpart and follows the same pattern already used in `start-controller`
- `inferFlow()` extended to recognise the new flags as OAuth flow hints (credentials / password)

## Jira

https://redhat.atlassian.net/browse/OSAC-1772

## Test plan

- [x] 20 unit tests added (`internal/cmd/cli/login/login_cmd_test.go`): file reading, whitespace trimming, mutual exclusion errors, flow inference for all 4 new flags, backwards compat for existing `--password` / `--client-secret`
- [x] `gofmt -s -w .` — no diff
- [x] `ginkgo run -r internal/cmd/cli/login` — 20/20 passing

## Notes

Raised during code review of PR #760. `--user-file` and `--client-id-file` added per Juan Hernandez's review comment on the Jira ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added file-based login options for passwords, client secrets, usernames, and client IDs.
  * Credential file contents are trimmed automatically and can guide login flow selection.
  * Added contextual help for file-based credential options.

* **Bug Fixes**
  * Added clear errors for unreadable, invalid, or non-regular credential paths.
  * Prevented conflicting use of direct flags, file options, and deprecated login aliases.
  * Client ID files no longer incorrectly trigger automatic credential-flow selection.

* **Documentation**
  * Added examples for file-based username/password and client credential login.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->