### PR TITLE
OSAC-3593: Sync test changes from osac-test-infra PRs #367, #410, #417

### DIFF
--- a/tests/catalog/test_catalog_item_lifecycle.py
+++ b/tests/catalog/test_catalog_item_lifecycle.py
@@ -86,13 +86,13 @@ def test_catalog_item_field_definitions(grpc: GRPCClient, cluster_template: str)
             "path": "spec.network.pod_cidr",
             "display_name": "Pod CIDR",
             "editable": True,
-            "default": {"stringValue": "10.128.0.0/14"},
+            "default": "10.128.0.0/14",
         },
         {
             "path": "spec.network.service_cidr",
             "display_name": "Service CIDR",
             "editable": False,
-            "default": {"stringValue": "172.30.0.0/16"},
+            "default": "172.30.0.0/16",
         },
     ]
     name = unique_name("e2e-fd")
@@ -117,13 +117,13 @@ def test_catalog_item_field_definitions(grpc: GRPCClient, cluster_template: str)
                 "path": "spec.network.pod_cidr",
                 "display_name": "Pod Network CIDR",
                 "editable": True,
-                "default": {"stringValue": "10.128.0.0/14"},
+                "default": "10.128.0.0/14",
             },
             {
                 "path": "spec.network.service_cidr",
                 "display_name": "Service CIDR",
                 "editable": False,
-                "default": {"stringValue": "172.30.0.0/16"},
+                "default": "172.30.0.0/16",
             },
         ]
         grpc.update_cluster_catalog_item(catalog_item_id=catalog_item_id, field_definitions=updated_fds)
@@ -139,7 +139,7 @@ def test_catalog_item_field_definitions(grpc: GRPCClient, cluster_template: str)
                 "path": "spec.network.pod_cidr",
                 "display_name": "Pod Network CIDR",
                 "editable": True,
-                "default": {"stringValue": "10.128.0.0/14"},
+                "default": "10.128.0.0/14",
             },
         ]
         grpc.update_cluster_catalog_item(catalog_item_id=catalog_item_id, field_definitions=reduced_fds)
@@ -236,7 +236,7 @@ def test_create_cluster_with_catalog_item_version(
                 "path": "version",
                 "display_name": "Version",
                 "editable": True,
-                "default": {"stringValue": version["name"]},
+                "default": version["name"],
             }
         ],
     )

