### PR TITLE
OSAC-4441: order-independent ClusterOrder feedback condition map with sub-stage detail

### DIFF
--- a/osac-operator/internal/controller/clusterorder_feedback_controller_test.go
+++ b/osac-operator/internal/controller/clusterorder_feedback_controller_test.go
@@ -16,6 +16,8 @@ package controller
 import (
 	"context"
 	"errors"
+	"slices"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -643,6 +645,362 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 			_, err := reconciler.Reconcile(testCtx, request)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mockClient.updateCalled).To(BeFalse())
+		})
+	})
+
+	Context("When syncing ClusterOrder conditions", func() {
+		findRemoteCondition := func(condType privatev1.ClusterConditionType) *privatev1.ClusterCondition {
+			for _, cond := range mockClient.lastUpdate.GetStatus().GetConditions() {
+				if cond.GetType() == condType {
+					return cond
+				}
+			}
+			return nil
+		}
+
+		setCRCondition := func(condType string, status metav1.ConditionStatus, reason, message string) {
+			clusterOrder := &osacv1alpha1.ClusterOrder{}
+			Expect(k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)).To(Succeed())
+			clusterOrder.Status.Conditions = append(clusterOrder.Status.Conditions, metav1.Condition{
+				Type:               condType,
+				Status:             status,
+				Reason:             reason,
+				Message:            message,
+				LastTransitionTime: metav1.NewTime(time.Now().UTC()),
+			})
+			Expect(k8sClient.Status().Update(testCtx, clusterOrder)).To(Succeed())
+		}
+
+		reconcileOnce := func() {
+			_, err := reconciler.Reconcile(testCtx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		BeforeEach(func() {
+			clusterOrder := &osacv1alpha1.ClusterOrder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: clusterOrderNS,
+					Labels: map[string]string{
+						osacClusterOrderIDLabel: clusterID,
+					},
+				},
+				Spec: osacv1alpha1.ClusterOrderSpec{
+					TemplateID: "test_template",
+				},
+			}
+			Expect(k8sClient.Create(testCtx, clusterOrder)).To(Succeed())
+
+			mockClient.getResponse = newClusterGetResponse()
+			mockClient.updateResponse = &privatev1.ClustersUpdateResponse{}
+		})
+
+		AfterEach(func() {
+			clusterOrder := &osacv1alpha1.ClusterOrder{}
+			err := k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)
+			if err == nil {
+				clusterOrder.Finalizers = nil
+				_ = k8sClient.Update(testCtx, clusterOrder)
+				_ = k8sClient.Delete(testCtx, clusterOrder)
+			}
+		})
+
+		It("should map ClusterAvailable to READY with reason preserved (latent bug 1)", func() {
+			setCRCondition(osacv1alpha1.ConditionClusterAvailable, metav1.ConditionTrue,
+				osacv1alpha1.ReasonAsExpected, "cluster is available")
+
+			reconcileOnce()
+			Expect(mockClient.updateCalled).To(BeTrue())
+
+			ready := findRemoteCondition(privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_READY)
+			Expect(ready).NotTo(BeNil())
+			Expect(ready.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
+			Expect(ready.GetReason()).To(Equal(osacv1alpha1.ReasonAsExpected))
+			Expect(ready.GetMessage()).To(Equal("cluster is available"))
+			Expect(findRemoteCondition(privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_PROGRESSING)).To(BeNil())
+		})
+
+		It("should take PROGRESSING status from Progressing and reason/message from the furthest stage (Accepted)", func() {
+			// The resource controller sets Accepted and Progressing together. PROGRESSING's
+			// status must come from Progressing (the installation-status condition), while its
+			// reason/message reflect the furthest installation stage reached - here Accepted.
+			// Accepted must not appear as its own fulfillment condition.
+			setCRCondition(osacv1alpha1.ConditionAccepted, metav1.ConditionTrue,
+				osacv1alpha1.ReasonInitialized, "order accepted")
+			setCRCondition(osacv1alpha1.ConditionProgressing, metav1.ConditionTrue,
+				osacv1alpha1.ReasonProgressing, "installing")
+
+			reconcileOnce()
+			Expect(mockClient.updateCalled).To(BeTrue())
+
+			progressing := findRemoteCondition(privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_PROGRESSING)
+			Expect(progressing).NotTo(BeNil())
+			Expect(progressing.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
+			// Furthest stage reached is Accepted, so it drives PROGRESSING's reason/message.
+			Expect(progressing.GetReason()).To(Equal(osacv1alpha1.ConditionAccepted))
+			Expect(progressing.GetMessage()).To(Equal("Accepted"))
+			// Only PROGRESSING is produced; Accepted does not become its own condition.
+			Expect(mockClient.lastUpdate.GetStatus().GetConditions()).To(HaveLen(1))
+		})
+
+		It("should map Progressing to PROGRESSING preserving False status, reason and message", func() {
+			setCRCondition(osacv1alpha1.ConditionProgressing, metav1.ConditionFalse,
+				osacv1alpha1.ReasonProvisioningFailed, "provisioning failed")
+
+			reconcileOnce()
+			Expect(mockClient.updateCalled).To(BeTrue())
+
+			progressing := findRemoteCondition(privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_PROGRESSING)
+			Expect(progressing).NotTo(BeNil())
+			Expect(progressing.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_FALSE))
+			Expect(progressing.GetReason()).To(Equal(osacv1alpha1.ReasonProvisioningFailed))
+			Expect(progressing.GetMessage()).To(Equal("provisioning failed"))
+		})
+
+		It("should fold installation-step conditions into PROGRESSING's reason/message without changing its status or adding conditions", func() {
+			// ControlPlaneCreated and ClusterStorageReady are individual installation steps.
+			// They are recognised (never logged as unknown) and refine PROGRESSING's
+			// reason/message to the furthest step reached, but must not change PROGRESSING's
+			// status or become their own fulfillment conditions.
+			setCRCondition(osacv1alpha1.ConditionProgressing, metav1.ConditionTrue,
+				osacv1alpha1.ReasonProgressing, "installing")
+			setCRCondition(osacv1alpha1.ConditionControlPlaneCreated, metav1.ConditionTrue,
+				osacv1alpha1.ReasonAsExpected, "control plane created")
+			setCRCondition(string(osacv1alpha1.ClusterOrderConditionClusterStorageReady), metav1.ConditionTrue,
+				osacv1alpha1.TenantReasonFound, "storage discovered")
+
+			reconcileOnce()
+			Expect(mockClient.updateCalled).To(BeTrue())
+
+			progressing := findRemoteCondition(privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_PROGRESSING)
+			Expect(progressing).NotTo(BeNil())
+			Expect(progressing.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
+			// ClusterStorageReady is the furthest stage reached, so it drives reason/message.
+			Expect(progressing.GetReason()).To(Equal(string(osacv1alpha1.ClusterOrderConditionClusterStorageReady)))
+			Expect(progressing.GetMessage()).To(Equal("Cluster Storage Ready"))
+			// Only PROGRESSING is produced; the installation steps do not add their own conditions.
+			Expect(mockClient.lastUpdate.GetStatus().GetConditions()).To(HaveLen(1))
+		})
+
+		It("should pick the furthest stage for PROGRESSING reason regardless of condition order", func() {
+			// Accepted and ControlPlaneCreated are True; ClusterStorageReady is not. The
+			// furthest stage is ControlPlaneCreated, selected from the fixed stage order, not
+			// from the order the conditions happen to appear in the CR status (here reversed:
+			// ControlPlaneCreated is appended before the earlier Accepted stage).
+			setCRCondition(osacv1alpha1.ConditionProgressing, metav1.ConditionTrue,
+				osacv1alpha1.ReasonProgressing, "installing")
+			setCRCondition(osacv1alpha1.ConditionControlPlaneCreated, metav1.ConditionTrue,
+				osacv1alpha1.ReasonAsExpected, "control plane created")
+			setCRCondition(osacv1alpha1.ConditionAccepted, metav1.ConditionTrue,
+				osacv1alpha1.ReasonInitialized, "order accepted")
+
+			reconcileOnce()
+
+			progressing := findRemoteCondition(privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_PROGRESSING)
+			Expect(progressing).NotTo(BeNil())
+			Expect(progressing.GetReason()).To(Equal(osacv1alpha1.ConditionControlPlaneCreated))
+			Expect(progressing.GetMessage()).To(Equal("Control Plane Created"))
+		})
+
+		It("should keep PROGRESSING's own reason/message when it is True but no installation stage is reached yet", func() {
+			// Progressing is True but none of the installation-step conditions is set
+			// (furthest stage is empty). The overlay must leave PROGRESSING's reason/message
+			// as copied from the Progressing condition itself, not blank them or panic.
+			setCRCondition(osacv1alpha1.ConditionProgressing, metav1.ConditionTrue,
+				osacv1alpha1.ReasonProgressing, "installing")
+
+			reconcileOnce()
+			Expect(mockClient.updateCalled).To(BeTrue())
+
+			progressing := findRemoteCondition(privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_PROGRESSING)
+			Expect(progressing).NotTo(BeNil())
+			Expect(progressing.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
+			// No stage reached, so reason/message stay as the Progressing condition set them.
+			Expect(progressing.GetReason()).To(Equal(osacv1alpha1.ReasonProgressing))
+			Expect(progressing.GetMessage()).To(Equal("installing"))
+			Expect(mockClient.lastUpdate.GetStatus().GetConditions()).To(HaveLen(1))
+		})
+
+		It("should not create a PROGRESSING condition from a stage when Progressing itself is absent", func() {
+			// A stage condition is True but the Progressing condition is missing. The overlay
+			// only refines an existing PROGRESSING condition; it must not fabricate one from a
+			// stage. Phase forces an update so the (empty) conditions list can be asserted.
+			clusterOrder := &osacv1alpha1.ClusterOrder{}
+			Expect(k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)).To(Succeed())
+			clusterOrder.Status.Phase = osacv1alpha1.ClusterOrderPhaseProgressing
+			clusterOrder.Status.Conditions = append(clusterOrder.Status.Conditions, metav1.Condition{
+				Type:               osacv1alpha1.ConditionControlPlaneCreated,
+				Status:             metav1.ConditionTrue,
+				Reason:             osacv1alpha1.ReasonAsExpected,
+				Message:            "control plane created",
+				LastTransitionTime: metav1.NewTime(time.Now().UTC()),
+			})
+			Expect(k8sClient.Status().Update(testCtx, clusterOrder)).To(Succeed())
+
+			reconcileOnce()
+			Expect(mockClient.updateCalled).To(BeTrue())
+			Expect(mockClient.lastUpdate.GetStatus().GetState()).To(Equal(privatev1.ClusterState_CLUSTER_STATE_PROGRESSING))
+			// The stage neither becomes its own condition nor conjures a PROGRESSING one.
+			Expect(findRemoteCondition(privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_PROGRESSING)).To(BeNil())
+			Expect(mockClient.lastUpdate.GetStatus().GetConditions()).To(BeEmpty())
+		})
+
+		It("should explicitly ignore NamespaceCreated without producing a proto condition", func() {
+			clusterOrder := &osacv1alpha1.ClusterOrder{}
+			Expect(k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)).To(Succeed())
+			clusterOrder.Status.Phase = osacv1alpha1.ClusterOrderPhaseProgressing
+			clusterOrder.Status.Conditions = append(clusterOrder.Status.Conditions, metav1.Condition{
+				Type:               osacv1alpha1.ConditionNamespaceCreated,
+				Status:             metav1.ConditionTrue,
+				Reason:             osacv1alpha1.ReasonAsExpected,
+				Message:            "namespace created",
+				LastTransitionTime: metav1.NewTime(time.Now().UTC()),
+			})
+			Expect(k8sClient.Status().Update(testCtx, clusterOrder)).To(Succeed())
+
+			reconcileOnce()
+			// Phase forces an update so we can assert the conditions list, and confirm
+			// the ignored condition did not silently create a proto condition.
+			Expect(mockClient.updateCalled).To(BeTrue())
+			Expect(mockClient.lastUpdate.GetStatus().GetState()).To(Equal(privatev1.ClusterState_CLUSTER_STATE_PROGRESSING))
+			Expect(mockClient.lastUpdate.GetStatus().GetConditions()).To(BeEmpty())
+		})
+
+		It("should not surface an unmapped, non-ignored condition as a proto condition (no silent default)", func() {
+			clusterOrder := &osacv1alpha1.ClusterOrder{}
+			Expect(k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)).To(Succeed())
+			clusterOrder.Status.Phase = osacv1alpha1.ClusterOrderPhaseProgressing
+			clusterOrder.Status.Conditions = append(clusterOrder.Status.Conditions, metav1.Condition{
+				Type:               "SomeFutureCondition",
+				Status:             metav1.ConditionTrue,
+				Reason:             osacv1alpha1.ReasonAsExpected,
+				Message:            "a condition with no mapping yet",
+				LastTransitionTime: metav1.NewTime(time.Now().UTC()),
+			})
+			Expect(k8sClient.Status().Update(testCtx, clusterOrder)).To(Succeed())
+
+			reconcileOnce()
+			// Phase forces an update so we can assert the conditions list: an unknown
+			// condition is logged and dropped, never silently mapped to a proto condition.
+			Expect(mockClient.updateCalled).To(BeTrue())
+			Expect(mockClient.lastUpdate.GetStatus().GetState()).To(Equal(privatev1.ClusterState_CLUSTER_STATE_PROGRESSING))
+			Expect(mockClient.lastUpdate.GetStatus().GetConditions()).To(BeEmpty())
+		})
+
+		It("should fill PROGRESSING from Progressing regardless of condition order and not invert once the cluster is available", func() {
+			// A finished cluster: Progressing is False, every installation step is True, and
+			// the cluster is Available. PROGRESSING must follow Progressing (False) - a
+			// completed step must not report the cluster as still installing - and the result
+			// must be the same no matter what order the conditions are stored in.
+			buildConditions := func() []metav1.Condition {
+				now := metav1.NewTime(time.Now().UTC())
+				return []metav1.Condition{
+					{Type: osacv1alpha1.ConditionAccepted, Status: metav1.ConditionTrue, Reason: osacv1alpha1.ReasonInitialized, Message: "accepted", LastTransitionTime: now},
+					{Type: osacv1alpha1.ConditionProgressing, Status: metav1.ConditionFalse, Reason: osacv1alpha1.ReasonAsExpected, Message: "installation complete", LastTransitionTime: now},
+					{Type: osacv1alpha1.ConditionControlPlaneCreated, Status: metav1.ConditionTrue, Reason: osacv1alpha1.ReasonAsExpected, Message: "control plane created", LastTransitionTime: now},
+					{Type: osacv1alpha1.ConditionControlPlaneAvailable, Status: metav1.ConditionTrue, Reason: osacv1alpha1.ReasonAsExpected, Message: "control plane available", LastTransitionTime: now},
+					{Type: string(osacv1alpha1.ClusterOrderConditionClusterStorageReady), Status: metav1.ConditionTrue, Reason: osacv1alpha1.TenantReasonFound, Message: "storage ready", LastTransitionTime: now},
+					{Type: osacv1alpha1.ConditionClusterAvailable, Status: metav1.ConditionTrue, Reason: osacv1alpha1.ReasonAsExpected, Message: "cluster available", LastTransitionTime: now},
+					{Type: osacv1alpha1.ConditionNamespaceCreated, Status: metav1.ConditionTrue, Reason: osacv1alpha1.ReasonAsExpected, Message: "namespace created", LastTransitionTime: now},
+				}
+			}
+
+			setConditions := func(conditions []metav1.Condition) {
+				clusterOrder := &osacv1alpha1.ClusterOrder{}
+				Expect(k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)).To(Succeed())
+				clusterOrder.Status.Conditions = conditions
+				Expect(k8sClient.Status().Update(testCtx, clusterOrder)).To(Succeed())
+			}
+
+			assertResult := func() {
+				// Two fulfillment conditions only: PROGRESSING and READY. The installation
+				// steps do not add their own conditions and NamespaceCreated is ignored.
+				Expect(mockClient.lastUpdate.GetStatus().GetConditions()).To(HaveLen(2))
+
+				ready := findRemoteCondition(privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_READY)
+				Expect(ready).NotTo(BeNil())
+				Expect(ready.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
+
+				progressing := findRemoteCondition(privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_PROGRESSING)
+				Expect(progressing).NotTo(BeNil())
+				// Follows Progressing (False); a completed step never flips it back to True.
+				Expect(progressing.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_FALSE))
+				Expect(progressing.GetMessage()).To(Equal("installation complete"))
+			}
+
+			// Stored order.
+			setConditions(buildConditions())
+			reconcileOnce()
+			Expect(mockClient.updateCalled).To(BeTrue())
+			assertResult()
+
+			// Reversed order - the fulfillment result must be identical. Reset the remote so
+			// the second reconcile rebuilds the conditions from an empty cluster.
+			reversed := buildConditions()
+			slices.Reverse(reversed)
+			mockClient.getResponse = newClusterGetResponse()
+			mockClient.updateCalled = false
+			mockClient.lastUpdate = nil
+			setConditions(reversed)
+			reconcileOnce()
+			Expect(mockClient.updateCalled).To(BeTrue())
+			assertResult()
+		})
+	})
+
+	Context("ClusterOrder condition mapping completeness", func() {
+		// Tripwire: every ClusterOrder condition must be handled by exactly one of the three
+		// dispositions in feedback_controller.go - mapped to a fulfillment condition, listed
+		// as a provisioning stage (refines PROGRESSING's reason/message), or explicitly
+		// unsurfaced. When a new ClusterOrder condition is added to the API, add it here and
+		// wire it into one of the three - otherwise this test fails, instead of the condition
+		// being silently dropped at runtime.
+		knownClusterOrderConditions := []string{
+			osacv1alpha1.ConditionAccepted,
+			osacv1alpha1.ConditionNamespaceCreated,
+			osacv1alpha1.ConditionControlPlaneCreated,
+			osacv1alpha1.ConditionControlPlaneAvailable,
+			osacv1alpha1.ConditionClusterAvailable,
+			string(osacv1alpha1.ClusterOrderConditionClusterStorageReady),
+			osacv1alpha1.ConditionProgressing,
+			osacv1alpha1.ConditionDeleting,
+		}
+
+		It("handles every known ClusterOrder condition exactly once", func() {
+			for _, condition := range knownClusterOrderConditions {
+				_, mapped := clusterOrderConditionMappings[condition]
+				stage := slices.Contains(clusterOrderProvisioningStages, condition)
+				_, unsurfaced := clusterOrderUnsurfacedConditions[condition]
+
+				handledCount := 0
+				for _, handled := range []bool{mapped, stage, unsurfaced} {
+					if handled {
+						handledCount++
+					}
+				}
+				Expect(handledCount).To(Equal(1),
+					"condition %q must be handled by exactly one of: mapping, provisioning stage, unsurfaced (got %d)",
+					condition, handledCount)
+			}
+		})
+
+		It("does not reference any unknown ClusterOrder condition", func() {
+			known := map[string]struct{}{}
+			for _, condition := range knownClusterOrderConditions {
+				known[condition] = struct{}{}
+			}
+			for condition := range clusterOrderConditionMappings {
+				_, ok := known[condition]
+				Expect(ok).To(BeTrue(), "mapped condition %q is not a known ClusterOrder condition", condition)
+			}
+			for _, condition := range clusterOrderProvisioningStages {
+				_, ok := known[condition]
+				Expect(ok).To(BeTrue(), "provisioning-stage condition %q is not a known ClusterOrder condition", condition)
+			}
+			for condition := range clusterOrderUnsurfacedConditions {
+				_, ok := known[condition]
+				Expect(ok).To(BeTrue(), "unsurfaced condition %q is not a known ClusterOrder condition", condition)
+			}
 		})
 	})
 })

