### PR TITLE
NO-ISSUE: Disable fullsend review agent

### DIFF
--- a/.fullsend/config.yaml
+++ b/.fullsend/config.yaml
@@ -4,8 +4,7 @@
 # This file configures fullsend for per-repo installation mode.
 # See ADR 0033 for details.
 version: "1"
-roles:
-    - review
+roles: []
 allowed_remote_resources:
     - https://raw.githubusercontent.com/fullsend-ai/fullsend/
     - https://raw.githubusercontent.com/fullsend-ai/agents/


### PR DESCRIPTION
## Summary
- Drop the `review` role from `.fullsend/config.yaml` so the fullsend bot no longer runs automated reviews on PRs/issues in this repo.

## Test plan
- [x] N/A — config-only change; verified the workflow only invokes agents for configured roles in `.fullsend/config.yaml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Disabled the review role by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->