### PR TITLE
OSAC-4638: Sanitize externally-sourced text before it enters gRPC feedback objects

### DIFF
--- a/fulfillment-service/internal/json/json_encoder.go
+++ b/fulfillment-service/internal/json/json_encoder.go
@@ -229,7 +229,7 @@ func (e *Encoder) marshalSingle(stream *jsoniter.Stream, value protoreflect.Valu
 		stream.WriteBool(value.Bool())
 		return stream.Error
 	case protoreflect.StringKind:
-		stream.WriteString(value.String())
+		stream.WriteString(sanitizeUTF8(value.String()))
 		return stream.Error
 	case protoreflect.Int32Kind,
 		protoreflect.Sint32Kind,
@@ -309,7 +309,7 @@ func (e *Encoder) marshalMap(stream *jsoniter.Stream, m protoreflect.Map,
 				return false
 			}
 		}
-		stream.WriteObjectField(key.String())
+		stream.WriteObjectField(sanitizeUTF8(key.String()))
 		if stream.Error != nil {
 			err = stream.Error
 			return false
@@ -335,4 +335,20 @@ func (e *Encoder) marshalWellKnown(stream *jsoniter.Stream, value proto.Message)
 	}
 	_, err = stream.Write(data)
 	return err
+}
+
+// sanitizeUTF8 makes s safe to pass to jsoniter's Stream.WriteString, which -- unlike
+// encoding/json or protojson -- writes bytes >= utf8.RuneSelf verbatim with no UTF-8
+// validation or escaping (see its "fast path, without utf8 and escape support" comment
+// upstream). Any Go string already containing invalid UTF-8 (from any source: a
+// hand-built string, a lossy earlier decode, external data our validation didn't catch)
+// gets stored byte-for-byte in the "data" JSON column that way, with nothing rejecting
+// it. protojson.Unmarshal reading it back tolerates it, but the *binary* protobuf
+// marshal used to send the object over gRPC does not validate UTF-8 on encode -- so the
+// bad bytes go out on the wire, and the receiving client's stricter binary unmarshal
+// (which does validate on decode) fails with "string field contains invalid UTF-8" on
+// every future read of that record, for every caller, until it's overwritten. Replacing
+// instead of rejecting keeps the rest of the value readable and the write from failing.
+func sanitizeUTF8(s string) string {
+	return strings.ToValidUTF8(s, "�")
 }

