### PR TITLE
OSAC-4571: Re-stamp dev/instance.yaml before generating images.txt

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -753,6 +753,24 @@ jobs:
           stamp_umbrella_nested_field "${UMBRELLA_VALUES}" ui images ui "ghcr.io/osac-project/osac-ui:${UI_SUB_VERSION}"
         fi
 
+        # dev/instance.yaml is the one CI overlay that ISN'T dead after e2e:
+        # "Generate images.txt" below renders the umbrella chart with it as
+        # an extra --values file (needed to fill in fields with no
+        # defaults), which means whatever it says for the 4 fields it
+        # overrides wins over the umbrella's own (just-promoted) values.
+        # Prepare only ever stamped it with the provisional sha tag, so
+        # without this re-stamp images.txt would report stale provisional
+        # tags for these 4 components even though the packaged chart itself
+        # is correctly pinned to the final version.
+        DEV_OVERLAY="osac-installer/values/dev/instance.yaml"
+        OPERATOR_VER=$(jq -r '.["osac-operator"] // empty' <<<"${COMPONENT_VERSIONS}")
+        FULFILLMENT_VER=$(jq -r '.["fulfillment-service"] // empty' <<<"${COMPONENT_VERSIONS}")
+        AAP_VER=$(jq -r '.["osac-aap"] // empty' <<<"${COMPONENT_VERSIONS}")
+        [[ -n "${OPERATOR_VER}" ]] && stamp_ci_overlay_if_present "${DEV_OVERLAY}" '.operator.image.tag' "${OPERATOR_VER}"
+        [[ -n "${FULFILLMENT_VER}" ]] && stamp_ci_overlay_if_present "${DEV_OVERLAY}" '.service.images.service' "ghcr.io/osac-project/fulfillment-service:${FULFILLMENT_VER}"
+        [[ -n "${AAP_VER}" ]] && stamp_ci_overlay_if_present "${DEV_OVERLAY}" '.aap.bootstrap.image' "ghcr.io/osac-project/osac-aap:${AAP_VER}"
+        [[ -n "${UI_SUB_VERSION}" ]] && stamp_ci_overlay_if_present "${DEV_OVERLAY}" '.ui.images.ui' "ghcr.io/osac-project/osac-ui:${UI_SUB_VERSION}"
+
     - name: Package and push sub-charts
       run: |
         set -euo pipefail


### PR DESCRIPTION
## Summary

Follow-up to #627. `publish`'s "Generate images.txt" step renders the umbrella chart with `osac-installer/values/dev/instance.yaml` as an extra `--values` override (needed to fill in required fields with no defaults). That overlay overrides exactly 4 fields (`operator.image.tag`, `service.images.service`, `aap.bootstrap.image`, `ui.images.ui`) — the same 4 fields the umbrella's own `values.yaml` just got promoted to their final version by the new "Promote images to nightly version" step.

`prepare` only ever stamps CI overlays with the provisional `sha-<short>` tag, on the assumption nothing reads them again after e2e. That assumption is wrong for `dev/instance.yaml` specifically — its stale provisional values win over the umbrella's promoted ones when `images.txt` renders, so it misreports exactly the components #627 was meant to make trustworthy.

Confirmed live on a real `publish` run (dispatched with `skip_e2e`, see #647): the packaged chart was correctly pinned to final versions, but `images.txt` showed:

```
ghcr.io/osac-project/fulfillment-service:sha-5c9c61a   # should be 0.0.92-nightly...
ghcr.io/osac-project/osac-aap:sha-5c9c61a               # should be 0.0.13-nightly...
ghcr.io/osac-project/osac-operator:sha-5c9c61a          # should be 0.0.12-nightly...
ghcr.io/osac-project/osac-ui:sha-22bd423                # should be 0.0.6-nightly...
```

## What changed

Re-stamp those same 4 fields in `dev/instance.yaml` right after promoting the umbrella's own values, using the existing `stamp_ci_overlay_if_present` helper (same one already used elsewhere for optional CI-overlay fields).

## Test plan

- [x] Local functional test: stamped `dev/instance.yaml` with a provisional tag, then the final version, confirmed both `.operator.image.tag` and `.service.images.service` update correctly via `stamp_ci_overlay_if_present`
- [x] `bash -n` syntax check on the extracted step
- [ ] Re-dispatch nightly (with `skip_e2e`) and confirm `images.txt` now shows final versions for all 4 fields

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **CI/deployment:** Re-stamps promoted nightly image values in `dev/instance.yaml` before rendering `images.txt`.
- Updates the operator, fulfillment service, AAP bootstrap, and UI image fields.
- Prevents provisional `sha-<short>` values from overriding promoted nightly versions.
- No API, controller, database, authentication, documentation, or public entity changes.
- No backward-compatibility impact is expected.
- Local functional and syntax tests passed. A nightly re-dispatch with `skip_e2e` remains pending.

## Risk classification

- **risk:ship** — The change is limited to CI image stamping and generated artifact accuracy. It does not change runtime behavior, APIs, data, authentication, or user-facing rollout behavior.
- It does not meet **risk:show** or **risk:ask** criteria because it introduces no staged rollout requirement, high-impact behavior, security-sensitive change, data migration, or irreversible operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->