--- a/osac-operator/internal/controller/clusterorder_feedback_controller_test.go
+++ b/osac-operator/internal/controller/clusterorder_feedback_controller_test.go
@@ -1004,3 +1004,19 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 		})
 	})
 })
+
+var _ = Describe("humanizeConditionName", func() {
+	DescribeTable("splits a PascalCase condition name into words",
+		func(name, expected string) {
+			Expect(humanizeConditionName(name)).To(Equal(expected))
+		},
+		Entry("single word", "Ready", "Ready"),
+		Entry("two words", "ClusterStorageReady", "Cluster Storage Ready"),
+		Entry("three words", "ControlPlaneCreated", "Control Plane Created"),
+		Entry("leading acronym", "CSIDriverReady", "CSI Driver Ready"),
+		Entry("trailing acronym", "EnableTLS", "Enable TLS"),
+		Entry("acronym-only", "TLS", "TLS"),
+		Entry("acronym then word", "TLSReady", "TLS Ready"),
+		Entry("empty string", "", ""),
+	)
+})

--- a/osac-operator/internal/controller/clusterorder_feedback_controller_test.go
+++ b/osac-operator/internal/controller/clusterorder_feedback_controller_test.go
@@ -152,7 +152,7 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 
 	Context("When reconciling a resource without the cluster ID label", func() {
 		BeforeEach(func() {
-			co := &osacv1alpha1.ClusterOrder{
+			clusterOrder := &osacv1alpha1.ClusterOrder{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
 					Namespace: clusterOrderNS,
@@ -161,16 +161,16 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 					TemplateID: "test_template",
 				},
 			}
-			Expect(k8sClient.Create(testCtx, co)).To(Succeed())
+			Expect(k8sClient.Create(testCtx, clusterOrder)).To(Succeed())
 		})
 
 		AfterEach(func() {
-			co := &osacv1alpha1.ClusterOrder{}
-			err := k8sClient.Get(testCtx, typeNamespacedName, co)
+			clusterOrder := &osacv1alpha1.ClusterOrder{}
+			err := k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)
 			if err == nil {
-				co.Finalizers = nil
-				_ = k8sClient.Update(testCtx, co)
-				_ = k8sClient.Delete(testCtx, co)
+				clusterOrder.Finalizers = nil
+				_ = k8sClient.Update(testCtx, clusterOrder)
+				_ = k8sClient.Delete(testCtx, clusterOrder)
 			}
 		})
 
@@ -185,13 +185,13 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 		})
 
 		It("should remove feedback finalizer from CR without cluster ID label being deleted", func() {
-			co := &osacv1alpha1.ClusterOrder{}
-			Expect(k8sClient.Get(testCtx, typeNamespacedName, co)).To(Succeed())
-			co.Finalizers = []string{osacClusterOrderFeedbackFinalizer}
-			Expect(k8sClient.Update(testCtx, co)).To(Succeed())
+			clusterOrder := &osacv1alpha1.ClusterOrder{}
+			Expect(k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)).To(Succeed())
+			clusterOrder.Finalizers = []string{osacClusterOrderFeedbackFinalizer}
+			Expect(k8sClient.Update(testCtx, clusterOrder)).To(Succeed())
 
-			Expect(k8sClient.Get(testCtx, typeNamespacedName, co)).To(Succeed())
-			Expect(k8sClient.Delete(testCtx, co)).To(Succeed())
+			Expect(k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)).To(Succeed())
+			Expect(k8sClient.Delete(testCtx, clusterOrder)).To(Succeed())
 
 			request := reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -209,7 +209,7 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 
 	Context("When reconciling a resource that is being deleted", func() {
 		BeforeEach(func() {
-			co := &osacv1alpha1.ClusterOrder{
+			clusterOrder := &osacv1alpha1.ClusterOrder{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
 					Namespace: clusterOrderNS,
@@ -222,25 +222,25 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 					TemplateID: "test_template",
 				},
 			}
-			Expect(k8sClient.Create(testCtx, co)).To(Succeed())
+			Expect(k8sClient.Create(testCtx, clusterOrder)).To(Succeed())
 
-			Expect(k8sClient.Get(testCtx, typeNamespacedName, co)).To(Succeed())
-			co.Status.Phase = osacv1alpha1.ClusterOrderPhaseDeleting
-			Expect(k8sClient.Status().Update(testCtx, co)).To(Succeed())
+			Expect(k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)).To(Succeed())
+			clusterOrder.Status.Phase = osacv1alpha1.ClusterOrderPhaseDeleting
+			Expect(k8sClient.Status().Update(testCtx, clusterOrder)).To(Succeed())
 
-			Expect(k8sClient.Get(testCtx, typeNamespacedName, co)).To(Succeed())
-			Expect(k8sClient.Delete(testCtx, co)).To(Succeed())
+			Expect(k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)).To(Succeed())
+			Expect(k8sClient.Delete(testCtx, clusterOrder)).To(Succeed())
 
 			mockClient.getResponse = newClusterGetResponse()
 			mockClient.updateResponse = &privatev1.ClustersUpdateResponse{}
 		})
 
 		AfterEach(func() {
-			co := &osacv1alpha1.ClusterOrder{}
-			err := k8sClient.Get(testCtx, typeNamespacedName, co)
+			clusterOrder := &osacv1alpha1.ClusterOrder{}
+			err := k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)
 			if err == nil {
-				co.Finalizers = nil
-				Expect(k8sClient.Update(testCtx, co)).To(Succeed())
+				clusterOrder.Finalizers = nil
+				Expect(k8sClient.Update(testCtx, clusterOrder)).To(Succeed())
 			}
 		})
 
