### PR TITLE
NO-ISSUE: Add skip_e2e workflow_dispatch input to nightly build

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -5,6 +5,16 @@ on:
     # Run nightly at 03:00 UTC
     - cron: '0 3 * * *'
   workflow_dispatch:
+    inputs:
+      skip_e2e:
+        description: >-
+          Skip e2e validation (vmaas/caas/bmaas) and publish anyway if
+          unit/integration/security tests pass. Manual runs only -- this
+          input does not exist on the scheduled trigger, so the nightly
+          cron can never skip e2e.
+        type: boolean
+        default: false
+        required: false
 
 concurrency:
   group: nightly-build
@@ -492,10 +502,18 @@ jobs:
   # github.sha). All three depend on `build` too, not just `prepare`:
   # none may install against images that don't exist yet or (pre-this-change)
   # a floating :latest.
+  #
+  # Skippable via workflow_dispatch's skip_e2e input (see `on:` above) --
+  # `github.event_name != 'workflow_dispatch'` makes the check a no-op
+  # (always true, so e2e always runs) on the scheduled trigger, where
+  # `github.event.inputs` doesn't exist at all. `publish` below tolerates
+  # these being skipped as well as succeeded; unit/integration/security
+  # tests are NOT skippable by this input.
   # -------------------------------------------------------------------
   e2e-vmaas-test:
     name: E2E validation (vmaas)
     needs: [prepare, build]
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.skip_e2e != 'true'
     permissions:
       contents: read
     uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main
@@ -509,6 +527,7 @@ jobs:
   e2e-caas-test:
     name: E2E validation (caas)
     needs: [prepare, build]
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.skip_e2e != 'true'
     permissions:
       contents: read
     uses: osac-project/osac-test-infra/.github/workflows/e2e-caas-full-install.yml@main
@@ -522,6 +541,7 @@ jobs:
   e2e-bmaas-test:
     name: E2E validation (bmaas)
     needs: [prepare, build]
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.skip_e2e != 'true'
     permissions:
       contents: read
     uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-full-install.yml@main
@@ -540,10 +560,27 @@ jobs:
   # values.yaml image-tag fields were stamped provisionally by prepare
   # and get re-stamped here to the same final version each image is
   # promoted to, immediately before packaging.
+  #
+  # `if:` (not just `needs:`) because a skipped job is not a `success()`
+  # by GitHub's default job-gating -- explicitly tolerating
+  # skipped alongside success only for the three e2e jobs (which can only
+  # be skipped via workflow_dispatch's skip_e2e input, see Job 4 above)
+  # keeps unit/integration/security tests hard-required in every case, on
+  # both triggers.
   # -------------------------------------------------------------------
   publish:
     name: Publish nightly chart
     needs: [prepare, build, unit-tests, integration-tests, security-tests, e2e-vmaas-test, e2e-caas-test, e2e-bmaas-test]
+    if: |
+      always() &&
+      needs.prepare.result == 'success' &&
+      needs.build.result == 'success' &&
+      needs.unit-tests.result == 'success' &&
+      needs.integration-tests.result == 'success' &&
+      needs.security-tests.result == 'success' &&
+      contains(fromJSON('["success", "skipped"]'), needs.e2e-vmaas-test.result) &&
+      contains(fromJSON('["success", "skipped"]'), needs.e2e-caas-test.result) &&
+      contains(fromJSON('["success", "skipped"]'), needs.e2e-bmaas-test.result)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -852,7 +889,13 @@ jobs:
     needs: [prepare, publish]
     runs-on: osac-ci
     timeout-minutes: 15
-    if: success()
+    # Bare success() checks the WHOLE transitive dependency graph, not just
+    # this job's direct needs -- confirmed live: with skip_e2e=true, the
+    # three e2e-*-test jobs (skipped, further back in the graph) cascaded
+    # a skip forward onto this job even though publish (its actual direct
+    # dependency) succeeded. Same subtlety cleanup's own comment below
+    # already documents. Check only this job's real dependencies instead.
+    if: always() && needs.prepare.result == 'success' && needs.publish.result == 'success'
     permissions:
       # Create the nightly git tag
       contents: write
@@ -872,6 +915,8 @@ jobs:
         # persist-credentials left enabled (default): this job pushes the nightly git tag.
 
     - name: Create nightly tag
+      env:
+        SKIP_E2E: ${{ github.event.inputs.skip_e2e }}
       run: |
         set -euo pipefail
         source osac-installer/scripts/nightly-charts.sh
@@ -879,6 +924,11 @@ jobs:
         git config user.email "github-actions[bot]@users.noreply.github.com"
         TAG="osac/v${VERSION}"
         COMMIT_SHA=$(git rev-parse HEAD)
+        TAG_MESSAGE="Nightly build ${VERSION}"
+        # Only ever true on a manual workflow_dispatch run (see the e2e
+        # jobs' own `if:` guards) -- keep this visible in the tag's own
+        # history, not just the transient Slack message below.
+        [[ "${SKIP_E2E}" == "true" ]] && TAG_MESSAGE="${TAG_MESSAGE} (e2e skipped: manual workflow_dispatch run)"
 
         if git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" 2>/dev/null; then
           EXISTING_SHA=$(git rev-parse "${TAG}^{commit}")
@@ -893,7 +943,7 @@ jobs:
           exit 1
         fi
 
-        git tag "${TAG}" -m "Nightly build ${VERSION}"
+        git tag "${TAG}" -m "${TAG_MESSAGE}"
         git push origin "${TAG}"
         echo "Tagged: ${TAG}"
 