--- a/tests/catalog/test_compute_instance_catalog_item_disk_image.py
+++ b/tests/catalog/test_compute_instance_catalog_item_disk_image.py
@@ -30,7 +30,7 @@ def test_catalog_item_disk_image_default_applied(
         # paths, then rejects any other spec leaf. The CI-create below sends network_attachments
         # (the subnet), so it must be a declared field or the create is rejected InvalidArgument.
         field_defs = [
-            {"path": "disk_image", "display_name": "Disk Image", "editable": True, "default": {"stringValue": di_name}},
+            {"path": "disk_image", "display_name": "Disk Image", "editable": True, "default": di_name},
             {"path": "network_attachments", "display_name": "Network", "editable": True},
         ]
         catalog_item_id = grpc.create_compute_instance_catalog_item(
@@ -72,7 +72,7 @@ def test_disk_image_deletion_protection_catalog_item(grpc: GRPCClient, compute_i
         # Same field_definition shape as the default-application test: prefix-less
         # "disk_image" + DiskImage name.
         field_defs = [
-            {"path": "disk_image", "display_name": "Disk Image", "editable": True, "default": {"stringValue": di_name}}
+            {"path": "disk_image", "display_name": "Disk Image", "editable": True, "default": di_name}
         ]
         catalog_item_id = grpc.create_compute_instance_catalog_item(
             name=unique_name("e2e-cidi-cat"),

--- a/tests/catalog/test_compute_instance_catalog_item_lifecycle.py
+++ b/tests/catalog/test_compute_instance_catalog_item_lifecycle.py
@@ -89,7 +89,7 @@ def test_compute_instance_catalog_item_field_definitions(
             "path": "spec.instance_type",
             "display_name": "Instance Type",
             "editable": True,
-            "default": {"stringValue": "standard-2x4"},
+            "default": "standard-2x4",
         },
     ]
     name = unique_name("e2e-ci-fd")
@@ -110,7 +110,7 @@ def test_compute_instance_catalog_item_field_definitions(
                 "path": "spec.instance_type",
                 "display_name": "VM Size",
                 "editable": True,
-                "default": {"stringValue": "standard-2x4"},
+                "default": "standard-2x4",
             },
         ]
         grpc.update_compute_instance_catalog_item(catalog_item_id=catalog_item_id, field_definitions=updated_fds)
@@ -126,7 +126,7 @@ def test_compute_instance_catalog_item_field_definitions(
                 "path": "spec.instance_type",
                 "display_name": "VM Size",
                 "editable": False,
-                "default": {"stringValue": "standard-4x8"},
+                "default": "standard-4x8",
             },
         ]
         grpc.update_compute_instance_catalog_item(catalog_item_id=catalog_item_id, field_definitions=updated_fds_v2)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import os
 import subprocess
+import textwrap
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -109,7 +110,7 @@ def private_grpc(fulfillment_private_address: str, namespace: str, service_accou
 
 
 @pytest.fixture(scope="session", autouse=True)
-def ensure_tenants(private_grpc: GRPCClient) -> None:
+def ensure_tenants(ensure_k8s_only_network_class: None, private_grpc: GRPCClient) -> None:
     for name in ("tenant1", "tenant2"):
         private_grpc.ensure_tenant(name=name)
 
@@ -197,6 +198,42 @@ def setup_organization_memberships(
 @pytest.fixture(scope="session")
 def k8s_hub_client(namespace: str) -> K8sClient:
     return K8sClient(namespace=namespace)
+
+
+_K8S_ONLY_NETWORK_MANAGER_CONFIGMAP = textwrap.dedent("""\
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: osac-network-k8s-manager-k8s-only
+      namespace: {namespace}
+      labels:
+        osac.openshift.io/network-k8s-manager: "true"
+    data:
+      name: k8s_only
+      description: "Composite k8s-only manager (CUDN + NetworkPolicy + MetalLB), no separate physical fabric"
+      capabilities: "ipv4,ipv6,dualStack"
+""")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ensure_k8s_only_network_class(private_grpc: GRPCClient, k8s_hub_client: K8sClient, namespace: str) -> None:
+    """No-op unless OSAC_NETWORK_CLASS_K8S_ONLY is set. When set, registers the
+    k8s_only k8s-manager ConfigMap and points the environment's singleton
+    NetworkClass at it (k8s_manager: k8s_only, fabric_manager cleared)."""
+    if not env("OSAC_NETWORK_CLASS_K8S_ONLY", ""):
+        return
+
+    k8s_hub_client.apply(manifest=_K8S_ONLY_NETWORK_MANAGER_CONFIGMAP.format(namespace=namespace))
+
+    network_classes = private_grpc.list_network_classes()
+    if not network_classes:
+        raise RuntimeError(
+            "OSAC_NETWORK_CLASS_K8S_ONLY is set but no NetworkClass exists — "
+            "expected the platform default to already be published by the publish-templates job"
+        )
+    private_grpc.update_network_class(
+        network_class_id=network_classes[0]["id"], fabric_manager="", k8s_manager="k8s_only"
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/core/grpc_client.py
+++ b/tests/core/grpc_client.py
@@ -707,3 +707,51 @@ class GRPCClient:
 
     def delete_project_membership(self, *, membership_id: str) -> None:
         self.call(service=f"{PUBLIC_API}.ProjectMemberships/Delete", data={"id": membership_id})
+
+    # NetworkClass operations (private API only)
+
+    def list_network_classes(self) -> list[dict[str, Any]]:
+        response: dict[str, Any] = self.call(service=f"{PRIVATE_API}.NetworkClasses/List")
+        return response.get("items", [])
+
+    def update_network_class(self, *, network_class_id: str, **fields: Any) -> dict[str, Any]:
+        if not fields:
+            raise ValueError("update_network_class requires at least one field to update")
+        obj: dict[str, Any] = {"id": network_class_id, **fields}
+        data: dict[str, Any] = {"object": obj, "updateMask": {"paths": list(fields.keys())}}
+        return self.call(service=f"{PRIVATE_API}.NetworkClasses/Update", data=data)
+
+    # StorageTier operations (private API)
+
+    def get_storage_tier(self, *, name: str) -> dict[str, Any]:
+        response: dict[str, Any] = self.call(
+            service=f"{PRIVATE_API}.StorageTiers/List",
+            data={"filter": f'this.metadata.name == "{name}"'},
+        )
+        items = response.get("items", [])
+        if not items:
+            raise ValueError(f"StorageTier '{name}' not found")
+        return items[0]
+
+    def create_storage_tier(self, *, name: str, backend_id: str) -> str:
+        response: dict[str, Any] = self.call(
+            service=f"{PRIVATE_API}.StorageTiers/Create",
+            data={
+                "object": {
+                    "metadata": {"name": name},
+                    "spec": {
+                        "description": "E2E test storage tier",
+                        "backends": [
+                            {
+                                "backend_id": backend_id,
+                                "protocol": "STORAGE_PROTOCOL_BLOCK",
+                            }
+                        ],
+                    },
+                }
+            },
+        )
+        return response["object"]["id"]
+
+    def delete_storage_tier(self, *, tier_id: str) -> None:
+        self.call(service=f"{PRIVATE_API}.StorageTiers/Delete", data={"id": tier_id})

--- a/tests/core/grpc_client.py
+++ b/tests/core/grpc_client.py
@@ -725,8 +725,7 @@ class GRPCClient:
 
     def get_storage_tier(self, *, name: str) -> dict[str, Any]:
         response: dict[str, Any] = self.call(
-            service=f"{PRIVATE_API}.StorageTiers/List",
-            data={"filter": f'this.metadata.name == "{name}"'},
+            service=f"{PRIVATE_API}.StorageTiers/List", data={"filter": f'this.metadata.name == "{name}"'}
         )
         items = response.get("items", [])
         if not items:
@@ -741,12 +740,8 @@ class GRPCClient:
                     "metadata": {"name": name},
                     "spec": {
                         "description": "E2E test storage tier",
-                        "backends": [
-                            {
-                                "backend_id": backend_id,
-                                "protocol": "STORAGE_PROTOCOL_BLOCK",
-                            }
-                        ],
+                        "protocol": "STORAGE_PROTOCOL_BLOCK",
+                        "backends": [{"backend_id": backend_id}],
                     },
                 }
             },

--- a/tests/core/k8s_client.py
+++ b/tests/core/k8s_client.py
@@ -197,6 +197,24 @@ class K8sClient:
             *self._base(), "get", "virtualmachine", name, "-n", vm_namespace, "-o", "jsonpath={.spec.runStrategy}"
         )
 
+    # Storage tier resolution
+
+    def get_storage_class_for_tier(self, *, tier_name: str) -> str:
+        """Resolve StorageClass name from tier name via Tenant.status.storageClasses."""
+        tenant = self.get_json(resource="tenant", name=self.namespace)
+        storage_classes = tenant.get("status", {}).get("storageClasses", [])
+
+        for sc in storage_classes:
+            if sc.get("tier", "").lower() == tier_name.lower():
+                return sc.get("name", "")
+
+        raise ValueError(f"No StorageClass found for tier '{tier_name}' in Tenant {self.namespace}")
+
+    def get_datavolume_storage_class(self, *, name: str) -> str:
+        """Get the StorageClass name from a DataVolume's PVC spec."""
+        dv = self.get_json(resource="datavolume", name=name)
+        return dv.get("spec", {}).get("pvc", {}).get("storageClassName", "")
+
     # ExternalIPPool queries
 
     def get_external_ip_pool_name(self, *, uuid: str, checked: bool = True) -> str:

--- a/tests/core/osac_cli.py
+++ b/tests/core/osac_cli.py
@@ -18,6 +18,7 @@ class OsacCLI:
         namespace: str,
         default_instance_type: str | None = None,
         default_disk_image: str | None = None,
+        default_storage_tier: str | None = None,
         private: bool = False,
     ) -> None:
         self.binary: str = binary
@@ -27,6 +28,7 @@ class OsacCLI:
         self._private: bool = private
         self.default_instance_type: str | None = default_instance_type
         self.default_disk_image: str | None = default_disk_image
+        self.default_storage_tier: str | None = default_storage_tier
         # Each OsacCLI instance gets its own config directory so that parallel
         # xdist workers (or multiple CLI fixtures) don't overwrite each other's
         # login credentials via the shared ~/.config/osac/config.json.
@@ -72,6 +74,8 @@ class OsacCLI:
         network_attachments: list[dict[str, Any]] | None = None,
         boot_disk_size: int = 20,
         disk_image: str | None = None,
+        boot_disk_storage_tier: str | None = None,
+        additional_disks: list[dict[str, Any]] | None = None,
         run_strategy: str = "Always",
         user_data_secret_ref: str | None = None,
         instance_type: str | None = None,
@@ -100,6 +104,34 @@ class OsacCLI:
             args.extend(["--disk-image", effective_disk_image])
         else:
             raise ValueError("disk_image or default_disk_image must be set")