@@ -290,7 +290,7 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 
 	Context("When reconciling a resource deleted while still in Progressing phase", func() {
 		BeforeEach(func() {
-			co := &osacv1alpha1.ClusterOrder{
+			clusterOrder := &osacv1alpha1.ClusterOrder{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
 					Namespace: clusterOrderNS,
@@ -303,25 +303,25 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 					TemplateID: "test_template",
 				},
 			}
-			Expect(k8sClient.Create(testCtx, co)).To(Succeed())
+			Expect(k8sClient.Create(testCtx, clusterOrder)).To(Succeed())
 
-			Expect(k8sClient.Get(testCtx, typeNamespacedName, co)).To(Succeed())
-			co.Status.Phase = osacv1alpha1.ClusterOrderPhaseProgressing
-			Expect(k8sClient.Status().Update(testCtx, co)).To(Succeed())
+			Expect(k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)).To(Succeed())
+			clusterOrder.Status.Phase = osacv1alpha1.ClusterOrderPhaseProgressing
+			Expect(k8sClient.Status().Update(testCtx, clusterOrder)).To(Succeed())
 
-			Expect(k8sClient.Get(testCtx, typeNamespacedName, co)).To(Succeed())
-			Expect(k8sClient.Delete(testCtx, co)).To(Succeed())
+			Expect(k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)).To(Succeed())
+			Expect(k8sClient.Delete(testCtx, clusterOrder)).To(Succeed())
 
 			mockClient.getResponse = newClusterGetResponse()
 			mockClient.updateResponse = &privatev1.ClustersUpdateResponse{}
 		})
 
 		AfterEach(func() {
-			co := &osacv1alpha1.ClusterOrder{}
-			err := k8sClient.Get(testCtx, typeNamespacedName, co)
+			clusterOrder := &osacv1alpha1.ClusterOrder{}
+			err := k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)
 			if err == nil {
-				co.Finalizers = nil
-				Expect(k8sClient.Update(testCtx, co)).To(Succeed())
+				clusterOrder.Finalizers = nil
+				Expect(k8sClient.Update(testCtx, clusterOrder)).To(Succeed())
 			}
 		})
 