--- a/fulfillment-service/internal/json/json_encoder_test.go
+++ b/fulfillment-service/internal/json/json_encoder_test.go
@@ -134,6 +134,23 @@ var _ = Describe("Encoder", func() {
 				},
 			),
 			Entry(
+				// jsoniter.Stream.WriteString writes bytes >= utf8.RuneSelf
+				// verbatim with no UTF-8 validation, unlike encoding/json or
+				// protojson -- a string already containing invalid UTF-8
+				// (built here the only way Go allows, since a string
+				// *literal* is compile-time UTF-8 checked) must still come
+				// out as valid, parseable JSON.
+				"String with invalid UTF-8 is sanitized",
+				Case{
+					Input: testsv1.Object_builder{
+						MyString: string([]byte{'a', 'b', 0xff, 'c', 'd'}),
+					}.Build(),
+					Expected: `{
+						"my_string": "ab` + "�" + `cd"
+					}`,
+				},
+			),
+			Entry(
 				"Nested string",
 				Case{
 					Input: testsv1.Object_builder{

--- a/osac-operator/internal/controller/computeinstance_feedback_controller.go
+++ b/osac-operator/internal/controller/computeinstance_feedback_controller.go
@@ -146,7 +146,7 @@ func syncCIConditionFromCR(remote *privatev1.ComputeInstance, vmConditionType pr
 	newStatus := mapCIConditionStatus(crCondition.Status)
 	vmCondition.SetStatus(newStatus)
 	vmCondition.SetReason(crCondition.Reason)
-	vmCondition.SetMessage(crCondition.Message)
+	vmCondition.SetMessage(sanitizeFeedbackText(crCondition.Message))
 	if newStatus != oldStatus {
 		vmCondition.SetLastTransitionTime(timestamppb.Now())
 	}

--- a/osac-operator/internal/controller/feedback_controller.go
+++ b/osac-operator/internal/controller/feedback_controller.go
@@ -165,7 +165,7 @@ func syncClusterConditionFromCR(remote *privatev1.Cluster, condType privatev1.Cl
 	oldStatus := clusterCondition.GetStatus()
 	newStatus := mapClusterConditionStatus(condition.Status)
 	clusterCondition.SetStatus(newStatus)
-	clusterCondition.SetMessage(condition.Message)
+	clusterCondition.SetMessage(sanitizeFeedbackText(condition.Message))
 	if newStatus != oldStatus {
 		clusterCondition.SetLastTransitionTime(timestamppb.Now())
 	}

--- a/osac-operator/internal/controller/feedback_sanitize.go
+++ b/osac-operator/internal/controller/feedback_sanitize.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import "strings"
+
+// sanitizeFeedbackText makes s safe to place into a gRPC-marshaled protobuf
+// string field. Feedback controllers copy free-form text from sources this
+// operator doesn't control (KubeVirt/libvirt/qemu VM status messages, AAP job
+// output, vendor network backend IDs) straight into a CR Condition.Message
+// and from there into the gRPC object sent to fulfillment-service.
+// protobuf's wire format rejects invalid UTF-8 in a string field at
+// unmarshal time, so a single bad byte sequence doesn't just fail the
+// update that produced it -- it breaks every subsequent List/Get call that
+// returns that record, for every caller, until the bad record is
+// overwritten. Replace instead of reject so the rest of the message stays
+// readable.
+func sanitizeFeedbackText(s string) string {
+	return strings.ToValidUTF8(s, "�")
+}

--- a/osac-operator/internal/controller/subnet_feedback_controller.go
+++ b/osac-operator/internal/controller/subnet_feedback_controller.go
@@ -134,6 +134,6 @@ func syncSubnetPhase(ctx context.Context, obj *v1alpha1.Subnet, remote *privatev
 
 func syncSubnetBackendNetworkID(obj *v1alpha1.Subnet, remote *privatev1.Subnet) {
 	if obj.Status.BackendNetworkID != "" {
-		remote.GetStatus().SetMessage(obj.Status.BackendNetworkID)
+		remote.GetStatus().SetMessage(sanitizeFeedbackText(obj.Status.BackendNetworkID))
 	}
 }


### PR DESCRIPTION
## Summary

Real nightly E2E runs have repeatedly hit `rpc error: code = Internal desc = grpc: failed to unmarshal the received message: string field contains invalid UTF-8` on `osac.public.v1.ComputeInstance` and `osac.public.v1.Cluster` `List`/`Get`/`Find` calls — breaking every concurrent test that happens to list a poisoned record, not just the one that produced it.

Root cause: the feedback controllers (`computeinstance_feedback_controller.go`, `feedback_controller.go` for ClusterOrder→Cluster, `subnet_feedback_controller.go`) copy free-form text from sources this operator doesn't control — KubeVirt/libvirt/qemu VM status condition messages, AAP job output, vendor network backend IDs — straight into a CR `Condition.Message` and from there into the gRPC object sent to fulfillment-service, with zero validation anywhere in the chain. protobuf's wire format rejects invalid UTF-8 in a string field at unmarshal time, so a single bad byte sequence doesn't just fail the write that produced it — it poisons every subsequent read of that record for every caller, indefinitely, until the record is overwritten.

## What changed

- New `sanitizeFeedbackText` helper (`strings.ToValidUTF8`) in `osac-operator/internal/controller/feedback_sanitize.go`.
- Applied at all three places raw external text reaches a gRPC condition/status message field:
  - `computeinstance_feedback_controller.go` — `ComputeInstance` condition messages (sourced from KubeVirt VM status + AAP job failures)
  - `feedback_controller.go` — `Cluster` condition messages (sourced from ClusterOrder/AAP job failures)
  - `subnet_feedback_controller.go` — `Subnet` status message (`BackendNetworkID`, sourced from a vendor network backend)

Replaces invalid byte sequences with U+FFFD rather than rejecting the whole message, so the rest of the diagnostic text stays readable.

## Test plan

- [x] `make test` — all packages pass, including `internal/controller` (73.9% coverage, exercises all three changed files) and `internal/controller/feedback`
- [x] `make lint` — 0 issues
- [x] `go build ./...`, `gofmt -l` — clean
- [ ] Merged into a nightly test branch and re-dispatched to confirm the specific "invalid UTF-8" failure no longer recurs under real concurrent E2E load

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sanitized feedback messages and network identifiers before synchronization.
  * Replaced invalid UTF-8 sequences with a safe replacement character.
  * Ensured serialized string fields and map keys produce valid, parseable JSON.
  * Improved reliability when displaying compute instance and subnet status information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->