+
+        effective_storage_tier = (
+            boot_disk_storage_tier if boot_disk_storage_tier is not None else self.default_storage_tier
+        )
+        if effective_storage_tier is not None:
+            args.extend(["--boot-disk-storage-tier", effective_storage_tier])
+        else:
+            raise ValueError("boot_disk_storage_tier or default_storage_tier must be set")
+
+        # Add additional disks
+        if additional_disks is not None:
+            for idx, disk in enumerate(additional_disks):
+                if not isinstance(disk, dict):
+                    raise ValueError(f"additional_disks[{idx}]: must be a dict, got {type(disk).__name__}")
+
+                size = disk.get("size_gib")
+                if not isinstance(size, int) or isinstance(size, bool) or size <= 0:
+                    raise ValueError(f"additional_disks[{idx}]: 'size_gib' must be a positive integer, got {size!r}")
+
+                storage_tier = disk.get("storage_tier")
+                if storage_tier is None:
+                    raise ValueError(
+                        f"additional_disks[{idx}]: 'storage_tier' is required, got None"
+                    )
+
+                # Build --additional-disk flag value: size=<GiB>,storage-tier=<name>
+                disk_spec = f"size={size},storage-tier={storage_tier}"
+                args.extend(["--additional-disk", disk_spec])
 
         # Add network attachments
         if network_attachments is not None:

--- a/tests/vmaas/conftest.py
+++ b/tests/vmaas/conftest.py
@@ -183,6 +183,52 @@ def default_disk_image(grpc: GRPCClient, test_run_id: str) -> Iterator[str]:
             raise
 
 