@@ -345,7 +345,7 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 
 	Context("When reconciling a resource being deleted with multiple finalizers", func() {
 		BeforeEach(func() {
-			co := &osacv1alpha1.ClusterOrder{
+			clusterOrder := &osacv1alpha1.ClusterOrder{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
 					Namespace: clusterOrderNS,
@@ -358,25 +358,25 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 					TemplateID: "test_template",
 				},
 			}
-			Expect(k8sClient.Create(testCtx, co)).To(Succeed())
+			Expect(k8sClient.Create(testCtx, clusterOrder)).To(Succeed())
 
-			Expect(k8sClient.Get(testCtx, typeNamespacedName, co)).To(Succeed())
-			co.Status.Phase = osacv1alpha1.ClusterOrderPhaseDeleting
-			Expect(k8sClient.Status().Update(testCtx, co)).To(Succeed())
+			Expect(k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)).To(Succeed())
+			clusterOrder.Status.Phase = osacv1alpha1.ClusterOrderPhaseDeleting
+			Expect(k8sClient.Status().Update(testCtx, clusterOrder)).To(Succeed())
 
-			Expect(k8sClient.Get(testCtx, typeNamespacedName, co)).To(Succeed())
-			Expect(k8sClient.Delete(testCtx, co)).To(Succeed())
+			Expect(k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)).To(Succeed())
+			Expect(k8sClient.Delete(testCtx, clusterOrder)).To(Succeed())
 
 			mockClient.getResponse = newClusterGetResponse()
 			mockClient.updateResponse = &privatev1.ClustersUpdateResponse{}
 		})
 
 		AfterEach(func() {
-			co := &osacv1alpha1.ClusterOrder{}
-			err := k8sClient.Get(testCtx, typeNamespacedName, co)
+			clusterOrder := &osacv1alpha1.ClusterOrder{}
+			err := k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)
 			if err == nil {
-				co.Finalizers = nil
-				Expect(k8sClient.Update(testCtx, co)).To(Succeed())
+				clusterOrder.Finalizers = nil
+				Expect(k8sClient.Update(testCtx, clusterOrder)).To(Succeed())
 			}
 		})
 
@@ -398,7 +398,7 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 
 	Context("When reconciling a resource being deleted without feedback finalizer", func() {
 		BeforeEach(func() {
-			co := &osacv1alpha1.ClusterOrder{
+			clusterOrder := &osacv1alpha1.ClusterOrder{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
 					Namespace: clusterOrderNS,
@@ -411,25 +411,25 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 					TemplateID: "test_template",
 				},
 			}
-			Expect(k8sClient.Create(testCtx, co)).To(Succeed())
+			Expect(k8sClient.Create(testCtx, clusterOrder)).To(Succeed())
 
-			Expect(k8sClient.Get(testCtx, typeNamespacedName, co)).To(Succeed())
-			co.Status.Phase = osacv1alpha1.ClusterOrderPhaseDeleting
-			Expect(k8sClient.Status().Update(testCtx, co)).To(Succeed())
+			Expect(k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)).To(Succeed())
+			clusterOrder.Status.Phase = osacv1alpha1.ClusterOrderPhaseDeleting
+			Expect(k8sClient.Status().Update(testCtx, clusterOrder)).To(Succeed())
 
-			Expect(k8sClient.Get(testCtx, typeNamespacedName, co)).To(Succeed())
-			Expect(k8sClient.Delete(testCtx, co)).To(Succeed())
+			Expect(k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)).To(Succeed())
+			Expect(k8sClient.Delete(testCtx, clusterOrder)).To(Succeed())
 
 			mockClient.getResponse = newClusterGetResponse()
 			mockClient.updateResponse = &privatev1.ClustersUpdateResponse{}
 		})
 
 		AfterEach(func() {
-			co := &osacv1alpha1.ClusterOrder{}
-			err := k8sClient.Get(testCtx, typeNamespacedName, co)
+			clusterOrder := &osacv1alpha1.ClusterOrder{}
+			err := k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)
 			if err == nil {
-				co.Finalizers = nil
-				Expect(k8sClient.Update(testCtx, co)).To(Succeed())
+				clusterOrder.Finalizers = nil
+				Expect(k8sClient.Update(testCtx, clusterOrder)).To(Succeed())
 			}
 		})
 
