### PR TITLE
OSAC-2985: Integration tests for secret references

### DIFF
--- a/fulfillment-service/internal/cmd/service/start/grpcserver/register_servers.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/register_servers.go
@@ -949,6 +949,7 @@ func RegisterResourceServers(ctx context.Context, registrar grpc.ServiceRegistra
 		SetAttributionLogic(deps.PrivateAttributionLogic).
 		SetTenancyLogic(deps.TenancyLogic).
 		SetMetricsRegisterer(deps.MetricsRegisterer).
+		SetSecretStore(deps.SecretStore).
 		Build()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create private identity providers server: %w", err)

--- a/fulfillment-service/internal/servers/private_identity_providers_server.go
+++ b/fulfillment-service/internal/servers/private_identity_providers_server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/osac/fulfillment-service/internal/events"
 	"github.com/osac-project/osac/fulfillment-service/internal/references"
+	"github.com/osac-project/osac/fulfillment-service/internal/vault"
 )
 
 type PrivateIdentityProvidersServerBuilder struct {
@@ -37,16 +38,18 @@ type PrivateIdentityProvidersServerBuilder struct {
 	tenancyLogic      auth.TenancyLogic
 	metricsRegisterer prometheus.Registerer
 	filterDesc        protoreflect.MessageDescriptor
+	secretStore       vault.SecretStore
 }
 
 var _ privatev1.IdentityProvidersServer = (*PrivateIdentityProvidersServer)(nil)
 
 type PrivateIdentityProvidersServer struct {
 	privatev1.UnimplementedIdentityProvidersServer
-	logger     *slog.Logger
-	generic    *GenericServer[*privatev1.IdentityProvider]
-	dao        *dao.GenericDAO[*privatev1.IdentityProvider]
-	secretsDao *dao.GenericDAO[*privatev1.Secret]
+	logger      *slog.Logger
+	generic     *GenericServer[*privatev1.IdentityProvider]
+	dao         *dao.GenericDAO[*privatev1.IdentityProvider]
+	secretsDao  *dao.GenericDAO[*privatev1.Secret]
+	secretStore vault.SecretStore
 }
 
 func NewPrivateIdentityProvidersServer() *PrivateIdentityProvidersServerBuilder {
@@ -85,6 +88,14 @@ func (b *PrivateIdentityProvidersServerBuilder) SetFilterDesc(value protoreflect
 	return b
 }
 
+// SetSecretStore sets the Vault secret store used to read the value of a Vault-backed secret
+// referenced by client_secret_secret. It is optional: when unset, the create/update validation
+// only sees data carried in the database column (which covers non-Vault backends and tests).
+func (b *PrivateIdentityProvidersServerBuilder) SetSecretStore(value vault.SecretStore) *PrivateIdentityProvidersServerBuilder {
+	b.secretStore = value
+	return b
+}
+
 func (b *PrivateIdentityProvidersServerBuilder) Build() (result *PrivateIdentityProvidersServer, err error) {
 	// Check parameters:
 	if b.logger == nil {
@@ -98,7 +109,8 @@ func (b *PrivateIdentityProvidersServerBuilder) Build() (result *PrivateIdentity
 
 	// Create the server early so that we can use its functions to set up other objects:
 	s := &PrivateIdentityProvidersServer{
-		logger: b.logger,
+		logger:      b.logger,
+		secretStore: b.secretStore,
 	}
 
 	// Create the generic server:
@@ -310,7 +322,24 @@ func (s *PrivateIdentityProvidersServer) validateClientSecretSecret(
 		s.logger.ErrorContext(ctx, "Failed to load client_secret_secret reference", "error", err)
 		return grpcstatus.Errorf(grpccodes.Internal, "failed to resolve client_secret_secret reference")
 	}
-	if value, ok := secretResp.GetObject().GetData()[secretValueKey]; !ok || len(value) == 0 {
+	secret := secretResp.GetObject()
+	data := secret.GetData()
+	// Vault-backed secrets do not carry their data in the database column: the Secrets server nulls
+	// it after writing to Vault. Hydrate the value from the store so this create/update-time check
+	// reads the same value the reconciler later resolves via the Secrets API. Secrets that keep
+	// their data in the database column (non-Vault backends, tests) are validated directly.
+	if len(data) == 0 && s.secretStore != nil &&
+		secret.GetBackend() == privatev1.SecretBackend_SECRET_BACKEND_VAULT {
+		metadata := secret.GetMetadata()
+		fetched, fetchErr := s.secretStore.Fetch(ctx,
+			metadata.GetTenant(), metadata.GetProject(), metadata.GetName())
+		if fetchErr != nil {
+			s.logger.ErrorContext(ctx, "Failed to load client_secret_secret value from store", "error", fetchErr)
+			return grpcstatus.Errorf(grpccodes.Internal, "failed to resolve client_secret_secret reference")
+		}
+		data = fetched
+	}
+	if value, ok := data[secretValueKey]; !ok || len(value) == 0 {
 		return grpcstatus.Errorf(grpccodes.InvalidArgument,
 			"secret '%s' referenced by client_secret_secret must contain a non-empty '%s' entry",
 			refKey(ref), secretValueKey)

--- a/fulfillment-service/internal/servers/private_identity_providers_server_test.go
+++ b/fulfillment-service/internal/servers/private_identity_providers_server_test.go
@@ -15,6 +15,7 @@ package servers
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -29,6 +30,7 @@ import (
 	"github.com/osac-project/osac/fulfillment-service/internal/database"
 	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/osac/fulfillment-service/internal/events"
+	"github.com/osac-project/osac/fulfillment-service/internal/vault"
 )
 
 var _ = Describe("Private identity providers server", func() {
@@ -901,6 +903,119 @@ var _ = Describe("Private identity providers server", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(grpcstatus.Code(err)).To(Equal(grpccodes.InvalidArgument))
 			Expect(grpcstatus.Convert(err).Message()).To(ContainSubstring("value"))
+		})
+	})
+
+	Describe("Client secret secret Vault hydration", func() {
+		var (
+			server    *PrivateIdentityProvidersServer
+			mockStore *vault.MockSecretStore
+		)
+
+		BeforeEach(func() {
+			var err error
+			mockStore = vault.NewMockSecretStore(ctrl)
+			server, err = NewPrivateIdentityProvidersServer().
+				SetLogger(logger).
+				SetAttributionLogic(attribution).
+				SetTenancyLogic(tenancy).
+				SetSecretStore(mockStore).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			secretsDao, err := dao.NewGenericDAO[*privatev1.Secret]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			// A Vault-backed secret carries no data in the database column: the Secrets server nulls it
+			// after writing to Vault. This mirrors what validateClientSecretSecret loads via the DAO, so
+			// the value must be hydrated from the store.
+			_, err = secretsDao.Create().SetObject(privatev1.Secret_builder{
+				Id: "vault-secret-id",
+				Metadata: privatev1.Metadata_builder{
+					Name:   "vault-secret-name",
+					Tenant: testTenant,
+				}.Build(),
+				Backend: privatev1.SecretBackend_SECRET_BACKEND_VAULT,
+			}.Build()).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		createIdp := func(oidc *privatev1.OidcConfig) (*privatev1.IdentityProvidersCreateResponse, error) {
+			return server.Create(ctx, privatev1.IdentityProvidersCreateRequest_builder{
+				Object: privatev1.IdentityProvider_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:   "test-oidc",
+						Tenant: "my-tenant",
+					}.Build(),
+					Spec: privatev1.IdentityProviderSpec_builder{
+						Title:   "Test OIDC",
+						Enabled: true,
+						Oidc:    oidc,
+					}.Build(),
+				}.Build(),
+			}.Build())
+		}
+
+		It("Hydrates the value from the store and creates when the database column is empty", func() {
+			// The DAO returns an empty data column for the Vault-backed secret, so the validation must
+			// fetch the value from the store using the secret's tenant/project/name.
+			mockStore.EXPECT().
+				Fetch(gomock.Any(), testTenant, "", "vault-secret-name").
+				Return(map[string][]byte{"value": []byte("resolved-from-vault")}, nil)
+
+			response, err := createIdp(privatev1.OidcConfig_builder{
+				AuthorizationUrl: "https://example.com/auth",
+				TokenUrl:         "https://example.com/token",
+				ClientId:         "client-id",
+				Issuer:           "https://example.com",
+				ClientSecretSecret: privatev1.SecretLocalReference_builder{
+					Id: "vault-secret-id",
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			ref := response.GetObject().GetSpec().GetOidc().GetClientSecretSecret()
+			Expect(ref.GetId()).To(Equal("vault-secret-id"))
+			Expect(ref.GetName()).To(Equal("vault-secret-name"))
+		})
+
+		It("Rejects create when the value hydrated from the store has no value entry", func() {
+			mockStore.EXPECT().
+				Fetch(gomock.Any(), testTenant, "", "vault-secret-name").
+				Return(map[string][]byte{"wrong-key": []byte("nope")}, nil)
+
+			_, err := createIdp(privatev1.OidcConfig_builder{
+				AuthorizationUrl: "https://example.com/auth",
+				TokenUrl:         "https://example.com/token",
+				ClientId:         "client-id",
+				Issuer:           "https://example.com",
+				ClientSecretSecret: privatev1.SecretLocalReference_builder{
+					Id: "vault-secret-id",
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(grpcstatus.Code(err)).To(Equal(grpccodes.InvalidArgument))
+			Expect(grpcstatus.Convert(err).Message()).To(ContainSubstring("value"))
+		})
+
+		It("Returns Internal when the store fails to load the value", func() {
+			mockStore.EXPECT().
+				Fetch(gomock.Any(), testTenant, "", "vault-secret-name").
+				Return(nil, fmt.Errorf("vault unavailable"))
+
+			_, err := createIdp(privatev1.OidcConfig_builder{
+				AuthorizationUrl: "https://example.com/auth",
+				TokenUrl:         "https://example.com/token",
+				ClientId:         "client-id",
+				Issuer:           "https://example.com",
+				ClientSecretSecret: privatev1.SecretLocalReference_builder{
+					Id: "vault-secret-id",
+				}.Build(),
+			}.Build())
+			Expect(err).To(HaveOccurred())
+			Expect(grpcstatus.Code(err)).To(Equal(grpccodes.Internal))
 		})
 	})
 })

--- a/fulfillment-service/it/it_cluster_pull_secret_test.go
+++ b/fulfillment-service/it/it_cluster_pull_secret_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Cluster pull_secret_secret", Label("secrets", "cluster"), func
 		}.Build())
 		Expect(err).ToNot(HaveOccurred())
 		clusterId := response.GetObject().GetId()
-		DeferCleanup(func() {
+		DeferCleanup(func(ctx context.Context) {
 			_, _ = clustersClient.Delete(ctx, publicv1.ClustersDeleteRequest_builder{Id: clusterId}.Build())
 		})
 
@@ -202,7 +202,7 @@ var _ = Describe("Cluster pull_secret_secret", Label("secrets", "cluster"), func
 		}.Build())
 		Expect(err).ToNot(HaveOccurred())
 		clusterId := response.GetObject().GetId()
-		DeferCleanup(func() {
+		DeferCleanup(func(ctx context.Context) {
 			_, _ = clustersClient.Delete(ctx, publicv1.ClustersDeleteRequest_builder{Id: clusterId}.Build())
 		})
 
@@ -282,7 +282,7 @@ var _ = Describe("Cluster pull_secret_secret", Label("secrets", "cluster"), func
 		}.Build())
 		Expect(err).ToNot(HaveOccurred())
 		clusterId := response.GetObject().GetId()
-		DeferCleanup(func() {
+		DeferCleanup(func(ctx context.Context) {
 			_, _ = clustersClient.Delete(ctx, publicv1.ClustersDeleteRequest_builder{Id: clusterId}.Build())
 		})
 
@@ -346,7 +346,7 @@ var _ = Describe("Cluster pull_secret_secret", Label("secrets", "cluster"), func
 		}.Build())
 		Expect(err).ToNot(HaveOccurred())
 		clusterId := response.GetObject().GetId()
-		DeferCleanup(func() {
+		DeferCleanup(func(ctx context.Context) {
 			_, _ = clustersClient.Delete(ctx, publicv1.ClustersDeleteRequest_builder{Id: clusterId}.Build())
 		})
 
@@ -377,7 +377,7 @@ var _ = Describe("Cluster pull_secret_secret", Label("secrets", "cluster"), func
 		}.Build())
 		Expect(err).ToNot(HaveOccurred())
 		clusterId := response.GetObject().GetId()
-		DeferCleanup(func() {
+		DeferCleanup(func(ctx context.Context) {
 			_, _ = clustersClient.Delete(ctx, publicv1.ClustersDeleteRequest_builder{Id: clusterId}.Build())
 		})
 

--- a/fulfillment-service/it/it_cluster_pull_secret_test.go
+++ b/fulfillment-service/it/it_cluster_pull_secret_test.go
@@ -1,0 +1,391 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package it
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
+	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
+	"github.com/osac-project/osac/fulfillment-service/internal/kubernetes/labels"
+	"github.com/osac-project/osac/fulfillment-service/internal/uuid"
+	osacv1alpha1 "github.com/osac-project/osac/osac-operator/api/v1alpha1"
+)
+
+// dockerConfigJSON is a representative (fake) container registry pull secret payload.
+const dockerConfigJSON = `{"auths":{"registry.example.com":{"auth":"dGVzdDp0ZXN0"}}}`
+
+var _ = Describe("Cluster pull_secret_secret", Label("secrets", "cluster"), func() {
+	var (
+		ctx             context.Context
+		clustersClient  publicv1.ClustersClient
+		secretsClient   publicv1.SecretsClient
+		hostTypesClient privatev1.HostTypesClient
+		templatesClient privatev1.ClusterTemplatesClient
+		hostTypeId      string
+
+		makeAny = func(value proto.Message) *anypb.Any {
+			result, err := anypb.New(value)
+			Expect(err).ToNot(HaveOccurred())
+			return result
+		}
+	)
+
+	// createSecret creates a Vault-backed secret owned by the same tenant that creates the
+	// clusters, so that both the server-side reference validation (create path) and the cluster
+	// reconciler (controller path) can resolve it.
+	createSecret := func(ctx context.Context, data map[string][]byte) (id, name string) {
+		name = fmt.Sprintf("pull-secret-%s", uuid.New()[24:32])
+		response, err := secretsClient.Create(ctx, publicv1.SecretsCreateRequest_builder{
+			Object: publicv1.Secret_builder{
+				Metadata: publicv1.Metadata_builder{
+					Name: name,
+				}.Build(),
+				Data: data,
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		id = response.GetObject().GetId()
+		DeferCleanup(func(ctx context.Context) {
+			_, _ = secretsClient.Delete(ctx, publicv1.SecretsDeleteRequest_builder{Id: id}.Build())
+		})
+		return id, name
+	}
+
+	// createTemplate creates a cluster template with a single required node set. When defaults is
+	// non-nil it is attached as the template's spec_defaults.
+	createTemplate := func(ctx context.Context, defaults *privatev1.ClusterTemplateSpecDefaults) string {
+		templateId := fmt.Sprintf("my_template_%s", uuid.New())
+		_, err := templatesClient.Create(ctx, privatev1.ClusterTemplatesCreateRequest_builder{
+			Object: privatev1.ClusterTemplate_builder{
+				Id:          templateId,
+				Title:       "Pull secret template",
+				Description: "Pull secret template.",
+				Metadata: privatev1.Metadata_builder{
+					Name: fmt.Sprintf("test-tmpl-%s", uuid.New()[24:32]),
+				}.Build(),
+				Parameters: []*privatev1.ClusterTemplateParameterDefinition{
+					privatev1.ClusterTemplateParameterDefinition_builder{
+						Name:        "my",
+						Type:        "type.googleapis.com/google.protobuf.StringValue",
+						Title:       "My required parameter",
+						Description: "My required parameter.",
+						Required:    true,
+					}.Build(),
+				},
+				NodeSets: map[string]*privatev1.ClusterTemplateNodeSet{
+					"my_node_set": privatev1.ClusterTemplateNodeSet_builder{
+						HostType: privatev1.HostTypeReference_builder{Id: hostTypeId}.Build(),
+						Size:     3,
+					}.Build(),
+				},
+				SpecDefaults: defaults,
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func(ctx context.Context) {
+			_, _ = templatesClient.Delete(ctx, privatev1.ClusterTemplatesDeleteRequest_builder{
+				Id: templateId,
+			}.Build())
+		})
+		return templateId
+	}
+
+	// waitForClusterOrder waits for the ClusterOrder Kubernetes object created for the given
+	// cluster and returns it.
+	waitForClusterOrder := func(ctx context.Context, clusterId string) *osacv1alpha1.ClusterOrder {
+		kubeClient := tool.KubeClient()
+		clusterOrderList := &osacv1alpha1.ClusterOrderList{}
+		var kubeObject *osacv1alpha1.ClusterOrder
+		Eventually(
+			func(g Gomega) {
+				err := kubeClient.List(ctx, clusterOrderList, crclient.MatchingLabels{
+					labels.ClusterOrderUuid: clusterId,
+				})
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(clusterOrderList.Items).To(HaveLen(1))
+				kubeObject = &clusterOrderList.Items[0]
+			},
+			time.Minute,
+			time.Second,
+		).Should(Succeed())
+		return kubeObject
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		clustersClient = publicv1.NewClustersClient(tool.ExternalView().UserConn())
+		secretsClient = publicv1.NewSecretsClient(tool.ExternalView().UserConn())
+		hostTypesClient = privatev1.NewHostTypesClient(tool.InternalView().AdminConn())
+		templatesClient = privatev1.NewClusterTemplatesClient(tool.InternalView().AdminConn())
+
+		hostTypeId = fmt.Sprintf("my_host_type_%s", uuid.New())
+		_, err := hostTypesClient.Create(ctx, privatev1.HostTypesCreateRequest_builder{
+			Object: privatev1.HostType_builder{
+				Id: hostTypeId,
+				Metadata: privatev1.Metadata_builder{
+					Name: fmt.Sprintf("test-ht-%s", uuid.New()[24:32]),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("resolves pull_secret_secret by id into the ClusterOrder pull secret", func() {
+		secretId, _ := createSecret(ctx, map[string][]byte{".dockerconfigjson": []byte(dockerConfigJSON)})
+		templateId := createTemplate(ctx, nil)
+
+		response, err := clustersClient.Create(ctx, publicv1.ClustersCreateRequest_builder{
+			Object: publicv1.Cluster_builder{
+				Metadata: publicv1.Metadata_builder{
+					Name: fmt.Sprintf("test-cluster-%s", uuid.New()[24:32]),
+				}.Build(),
+				Spec: publicv1.ClusterSpec_builder{
+					Template: publicv1.ClusterTemplateReference_builder{Id: templateId}.Build(),
+					TemplateParameters: map[string]*anypb.Any{
+						"my": makeAny(wrapperspb.String("my_value")),
+					},
+					PullSecretSecret: publicv1.SecretLocalReference_builder{Id: secretId}.Build(),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		clusterId := response.GetObject().GetId()
+		DeferCleanup(func() {
+			_, _ = clustersClient.Delete(ctx, publicv1.ClustersDeleteRequest_builder{Id: clusterId}.Build())
+		})
+
+		kubeObject := waitForClusterOrder(ctx, clusterId)
+		Expect(kubeObject.Spec.PullSecret).To(Equal(dockerConfigJSON))
+	})
+
+	It("resolves pull_secret_secret by name into the ClusterOrder pull secret", func() {
+		_, secretName := createSecret(ctx, map[string][]byte{".dockerconfigjson": []byte(dockerConfigJSON)})
+		templateId := createTemplate(ctx, nil)
+
+		response, err := clustersClient.Create(ctx, publicv1.ClustersCreateRequest_builder{
+			Object: publicv1.Cluster_builder{
+				Metadata: publicv1.Metadata_builder{
+					Name: fmt.Sprintf("test-cluster-%s", uuid.New()[24:32]),
+				}.Build(),
+				Spec: publicv1.ClusterSpec_builder{
+					Template: publicv1.ClusterTemplateReference_builder{Id: templateId}.Build(),
+					TemplateParameters: map[string]*anypb.Any{
+						"my": makeAny(wrapperspb.String("my_value")),
+					},
+					PullSecretSecret: publicv1.SecretLocalReference_builder{Name: secretName}.Build(),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		clusterId := response.GetObject().GetId()
+		DeferCleanup(func() {
+			_, _ = clustersClient.Delete(ctx, publicv1.ClustersDeleteRequest_builder{Id: clusterId}.Build())
+		})
+
+		kubeObject := waitForClusterOrder(ctx, clusterId)
+		Expect(kubeObject.Spec.PullSecret).To(Equal(dockerConfigJSON))
+	})
+
+	It("rejects a cluster that sets both pull_secret and pull_secret_secret", func() {
+		secretId, _ := createSecret(ctx, map[string][]byte{".dockerconfigjson": []byte(dockerConfigJSON)})
+		templateId := createTemplate(ctx, nil)
+
+		_, err := clustersClient.Create(ctx, publicv1.ClustersCreateRequest_builder{
+			Object: publicv1.Cluster_builder{
+				Metadata: publicv1.Metadata_builder{
+					Name: fmt.Sprintf("test-cluster-%s", uuid.New()[24:32]),
+				}.Build(),
+				Spec: publicv1.ClusterSpec_builder{
+					Template: publicv1.ClusterTemplateReference_builder{Id: templateId}.Build(),
+					TemplateParameters: map[string]*anypb.Any{
+						"my": makeAny(wrapperspb.String("my_value")),
+					},
+					PullSecret:       proto.String(dockerConfigJSON),
+					PullSecretSecret: publicv1.SecretLocalReference_builder{Id: secretId}.Build(),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).To(HaveOccurred())
+		status, ok := grpcstatus.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+	})
+
+	It("rejects a cluster that references a nonexistent secret", func() {
+		templateId := createTemplate(ctx, nil)
+
+		_, err := clustersClient.Create(ctx, publicv1.ClustersCreateRequest_builder{
+			Object: publicv1.Cluster_builder{
+				Metadata: publicv1.Metadata_builder{
+					Name: fmt.Sprintf("test-cluster-%s", uuid.New()[24:32]),
+				}.Build(),
+				Spec: publicv1.ClusterSpec_builder{
+					Template: publicv1.ClusterTemplateReference_builder{Id: templateId}.Build(),
+					TemplateParameters: map[string]*anypb.Any{
+						"my": makeAny(wrapperspb.String("my_value")),
+					},
+					PullSecretSecret: publicv1.SecretLocalReference_builder{
+						Id: uuid.New(),
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).To(HaveOccurred())
+		status, ok := grpcstatus.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+	})
+
+	It("reports SecretResolutionFailed and creates no ClusterOrder when the secret lacks .dockerconfigjson", func() {
+		// The secret exists (so create-time existence validation passes) but has the wrong shape,
+		// so the reconciler fails to resolve it.
+		secretId, _ := createSecret(ctx, map[string][]byte{"wrong-key": []byte("nope")})
+		templateId := createTemplate(ctx, nil)
+
+		response, err := clustersClient.Create(ctx, publicv1.ClustersCreateRequest_builder{
+			Object: publicv1.Cluster_builder{
+				Metadata: publicv1.Metadata_builder{
+					Name: fmt.Sprintf("test-cluster-%s", uuid.New()[24:32]),
+				}.Build(),
+				Spec: publicv1.ClusterSpec_builder{
+					Template: publicv1.ClusterTemplateReference_builder{Id: templateId}.Build(),
+					TemplateParameters: map[string]*anypb.Any{
+						"my": makeAny(wrapperspb.String("my_value")),
+					},
+					PullSecretSecret: publicv1.SecretLocalReference_builder{Id: secretId}.Build(),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		clusterId := response.GetObject().GetId()
+		DeferCleanup(func() {
+			_, _ = clustersClient.Delete(ctx, publicv1.ClustersDeleteRequest_builder{Id: clusterId}.Build())
+		})
+
+		// The cluster should report the resolution failure on its PROGRESSING condition.
+		Eventually(
+			func(g Gomega) {
+				getResponse, err := clustersClient.Get(ctx, publicv1.ClustersGetRequest_builder{
+					Id: clusterId,
+				}.Build())
+				g.Expect(err).ToNot(HaveOccurred())
+				var progressing *publicv1.ClusterCondition
+				for _, condition := range getResponse.GetObject().GetStatus().GetConditions() {
+					if condition.GetType() == publicv1.ClusterConditionType_CLUSTER_CONDITION_TYPE_PROGRESSING {
+						progressing = condition
+						break
+					}
+				}
+				g.Expect(progressing).ToNot(BeNil())
+				g.Expect(progressing.GetStatus()).To(Equal(publicv1.ConditionStatus_CONDITION_STATUS_FALSE))
+				g.Expect(progressing.GetReason()).To(Equal("SecretResolutionFailed"))
+			},
+			time.Minute,
+			time.Second,
+		).Should(Succeed())
+
+		// No ClusterOrder should be created while the pull secret cannot be resolved.
+		kubeClient := tool.KubeClient()
+		Consistently(
+			func(g Gomega) {
+				clusterOrderList := &osacv1alpha1.ClusterOrderList{}
+				err := kubeClient.List(ctx, clusterOrderList, crclient.MatchingLabels{
+					labels.ClusterOrderUuid: clusterId,
+				})
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(clusterOrderList.Items).To(BeEmpty())
+			},
+			10*time.Second,
+			time.Second,
+		).Should(Succeed())
+	})
+
+	It("propagates a template default pull_secret_secret into the ClusterOrder", func() {
+		secretId, _ := createSecret(ctx, map[string][]byte{".dockerconfigjson": []byte(dockerConfigJSON)})
+		templateId := createTemplate(ctx, privatev1.ClusterTemplateSpecDefaults_builder{
+			PullSecretSecret: privatev1.SecretLocalReference_builder{Id: secretId}.Build(),
+		}.Build())
+
+		// Create a cluster from the template without any pull secret of its own.
+		response, err := clustersClient.Create(ctx, publicv1.ClustersCreateRequest_builder{
+			Object: publicv1.Cluster_builder{
+				Metadata: publicv1.Metadata_builder{
+					Name: fmt.Sprintf("test-cluster-%s", uuid.New()[24:32]),
+				}.Build(),
+				Spec: publicv1.ClusterSpec_builder{
+					Template: publicv1.ClusterTemplateReference_builder{Id: templateId}.Build(),
+					TemplateParameters: map[string]*anypb.Any{
+						"my": makeAny(wrapperspb.String("my_value")),
+					},
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		clusterId := response.GetObject().GetId()
+		DeferCleanup(func() {
+			_, _ = clustersClient.Delete(ctx, publicv1.ClustersDeleteRequest_builder{Id: clusterId}.Build())
+		})
+
+		kubeObject := waitForClusterOrder(ctx, clusterId)
+		Expect(kubeObject.Spec.PullSecret).To(Equal(dockerConfigJSON))
+	})
+
+	It("lets a user inline pull_secret override a template default pull_secret_secret", func() {
+		secretId, _ := createSecret(ctx, map[string][]byte{".dockerconfigjson": []byte(dockerConfigJSON)})
+		templateId := createTemplate(ctx, privatev1.ClusterTemplateSpecDefaults_builder{
+			PullSecretSecret: privatev1.SecretLocalReference_builder{Id: secretId}.Build(),
+		}.Build())
+
+		const inlinePullSecret = `{"auths":{"inline.example.com":{"auth":"aW5saW5lOnZhbHVl"}}}`
+		response, err := clustersClient.Create(ctx, publicv1.ClustersCreateRequest_builder{
+			Object: publicv1.Cluster_builder{
+				Metadata: publicv1.Metadata_builder{
+					Name: fmt.Sprintf("test-cluster-%s", uuid.New()[24:32]),
+				}.Build(),
+				Spec: publicv1.ClusterSpec_builder{
+					Template: publicv1.ClusterTemplateReference_builder{Id: templateId}.Build(),
+					TemplateParameters: map[string]*anypb.Any{
+						"my": makeAny(wrapperspb.String("my_value")),
+					},
+					PullSecret: proto.String(inlinePullSecret),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		clusterId := response.GetObject().GetId()
+		DeferCleanup(func() {
+			_, _ = clustersClient.Delete(ctx, publicv1.ClustersDeleteRequest_builder{Id: clusterId}.Build())
+		})
+
+		kubeObject := waitForClusterOrder(ctx, clusterId)
+		Expect(kubeObject.Spec.PullSecret).To(Equal(inlinePullSecret))
+	})
+})
+
+// ensure grpc import is retained for status parsing helpers used above.
+var _ = grpc.ClientConn{}

--- a/fulfillment-service/it/it_cluster_pull_secret_test.go
+++ b/fulfillment-service/it/it_cluster_pull_secret_test.go
@@ -20,7 +20,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"google.golang.org/grpc"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -155,7 +154,7 @@ var _ = Describe("Cluster pull_secret_secret", Label("secrets", "cluster"), func
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("resolves pull_secret_secret by id into the ClusterOrder pull secret", func() {
+	It("Resolves pull_secret_secret by id into the ClusterOrder pull secret", func() {
 		secretId, _ := createSecret(ctx, map[string][]byte{".dockerconfigjson": []byte(dockerConfigJSON)})
 		templateId := createTemplate(ctx, nil)
 
@@ -183,7 +182,7 @@ var _ = Describe("Cluster pull_secret_secret", Label("secrets", "cluster"), func
 		Expect(kubeObject.Spec.PullSecret).To(Equal(dockerConfigJSON))
 	})
 
-	It("resolves pull_secret_secret by name into the ClusterOrder pull secret", func() {
+	It("Resolves pull_secret_secret by name into the ClusterOrder pull secret", func() {
 		_, secretName := createSecret(ctx, map[string][]byte{".dockerconfigjson": []byte(dockerConfigJSON)})
 		templateId := createTemplate(ctx, nil)
 
@@ -211,7 +210,7 @@ var _ = Describe("Cluster pull_secret_secret", Label("secrets", "cluster"), func
 		Expect(kubeObject.Spec.PullSecret).To(Equal(dockerConfigJSON))
 	})
 
-	It("rejects a cluster that sets both pull_secret and pull_secret_secret", func() {
+	It("Rejects a cluster that sets both pull_secret and pull_secret_secret", func() {
 		secretId, _ := createSecret(ctx, map[string][]byte{".dockerconfigjson": []byte(dockerConfigJSON)})
 		templateId := createTemplate(ctx, nil)
 
@@ -236,7 +235,7 @@ var _ = Describe("Cluster pull_secret_secret", Label("secrets", "cluster"), func
 		Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
 	})
 
-	It("rejects a cluster that references a nonexistent secret", func() {
+	It("Rejects a cluster that references a nonexistent secret", func() {
 		templateId := createTemplate(ctx, nil)
 
 		_, err := clustersClient.Create(ctx, publicv1.ClustersCreateRequest_builder{
@@ -261,7 +260,7 @@ var _ = Describe("Cluster pull_secret_secret", Label("secrets", "cluster"), func
 		Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
 	})
 
-	It("reports SecretResolutionFailed and creates no ClusterOrder when the secret lacks .dockerconfigjson", func() {
+	It("Reports SecretResolutionFailed and creates no ClusterOrder when the secret lacks .dockerconfigjson", func() {
 		// The secret exists (so create-time existence validation passes) but has the wrong shape,
 		// so the reconciler fails to resolve it.
 		secretId, _ := createSecret(ctx, map[string][]byte{"wrong-key": []byte("nope")})
@@ -325,7 +324,7 @@ var _ = Describe("Cluster pull_secret_secret", Label("secrets", "cluster"), func
 		).Should(Succeed())
 	})
 
-	It("propagates a template default pull_secret_secret into the ClusterOrder", func() {
+	It("Propagates a template default pull_secret_secret into the ClusterOrder", func() {
 		secretId, _ := createSecret(ctx, map[string][]byte{".dockerconfigjson": []byte(dockerConfigJSON)})
 		templateId := createTemplate(ctx, privatev1.ClusterTemplateSpecDefaults_builder{
 			PullSecretSecret: privatev1.SecretLocalReference_builder{Id: secretId}.Build(),
@@ -355,7 +354,7 @@ var _ = Describe("Cluster pull_secret_secret", Label("secrets", "cluster"), func
 		Expect(kubeObject.Spec.PullSecret).To(Equal(dockerConfigJSON))
 	})
 
-	It("lets a user inline pull_secret override a template default pull_secret_secret", func() {
+	It("Lets a user inline pull_secret override a template default pull_secret_secret", func() {
 		secretId, _ := createSecret(ctx, map[string][]byte{".dockerconfigjson": []byte(dockerConfigJSON)})
 		templateId := createTemplate(ctx, privatev1.ClusterTemplateSpecDefaults_builder{
 			PullSecretSecret: privatev1.SecretLocalReference_builder{Id: secretId}.Build(),
@@ -386,6 +385,3 @@ var _ = Describe("Cluster pull_secret_secret", Label("secrets", "cluster"), func
 		Expect(kubeObject.Spec.PullSecret).To(Equal(inlinePullSecret))
 	})
 })
-
-// ensure grpc import is retained for status parsing helpers used above.
-var _ = grpc.ClientConn{}

--- a/fulfillment-service/it/it_hub_kubeconfig_secret_test.go
+++ b/fulfillment-service/it/it_hub_kubeconfig_secret_test.go
@@ -1,0 +1,231 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package it
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/osac/fulfillment-service/internal/uuid"
+)
+
+// sampleHubKubeconfig is a syntactically-plausible kubeconfig payload. The Hubs server validation
+// only checks that the referenced Secret exists (it never reads the data), so the exact content is
+// immaterial to these create-time tests.
+const sampleHubKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- name: hub
+  cluster:
+    server: https://kubernetes.default.svc
+contexts:
+- name: hub
+  context:
+    cluster: hub
+    user: hub
+current-context: hub
+users:
+- name: hub
+  user:
+    token: fake-token
+`
+
+var _ = Describe("Hub kubeconfig_secret", Label("secrets", "hub"), func() {
+	var (
+		ctx           context.Context
+		hubsClient    privatev1.HubsClient
+		secretsClient privatev1.SecretsClient
+		tenantsClient privatev1.TenantsClient
+		tenantName    string
+		tenantID      string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		hubsClient = privatev1.NewHubsClient(tool.InternalView().AdminConn())
+		secretsClient = privatev1.NewSecretsClient(tool.InternalView().AdminConn())
+		tenantsClient = privatev1.NewTenantsClient(tool.InternalView().AdminConn())
+
+		// A fresh, SYNCED tenant guarantees a Vault namespace exists so the kubeconfig secret can be
+		// stored. Hubs live in the shared tenant, but the create-time kubeconfig_secret validation
+		// resolves the reference by id/name via the admin-scoped secrets DAO, which is tenant-agnostic
+		// -- so the secret's tenant does not affect these assertions.
+		tenantName = fmt.Sprintf("hub-sec-%s", uuid.New())
+		createResponse, err := tenantsClient.Create(ctx, privatev1.TenantsCreateRequest_builder{
+			Object: privatev1.Tenant_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name: tenantName,
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		tenantID = createResponse.GetObject().GetId()
+		DeferCleanup(func() {
+			_, _ = tenantsClient.Delete(ctx, privatev1.TenantsDeleteRequest_builder{
+				Id: tenantID,
+			}.Build())
+		})
+		waitForTenantSynced(ctx, tenantsClient, tenantID)
+	})
+
+	// createKubeconfigSecret creates a Vault-backed secret carrying a kubeconfig payload and returns
+	// its id and name.
+	createKubeconfigSecret := func(ctx context.Context, data map[string][]byte) (id, name string) {
+		name = fmt.Sprintf("hub-kubeconfig-%s", uuid.New()[24:32])
+		response, err := secretsClient.Create(ctx, privatev1.SecretsCreateRequest_builder{
+			Object: privatev1.Secret_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   name,
+					Tenant: tenantName,
+				}.Build(),
+				Data: data,
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		id = response.GetObject().GetId()
+		DeferCleanup(func() {
+			_, _ = secretsClient.Delete(ctx, privatev1.SecretsDeleteRequest_builder{Id: id}.Build())
+		})
+		return id, name
+	}
+
+	// createHub creates a hub with a unique id/namespace using the given spec and registers cleanup.
+	createHub := func(ctx context.Context, spec *privatev1.HubSpec) (*privatev1.Hub, error) {
+		hubId := fmt.Sprintf("test-hub-%s", uuid.New())
+		response, err := hubsClient.Create(ctx, privatev1.HubsCreateRequest_builder{
+			Object: privatev1.Hub_builder{
+				Id: hubId,
+				Metadata: privatev1.Metadata_builder{
+					Name: hubId,
+				}.Build(),
+				Spec: spec,
+			}.Build(),
+		}.Build())
+		if err == nil {
+			DeferCleanup(func() {
+				_, _ = hubsClient.Delete(ctx, privatev1.HubsDeleteRequest_builder{Id: hubId}.Build())
+			})
+		}
+		return response.GetObject(), err
+	}
+
+	It("accepts a hub referencing kubeconfig_secret by id and writes back the resolved ref", func() {
+		secretId, secretName := createKubeconfigSecret(ctx, map[string][]byte{
+			"kubeconfig": []byte(sampleHubKubeconfig),
+		})
+
+		hub, err := createHub(ctx, privatev1.HubSpec_builder{
+			Namespace:        fmt.Sprintf("test-hub-ns-%s", uuid.New()[24:32]),
+			KubeconfigSecret: privatev1.SecretLocalReference_builder{Id: secretId}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		// The server resolves the reference and writes back both id and name.
+		ref := hub.GetSpec().GetKubeconfigSecret()
+		Expect(ref).ToNot(BeNil())
+		Expect(ref.GetId()).To(Equal(secretId))
+		Expect(ref.GetName()).To(Equal(secretName))
+	})
+
+	It("accepts a hub referencing kubeconfig_secret by name and resolves the id", func() {
+		secretId, secretName := createKubeconfigSecret(ctx, map[string][]byte{
+			"kubeconfig": []byte(sampleHubKubeconfig),
+		})
+
+		hub, err := createHub(ctx, privatev1.HubSpec_builder{
+			Namespace:        fmt.Sprintf("test-hub-ns-%s", uuid.New()[24:32]),
+			KubeconfigSecret: privatev1.SecretLocalReference_builder{Name: secretName}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+
+		ref := hub.GetSpec().GetKubeconfigSecret()
+		Expect(ref).ToNot(BeNil())
+		Expect(ref.GetId()).To(Equal(secretId))
+		Expect(ref.GetName()).To(Equal(secretName))
+	})
+
+	It("rejects a hub that sets both kubeconfig and kubeconfig_secret", func() {
+		secretId, _ := createKubeconfigSecret(ctx, map[string][]byte{
+			"kubeconfig": []byte(sampleHubKubeconfig),
+		})
+
+		_, err := createHub(ctx, privatev1.HubSpec_builder{
+			Namespace:        fmt.Sprintf("test-hub-ns-%s", uuid.New()[24:32]),
+			Kubeconfig:       []byte(sampleHubKubeconfig),
+			KubeconfigSecret: privatev1.SecretLocalReference_builder{Id: secretId}.Build(),
+		}.Build())
+		Expect(err).To(HaveOccurred())
+		status, ok := grpcstatus.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+	})
+
+	It("rejects a hub referencing a nonexistent secret", func() {
+		_, err := createHub(ctx, privatev1.HubSpec_builder{
+			Namespace:        fmt.Sprintf("test-hub-ns-%s", uuid.New()[24:32]),
+			KubeconfigSecret: privatev1.SecretLocalReference_builder{Id: uuid.New()}.Build(),
+		}.Build())
+		Expect(err).To(HaveOccurred())
+		status, ok := grpcstatus.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+	})
+
+	It("rejects updating kubeconfig while kubeconfig_secret is set", func() {
+		secretId, _ := createKubeconfigSecret(ctx, map[string][]byte{
+			"kubeconfig": []byte(sampleHubKubeconfig),
+		})
+
+		hubId := fmt.Sprintf("test-hub-%s", uuid.New())
+		_, err := hubsClient.Create(ctx, privatev1.HubsCreateRequest_builder{
+			Object: privatev1.Hub_builder{
+				Id: hubId,
+				Metadata: privatev1.Metadata_builder{
+					Name: hubId,
+				}.Build(),
+				Spec: privatev1.HubSpec_builder{
+					Namespace:        fmt.Sprintf("test-hub-ns-%s", uuid.New()[24:32]),
+					KubeconfigSecret: privatev1.SecretLocalReference_builder{Id: secretId}.Build(),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			_, _ = hubsClient.Delete(ctx, privatev1.HubsDeleteRequest_builder{Id: hubId}.Build())
+		})
+
+		// Setting the inline kubeconfig via the mask while the stored hub still carries a
+		// kubeconfig_secret (not cleared in the same request) is a mutual-exclusion conflict.
+		_, err = hubsClient.Update(ctx, privatev1.HubsUpdateRequest_builder{
+			Object: privatev1.Hub_builder{
+				Id: hubId,
+				Spec: privatev1.HubSpec_builder{
+					Kubeconfig: []byte(sampleHubKubeconfig),
+				}.Build(),
+			}.Build(),
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.kubeconfig"}},
+		}.Build())
+		Expect(err).To(HaveOccurred())
+		status, ok := grpcstatus.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+	})
+})

--- a/fulfillment-service/it/it_hub_kubeconfig_secret_test.go
+++ b/fulfillment-service/it/it_hub_kubeconfig_secret_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Hub kubeconfig_secret", Label("secrets", "hub"), func() {
 		return response.GetObject(), err
 	}
 
-	It("accepts a hub referencing kubeconfig_secret by id and writes back the resolved ref", func() {
+	It("Accepts a hub referencing kubeconfig_secret by id and writes back the resolved ref", func() {
 		secretId, secretName := createKubeconfigSecret(ctx, map[string][]byte{
 			"kubeconfig": []byte(sampleHubKubeconfig),
 		})
@@ -145,7 +145,7 @@ var _ = Describe("Hub kubeconfig_secret", Label("secrets", "hub"), func() {
 		Expect(ref.GetName()).To(Equal(secretName))
 	})
 
-	It("accepts a hub referencing kubeconfig_secret by name and resolves the id", func() {
+	It("Accepts a hub referencing kubeconfig_secret by name and resolves the id", func() {
 		secretId, secretName := createKubeconfigSecret(ctx, map[string][]byte{
 			"kubeconfig": []byte(sampleHubKubeconfig),
 		})
@@ -162,7 +162,7 @@ var _ = Describe("Hub kubeconfig_secret", Label("secrets", "hub"), func() {
 		Expect(ref.GetName()).To(Equal(secretName))
 	})
 
-	It("rejects a hub that sets both kubeconfig and kubeconfig_secret", func() {
+	It("Rejects a hub that sets both kubeconfig and kubeconfig_secret", func() {
 		secretId, _ := createKubeconfigSecret(ctx, map[string][]byte{
 			"kubeconfig": []byte(sampleHubKubeconfig),
 		})
@@ -178,7 +178,7 @@ var _ = Describe("Hub kubeconfig_secret", Label("secrets", "hub"), func() {
 		Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
 	})
 
-	It("rejects a hub referencing a nonexistent secret", func() {
+	It("Rejects a hub referencing a nonexistent secret", func() {
 		_, err := createHub(ctx, privatev1.HubSpec_builder{
 			Namespace:        fmt.Sprintf("test-hub-ns-%s", uuid.New()[24:32]),
 			KubeconfigSecret: privatev1.SecretLocalReference_builder{Id: uuid.New()}.Build(),
@@ -189,7 +189,7 @@ var _ = Describe("Hub kubeconfig_secret", Label("secrets", "hub"), func() {
 		Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
 	})
 
-	It("rejects updating kubeconfig while kubeconfig_secret is set", func() {
+	It("Rejects updating kubeconfig while kubeconfig_secret is set", func() {
 		secretId, _ := createKubeconfigSecret(ctx, map[string][]byte{
 			"kubeconfig": []byte(sampleHubKubeconfig),
 		})

--- a/fulfillment-service/it/it_identity_providers_test.go
+++ b/fulfillment-service/it/it_identity_providers_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
 	publicv1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/public/v1"
@@ -550,5 +551,255 @@ var _ = Describe("Identity provider lifecycle", func() {
 			Expect(code).To(Equal(http.StatusOK),
 				"IdP with alias %q should exist in Keycloak", entry.alias)
 		}
+	})
+})
+
+var _ = Describe("Identity provider client_secret_secret", func() {
+	var (
+		ctx           context.Context
+		client        privatev1.IdentityProvidersClient
+		tenantsClient privatev1.TenantsClient
+		secretsClient privatev1.SecretsClient
+		tenantName    string
+		tenantID      string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		client = privatev1.NewIdentityProvidersClient(tool.InternalView().AdminConn())
+		tenantsClient = privatev1.NewTenantsClient(tool.InternalView().AdminConn())
+		secretsClient = privatev1.NewSecretsClient(tool.InternalView().AdminConn())
+
+		tenantName = fmt.Sprintf("idp-sec-%s", uuid.New())
+		createResponse, err := tenantsClient.Create(ctx, privatev1.TenantsCreateRequest_builder{
+			Object: privatev1.Tenant_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name: tenantName,
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		tenantID = createResponse.GetObject().GetId()
+		DeferCleanup(func() {
+			_, _ = tenantsClient.Delete(ctx, privatev1.TenantsDeleteRequest_builder{
+				Id: tenantID,
+			}.Build())
+		})
+
+		// The tenant must be SYNCED before its Vault namespace exists and secrets can be stored.
+		waitForTenantSynced(ctx, tenantsClient, tenantID)
+	})
+
+	// createClientSecret creates a Vault-backed secret owned by the IdP's tenant with the given
+	// data map, and returns its id and name.
+	createClientSecret := func(ctx context.Context, data map[string][]byte) (id, name string) {
+		name = fmt.Sprintf("idp-client-secret-%s", uuid.New()[24:32])
+		response, err := secretsClient.Create(ctx, privatev1.SecretsCreateRequest_builder{
+			Object: privatev1.Secret_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   name,
+					Tenant: tenantName,
+				}.Build(),
+				Data: data,
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		id = response.GetObject().GetId()
+		DeferCleanup(func() {
+			_, _ = secretsClient.Delete(ctx, privatev1.SecretsDeleteRequest_builder{Id: id}.Build())
+		})
+		return id, name
+	}
+
+	It("Creates an OIDC identity provider using client_secret_secret and reconciles to READY", func() {
+		secretId, _ := createClientSecret(ctx, map[string][]byte{"value": []byte("resolved-client-secret")})
+
+		idpName := fmt.Sprintf("test-oidc-sec-%s", uuid.New())
+		expectedAlias := fmt.Sprintf("%s-%s", tenantName, idpName)
+
+		createResponse, err := client.Create(ctx, privatev1.IdentityProvidersCreateRequest_builder{
+			Object: privatev1.IdentityProvider_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   idpName,
+					Tenant: tenantName,
+				}.Build(),
+				Spec: privatev1.IdentityProviderSpec_builder{
+					Title:   "Test OIDC Provider (secret ref)",
+					Enabled: true,
+					Oidc: privatev1.OidcConfig_builder{
+						AuthorizationUrl:   "https://oidc.example.com/authorize",
+						TokenUrl:           "https://oidc.example.com/token",
+						ClientId:           "test-client",
+						ClientSecretSecret: privatev1.SecretLocalReference_builder{Id: secretId}.Build(),
+						Issuer:             "https://oidc.example.com",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		idpID := createResponse.GetObject().GetId()
+		DeferCleanup(func() {
+			_, _ = client.Delete(ctx, privatev1.IdentityProvidersDeleteRequest_builder{
+				Id: idpID,
+			}.Build())
+		})
+
+		// Reaching READY proves the reconciler resolved the client secret from the referenced
+		// Secret (a resolution failure would leave the provider un-synced).
+		Eventually(
+			func(g Gomega) {
+				getResponse, err := client.Get(ctx, privatev1.IdentityProvidersGetRequest_builder{
+					Id: idpID,
+				}.Build())
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(getResponse.GetObject().GetStatus().GetPhase()).To(
+					Equal(privatev1.IdentityProviderPhase_IDENTITY_PROVIDER_PHASE_READY),
+				)
+			},
+			2*time.Minute,
+			time.Second,
+		).Should(Succeed())
+
+		code, _, err := tool.KeycloakAdminRequest(ctx, http.MethodGet,
+			fmt.Sprintf("/identity-provider/instances/%s", expectedAlias), nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(code).To(Equal(http.StatusOK))
+	})
+
+	It("Rejects setting both client_secret and client_secret_secret", func() {
+		secretId, _ := createClientSecret(ctx, map[string][]byte{"value": []byte("resolved-client-secret")})
+
+		idpName := fmt.Sprintf("test-both-%s", uuid.New())
+		_, err := client.Create(ctx, privatev1.IdentityProvidersCreateRequest_builder{
+			Object: privatev1.IdentityProvider_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   idpName,
+					Tenant: tenantName,
+				}.Build(),
+				Spec: privatev1.IdentityProviderSpec_builder{
+					Title:   "Conflicting Provider",
+					Enabled: true,
+					Oidc: privatev1.OidcConfig_builder{
+						AuthorizationUrl:   "https://oidc.example.com/authorize",
+						TokenUrl:           "https://oidc.example.com/token",
+						ClientId:           "test-client",
+						ClientSecret:       "inline-secret",
+						ClientSecretSecret: privatev1.SecretLocalReference_builder{Id: secretId}.Build(),
+						Issuer:             "https://oidc.example.com",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).To(HaveOccurred())
+		status, ok := grpcstatus.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+	})
+
+	It("Rejects a nonexistent client_secret_secret reference", func() {
+		idpName := fmt.Sprintf("test-missing-%s", uuid.New())
+		_, err := client.Create(ctx, privatev1.IdentityProvidersCreateRequest_builder{
+			Object: privatev1.IdentityProvider_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   idpName,
+					Tenant: tenantName,
+				}.Build(),
+				Spec: privatev1.IdentityProviderSpec_builder{
+					Title:   "Missing Secret Provider",
+					Enabled: true,
+					Oidc: privatev1.OidcConfig_builder{
+						AuthorizationUrl:   "https://oidc.example.com/authorize",
+						TokenUrl:           "https://oidc.example.com/token",
+						ClientId:           "test-client",
+						ClientSecretSecret: privatev1.SecretLocalReference_builder{Id: uuid.New()}.Build(),
+						Issuer:             "https://oidc.example.com",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).To(HaveOccurred())
+		status, ok := grpcstatus.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+	})
+
+	It("Rejects a client_secret_secret whose secret lacks a non-empty value", func() {
+		// The secret exists but has no "value" data entry, which the create-time validation rejects.
+		secretId, _ := createClientSecret(ctx, map[string][]byte{"wrong-key": []byte("nope")})
+
+		idpName := fmt.Sprintf("test-novalue-%s", uuid.New())
+		_, err := client.Create(ctx, privatev1.IdentityProvidersCreateRequest_builder{
+			Object: privatev1.IdentityProvider_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   idpName,
+					Tenant: tenantName,
+				}.Build(),
+				Spec: privatev1.IdentityProviderSpec_builder{
+					Title:   "Empty Value Provider",
+					Enabled: true,
+					Oidc: privatev1.OidcConfig_builder{
+						AuthorizationUrl:   "https://oidc.example.com/authorize",
+						TokenUrl:           "https://oidc.example.com/token",
+						ClientId:           "test-client",
+						ClientSecretSecret: privatev1.SecretLocalReference_builder{Id: secretId}.Build(),
+						Issuer:             "https://oidc.example.com",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).To(HaveOccurred())
+		status, ok := grpcstatus.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+	})
+
+	It("Rejects updating client_secret while client_secret_secret is set", func() {
+		secretId, _ := createClientSecret(ctx, map[string][]byte{"value": []byte("resolved-client-secret")})
+
+		idpName := fmt.Sprintf("test-update-%s", uuid.New())
+		createResponse, err := client.Create(ctx, privatev1.IdentityProvidersCreateRequest_builder{
+			Object: privatev1.IdentityProvider_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   idpName,
+					Tenant: tenantName,
+				}.Build(),
+				Spec: privatev1.IdentityProviderSpec_builder{
+					Title:   "Update Conflict Provider",
+					Enabled: true,
+					Oidc: privatev1.OidcConfig_builder{
+						AuthorizationUrl:   "https://oidc.example.com/authorize",
+						TokenUrl:           "https://oidc.example.com/token",
+						ClientId:           "test-client",
+						ClientSecretSecret: privatev1.SecretLocalReference_builder{Id: secretId}.Build(),
+						Issuer:             "https://oidc.example.com",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		idpID := createResponse.GetObject().GetId()
+		DeferCleanup(func() {
+			_, _ = client.Delete(ctx, privatev1.IdentityProvidersDeleteRequest_builder{
+				Id: idpID,
+			}.Build())
+		})
+
+		// Setting the inline client_secret via the mask while the stored provider still carries a
+		// client_secret_secret (not cleared in the same request) is a mutual-exclusion conflict.
+		_, err = client.Update(ctx, privatev1.IdentityProvidersUpdateRequest_builder{
+			Object: privatev1.IdentityProvider_builder{
+				Id: idpID,
+				Spec: privatev1.IdentityProviderSpec_builder{
+					Oidc: privatev1.OidcConfig_builder{
+						ClientSecret: "inline-secret",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.oidc.client_secret"}},
+		}.Build())
+		Expect(err).To(HaveOccurred())
+		status, ok := grpcstatus.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
 	})
 })

--- a/fulfillment-service/it/it_identity_providers_test.go
+++ b/fulfillment-service/it/it_identity_providers_test.go
@@ -802,4 +802,57 @@ var _ = Describe("Identity provider client_secret_secret", func() {
 		Expect(ok).To(BeTrue())
 		Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
 	})
+
+	It("Updates client_secret_secret to another Vault-backed secret", func() {
+		// Both secrets go through the real Secrets API, so their values live in Vault (not the
+		// database column). A successful update proves the update-path validation hydrates the
+		// value from the store, exactly as the create path does.
+		firstSecretId, _ := createClientSecret(ctx, map[string][]byte{"value": []byte("first-client-secret")})
+		secondSecretId, secondSecretName := createClientSecret(ctx,
+			map[string][]byte{"value": []byte("second-client-secret")})
+
+		idpName := fmt.Sprintf("test-update-ref-%s", uuid.New())
+		createResponse, err := client.Create(ctx, privatev1.IdentityProvidersCreateRequest_builder{
+			Object: privatev1.IdentityProvider_builder{
+				Metadata: privatev1.Metadata_builder{
+					Name:   idpName,
+					Tenant: tenantName,
+				}.Build(),
+				Spec: privatev1.IdentityProviderSpec_builder{
+					Title:   "Update Reference Provider",
+					Enabled: true,
+					Oidc: privatev1.OidcConfig_builder{
+						AuthorizationUrl:   "https://oidc.example.com/authorize",
+						TokenUrl:           "https://oidc.example.com/token",
+						ClientId:           "test-client",
+						ClientSecretSecret: privatev1.SecretLocalReference_builder{Id: firstSecretId}.Build(),
+						Issuer:             "https://oidc.example.com",
+					}.Build(),
+				}.Build(),
+			}.Build(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		idpID := createResponse.GetObject().GetId()
+		DeferCleanup(func() {
+			_, _ = client.Delete(ctx, privatev1.IdentityProvidersDeleteRequest_builder{
+				Id: idpID,
+			}.Build())
+		})
+
+		updateResponse, err := client.Update(ctx, privatev1.IdentityProvidersUpdateRequest_builder{
+			Object: privatev1.IdentityProvider_builder{
+				Id: idpID,
+				Spec: privatev1.IdentityProviderSpec_builder{
+					Oidc: privatev1.OidcConfig_builder{
+						ClientSecretSecret: privatev1.SecretLocalReference_builder{Id: secondSecretId}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build(),
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.oidc.client_secret_secret"}},
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		ref := updateResponse.GetObject().GetSpec().GetOidc().GetClientSecretSecret()
+		Expect(ref.GetId()).To(Equal(secondSecretId))
+		Expect(ref.GetName()).To(Equal(secondSecretName))
+	})
 })

--- a/fulfillment-service/it/it_tenant_lifecycle_test.go
+++ b/fulfillment-service/it/it_tenant_lifecycle_test.go
@@ -374,6 +374,70 @@ var _ = Describe("Tenant lifecycle", func() {
 		Expect(status.Code()).To(Equal(grpccodes.PermissionDenied))
 	})
 
+	It("Persists break-glass credentials to a Secret and clears inline status", func(ctx context.Context) {
+		// breakGlassSecretName mirrors the unexported constant in the tenant reconciler.
+		const breakGlassSecretName = "break-glass-credentials"
+
+		name := fmt.Sprintf("test-%s", uuid.New())
+
+		By(fmt.Sprintf("Creating tenant %q", name))
+		id := createTenant(ctx, tenantsClient, name)
+
+		By("Waiting for tenant to reach SYNCED state")
+		waitForTenantSynced(ctx, tenantsClient, id)
+
+		By("Verifying the break-glass credentials secret reference is recorded on the spec")
+		getResponse, err := tenantsClient.Get(ctx, privatev1.TenantsGetRequest_builder{
+			Id: id,
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		object := getResponse.GetObject()
+
+		ref := object.GetSpec().GetBreakGlassCredentialsSecret()
+		Expect(ref).ToNot(BeNil(), "spec.break_glass_credentials_secret should be set after sync")
+		Expect(ref.GetId()).ToNot(BeEmpty())
+		Expect(ref.GetName()).To(Equal(breakGlassSecretName))
+
+		By("Verifying inline break-glass credentials are cleared from status")
+		Expect(object.GetStatus().GetBreakGlassCredentials().GetPassword()).To(BeEmpty(),
+			"inline status credentials should be cleared once persisted to a secret")
+		Expect(object.GetStatus().GetBreakGlassUserId()).ToNot(BeEmpty())
+
+		By("Fetching the referenced secret and verifying it carries the credentials")
+		secretsClient := privatev1.NewSecretsClient(tool.InternalView().AdminConn())
+		secretResponse, err := secretsClient.Get(ctx, privatev1.SecretsGetRequest_builder{
+			Id: ref.GetId(),
+		}.Build())
+		Expect(err).ToNot(HaveOccurred())
+		data := secretResponse.GetObject().GetData()
+		Expect(data).To(HaveKey("password"))
+		Expect(data).To(HaveKey("username"))
+		Expect(data["password"]).ToNot(BeEmpty())
+		Expect(string(data["username"])).To(Equal(fmt.Sprintf("%s-osac-break-glass", name)))
+
+		By("Verifying the persisted password authenticates as the break-glass user")
+		// The credential is created temporary, so the UPDATE_PASSWORD required action must be
+		// cleared before the stored password can be used to obtain a token.
+		code, _, err := tool.KeycloakAdminRequest(ctx, http.MethodPut,
+			fmt.Sprintf("/users/%s", object.GetStatus().GetBreakGlassUserId()),
+			map[string]any{
+				"requiredActions": []string{},
+			})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(code).To(Equal(http.StatusNoContent))
+
+		tokenSource, err := tool.makeKeycloakTokenSource(ctx, string(data["username"]), string(data["password"]))
+		Expect(err).ToNot(HaveOccurred())
+
+		// Obtaining an access token from the OIDC password flow proves the persisted password
+		// authenticates as the break-glass user. We deliberately do not exercise a downstream gRPC
+		// call here: that would assert the break-glass user's API authorization, which is out of
+		// scope for this test (and covered separately by the break-glass JWT/role specs).
+		token, err := tokenSource.Token(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(token.Access).ToNot(BeEmpty())
+	})
+
 	It("Duplicate tenant name fails", func(ctx context.Context) {
 		name := fmt.Sprintf("test-%s", uuid.New())
 


### PR DESCRIPTION
## What

Adds Ginkgo integration tests in `fulfillment-service/it/` covering the
[OSAC-2953](https://redhat.atlassian.net/browse/OSAC-2953) secret-reference validation across every reference site, and fixes a
product bug in the identity-provider server that the new tests uncovered.

Relates to:
- [OSAC-2985](https://redhat.atlassian.net/browse/OSAC-2985) (this task): https://redhat.atlassian.net/browse/OSAC-2985
- [OSAC-2953](https://redhat.atlassian.net/browse/OSAC-2953) (epic): https://redhat.atlassian.net/browse/OSAC-2953

## Integration tests (`it/`)

- **`it_cluster_pull_secret_test.go`** — `pull_secret_secret` on ClusterOrder (7 specs)
- **`it_hub_kubeconfig_secret_test.go`** — Hub `kubeconfig_secret` (5 specs)
- **`it_identity_providers_test.go`** — IDP `client_secret_secret`: create reaches
  READY, mutual exclusion with inline `client_secret`, nonexistent reference,
  reference to a secret lacking a `value` entry, and update conflict (5 specs)
- **`it_tenant_lifecycle_test.go`** — break-glass secret: the spec now asserts the
  persisted credentials authenticate via OIDC token issuance rather than making a
  downstream authorized RPC (the break-glass user's API authorization is out of
  scope here and covered by the JWT/role specs)

All 18 new secret specs pass in a full local IT run.

## Product fix

`validateClientSecretSecret` read the referenced secret's value directly from the
raw DAO (the database `data` column), which is empty for Vault-backed secrets
because the Secrets server nulls it after writing the value to Vault. As a result
every valid Vault-backed secret was rejected at create/update time with
`must contain a non-empty 'value' entry`, even though the reconciler resolved it
correctly through the Secrets API.

The fix injects `vault.SecretStore` into the private identity-providers server and
hydrates the value from the store when the DB column is empty for a
`SECRET_BACKEND_VAULT` secret, mirroring the reconciler's read path. Non-Vault
backends (and unit tests that keep data in the DB column) are unaffected.

- `internal/servers/private_identity_providers_server.go` — `SetSecretStore` +
  Vault-aware hydration in `validateClientSecretSecret`
- `internal/cmd/service/start/grpcserver/register_servers.go` — wire
  `deps.SecretStore` into the private IDP server

## Testing

- Full `fulfillment-service` IT suite locally (kind): 301 passed. The only 4
  failures were pre-existing, stale-domain `AlreadyExists` collisions in
  `it_tenant_domain_validation_test.go` (fixed domain strings + soft-delete with a
  stuck finalizer under `operator.enabled=false`); a clean-DB rerun of that file
  passes 16/16. Unrelated to this change.
- All new secret specs green, including the two IDP specs that exercise the Vault
  round-trip and previously reproduced the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for resolving private identity provider client secrets from Vault-backed secrets.
  * Added support for resolving cluster pull secrets and Hub kubeconfig secrets by ID or name.
  * Added persistence of tenant break-glass credentials in Kubernetes Secrets.

* **Bug Fixes**
  * Improved validation and error handling for missing, invalid, or conflicting inline and referenced secrets.

* **Tests**
  * Expanded integration coverage for secret resolution, validation, updates, and credential persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->