@@ -915,6 +965,7 @@ jobs:
         RUN_ID: ${{ github.run_id }}
         REPO_OWNER: ${{ github.repository_owner }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SKIP_E2E: ${{ github.event.inputs.skip_e2e }}
       run: |
         set -euo pipefail
         source osac-installer/scripts/nightly-charts.sh
@@ -923,8 +974,17 @@ jobs:
         SUMMARY_TEXT=$(build_slack_charts_published_summary nightly-artifacts/chart-sources.txt "${REPO_OWNER}")
         IMAGES_TEXT=$(build_slack_images_published_summary nightly-artifacts/images.txt)
 
+        # Only ever true on a manual workflow_dispatch run (see the e2e
+        # jobs' own `if:` guards) -- never silent: a release that skipped
+        # e2e must be obvious in the same place every other nightly
+        # success is announced, not just in the tag message/run log.
+        HEADER_TEXT=":white_check_mark: Nightly Build ${VERSION} - Published"
+        if [[ "${SKIP_E2E}" == "true" ]]; then
+          HEADER_TEXT=":warning: Nightly Build ${VERSION} - Published (e2e SKIPPED)"
+        fi
+
         jq -n \
-          --arg version "${VERSION}" \
+          --arg header "${HEADER_TEXT}" \
           --arg summary "${SUMMARY_TEXT}" \
           --arg images "${IMAGES_TEXT}" \
           --arg workflow_url "${WORKFLOW_URL}" \
@@ -933,7 +993,7 @@ jobs:
               [
                 {
                   "type": "header",
-                  "text": {"type": "plain_text", "text": (":white_check_mark: Nightly Build " + $version + " - Published")}
+                  "text": {"type": "plain_text", "text": $header}
                 },
                 {
                   "type": "section",


### PR DESCRIPTION
## Summary
Adds a `skip_e2e` boolean input to `nightly-build.yaml`'s `workflow_dispatch` trigger. When set on a manual run (via `gh workflow run` or the Actions UI), the three e2e validation jobs (vmaas/caas/bmaas) are skipped and `publish` proceeds anyway, provided unit/integration/security tests still pass. The scheduled nightly cron can never skip e2e -- `github.event.inputs` doesn't exist on that trigger, so the relevant checks always evaluate to "don't skip."

## Changes
- `workflow_dispatch.inputs.skip_e2e` (boolean, default `false`).
- Each `e2e-*-test` job: `if: github.event_name != 'workflow_dispatch' || github.event.inputs.skip_e2e != 'true'`.
- `publish`: changed from plain `needs:` to an explicit `if:` that tolerates the three e2e jobs' result being `skipped` as well as `success`, while still hard-requiring `prepare`/`build`/`unit-tests`/`integration-tests`/`security-tests` -- those are **not** skippable by this input.
- `tag-and-notify`: its bare `if: success()` also needed fixing -- a real live test run (see below) caught that `success()` checks the **whole transitive dependency graph**, not just a job's direct `needs:`. The skipped e2e jobs (further back in the graph) cascaded a skip forward onto `tag-and-notify` even though its actual direct dependency (`publish`) had succeeded. Same subtlety the existing `cleanup` job's own comment already documents. Fixed by checking only its real dependencies (`prepare`, `publish`) explicitly, with `always()` to prevent the default cascade.
- `notify-failure`/`cleanup` needed no changes: `failure()` correctly doesn't treat a skip as a failure, and `cleanup` already checked only its direct need (`tag-and-notify`) with `always()`.
- A skipped-e2e release is never silent: the git tag message gets `(e2e skipped: manual workflow_dispatch run)` appended, and the success Slack notification's header switches to a visible `:warning:` instead of `:white_check_mark:`.

## Verification
Static: validated with `actionlint` -- no new findings (only two pre-existing, unrelated "osac-ci runner label unknown" notices also present on `upstream/main`).

**Live-tested twice** with real `workflow_dispatch` runs (`skip_e2e=true`) against a disposable branch (deleted after testing):
- First run (https://github.com/osac-project/osac/actions/runs/33399015812): confirmed e2e jobs correctly show `skipped`, and `publish` correctly runs and succeeds despite that -- but caught the `tag-and-notify` skip-cascade bug described above (it was wrongly `skipped`).
- Second run, after that fix (https://github.com/osac-project/osac/actions/runs/33410711022): full pipeline succeeds end to end. `tag-and-notify` and `cleanup` now correctly run and succeed. Fetched the **real created git tag object** via the API (not just script log echo) to confirm the message content: `"Nightly build 0.0.9-nightly.20260831.8596caf.58.1 (e2e skipped: manual workflow_dispatch run)"`.

Real side effects from this testing (expected/accepted, same as any other nightly run): two ordinary-looking `osac/vX.Y.Z-nightly.*` tags and their corresponding chart/image publishes now exist in the repo/registry, indistinguishable from normal nightly cadence output.

## Test plan
- [x] Manual dispatch with `skip_e2e=true`: e2e jobs skipped (not failed), `publish`/`tag-and-notify`/`cleanup` all succeed, tag message and Slack header both flag the skip -- confirmed via two real runs.
- [ ] Confirm a normal scheduled/default-dispatch run is completely unaffected (e2e still runs as before) -- not yet observed live (would require waiting for the next real nightly cron, or a manual dispatch with `skip_e2e` left at its default `false`).