### PR TITLE
OSAC-4571: Post the promoted image list in the nightly Slack notification

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -921,28 +921,37 @@ jobs:
 
         WORKFLOW_URL="${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}"
         SUMMARY_TEXT=$(build_slack_charts_published_summary nightly-artifacts/chart-sources.txt "${REPO_OWNER}")
+        IMAGES_TEXT=$(build_slack_images_published_summary nightly-artifacts/images.txt)
 
         jq -n \
           --arg version "${VERSION}" \
           --arg summary "${SUMMARY_TEXT}" \
+          --arg images "${IMAGES_TEXT}" \
           --arg workflow_url "${WORKFLOW_URL}" \
           '{
-            "blocks": [
-              {
-                "type": "header",
-                "text": {"type": "plain_text", "text": (":white_check_mark: Nightly Build " + $version + " - Published")}
-              },
-              {
-                "type": "section",
-                "text": {"type": "mrkdwn", "text": $summary}
-              },
-              {
-                "type": "actions",
-                "elements": [
-                  {"type": "button", "text": {"type": "plain_text", "text": "View Run"}, "url": $workflow_url}
-                ]
-              }
-            ]
+            "blocks": (
+              [
+                {
+                  "type": "header",
+                  "text": {"type": "plain_text", "text": (":white_check_mark: Nightly Build " + $version + " - Published")}
+                },
+                {
+                  "type": "section",
+                  "text": {"type": "mrkdwn", "text": $summary}
+                }
+              ]
+              # Slack rejects a section with empty text -- omit it entirely
+              # rather than send one if images.txt was somehow unavailable.
+              + (if $images != "" then [{"type": "section", "text": {"type": "mrkdwn", "text": $images}}] else [] end)
+              + [
+                {
+                  "type": "actions",
+                  "elements": [
+                    {"type": "button", "text": {"type": "plain_text", "text": "View Run"}, "url": $workflow_url}
+                  ]
+                }
+              ]
+            )
           }' > /tmp/slack-payload.json
 
         curl -sf --max-time 15 -X POST "${SLACK_WEBHOOK_URL}" \

--- a/osac-installer/scripts/nightly-charts.sh
+++ b/osac-installer/scripts/nightly-charts.sh
@@ -594,7 +594,7 @@ _osac_ui_source_from_manifest() {
 # everyone, rather than something you have to know to go look for.
 build_slack_images_published_summary() {
     local images_file="$1"
-    local content
+    local content truncated last_line_boundary
 
     if [[ ! -f "${images_file}" ]]; then
         echo "::warning title=build_slack_images_published_summary::images.txt not found: ${images_file}" >&2
@@ -605,9 +605,16 @@ build_slack_images_published_summary() {
     # Slack's own block.text.text limit is 3000 chars; images.txt isn't
     # expected to get anywhere near that today, but truncate defensively
     # rather than have the whole Slack API call fail on some future
-    # component explosion.
+    # component explosion. Cut at the last newline at or before the limit
+    # (not a hard byte count) so a truncated message never ends mid-line
+    # with a broken, unusable image reference.
     if (( ${#content} > 2800 )); then
-        content="${content:0:2800}"$'\n... (truncated -- see the workflow run artifact for the full list)'
+        truncated="${content:0:2800}"
+        last_line_boundary="${truncated%$'\n'*}"
+        if [[ "${last_line_boundary}" != "${truncated}" ]]; then
+            truncated="${last_line_boundary}"
+        fi
+        content="${truncated}"$'\n... (truncated -- see the workflow run artifact for the full list)'
     fi
 
     printf '*Images published:*\n```\n%s\n```' "${content}"

--- a/osac-installer/scripts/nightly-charts.sh
+++ b/osac-installer/scripts/nightly-charts.sh
@@ -584,6 +584,35 @@ _osac_ui_source_from_manifest() {
     done < "${manifest_file}"
 }
 
+# Usage: build_slack_images_published_summary <images_file>
+# Wraps images.txt's content in a fenced code block for Slack -- same
+# rationale as build_slack_charts_published_summary's table: unfenced,
+# Slack reflows the plain-text list into a proportional font and long
+# image refs wrap awkwardly. This is the one place a nightly's exact,
+# already-promoted image tags show up without downloading the run
+# artifact -- the Slack message a nightly success already sends to
+# everyone, rather than something you have to know to go look for.
+build_slack_images_published_summary() {
+    local images_file="$1"
+    local content
+
+    if [[ ! -f "${images_file}" ]]; then
+        echo "::warning title=build_slack_images_published_summary::images.txt not found: ${images_file}" >&2
+        return 0
+    fi
+
+    content=$(<"${images_file}")
+    # Slack's own block.text.text limit is 3000 chars; images.txt isn't
+    # expected to get anywhere near that today, but truncate defensively
+    # rather than have the whole Slack API call fail on some future
+    # component explosion.
+    if (( ${#content} > 2800 )); then
+        content="${content:0:2800}"$'\n... (truncated -- see the workflow run artifact for the full list)'
+    fi
+
+    printf '*Images published:*\n```\n%s\n```' "${content}"
+}
+
 # Usage: build_slack_charts_published_summary <manifest_file> <repo_owner>
 # Reads GH_TOKEN from environment.
 build_slack_charts_published_summary() {


### PR DESCRIPTION
## Summary

Follow-up to #627 / #651. Today, seeing exactly which image tags a given nightly actually shipped means knowing which workflow run to look at and downloading its `nightly-<version>` artifact for `images.txt` — nothing surfaces it automatically. Since the whole point of #627 is that nightly image tags are now trustworthy and reproducible, that information should be visible without digging.

## What changed

- New `build_slack_images_published_summary` helper in `nightly-charts.sh`, mirroring the existing `build_slack_charts_published_summary`'s fenced-code-block approach (unfenced, Slack reflows plain text into a proportional font and long image refs wrap badly).
- `tag-and-notify`'s success notification now posts a second section with the full `images.txt` content, right after the existing charts table. `images.txt` is already downloaded into `nightly-artifacts/` for `chart-sources.txt`, so this just reads a second file already sitting there — no new download/artifact step.
- Defensive: if `images.txt` is ever unavailable, the block is omitted entirely rather than sent with empty text (Slack rejects empty `section.text`). Also defensively truncates past 2800 chars (Slack's own block-text limit is 3000).

## Test plan

- [x] Local test of `build_slack_images_published_summary` against a real `images.txt` sample — produces the expected fenced block
- [x] Validated the resulting jq output is well-formed JSON (including the empty-images-file omission path)
- [x] YAML/bash syntax checks
- [ ] Confirm live in a real nightly Slack notification

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nightly build notifications now include a summary of published images when available.
  * Image lists are formatted for readability and shortened when lengthy, while preserving complete image-reference lines.

* **Bug Fixes**
  * The image summary is omitted when no images are available.
  * Notifications continue to work when image-list data is unavailable or empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->