+@pytest.fixture(scope="session")
+def default_storage_tier() -> str:
+    """
+    Reference installer-provided storage tier (matches network_class pattern).
+
+    Defaults to "local" tier created by osac-installer when lvms.enabled=true.
+    """
+    return env("OSAC_STORAGE_TIER", "local")
+
+
+@pytest.fixture(scope="session")
+def additional_storage_tiers(private_grpc: GRPCClient, test_run_id: str) -> Iterator[dict[str, dict[str, str]]]:
+    """
+    Create additional storage tiers on the real backend for multi-tier tests.
+
+    Uses the installer-provided "local" backend (real LVMS infrastructure).
+    """
+    # Get the real backend ID from the "local" tier
+    local_tier = private_grpc.get_storage_tier(name="local")
+    real_backend_id = local_tier["spec"]["backends"][0]["backendId"]
+
+    created_tiers: dict[str, dict[str, str]] = {}
+
+    try:
+        # Create fast tier on REAL backend
+        fast_name = f"e2e-tier-fast-{test_run_id}"
+        fast_id = private_grpc.create_storage_tier(name=fast_name, backend_id=real_backend_id)
+        created_tiers["fast"] = {"name": fast_name, "id": fast_id}
+
+        # Create archive tier on REAL backend
+        archive_name = f"e2e-tier-archive-{test_run_id}"
+        archive_id = private_grpc.create_storage_tier(name=archive_name, backend_id=real_backend_id)
+        created_tiers["archive"] = {"name": archive_name, "id": archive_id}
+
+        yield created_tiers
+    finally:
+        # Cleanup tiers (but NOT the backend - it's real infrastructure)
+        for tier_info in created_tiers.values():
+            try:
+                private_grpc.delete_storage_tier(tier_id=tier_info["id"])
+            except subprocess.CalledProcessError as e:
+                output = ((e.stdout or "") + (e.stderr or "")).lower()
+                if "not found" not in output:
+                    raise
+
+
 @pytest.fixture(scope="session", autouse=True)
 def _wait_for_tenant_storage_ready(k8s_hub_client: K8sClient, namespace: str) -> None:
     """Wait for ClusterStorageReady=True before any VMaaS tests if storage is configured.
@@ -229,3 +275,9 @@ def _set_cli_default_instance_type(cli: OsacCLI, default_instance_type: str) -> 
 def _set_cli_default_disk_image(cli: OsacCLI, default_disk_image: str) -> None:
     """Wire the session-scoped default disk image into the shared CLI fixture."""
     cli.default_disk_image = default_disk_image
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _set_cli_default_storage_tier(cli: OsacCLI, default_storage_tier: str) -> None:
+    """Wire the session-scoped default storage tier into the shared CLI fixture."""
+    cli.default_storage_tier = default_storage_tier

--- a/tests/vmaas/test_compute_instance_storage_tier.py
+++ b/tests/vmaas/test_compute_instance_storage_tier.py
@@ -1,0 +1,978 @@
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+
+import pytest
+
+from tests.catalog.conftest import unique_name
+from tests.core.grpc_client import GRPCClient
+from tests.core.helpers import (
+    assert_grpc_rejected,
+    wait_for_cr,
+    wait_for_deletion,
+    wait_for_provision,
+)
+from tests.core.k8s_client import K8sClient
+from tests.core.osac_cli import OsacCLI
+
+
+def verify_datavolume_storage_classes(
+    k8s_hub_client: K8sClient,
+    k8s_virt_client: K8sClient,
+    ci_name: str,
+    cr: dict[str, Any],
+) -> None:
+    """Verify that DataVolumes were created with correct StorageClasses.
+
+    NOTE: Commented out in all tests until osac PR #257 (OSAC-3632) merges.
+    AAP currently uses global _requested_storage_tier and ignores per-disk storageTier fields.
+    After PR #257 merges, uncomment the verify_datavolume_storage_classes() calls in tests.
+    """
+    vmi_ns = k8s_hub_client.get_compute_instance_vm_namespace(name=ci_name)
+
+    # Verify boot disk
+    boot_tier = cr["spec"]["bootDisk"]["storageTier"]
+    expected_boot_sc = k8s_hub_client.get_storage_class_for_tier(tier_name=boot_tier)
+    boot_dv_name = f"{ci_name}-root-disk"
+    actual_boot_sc = k8s_virt_client.get_datavolume_storage_class(name=boot_dv_name)
+    assert actual_boot_sc == expected_boot_sc, (
+        f"Boot disk StorageClass mismatch: {actual_boot_sc!r} != {expected_boot_sc!r}"
+    )
+
+    # Verify additional disks (1-indexed)
+    for idx, disk in enumerate(cr.get("spec", {}).get("additionalDisks", [])):
+        tier = disk["storageTier"]
+        expected_sc = k8s_hub_client.get_storage_class_for_tier(tier_name=tier)
+
+        dv_name = f"{ci_name}-disk-{idx + 1}"
+        actual_sc = k8s_virt_client.get_datavolume_storage_class(name=dv_name)
+        assert actual_sc == expected_sc, (
+            f"Additional disk {idx} StorageClass mismatch: {actual_sc!r} != {expected_sc!r}"
+        )
+
+
+def test_compute_instance_explicit_boot_disk_tier(
+    cli: OsacCLI,
+    grpc: GRPCClient,
+    k8s_hub_client: K8sClient,
+    k8s_virt_client: K8sClient,
+    vm_template: str,
+    default_subnet: str,
+    default_storage_tier: str,
+    default_instance_type: str,
+) -> None:
+    """Verify that explicit boot disk storage tier is persisted correctly."""
+    name = unique_name("e2e-ci-tier")
+    uuid = cli.create_compute_instance(
+        name=name,
+        template=vm_template,
+        instance_type=default_instance_type,
+        network_attachments=[{"subnet": default_subnet}],
+        boot_disk_storage_tier=default_storage_tier,
+    )
+
+    ci_name = None
+    try:
+        ci_name = wait_for_cr(k8s=k8s_hub_client, uuid=uuid)
+        wait_for_provision(k8s=k8s_hub_client, name=ci_name)
+
+        # Verify CR has the correct storage tier
+        cr = k8s_hub_client.get_json(resource="computeinstance", name=ci_name)
+        assert cr["spec"]["bootDisk"]["storageTier"] == default_storage_tier, (
+            f"Boot disk tier mismatch: "
+            f"{cr['spec']['bootDisk']['storageTier']!r} != {default_storage_tier!r}"
+        )
+
+        # E2E: Verify DataVolume StorageClass (commented out until osac PR #257)
+        # verify_datavolume_storage_classes(
+        #     k8s_hub_client=k8s_hub_client,
+        #     k8s_virt_client=k8s_virt_client,
+        #     ci_name=ci_name,
+        #     cr=cr,
+        # )
+    finally:
+        grpc.delete_compute_instance(ci_id=uuid)
+        if ci_name is not None:
+            wait_for_deletion(k8s=k8s_hub_client, name=ci_name)
+
+
+def test_compute_instance_multiple_disks_different_tiers(
+    cli: OsacCLI,
+    grpc: GRPCClient,
+    k8s_hub_client: K8sClient,
+    k8s_virt_client: K8sClient,
+    vm_template: str,
+    default_subnet: str,
+    default_storage_tier: str,
+    additional_storage_tiers: dict[str, dict[str, str]],
+    default_instance_type: str,
+) -> None:
+    """Verify that boot disk and additional disks can use different storage tiers independently."""
+    fast_tier = additional_storage_tiers["fast"]["name"]
+    archive_tier = additional_storage_tiers["archive"]["name"]
+
+    name = unique_name("e2e-ci-multi-tier")
+    uuid = cli.create_compute_instance(
+        name=name,
+        template=vm_template,
+        instance_type=default_instance_type,
+        network_attachments=[{"subnet": default_subnet}],
+        boot_disk_storage_tier=fast_tier,
+        additional_disks=[
+            {"size_gib": 1, "storage_tier": default_storage_tier},
+            {"size_gib": 2, "storage_tier": archive_tier},
+        ],
+    )
+
+    ci_name = None
+    try:
+        ci_name = wait_for_cr(k8s=k8s_hub_client, uuid=uuid)
+        wait_for_provision(k8s=k8s_hub_client, name=ci_name)
+
+        # Verify CR has the correct storage tiers
+        cr = k8s_hub_client.get_json(resource="computeinstance", name=ci_name)
+        assert cr["spec"]["bootDisk"]["storageTier"] == fast_tier
+        assert len(cr["spec"]["additionalDisks"]) == 2
+        assert cr["spec"]["additionalDisks"][0]["storageTier"] == default_storage_tier
+        assert cr["spec"]["additionalDisks"][1]["storageTier"] == archive_tier
+
+        # E2E: Verify DataVolume StorageClass (commented out until osac PR #257)
+        # verify_datavolume_storage_classes(
+        #     k8s_hub_client=k8s_hub_client,
+        #     k8s_virt_client=k8s_virt_client,
+        #     ci_name=ci_name,
+        #     cr=cr,
+        # )
+    finally:
+        grpc.delete_compute_instance(ci_id=uuid)
+        if ci_name is not None:
+            wait_for_deletion(k8s=k8s_hub_client, name=ci_name)
+
+
+def test_compute_instance_nonexistent_tier_rejected(
+    private_grpc: GRPCClient,
+    vm_template: str,
+    default_subnet: str,
+    default_instance_type: str,
+    default_disk_image: str,
+) -> None:
+    """Verify that requesting a nonexistent storage tier returns INVALID_ARGUMENT."""
+    nonexistent_tier = f"nonexistent-tier-{unique_name('test')}"
+
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        private_grpc.call(
+            service="osac.private.v1.ComputeInstances/Create",
+            data={
+                "object": {
+                    "metadata": {"name": unique_name("e2e-ci-bad-tier")},
+                    "spec": {
+                        "template": {"name": vm_template},
+                        "instance_type": {"name": default_instance_type},
+                        "boot_disk": {"size_gib": 20, "storage_tier": nonexistent_tier},
+                        "network_attachments": [{"subnet": {"id": default_subnet}}],
+                        "disk_image": {"name": default_disk_image},
+                        "run_strategy": "Always",
+                    },
+                }
+            },
+        )
+
+    assert_grpc_rejected(exc_info, "InvalidArgument")
+    error_lower = str(exc_info.value.stderr).lower()
+    assert any(term in error_lower for term in [
+        "not found", "does not exist", "notfound",
+    ]), f"Expected not-found/does-not-exist error, got: {exc_info.value.stderr}"
+
+
+def test_compute_instance_tier_immutability(
+    cli: OsacCLI,
+    grpc: GRPCClient,
+    k8s_hub_client: K8sClient,
+    k8s_virt_client: K8sClient,
+    vm_template: str,
+    default_subnet: str,
+    default_storage_tier: str,
+    additional_storage_tiers: dict[str, dict[str, str]],
+    default_instance_type: str,
+) -> None:
+    """Verify that storage tier cannot be changed after ComputeInstance creation."""
+    fast_tier = additional_storage_tiers["fast"]["name"]
+
+    name = unique_name("e2e-ci-immutable")
+    uuid = cli.create_compute_instance(
+        name=name,
+        template=vm_template,
+        instance_type=default_instance_type,
+        network_attachments=[{"subnet": default_subnet}],
+        boot_disk_storage_tier=default_storage_tier,
+    )
+
+    ci_name = None
+    try:
+        ci_name = wait_for_cr(k8s=k8s_hub_client, uuid=uuid)
+        wait_for_provision(k8s=k8s_hub_client, name=ci_name)
+
+        # Verify CR has the correct storage tier
+        cr = k8s_hub_client.get_json(resource="computeinstance", name=ci_name)
+        assert cr["spec"]["bootDisk"]["storageTier"] == default_storage_tier
+
+        # E2E: Verify DataVolume StorageClass (commented out until osac PR #257)
+        # verify_datavolume_storage_classes(
+        #     k8s_hub_client=k8s_hub_client,
+        #     k8s_virt_client=k8s_virt_client,
+        #     ci_name=ci_name,
+        #     cr=cr,
+        # )
+
+        # Attempt to update the storage tier via K8s
+        import json
+        patch_json = json.dumps({"spec": {"bootDisk": {"storageTier": fast_tier}}})
+        output, rc = k8s_hub_client.patch(
+            resource="computeinstance",
+            name=ci_name,
+            patch=patch_json,
+        )
+
+        # Verify patch was rejected
+        assert rc != 0, "storage tier should be immutable"
+
+        # Verify error mentions immutability
+        error_output = output.lower()
+        assert "immutable" in error_output or "invalid" in error_output, (
+            f"Expected immutability error, got: {output}"
+        )
+    finally:
+        grpc.delete_compute_instance(ci_id=uuid)
+        if ci_name is not None:
+            wait_for_deletion(k8s=k8s_hub_client, name=ci_name)
+
+
+@pytest.mark.skip(
+    reason="Requires mandatory storage_tier validation (follow-up osac PR after this test infrastructure lands)"
+)
+def test_compute_instance_boot_disk_tier_required(
+    private_grpc: GRPCClient,
+    vm_template: str,
+    default_subnet: str,
+    default_instance_type: str,
+    default_disk_image: str,
+) -> None:
+    """Verify that missing boot disk tier returns INVALID_ARGUMENT.
+
+    Skipped until follow-up PR makes storage_tier mandatory.
+    """
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        private_grpc.call(
+            service="osac.private.v1.ComputeInstances/Create",
+            data={
+                "object": {
+                    "metadata": {"name": unique_name("e2e-ci-no-tier")},
+                    "spec": {
+                        "template": {"name": vm_template},
+                        "instance_type": {"name": default_instance_type},
+                        "boot_disk": {"size_gib": 20},  # No storage_tier
+                        "network_attachments": [{"subnet": {"id": default_subnet}}],
+                        "disk_image": {"name": default_disk_image},
+                        "run_strategy": "Always",
+                    },
+                }
+            },
+        )
+
+    assert_grpc_rejected(exc_info, "InvalidArgument")
+    assert "storage_tier is required" in str(exc_info.value.stderr).lower()
+
+
+@pytest.mark.skip(
+    reason="Requires mandatory storage_tier validation (follow-up osac PR after this test infrastructure lands)"
+)
+def test_compute_instance_additional_disk_tier_required(
+    private_grpc: GRPCClient,
+    vm_template: str,
+    default_subnet: str,
+    default_storage_tier: str,
+    default_instance_type: str,
+    default_disk_image: str,
+) -> None:
+    """Verify that missing additional disk tier returns INVALID_ARGUMENT.
+
+    Skipped until follow-up PR makes storage_tier mandatory.
+    """
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        private_grpc.call(
+            service="osac.private.v1.ComputeInstances/Create",
+            data={
+                "object": {
+                    "metadata": {"name": unique_name("e2e-ci-add-disk-no-tier")},
+                    "spec": {
+                        "template": {"name": vm_template},
+                        "instance_type": {"name": default_instance_type},
+                        "boot_disk": {"size_gib": 20, "storage_tier": default_storage_tier},
+                        "additional_disks": [
+                            {"size_gib": 50}  # No storage_tier
+                        ],
+                        "network_attachments": [{"subnet": {"id": default_subnet}}],
+                        "disk_image": {"name": default_disk_image},
+                        "run_strategy": "Always",
+                    },
+                }
+            },
+        )
+
+    assert_grpc_rejected(exc_info, "InvalidArgument")
+    assert "additional_disks[0].storage_tier is required" in str(exc_info.value.stderr).lower()
+
+
+def test_compute_instance_boot_disk_tier_from_catalog_item_default(
+    private_grpc: GRPCClient,
+    grpc: GRPCClient,
+    k8s_hub_client: K8sClient,
+    k8s_virt_client: K8sClient,
+    vm_template: str,
+    default_subnet: str,
+    default_storage_tier: str,
+    default_instance_type: str,
+    default_disk_image: str,
+) -> None:
+    """Verify that boot disk tier is resolved from CatalogItem FieldDefinition default."""
+    field_defs = [
+        {
+            "path": "boot_disk.storage_tier",
+            "display_name": "Boot Disk Storage Tier",
+            "editable": True,
+            "default": default_storage_tier,
+        },
+        {
+            "path": "boot_disk.size_gib",
+            "display_name": "Boot Disk Size",
+            "editable": True,
+        },
+        {
+            "path": "network_attachments",
+            "display_name": "Network Attachments",
+            "editable": True,
+        },
+        {
+            "path": "disk_image",
+            "display_name": "Disk Image",
+            "editable": True,
+        },
+        {
+            "path": "instance_type",
+            "display_name": "Instance Type",
+            "editable": True,
+        },
+        {
+            "path": "run_strategy",
+            "display_name": "Run Strategy",
+            "editable": True,
+        },
+    ]
+    catalog_item_id = private_grpc.create_compute_instance_catalog_item(
+        name=unique_name("e2e-cat-tier"),
+        template=vm_template,
+        published=True,
+        field_definitions=field_defs,
+    )
+
+    try:
+        # Create CI using catalog item WITHOUT specifying boot_disk_storage_tier
+        ci_obj = grpc.call(
+            service="osac.public.v1.ComputeInstances/Create",
+            data={
+                "object": {
+                    "metadata": {"name": unique_name("e2e-ci-cat-def")},
+                    "spec": {
+                        "catalog_item": {"id": catalog_item_id},
+                        "instance_type": {"name": default_instance_type},
+                        "boot_disk": {"size_gib": 20},  # No storage_tier
+                        "network_attachments": [{"subnet": {"id": default_subnet}}],
+                        "disk_image": {"name": default_disk_image},
+                        "run_strategy": "Always",
+                    },
+                }
+            },
+        )
+        uuid = ci_obj["object"]["id"]
+
+        ci_name = None
+        try:
+            ci_name = wait_for_cr(k8s=k8s_hub_client, uuid=uuid)
+            wait_for_provision(k8s=k8s_hub_client, name=ci_name)
+
+            # Verify CatalogItem default was applied
+            cr = k8s_hub_client.get_json(resource="computeinstance", name=ci_name)
+            assert cr["spec"]["bootDisk"]["storageTier"] == default_storage_tier
+            assert len(cr["spec"].get("additionalDisks", [])) == 0
+
+            # E2E: Verify DataVolume StorageClass (commented out until osac PR #257)
+            # verify_datavolume_storage_classes(
+            #     k8s_hub_client=k8s_hub_client,
+            #     k8s_virt_client=k8s_virt_client,
+            #     ci_name=ci_name,
+            #     cr=cr,
+            # )
+        finally:
+            grpc.delete_compute_instance(ci_id=uuid)
+            wait_for_deletion(k8s=k8s_hub_client, name=ci_name)
+    finally:
+        private_grpc.delete_compute_instance_catalog_item(catalog_item_id=catalog_item_id)
+
+
+@pytest.mark.skip(
+    reason="Custom-template CI provisioning is not e2e-testable: spec.templateID is used verbatim "
+    "by AAP as the Ansible role to include, and only shipped templates (e.g. ocp-virt-vm) have a "
+    "backing role, so a CI created from a custom template can neither provision nor delete "
+    "(hangs wait_for_provision, then teardown). Unskip when the backend supports provisionable "
+    "custom templates."
+)
+def test_compute_instance_boot_disk_tier_from_template_default() -> None:
+    """Verify a ComputeInstance resolves its boot disk storage_tier from Template spec_defaults.
+
+    Intent: create a ComputeInstanceTemplate with spec_defaults.boot_disk.storage_tier, then
+    create a CI referencing it WITHOUT a boot_disk, and assert the CR's spec.bootDisk.storageTier
+    (and sizeGiB) are inherited from the template — and the VM provisions.
+
+    Why skipped: a custom template cannot drive real VM provisioning in e2e. Its spec.templateID
+    is written verbatim into the CR and used by AAP as the role name to include
+    (playbook_osac_create_compute_instance.yml), and only AAP-published templates have a backing
+    role, so the CI can neither provision nor delete. This constraint is documented on the sibling
+    test tests/vmaas/test_compute_instance_disk_image.py::test_template_disk_image_default, which
+    hit the same limitation and works around it by asserting on the template object only.
+    """
+
+
+def test_compute_instance_user_tier_overrides_catalog_item_default(
+    private_grpc: GRPCClient,
+    grpc: GRPCClient,
+    k8s_hub_client: K8sClient,
+    k8s_virt_client: K8sClient,
+    vm_template: str,
+    default_subnet: str,
+    default_storage_tier: str,
+    additional_storage_tiers: dict[str, dict[str, str]],
+    default_instance_type: str,
+    default_disk_image: str,
+) -> None:
+    """Verify that user-provided tier overrides CatalogItem default."""
+    fast_tier = additional_storage_tiers["fast"]["name"]
+
+    field_defs = [
+        {
+            "path": "boot_disk.storage_tier",
+            "display_name": "Boot Disk Storage Tier",
+            "editable": True,
+            "default": default_storage_tier,
+        },
+        {
+            "path": "boot_disk.size_gib",
+            "display_name": "Boot Disk Size",
+            "editable": True,
+        },
+        {
+            "path": "network_attachments",
+            "display_name": "Network Attachments",
+            "editable": True,
+        },
+        {
+            "path": "disk_image",
+            "display_name": "Disk Image",
+            "editable": True,
+        },
+        {
+            "path": "instance_type",
+            "display_name": "Instance Type",
+            "editable": True,
+        },
+        {
+            "path": "run_strategy",
+            "display_name": "Run Strategy",
+            "editable": True,
+        },
+    ]
+    catalog_item_id = private_grpc.create_compute_instance_catalog_item(
+        name=unique_name("e2e-cat-override"),
+        template=vm_template,
+        published=True,
+        field_definitions=field_defs,
+    )
+
+    try:
+        # Create CI with explicit storage_tier (should override default)
+        ci_obj = grpc.call(
+            service="osac.public.v1.ComputeInstances/Create",
+            data={
+                "object": {
+                    "metadata": {"name": unique_name("e2e-ci-override")},
+                    "spec": {
+                        "catalog_item": {"id": catalog_item_id},
+                        "instance_type": {"name": default_instance_type},
+                        "boot_disk": {"size_gib": 20, "storage_tier": fast_tier},  # Override
+                        "network_attachments": [{"subnet": {"id": default_subnet}}],
+                        "disk_image": {"name": default_disk_image},
+                        "run_strategy": "Always",
+                    },
+                }
+            },
+        )
+        uuid = ci_obj["object"]["id"]
+
+        ci_name = None
+        try:
+            ci_name = wait_for_cr(k8s=k8s_hub_client, uuid=uuid)
+            wait_for_provision(k8s=k8s_hub_client, name=ci_name)
+
+            # Verify user value was used, not CatalogItem default
+            cr = k8s_hub_client.get_json(resource="computeinstance", name=ci_name)
+            assert cr["spec"]["bootDisk"]["storageTier"] == fast_tier
+            assert len(cr["spec"].get("additionalDisks", [])) == 0
+
+            # E2E: Verify DataVolume StorageClass (commented out until osac PR #257)
+            # verify_datavolume_storage_classes(
+            #     k8s_hub_client=k8s_hub_client,
+            #     k8s_virt_client=k8s_virt_client,
+            #     ci_name=ci_name,
+            #     cr=cr,
+            # )
+        finally:
+            grpc.delete_compute_instance(ci_id=uuid)
+            wait_for_deletion(k8s=k8s_hub_client, name=ci_name)
+    finally:
+        private_grpc.delete_compute_instance_catalog_item(catalog_item_id=catalog_item_id)
+
+
+def test_compute_instance_explicit_additional_disks_without_catalog_item_default(
+    private_grpc: GRPCClient,
+    grpc: GRPCClient,
+    k8s_hub_client: K8sClient,
+    k8s_virt_client: K8sClient,
+    vm_template: str,
+    default_subnet: str,
+    default_storage_tier: str,
+    additional_storage_tiers: dict[str, dict[str, str]],
+    default_instance_type: str,
+    default_disk_image: str,
+) -> None:
+    """Verify that explicit additional disks work when CatalogItem has no additional_disks default."""
+    fast_tier = additional_storage_tiers["fast"]["name"]
+    archive_tier = additional_storage_tiers["archive"]["name"]
+
+    # CatalogItem with boot_disk.storage_tier default ONLY (no additional_disks default)
+    field_defs = [
+        {
+            "path": "boot_disk.storage_tier",
+            "display_name": "Boot Disk Storage Tier",
+            "editable": True,
+            "default": default_storage_tier,
+        },
+        {
+            "path": "boot_disk.size_gib",
+            "display_name": "Boot Disk Size",
+            "editable": True,
+        },
+        {
+            "path": "additional_disks",
+            "display_name": "Additional Disks",
+            "editable": True,
+        },
+        {
+            "path": "network_attachments",
+            "display_name": "Network Attachments",
+            "editable": True,
+        },
+        {
+            "path": "disk_image",
+            "display_name": "Disk Image",
+            "editable": True,
+        },
+        {
+            "path": "instance_type",
+            "display_name": "Instance Type",
+            "editable": True,
+        },
+        {
+            "path": "run_strategy",
+            "display_name": "Run Strategy",
+            "editable": True,
+        },
+    ]
+    catalog_item_id = private_grpc.create_compute_instance_catalog_item(
+        name=unique_name("e2e-cat-no-add-def"),
+        template=vm_template,
+        published=True,
+        field_definitions=field_defs,
+    )
+
+    try:
+        # Create CI with explicit additional_disks (CatalogItem has no default for this field)
+        ci_obj = grpc.call(
+            service="osac.public.v1.ComputeInstances/Create",
+            data={
+                "object": {
+                    "metadata": {"name": unique_name("e2e-ci-explicit-add")},
+                    "spec": {
+                        "catalog_item": {"id": catalog_item_id},
+                        "instance_type": {"name": default_instance_type},
+                        "boot_disk": {"size_gib": 20},  # Uses CatalogItem default tier
+                        "additional_disks": [
+                            {"size_gib": 5, "storage_tier": fast_tier},
+                            {"size_gib": 10, "storage_tier": archive_tier},
+                        ],
+                        "network_attachments": [{"subnet": {"id": default_subnet}}],
+                        "disk_image": {"name": default_disk_image},
+                        "run_strategy": "Always",
+                    },
+                }
+            },
+        )
+        uuid = ci_obj["object"]["id"]
+
+        ci_name = None
+        try:
+            ci_name = wait_for_cr(k8s=k8s_hub_client, uuid=uuid)
+            wait_for_provision(k8s=k8s_hub_client, name=ci_name)
+
+            # Verify boot disk got CatalogItem default, additional disks got user values
+            cr = k8s_hub_client.get_json(resource="computeinstance", name=ci_name)
+            assert cr["spec"]["bootDisk"]["storageTier"] == default_storage_tier
+            assert len(cr["spec"]["additionalDisks"]) == 2
+            assert cr["spec"]["additionalDisks"][0]["sizeGiB"] == 5
+            assert cr["spec"]["additionalDisks"][0]["storageTier"] == fast_tier
+            assert cr["spec"]["additionalDisks"][1]["sizeGiB"] == 10
+            assert cr["spec"]["additionalDisks"][1]["storageTier"] == archive_tier
+
+            # E2E: Verify DataVolume StorageClass (commented out until osac PR #257)
+            # verify_datavolume_storage_classes(
+            #     k8s_hub_client=k8s_hub_client,
+            #     k8s_virt_client=k8s_virt_client,
+            #     ci_name=ci_name,
+            #     cr=cr,
+            # )
+        finally:
+            grpc.delete_compute_instance(ci_id=uuid)
+            wait_for_deletion(k8s=k8s_hub_client, name=ci_name)
+    finally:
+        private_grpc.delete_compute_instance_catalog_item(catalog_item_id=catalog_item_id)
+
+
+def test_compute_instance_additional_disks_from_catalog_item_default(
+    private_grpc: GRPCClient,
+    grpc: GRPCClient,
+    k8s_hub_client: K8sClient,
+    k8s_virt_client: K8sClient,
+    vm_template: str,
+    default_subnet: str,
+    default_storage_tier: str,
+    additional_storage_tiers: dict[str, dict[str, str]],
+    default_instance_type: str,
+    default_disk_image: str,
+) -> None:
+    """Verify that additional disks are defaulted from CatalogItem FieldDefinition."""
+    fast_tier = additional_storage_tiers["fast"]["name"]
+
+    field_defs = [
+        {
+            "path": "additional_disks",
+            "display_name": "Additional Disks",
+            "editable": True,
+            "default": [{"size_gib": 10, "storage_tier": fast_tier}],
+        },
+        {
+            "path": "boot_disk.size_gib",
+            "display_name": "Boot Disk Size",
+            "editable": True,
+        },
+        {
+            "path": "boot_disk.storage_tier",
+            "display_name": "Boot Disk Storage Tier",
+            "editable": True,
+        },
+        {
+            "path": "network_attachments",
+            "display_name": "Network Attachments",
+            "editable": True,
+        },
+        {
+            "path": "disk_image",
+            "display_name": "Disk Image",
+            "editable": True,
+        },
+        {
+            "path": "instance_type",
+            "display_name": "Instance Type",
+            "editable": True,
+        },
+        {
+            "path": "run_strategy",
+            "display_name": "Run Strategy",
+            "editable": True,
+        },
+    ]
+    catalog_item_id = private_grpc.create_compute_instance_catalog_item(
+        name=unique_name("e2e-cat-add-disks"),
+        template=vm_template,
+        published=True,
+        field_definitions=field_defs,
+    )
+
+    try:
+        # Create CI WITHOUT specifying additional_disks (should use default)
+        ci_obj = grpc.call(
+            service="osac.public.v1.ComputeInstances/Create",
+            data={
+                "object": {
+                    "metadata": {"name": unique_name("e2e-ci-add-def")},
+                    "spec": {
+                        "catalog_item": {"id": catalog_item_id},
+                        "instance_type": {"name": default_instance_type},
+                        "boot_disk": {"size_gib": 20, "storage_tier": default_storage_tier},
+                        # No additional_disks specified
+                        "network_attachments": [{"subnet": {"id": default_subnet}}],
+                        "disk_image": {"name": default_disk_image},
+                        "run_strategy": "Always",
+                    },
+                }
+            },
+        )
+        uuid = ci_obj["object"]["id"]
+
+        ci_name = None
+        try:
+            ci_name = wait_for_cr(k8s=k8s_hub_client, uuid=uuid)
+            wait_for_provision(k8s=k8s_hub_client, name=ci_name)
+
+            # Verify CatalogItem default was applied
+            cr = k8s_hub_client.get_json(resource="computeinstance", name=ci_name)
+            assert len(cr["spec"]["additionalDisks"]) == 1
+            assert cr["spec"]["additionalDisks"][0]["sizeGiB"] == 10
+            assert cr["spec"]["additionalDisks"][0]["storageTier"] == fast_tier
+
+            # E2E: Verify DataVolume StorageClass (commented out until osac PR #257)
+            # verify_datavolume_storage_classes(
+            #     k8s_hub_client=k8s_hub_client,
+            #     k8s_virt_client=k8s_virt_client,
+            #     ci_name=ci_name,
+            #     cr=cr,
+            # )
+        finally:
+            grpc.delete_compute_instance(ci_id=uuid)
+            wait_for_deletion(k8s=k8s_hub_client, name=ci_name)
+    finally:
+        private_grpc.delete_compute_instance_catalog_item(catalog_item_id=catalog_item_id)
+
+
+def test_compute_instance_user_additional_disks_override_catalog_item_default(
+    private_grpc: GRPCClient,
+    grpc: GRPCClient,
+    k8s_hub_client: K8sClient,
+    k8s_virt_client: K8sClient,
+    vm_template: str,
+    default_subnet: str,
+    default_storage_tier: str,
+    additional_storage_tiers: dict[str, dict[str, str]],
+    default_instance_type: str,
+    default_disk_image: str,
+) -> None:
+    """Verify that user-provided additional disks replace CatalogItem default entirely."""
+    fast_tier = additional_storage_tiers["fast"]["name"]
+    archive_tier = additional_storage_tiers["archive"]["name"]
+
+    field_defs = [
+        {
+            "path": "additional_disks",
+            "display_name": "Additional Disks",
+            "editable": True,
+            "default": [{"size_gib": 10, "storage_tier": fast_tier}],
+        },
+        {
+            "path": "boot_disk.size_gib",
+            "display_name": "Boot Disk Size",
+            "editable": True,
+        },
+        {
+            "path": "boot_disk.storage_tier",
+            "display_name": "Boot Disk Storage Tier",
+            "editable": True,
+        },
+        {
+            "path": "network_attachments",
+            "display_name": "Network Attachments",
+            "editable": True,
+        },
+        {
+            "path": "disk_image",
+            "display_name": "Disk Image",
+            "editable": True,
+        },
+        {
+            "path": "instance_type",
+            "display_name": "Instance Type",
+            "editable": True,
+        },
+        {
+            "path": "run_strategy",
+            "display_name": "Run Strategy",
+            "editable": True,
+        },
+    ]
+    catalog_item_id = private_grpc.create_compute_instance_catalog_item(
+        name=unique_name("e2e-cat-add-override"),
+        template=vm_template,
+        published=True,
+        field_definitions=field_defs,
+    )
+
+    try:
+        # Create CI with explicit additional_disks (should replace default)
+        ci_obj = grpc.call(
+            service="osac.public.v1.ComputeInstances/Create",
+            data={
+                "object": {
+                    "metadata": {"name": unique_name("e2e-ci-add-override")},
+                    "spec": {
+                        "catalog_item": {"id": catalog_item_id},
+                        "instance_type": {"name": default_instance_type},
+                        "boot_disk": {"size_gib": 20, "storage_tier": default_storage_tier},
+                        "additional_disks": [  # Override
+                            {"size_gib": 10, "storage_tier": archive_tier}
+                        ],
+                        "network_attachments": [{"subnet": {"id": default_subnet}}],
+                        "disk_image": {"name": default_disk_image},
+                        "run_strategy": "Always",
+                    },
+                }
+            },
+        )
+        uuid = ci_obj["object"]["id"]
+
+        ci_name = None
+        try:
+            ci_name = wait_for_cr(k8s=k8s_hub_client, uuid=uuid)
+            wait_for_provision(k8s=k8s_hub_client, name=ci_name)
+
+            # Verify user value was used (1 disk with archive tier), not default (1 disk with fast tier)
+            cr = k8s_hub_client.get_json(resource="computeinstance", name=ci_name)
+            assert len(cr["spec"]["additionalDisks"]) == 1
+            assert cr["spec"]["additionalDisks"][0]["sizeGiB"] == 10
+            assert cr["spec"]["additionalDisks"][0]["storageTier"] == archive_tier
+
+            # E2E: Verify DataVolume StorageClass (commented out until osac PR #257)
+            # verify_datavolume_storage_classes(
+            #     k8s_hub_client=k8s_hub_client,
+            #     k8s_virt_client=k8s_virt_client,
+            #     ci_name=ci_name,
+            #     cr=cr,
+            # )
+        finally:
+            grpc.delete_compute_instance(ci_id=uuid)
+            wait_for_deletion(k8s=k8s_hub_client, name=ci_name)
+    finally:
+        private_grpc.delete_compute_instance_catalog_item(catalog_item_id=catalog_item_id)
+
+
+@pytest.mark.skip(
+    reason="OSAC-4356: empty additional_disks: [] does not opt out of the CatalogItem default (backend gap)"
+)
+def test_compute_instance_empty_additional_disks_opts_out_of_catalog_item_default(
+    private_grpc: GRPCClient,
+    grpc: GRPCClient,
+    k8s_hub_client: K8sClient,
+    k8s_virt_client: K8sClient,
+    vm_template: str,
+    default_subnet: str,
+    default_storage_tier: str,
+    additional_storage_tiers: dict[str, dict[str, str]],
+    default_instance_type: str,
+    default_disk_image: str,
+) -> None:
+    """Verify that empty additional disks array opts out of CatalogItem default."""
+    fast_tier = additional_storage_tiers["fast"]["name"]
+
+    field_defs = [
+        {
+            "path": "additional_disks",
+            "display_name": "Additional Disks",
+            "editable": True,
+            "default": [{"size_gib": 10, "storage_tier": fast_tier}],
+        },
+        {
+            "path": "boot_disk.size_gib",
+            "display_name": "Boot Disk Size",
+            "editable": True,
+        },
+        {
+            "path": "boot_disk.storage_tier",
+            "display_name": "Boot Disk Storage Tier",
+            "editable": True,
+        },
+        {
+            "path": "network_attachments",
+            "display_name": "Network Attachments",
+            "editable": True,
+        },
+        {
+            "path": "disk_image",
+            "display_name": "Disk Image",
+            "editable": True,
+        },
+        {
+            "path": "instance_type",
+            "display_name": "Instance Type",
+            "editable": True,
+        },
+        {
+            "path": "run_strategy",
+            "display_name": "Run Strategy",
+            "editable": True,
+        },
+    ]
+    catalog_item_id = private_grpc.create_compute_instance_catalog_item(
+        name=unique_name("e2e-cat-add-empty"),
+        template=vm_template,
+        published=True,
+        field_definitions=field_defs,
+    )
+
+    try:
+        # Create CI with explicit empty additional_disks array
+        ci_obj = grpc.call(
+            service="osac.public.v1.ComputeInstances/Create",
+            data={
+                "object": {
+                    "metadata": {"name": unique_name("e2e-ci-add-empty")},
+                    "spec": {
+                        "catalog_item": {"id": catalog_item_id},
+                        "instance_type": {"name": default_instance_type},
+                        "boot_disk": {"size_gib": 20, "storage_tier": default_storage_tier},
+                        "additional_disks": [],  # Explicit empty array
+                        "network_attachments": [{"subnet": {"id": default_subnet}}],
+                        "disk_image": {"name": default_disk_image},
+                        "run_strategy": "Always",
+                    },
+                }
+            },
+        )
+        uuid = ci_obj["object"]["id"]
+
+        ci_name = None
+        try:
+            ci_name = wait_for_cr(k8s=k8s_hub_client, uuid=uuid)
+            wait_for_provision(k8s=k8s_hub_client, name=ci_name)
+
+            # Verify no additional disks were created
+            cr = k8s_hub_client.get_json(resource="computeinstance", name=ci_name)
+            assert len(cr["spec"].get("additionalDisks", [])) == 0
+
+            # E2E: Verify DataVolume StorageClass (commented out until osac PR #257)
+            # verify_datavolume_storage_classes(
+            #     k8s_hub_client=k8s_hub_client,
+            #     k8s_virt_client=k8s_virt_client,
+            #     ci_name=ci_name,
+            #     cr=cr,
+            # )
+        finally:
+            grpc.delete_compute_instance(ci_id=uuid)
+            wait_for_deletion(k8s=k8s_hub_client, name=ci_name)
+    finally:
+        private_grpc.delete_compute_instance_catalog_item(catalog_item_id=catalog_item_id)


### PR DESCRIPTION
At time of publishing this PR ( Aug 31 2026 )
Whats present in the osac-test-infra but missing from the osac mono repo are

- PR#410: [OSAC-4272](https://redhat.atlassian.net/browse/OSAC-4272): register k8s_only NetworkClass manager for E2E - #410
- PR#417 : Storage tier protocol refactor (grpc_client.py)
- PR#367: Per-disk storage tier tests (8 files)