@@ -446,7 +446,7 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 
 	Context("When reconciling a resource being deleted and fulfillment-service returns NotFound", func() {
 		BeforeEach(func() {
-			co := &osacv1alpha1.ClusterOrder{
+			clusterOrder := &osacv1alpha1.ClusterOrder{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
 					Namespace: clusterOrderNS,
@@ -459,24 +459,24 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 					TemplateID: "test_template",
 				},
 			}
-			Expect(k8sClient.Create(testCtx, co)).To(Succeed())
+			Expect(k8sClient.Create(testCtx, clusterOrder)).To(Succeed())
 
-			Expect(k8sClient.Get(testCtx, typeNamespacedName, co)).To(Succeed())
-			co.Status.Phase = osacv1alpha1.ClusterOrderPhaseDeleting
-			Expect(k8sClient.Status().Update(testCtx, co)).To(Succeed())
+			Expect(k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)).To(Succeed())
+			clusterOrder.Status.Phase = osacv1alpha1.ClusterOrderPhaseDeleting
+			Expect(k8sClient.Status().Update(testCtx, clusterOrder)).To(Succeed())
 
-			Expect(k8sClient.Get(testCtx, typeNamespacedName, co)).To(Succeed())
-			Expect(k8sClient.Delete(testCtx, co)).To(Succeed())
+			Expect(k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)).To(Succeed())
+			Expect(k8sClient.Delete(testCtx, clusterOrder)).To(Succeed())
 
 			mockClient.getError = grpcstatus.Errorf(codes.NotFound, "object with identifier '%s' not found", clusterID)
 		})
 
 		AfterEach(func() {
-			co := &osacv1alpha1.ClusterOrder{}
-			err := k8sClient.Get(testCtx, typeNamespacedName, co)
+			clusterOrder := &osacv1alpha1.ClusterOrder{}
+			err := k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)
 			if err == nil {
-				co.Finalizers = nil
-				Expect(k8sClient.Update(testCtx, co)).To(Succeed())
+				clusterOrder.Finalizers = nil
+				Expect(k8sClient.Update(testCtx, clusterOrder)).To(Succeed())
 			}
 		})
 
