### PR TITLE
NO-ISSUE: Fix no-op fullsend disable (roles: [] doesn't restrict)

### DIFF
--- a/.fullsend/config.yaml
+++ b/.fullsend/config.yaml
@@ -3,8 +3,13 @@
 #
 # This file configures fullsend for per-repo installation mode.
 # See ADR 0033 for details.
+# `roles: []` is a no-op in fullsend's dispatch script (empty list parses to
+# an empty string, which is treated the same as roles being unset — i.e.
+# unrestricted). Use a role name that never matches a real stage to disable
+# fullsend for this repo.
 version: "1"
-roles: []
+roles:
+    - disabled
 allowed_remote_resources:
     - https://raw.githubusercontent.com/fullsend-ai/fullsend/
     - https://raw.githubusercontent.com/fullsend-ai/agents/


### PR DESCRIPTION
## Summary
- #653 set `roles: []` in `.fullsend/config.yaml` to disable the fullsend review agent, but this is a no-op: fullsend's dispatch script only enforces a role restriction when the parsed roles string is non-empty (`[[ -n "$ROLES" ]]`), so an empty list behaves identically to `roles` being unset — unrestricted.
- Confirmed in practice: PR #655 (opened after #653 merged) still received a `fullsend-ai-review[bot]` approval.
- Fix: use a role name (`disabled`) that matches no real stage, so the restriction actually triggers and every stage is skipped.

## Test plan
- [x] N/A — config-only change. Will verify by watching that new PRs no longer get a fullsend review after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled fullsend dispatch for this repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->