@@ -498,7 +498,7 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 
 	Context("When fulfillment-service returns NotFound for a resource that is NOT being deleted", func() {
 		BeforeEach(func() {
-			co := &osacv1alpha1.ClusterOrder{
+			clusterOrder := &osacv1alpha1.ClusterOrder{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
 					Namespace: clusterOrderNS,
@@ -511,18 +511,18 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 					TemplateID: "test_template",
 				},
 			}
-			Expect(k8sClient.Create(testCtx, co)).To(Succeed())
+			Expect(k8sClient.Create(testCtx, clusterOrder)).To(Succeed())
 
 			mockClient.getError = grpcstatus.Errorf(codes.NotFound, "object with identifier '%s' not found", clusterID)
 		})
 
 		AfterEach(func() {
-			co := &osacv1alpha1.ClusterOrder{}
-			err := k8sClient.Get(testCtx, typeNamespacedName, co)
+			clusterOrder := &osacv1alpha1.ClusterOrder{}
+			err := k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)
 			if err == nil {
-				co.Finalizers = nil
-				_ = k8sClient.Update(testCtx, co)
-				_ = k8sClient.Delete(testCtx, co)
+				clusterOrder.Finalizers = nil
+				_ = k8sClient.Update(testCtx, clusterOrder)
+				_ = k8sClient.Delete(testCtx, clusterOrder)
 			}
 		})
 
@@ -538,7 +538,7 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 
 	Context("When reconciling a valid resource", func() {
 		BeforeEach(func() {
-			co := &osacv1alpha1.ClusterOrder{
+			clusterOrder := &osacv1alpha1.ClusterOrder{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      resourceName,
 					Namespace: clusterOrderNS,
@@ -550,19 +550,19 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 					TemplateID: "test_template",
 				},
 			}
-			Expect(k8sClient.Create(testCtx, co)).To(Succeed())
+			Expect(k8sClient.Create(testCtx, clusterOrder)).To(Succeed())
 
 			mockClient.getResponse = newClusterGetResponse()
 			mockClient.updateResponse = &privatev1.ClustersUpdateResponse{}
 		})
 
 		AfterEach(func() {
-			co := &osacv1alpha1.ClusterOrder{}
-			err := k8sClient.Get(testCtx, typeNamespacedName, co)
+			clusterOrder := &osacv1alpha1.ClusterOrder{}
+			err := k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)
 			if err == nil {
-				co.Finalizers = nil
-				_ = k8sClient.Update(testCtx, co)
-				_ = k8sClient.Delete(testCtx, co)
+				clusterOrder.Finalizers = nil
+				_ = k8sClient.Update(testCtx, clusterOrder)
+				_ = k8sClient.Delete(testCtx, clusterOrder)
 			}
 		})
 
@@ -579,10 +579,10 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 		})
 
 		It("should sync Progressing phase", func() {
-			co := &osacv1alpha1.ClusterOrder{}
-			Expect(k8sClient.Get(testCtx, typeNamespacedName, co)).To(Succeed())
-			co.Status.Phase = osacv1alpha1.ClusterOrderPhaseProgressing
-			Expect(k8sClient.Status().Update(testCtx, co)).To(Succeed())
+			clusterOrder := &osacv1alpha1.ClusterOrder{}
+			Expect(k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)).To(Succeed())
+			clusterOrder.Status.Phase = osacv1alpha1.ClusterOrderPhaseProgressing
+			Expect(k8sClient.Status().Update(testCtx, clusterOrder)).To(Succeed())
 
 			request := reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -594,10 +594,10 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 		})
 
 		It("should sync Failed phase", func() {
-			co := &osacv1alpha1.ClusterOrder{}
-			Expect(k8sClient.Get(testCtx, typeNamespacedName, co)).To(Succeed())
-			co.Status.Phase = osacv1alpha1.ClusterOrderPhaseFailed
-			Expect(k8sClient.Status().Update(testCtx, co)).To(Succeed())
+			clusterOrder := &osacv1alpha1.ClusterOrder{}
+			Expect(k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)).To(Succeed())
+			clusterOrder.Status.Phase = osacv1alpha1.ClusterOrderPhaseFailed
+			Expect(k8sClient.Status().Update(testCtx, clusterOrder)).To(Succeed())
 
 			request := reconcile.Request{
 				NamespacedName: typeNamespacedName,
@@ -609,11 +609,11 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 		})
 
 		It("should sync VIP endpoints to Cluster proto when set in status", func() {
-			co := &osacv1alpha1.ClusterOrder{}
-			Expect(k8sClient.Get(testCtx, typeNamespacedName, co)).To(Succeed())
-			co.Status.ApiEndpoint = "10.0.0.1"
-			co.Status.IngressEndpoint = "10.0.0.2"
-			Expect(k8sClient.Status().Update(testCtx, co)).To(Succeed())
+			clusterOrder := &osacv1alpha1.ClusterOrder{}
+			Expect(k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)).To(Succeed())
+			clusterOrder.Status.ApiEndpoint = "10.0.0.1"
+			clusterOrder.Status.IngressEndpoint = "10.0.0.2"
+			Expect(k8sClient.Status().Update(testCtx, clusterOrder)).To(Succeed())
 
 			request := reconcile.Request{NamespacedName: typeNamespacedName}
 			_, err := reconciler.Reconcile(testCtx, request)
@@ -632,10 +632,10 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 		})
 
 		It("should not call update when reconciled twice with same data", func() {
-			co := &osacv1alpha1.ClusterOrder{}
-			Expect(k8sClient.Get(testCtx, typeNamespacedName, co)).To(Succeed())
-			co.Status.Phase = osacv1alpha1.ClusterOrderPhaseProgressing
-			Expect(k8sClient.Status().Update(testCtx, co)).To(Succeed())
+			clusterOrder := &osacv1alpha1.ClusterOrder{}
+			Expect(k8sClient.Get(testCtx, typeNamespacedName, clusterOrder)).To(Succeed())
+			clusterOrder.Status.Phase = osacv1alpha1.ClusterOrderPhaseProgressing
+			Expect(k8sClient.Status().Update(testCtx, clusterOrder)).To(Succeed())
 
 			mockClient.getResponse.GetObject().GetStatus().SetState(privatev1.ClusterState_CLUSTER_STATE_PROGRESSING)
 

--- a/osac-operator/internal/controller/feedback_controller.go
+++ b/osac-operator/internal/controller/feedback_controller.go
@@ -17,6 +17,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
+	"unicode"
 
 	hypershiftv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	"google.golang.org/grpc"
@@ -145,19 +148,139 @@ func syncClusterOrderDelete(ctx context.Context, obj *ckv1alpha1.ClusterOrder, r
 	return nil
 }
 
-func syncClusterOrderConditions(ctx context.Context, obj *ckv1alpha1.ClusterOrder, remote *privatev1.Cluster) {
+// clusterOrderConditionMappings maps a ClusterOrder condition to the fulfillment
+// condition whose status it drives. Each fulfillment condition has exactly one source
+// condition, so the derived status never depends on the order of the conditions. The
+// fulfillment API has a single PROGRESSING condition, and only "Progressing" drives its
+// status (True while the cluster is still being installed, False once it is ready or has
+// failed); "ClusterAvailable" drives READY.
+//
+// The PROGRESSING condition's *reason* and *message* are refined separately, from the
+// furthest-advanced installation stage, by applyProgressingStageDetail below.
+var clusterOrderConditionMappings = map[string]privatev1.ClusterConditionType{
+	ckv1alpha1.ConditionProgressing:      privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_PROGRESSING,
+	ckv1alpha1.ConditionClusterAvailable: privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_READY,
+}
+
+// clusterOrderProvisioningStages are the ClusterOrder conditions that mark individual
+// installation steps, ordered from earliest to furthest-advanced. While the cluster is
+// still installing, they do not become their own fulfillment conditions; instead they
+// refine the single PROGRESSING condition's reason/message to the furthest step reached
+// (see applyProgressingStageDetail). Selecting the furthest stage from this fixed order,
+// rather than from the order the conditions happen to appear in the CR status, keeps the
+// result deterministic (order-independent).
+//
+// ControlPlaneAvailable also refines PROGRESSING today; in Epic 2 it additionally gains
+// its own orthogonal CONTROL_PLANE_AVAILABLE fulfillment condition. ClusterStorageReady
+// is written by the storage controller, which uses the typed
+// ClusterOrderConditionClusterStorageReady constant, so we key off that same constant to
+// avoid reader/writer drift.
+var clusterOrderProvisioningStages = []string{
+	ckv1alpha1.ConditionAccepted,
+	ckv1alpha1.ConditionControlPlaneCreated,
+	ckv1alpha1.ConditionControlPlaneAvailable,
+	string(ckv1alpha1.ClusterOrderConditionClusterStorageReady),
+}
+
+// clusterOrderUnsurfacedConditions are ClusterOrder conditions we know about but neither
+// copy to the fulfillment API nor use to refine PROGRESSING. They are listed so they are
+// not reported as unknown:
+//   - NamespaceCreated is internal bookkeeping with no tenant-facing meaning.
+//   - Deleting is reported through the DELETING state (see syncClusterOrderPhase and
+//     syncClusterOrderDelete), not as a condition.
+var clusterOrderUnsurfacedConditions = map[string]struct{}{
+	ckv1alpha1.ConditionNamespaceCreated: {},
+	ckv1alpha1.ConditionDeleting:         {},
+}
+
+func syncClusterOrderConditions(ctx context.Context, clusterOrder *ckv1alpha1.ClusterOrder, remote *privatev1.Cluster) {
 	log := ctrllog.FromContext(ctx)
-	for _, condition := range obj.Status.Conditions {
-		switch ckv1alpha1.ClusterOrderConditionType(condition.Type) {
-		case ckv1alpha1.ClusterOrderConditionAccepted,
-			ckv1alpha1.ClusterOrderConditionProgressing,
-			ckv1alpha1.ClusterOrderConditionControlPlaneAvailable,
-			ckv1alpha1.ClusterOrderConditionAvailable:
-			syncClusterConditionFromCR(remote, privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_PROGRESSING, condition)
-		default:
-			log.Info("Unknown condition, will ignore it", "condition", condition.Type)
+
+	for i := range clusterOrder.Status.Conditions {
+		condition := clusterOrder.Status.Conditions[i]
+		if protoType, ok := clusterOrderConditionMappings[condition.Type]; ok {
+			syncClusterConditionFromCR(remote, protoType, condition)
+			continue
+		}
+		if slices.Contains(clusterOrderProvisioningStages, condition.Type) {
+			// An installation-step condition: it refines PROGRESSING's reason/message
+			// (handled by applyProgressingStageDetail after this loop), not its own
+			// fulfillment condition.
+			continue
+		}
+		if _, ok := clusterOrderUnsurfacedConditions[condition.Type]; ok {
+			continue
+		}
+		// A condition we do not recognise: log it so a newly added ClusterOrder condition
+		// is noticed instead of being silently ignored.
+		log.Info("Unmapped ClusterOrder condition, will ignore it", "condition", condition.Type)
+	}
+
+	applyProgressingStageDetail(clusterOrder, remote)
+}
+
+// applyProgressingStageDetail refines the PROGRESSING condition's reason and message to
+// the furthest-advanced installation stage that has been reached, while leaving its
+// status untouched (the status is single-sourced from "Progressing" in the loop above).
+// The reason is the stage condition's name (e.g. "ControlPlaneCreated") and the message
+// is that name split into words (e.g. "Control Plane Created").
+//
+// This only applies while PROGRESSING is True (installation underway). Once the cluster
+// is ready or has failed, PROGRESSING is False and keeps the terminal reason/message that
+// "Progressing" itself carried, rather than a mid-installation stage.
+func applyProgressingStageDetail(clusterOrder *ckv1alpha1.ClusterOrder, remote *privatev1.Cluster) {
+	var progressing *privatev1.ClusterCondition
+	for _, current := range remote.Status.Conditions {
+		if current.Type == privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_PROGRESSING {
+			progressing = current
+			break
 		}
 	}
+	if progressing == nil || progressing.GetStatus() != privatev1.ConditionStatus_CONDITION_STATUS_TRUE {
+		return
+	}
+
+	trueConditions := trueConditionTypes(clusterOrder)
+	furthestStage := ""
+	for _, stage := range clusterOrderProvisioningStages {
+		if _, ok := trueConditions[stage]; ok {
+			furthestStage = stage
+		}
+	}
+	if furthestStage == "" {
+		return
+	}
+
+	progressing.SetReason(furthestStage)
+	progressing.SetMessage(humanizeConditionName(furthestStage))
+}
+
+// trueConditionTypes returns the set of ClusterOrder condition types whose status is
+// True.
+func trueConditionTypes(clusterOrder *ckv1alpha1.ClusterOrder) map[string]struct{} {
+	trueConditions := map[string]struct{}{}
+	for i := range clusterOrder.Status.Conditions {
+		condition := clusterOrder.Status.Conditions[i]
+		if condition.Status == metav1.ConditionTrue {
+			trueConditions[condition.Type] = struct{}{}
+		}
+	}
+	return trueConditions
+}
+
+// humanizeConditionName turns a PascalCase condition name into space-separated words for
+// a human-readable message, e.g. "ControlPlaneCreated" -> "Control Plane Created".
+// ClusterOrder condition names are simple PascalCase without acronyms, so inserting a
+// space before each interior uppercase rune is sufficient.
+func humanizeConditionName(name string) string {
+	var builder strings.Builder
+	for index, runeValue := range name {
+		if index > 0 && unicode.IsUpper(runeValue) {
+			builder.WriteRune(' ')
+		}
+		builder.WriteRune(runeValue)
+	}
+	return builder.String()
 }
 
 func syncClusterConditionFromCR(remote *privatev1.Cluster, condType privatev1.ClusterConditionType, condition metav1.Condition) {
@@ -165,6 +288,7 @@ func syncClusterConditionFromCR(remote *privatev1.Cluster, condType privatev1.Cl
 	oldStatus := clusterCondition.GetStatus()
 	newStatus := mapClusterConditionStatus(condition.Status)
 	clusterCondition.SetStatus(newStatus)
+	clusterCondition.SetReason(condition.Reason)
 	clusterCondition.SetMessage(sanitizeFeedbackText(condition.Message))
 	if newStatus != oldStatus {
 		clusterCondition.SetLastTransitionTime(timestamppb.Now())

--- a/osac-operator/internal/controller/feedback_controller.go
+++ b/osac-operator/internal/controller/feedback_controller.go
@@ -116,14 +116,14 @@ func newClusterOrderFeedbackBridge(hubClient clnt.Client, clustersClient private
 // newClusterOrderSyncUpdate returns a SyncUpdate function that captures hubClient
 // for HostedCluster URL lookups on the Ready phase.
 func newClusterOrderSyncUpdate(hubClient clnt.Client) func(context.Context, *ckv1alpha1.ClusterOrder, *privatev1.Cluster) error {
-	return func(ctx context.Context, obj *ckv1alpha1.ClusterOrder, remote *privatev1.Cluster) error {
-		syncClusterOrderConditions(ctx, obj, remote)
-		syncClusterOrderPhase(ctx, obj, remote)
-		if err := syncClusterOrderURLs(ctx, hubClient, obj, remote); err != nil {
+	return func(ctx context.Context, clusterOrder *ckv1alpha1.ClusterOrder, remote *privatev1.Cluster) error {
+		syncClusterOrderConditions(ctx, clusterOrder, remote)
+		syncClusterOrderPhase(ctx, clusterOrder, remote)
+		if err := syncClusterOrderURLs(ctx, hubClient, clusterOrder, remote); err != nil {
 			return err
 		}
-		syncClusterOrderNodeRequests(ctx, obj, remote)
-		syncClusterOrderVIPEndpoints(obj, remote)
+		syncClusterOrderNodeRequests(ctx, clusterOrder, remote)
+		syncClusterOrderVIPEndpoints(clusterOrder, remote)
 		return nil
 	}
 }
@@ -131,19 +131,19 @@ func newClusterOrderSyncUpdate(hubClient clnt.Client) func(context.Context, *ckv
 // syncClusterOrderVIPEndpoints copies MetalLB VIP addresses from ClusterOrder status
 // to the Cluster proto. The VIPs are written by the CaaS template and consumed by the
 // ExternalIPAttachment controller and the fulfillment-service API surface.
-func syncClusterOrderVIPEndpoints(obj *ckv1alpha1.ClusterOrder, remote *privatev1.Cluster) {
-	if obj.Status.ApiEndpoint != "" {
-		remote.GetStatus().SetApiEndpoint(obj.Status.ApiEndpoint)
+func syncClusterOrderVIPEndpoints(clusterOrder *ckv1alpha1.ClusterOrder, remote *privatev1.Cluster) {
+	if clusterOrder.Status.ApiEndpoint != "" {
+		remote.GetStatus().SetApiEndpoint(clusterOrder.Status.ApiEndpoint)
 	}
-	if obj.Status.IngressEndpoint != "" {
-		remote.GetStatus().SetIngressEndpoint(obj.Status.IngressEndpoint)
+	if clusterOrder.Status.IngressEndpoint != "" {
+		remote.GetStatus().SetIngressEndpoint(clusterOrder.Status.IngressEndpoint)
 	}
 }
 
-func syncClusterOrderDelete(ctx context.Context, obj *ckv1alpha1.ClusterOrder, remote *privatev1.Cluster) error {
-	syncClusterOrderConditions(ctx, obj, remote)
-	syncClusterOrderPhase(ctx, obj, remote)
-	syncClusterOrderNodeRequests(ctx, obj, remote)
+func syncClusterOrderDelete(ctx context.Context, clusterOrder *ckv1alpha1.ClusterOrder, remote *privatev1.Cluster) error {
+	syncClusterOrderConditions(ctx, clusterOrder, remote)
+	syncClusterOrderPhase(ctx, clusterOrder, remote)
+	syncClusterOrderNodeRequests(ctx, clusterOrder, remote)
 	remote.GetStatus().SetState(privatev1.ClusterState_CLUSTER_STATE_DELETING)
 	return nil
 }
@@ -306,9 +306,9 @@ func mapClusterConditionStatus(status metav1.ConditionStatus) privatev1.Conditio
 	}
 }
 
-func syncClusterOrderPhase(ctx context.Context, obj *ckv1alpha1.ClusterOrder, remote *privatev1.Cluster) {
+func syncClusterOrderPhase(ctx context.Context, clusterOrder *ckv1alpha1.ClusterOrder, remote *privatev1.Cluster) {
 	log := ctrllog.FromContext(ctx)
-	switch obj.Status.Phase {
+	switch clusterOrder.Status.Phase {
 	case ckv1alpha1.ClusterOrderPhaseProgressing:
 		remote.GetStatus().SetState(privatev1.ClusterState_CLUSTER_STATE_PROGRESSING)
 	case ckv1alpha1.ClusterOrderPhaseFailed:
@@ -318,18 +318,18 @@ func syncClusterOrderPhase(ctx context.Context, obj *ckv1alpha1.ClusterOrder, re
 	case ckv1alpha1.ClusterOrderPhaseDeleting:
 		remote.GetStatus().SetState(privatev1.ClusterState_CLUSTER_STATE_DELETING)
 	default:
-		log.Info("Unknown phase, will ignore it", "phase", obj.Status.Phase)
+		log.Info("Unknown phase, will ignore it", "phase", clusterOrder.Status.Phase)
 	}
 }
 
 // syncClusterOrderURLs fetches the HostedCluster and populates API/console URLs
 // on the Ready phase. Only called on the update path.
-func syncClusterOrderURLs(ctx context.Context, hubClient clnt.Client, obj *ckv1alpha1.ClusterOrder, remote *privatev1.Cluster) error {
-	if obj.Status.Phase != ckv1alpha1.ClusterOrderPhaseReady {
+func syncClusterOrderURLs(ctx context.Context, hubClient clnt.Client, clusterOrder *ckv1alpha1.ClusterOrder, remote *privatev1.Cluster) error {
+	if clusterOrder.Status.Phase != ckv1alpha1.ClusterOrderPhaseReady {
 		return nil
 	}
 
-	hostedCluster, err := fetchHostedCluster(ctx, hubClient, obj)
+	hostedCluster, err := fetchHostedCluster(ctx, hubClient, clusterOrder)
 	if err != nil {
 		return err
 	}
@@ -347,10 +347,10 @@ func syncClusterOrderURLs(ctx context.Context, hubClient clnt.Client, obj *ckv1a
 	return nil
 }
 
-func syncClusterOrderNodeRequests(ctx context.Context, obj *ckv1alpha1.ClusterOrder, remote *privatev1.Cluster) {
+func syncClusterOrderNodeRequests(ctx context.Context, clusterOrder *ckv1alpha1.ClusterOrder, remote *privatev1.Cluster) {
 	log := ctrllog.FromContext(ctx)
-	for i := range len(obj.Status.NodeRequests) {
-		nodeRequest := &obj.Status.NodeRequests[i]
+	for i := range len(clusterOrder.Status.NodeRequests) {
+		nodeRequest := &clusterOrder.Status.NodeRequests[i]
 
 		var nodeSetID string
 		for candidateNodeSetID, candidateNodeSet := range remote.GetSpec().GetNodeSets() {
@@ -392,8 +392,8 @@ func syncClusterOrderNodeRequests(ctx context.Context, obj *ckv1alpha1.ClusterOr
 	}
 }
 
-func fetchHostedCluster(ctx context.Context, hubClient clnt.Client, obj *ckv1alpha1.ClusterOrder) (*hypershiftv1beta1.HostedCluster, error) {
-	hostedClusterRef := obj.Status.ClusterReference
+func fetchHostedCluster(ctx context.Context, hubClient clnt.Client, clusterOrder *ckv1alpha1.ClusterOrder) (*hypershiftv1beta1.HostedCluster, error) {
+	hostedClusterRef := clusterOrder.Status.ClusterReference
 	if hostedClusterRef == nil || hostedClusterRef.Namespace == "" || hostedClusterRef.HostedClusterName == "" {
 		return nil, nil
 	}

--- a/osac-operator/internal/controller/feedback_controller.go
+++ b/osac-operator/internal/controller/feedback_controller.go
@@ -270,13 +270,29 @@ func trueConditionTypes(clusterOrder *ckv1alpha1.ClusterOrder) map[string]struct
 
 // humanizeConditionName turns a PascalCase condition name into space-separated words for
 // a human-readable message, e.g. "ControlPlaneCreated" -> "Control Plane Created".
-// ClusterOrder condition names are simple PascalCase without acronyms, so inserting a
-// space before each interior uppercase rune is sufficient.
+// Multi-letter acronyms are kept intact, e.g. "CSIDriverReady" -> "CSI Driver Ready" and
+// "EnableTLS" -> "Enable TLS", so a space is only inserted at a genuine word boundary.
+//
+// Version-suffixed acronyms such as "IPv4"/"IPv6" are not handled: the trailing lowercase
+// of the suffix is indistinguishable from an acronym-to-word boundary with single-rune
+// lookahead, so "IPv4Ready" splits as "I Pv4 Ready". No ClusterOrder condition name uses
+// that form today; add explicit handling here if one is ever introduced.
 func humanizeConditionName(name string) string {
+	runes := []rune(name)
 	var builder strings.Builder
-	for index, runeValue := range name {
+	for index, runeValue := range runes {
 		if index > 0 && unicode.IsUpper(runeValue) {
-			builder.WriteRune(' ')
+			previous := runes[index-1]
+			// A new word starts when an uppercase rune follows a lowercase rune or a
+			// digit (e.g. the "P" in "ControlPlane"), or when an uppercase rune ends a
+			// run of uppercase letters that begins the next word, i.e. the following
+			// rune is lowercase (e.g. the "D" in "CSIDriver"). Both checks leave a run
+			// of uppercase letters such as "CSI" or "TLS" unsplit.
+			startsWord := unicode.IsLower(previous) || unicode.IsDigit(previous)
+			endsAcronym := unicode.IsUpper(previous) && index+1 < len(runes) && unicode.IsLower(runes[index+1])
+			if startsWord || endsAcronym {
+				builder.WriteRune(' ')
+			}
 		}
 		builder.WriteRune(runeValue)
 	}


### PR DESCRIPTION
## [OSAC-4441](https://redhat.atlassian.net/browse/OSAC-4441): order-independent ClusterOrder feedback condition map with sub-stage detail

**Jira:** https://redhat.atlassian.net/browse/OSAC-4441
**Story type:** [DEV] (Story 1.01 of [OSAC-1604](https://redhat.atlassian.net/browse/OSAC-1604))

### Summary

The ClusterOrder feedback controller previously collapsed several ClusterOrder
status conditions into the single fulfillment `PROGRESSING` condition inside one
`switch`, so the derived `PROGRESSING` status depended on the order the
conditions happened to appear in the CR — a completed installation step could
flip `PROGRESSING` back to `True` on an already-ready cluster. This reworks the
mapping so each fulfillment proto condition has exactly one source condition
(order-independent by construction) and installation-step conditions refine
`PROGRESSING`'s reason/message instead of driving its status.

### Changes

`osac-operator/internal/controller/feedback_controller.go`:
- **Three-bucket classification** of every ClusterOrder condition:
  - `clusterOrderConditionMappings` — one source condition per fulfillment proto
    condition: `Progressing` → `PROGRESSING`, `ClusterAvailable` → `READY`. Status
    is single-sourced, so it never depends on condition order.
  - `clusterOrderProvisioningStages` — installation-step conditions (`Accepted`,
    `ControlPlaneCreated`, `ControlPlaneAvailable`, `ClusterStorageReady`) that
    refine `PROGRESSING`'s reason/message rather than becoming their own proto
    conditions.
  - `clusterOrderUnsurfacedConditions` — internal conditions (`NamespaceCreated`,
    `Deleting`) explicitly recognised so they are not logged as unknown.
- `applyProgressingStageDetail` — while `PROGRESSING` is `True`, sets its reason to
  the furthest-advanced stage (selected by fixed stage rank, not CR slice order)
  and its message to that stage name humanized. Never touches `PROGRESSING`'s status.
- `humanizeConditionName` — `ControlPlaneCreated` → `Control Plane Created`.
- `syncClusterConditionFromCR` now copies the CR condition `Reason` to the proto
  condition (parity with the ComputeInstance feedback controller, which already
  did this).
- Unrecognised conditions are logged (not silently dropped) so a newly added
  ClusterOrder condition is noticed.

`ClusterStorageReady` is keyed off the typed, storage-controller-owned
`ClusterOrderConditionClusterStorageReady` constant to avoid reader/writer drift.

### Testing

- **Unit tests:** New Ginkgo specs in `clusterorder_feedback_controller_test.go`
  (via envtest) covering: `ClusterAvailable` → `READY` with reason preserved;
  `PROGRESSING` status sourced from `Progressing` while reason/message come from
  the furthest stage; installation steps folded into `PROGRESSING` without adding
  proto conditions or changing status; furthest-stage selection independent of CR
  condition order; a full-order-vs-reversed regression asserting an identical
  result (the direct regression for the original order-dependence bug); guard
  branches (True with no stage reached; stage True while `Progressing` absent);
  `NamespaceCreated` ignored; unmapped condition logged, not surfaced.
- **Completeness tripwire:** a unit test asserting every known ClusterOrder
  condition is handled by exactly one of the three buckets, and that no bucket
  references an unknown condition — a newly added condition fails the suite
  instead of being silently dropped at runtime.
- **Integration tests:** N/A (no CRD/proto type change; feedback-path logic only).
- **Coverage:** New mapping/overlay logic is exercised across positive, negative,
  and order-independence paths.

Validation (from `osac-operator/`): `gofmt` clean, `go vet` clean,
`golangci-lint run` (whole module) 0 issues, controller unit suite green via
envtest. No `make manifests generate` / `buf generate` needed — no CRD/proto type
change in this branch.

### Acceptance Criteria

- [ ] AC-1: ClusterOrder conditions map to distinct fulfillment proto types, not all collapsed into `PROGRESSING`.
- [ ] AC-2: Condition `Reason` is copied CR → proto (plus sub-stage reason via the overlay).
- [ ] AC-3: `ClusterAvailable` maps to `READY` (latent bug 1).
- [ ] AC-4: `PROGRESSING` is order-independent; unsurfaced conditions are explicit; no silent default; installation-step conditions are folded in, not dropped (latent bug 2).
- [ ] AC-5: VMaaS/ComputeInstance feedback path unchanged.
- [ ] AC-6: Unit tests gate the behavior, including a condition-mapping completeness tripwire.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **Controllers**
  - Made `ClusterOrder` feedback condition mapping order-independent.
  - Mapped `Progressing` to `PROGRESSING` and `ClusterAvailable` to `READY`.
  - Used the furthest installation stage to refine the `PROGRESSING` reason and message.
  - Added handling for unsurfaced and unknown conditions.
  - Added reason propagation, humanized stage names, and typed `ClusterStorageReady` handling.
  - Preserved the existing proto condition surface. Installation stages do not create additional proto conditions.

- **Tests**
  - Added comprehensive unit tests for condition mapping, stage refinement, ignored conditions, unknown conditions, completeness, and condition-name formatting.
  - Validation passed formatting, vet, lint, and controller tests.

## Backward compatibility

- No exported API changes.
- The proto condition set remains unchanged.
- Feedback reason and message values can change to reflect the furthest installation stage.

## Risk classification

- **risk:ship** — The change is limited to controller feedback mapping, has no API or database changes, and includes comprehensive unit test coverage with formatting, vet, lint, and controller validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->