### PR TITLE
OSAC-3593:  Specifies the path of the component unique_name post migration of e2e tests

### DIFF
--- a/tests/core/grpc_client.py
+++ b/tests/core/grpc_client.py
@@ -212,7 +212,7 @@ class GRPCClient:
         # other error still fails fast. Note the two error shapes are matched
         # differently: a completed RPC prints grpcurl's `Code: <Name>` block
         # (AlreadyExists), while a transport failure prints the Go status string
-        # `code = Unavailable desc = ...` -- see tests/vmaas/external_ip/conftest.py.
+        # `code = Unavailable desc = ...` -- see tests/e2e/vmaas/external_ip/conftest.py.
         for attempt in range(retries):
             try:
                 self.call(service=f"{PRIVATE_API}.Tenants/Create", data={"object": {"metadata": {"name": name}}})

--- a/tests/e2e/bmaas/networking/test_bmaas_networking.py
+++ b/tests/e2e/bmaas/networking/test_bmaas_networking.py
@@ -5,7 +5,7 @@ from typing import Any, ClassVar
 
 import pytest
 
-from tests.bmaas.networking import bmi_ssh
+from tests.e2e.bmaas.networking import bmi_ssh
 from tests.core.grpc_client import GRPCClient
 from tests.core.helpers import (
     wait_for_bmh_available,

--- a/tests/e2e/caas/test_cluster_create.py
+++ b/tests/e2e/caas/test_cluster_create.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.catalog.conftest import unique_name
+from tests.e2e.catalog.conftest import unique_name
 from tests.core.grpc_client import GRPCClient
 from tests.core.helpers import (
     wait_for_cluster_deleting,

--- a/tests/e2e/caas/test_cluster_delete_feedback_light.py
+++ b/tests/e2e/caas/test_cluster_delete_feedback_light.py
@@ -4,7 +4,7 @@ import contextlib
 import subprocess
 from pathlib import Path
 
-from tests.catalog.conftest import unique_name
+from tests.e2e.catalog.conftest import unique_name
 from tests.core.grpc_client import GRPCClient
 from tests.core.helpers import (
     wait_for_cluster_deleting,

--- a/tests/e2e/catalog/test_catalog_item_lifecycle.py
+++ b/tests/e2e/catalog/test_catalog_item_lifecycle.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import subprocess
 
-from tests.catalog.conftest import unique_name
+from tests.e2e.catalog.conftest import unique_name
 from tests.core.grpc_client import GRPCClient
 from tests.core.helpers import wait_for_cluster_order_cr
 from tests.core.k8s_client import K8sClient

--- a/tests/e2e/catalog/test_compute_instance_catalog_item_disk_image.py
+++ b/tests/e2e/catalog/test_compute_instance_catalog_item_disk_image.py
@@ -4,7 +4,7 @@ import subprocess
 
 import pytest
 
-from tests.catalog.conftest import unique_name
+from tests.e2e.catalog.conftest import unique_name
 from tests.core.grpc_client import GRPCClient
 from tests.core.helpers import assert_grpc_rejected, wait_for_grpc_removal
 

--- a/tests/e2e/catalog/test_compute_instance_catalog_item_lifecycle.py
+++ b/tests/e2e/catalog/test_compute_instance_catalog_item_lifecycle.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from tests.catalog.conftest import unique_name
+from tests.e2e.catalog.conftest import unique_name
 from tests.core.grpc_client import GRPCClient
 from tests.core.runner import poll_until
 

--- a/tests/e2e/storage/test_caas_cluster_storage.py
+++ b/tests/e2e/storage/test_caas_cluster_storage.py
@@ -20,7 +20,7 @@ import textwrap
 from pathlib import Path
 from uuid import uuid4
 
-from tests.catalog.conftest import unique_name
+from tests.e2e.catalog.conftest import unique_name
 from tests.core.helpers import (
     wait_for_cluster_deletion,
     wait_for_cluster_order_condition,

--- a/tests/e2e/vmaas/external_ip/conftest.py
+++ b/tests/e2e/vmaas/external_ip/conftest.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 import pytest
 
-from tests.catalog.conftest import unique_name
+from tests.e2e.catalog.conftest import unique_name
 from tests.core.grpc_client import GRPCClient
 from tests.core.helpers import (
     wait_for_cr,
@@ -22,7 +22,7 @@ from tests.core.helpers import (
 )
 from tests.core.k8s_client import K8sClient
 from tests.core.osac_cli import OsacCLI
-from tests.vmaas.external_ip.helpers import allocate_worker_subnet, create_ip
+from tests.e2e.vmaas.external_ip.helpers import allocate_worker_subnet, create_ip
 
 logger = logging.getLogger(__name__)
 

--- a/tests/e2e/vmaas/external_ip/test_external_ip_pool_capacity.py
+++ b/tests/e2e/vmaas/external_ip/test_external_ip_pool_capacity.py
@@ -9,7 +9,7 @@ from tests.core.grpc_client import GRPCClient
 from tests.core.helpers import assert_grpc_rejected, wait_for_external_ip_pool_deletion
 from tests.core.k8s_client import K8sClient
 from tests.core.runner import poll_until
-from tests.vmaas.external_ip.helpers import create_ip, delete_ip, pool_status
+from tests.e2e.vmaas.external_ip.helpers import create_ip, delete_ip, pool_status
 
 
 class TestPoolCapacity:

--- a/tests/e2e/vmaas/test_compute_instance_api_fields.py
+++ b/tests/e2e/vmaas/test_compute_instance_api_fields.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from tests.catalog.conftest import unique_name
+from tests.e2e.catalog.conftest import unique_name
 from tests.core.grpc_client import GRPCClient
 from tests.core.helpers import wait_for_cr, wait_for_deletion, wait_for_provision, wait_for_running
 from tests.core.k8s_client import K8sClient

--- a/tests/e2e/vmaas/test_compute_instance_cli_fields.py
+++ b/tests/e2e/vmaas/test_compute_instance_cli_fields.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import base64
 from typing import Any
 
-from tests.catalog.conftest import unique_name
+from tests.e2e.catalog.conftest import unique_name
 from tests.core.grpc_client import GRPCClient
 from tests.core.helpers import wait_for_cr, wait_for_deletion, wait_for_provision, wait_for_running
 from tests.core.k8s_client import K8sClient
 from tests.core.osac_cli import OsacCLI
-from tests.vmaas.conftest import DEFAULT_IT_CORES, DEFAULT_IT_MEMORY_GIB
+from tests.e2e.vmaas.conftest import DEFAULT_IT_CORES, DEFAULT_IT_MEMORY_GIB
 
 TEST_BOOT_DISK_SIZE: int = 20
 TEST_RUN_STRATEGY: str = "Always"

--- a/tests/e2e/vmaas/test_compute_instance_creation.py
+++ b/tests/e2e/vmaas/test_compute_instance_creation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from tests.catalog.conftest import unique_name
+from tests.e2e.catalog.conftest import unique_name
 
 from tests.core.grpc_client import GRPCClient
 from tests.core.helpers import (

--- a/tests/e2e/vmaas/test_compute_instance_delete_during_provision.py
+++ b/tests/e2e/vmaas/test_compute_instance_delete_during_provision.py
@@ -4,7 +4,7 @@ import time
 
 import pytest
 
-from tests.catalog.conftest import unique_name
+from tests.e2e.catalog.conftest import unique_name
 
 from tests.core.grpc_client import GRPCClient
 from tests.core.helpers import wait_for_cr, wait_for_deletion, wait_for_grpc_removal

--- a/tests/e2e/vmaas/test_compute_instance_gpu.py
+++ b/tests/e2e/vmaas/test_compute_instance_gpu.py
@@ -4,7 +4,7 @@ import json
 import subprocess
 from typing import Any
 
-from tests.catalog.conftest import unique_name
+from tests.e2e.catalog.conftest import unique_name
 from tests.core.grpc_client import GRPCClient
 from tests.core.helpers import wait_for_cr, wait_for_deletion, wait_for_grpc_removal
 from tests.core.k8s_client import K8sClient

--- a/tests/e2e/vmaas/test_compute_instance_heartbeat.py
+++ b/tests/e2e/vmaas/test_compute_instance_heartbeat.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from tests.catalog.conftest import unique_name
+from tests.e2e.catalog.conftest import unique_name
 
 from tests.core.grpc_client import GRPCClient
 from tests.core.helpers import wait_for_cr, wait_for_deletion, wait_for_grpc_removal, wait_for_provision, wait_for_running

--- a/tests/e2e/vmaas/test_compute_instance_instance_type.py
+++ b/tests/e2e/vmaas/test_compute_instance_instance_type.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 import pytest
 
-from tests.catalog.conftest import unique_name
+from tests.e2e.catalog.conftest import unique_name
 from tests.core.grpc_client import GRPCClient
 from tests.core.helpers import wait_for_cr, wait_for_deletion
 from tests.core.k8s_client import K8sClient

--- a/tests/e2e/vmaas/test_compute_instance_restart.py
+++ b/tests/e2e/vmaas/test_compute_instance_restart.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 
 import pytest
 
-from tests.catalog.conftest import unique_name
+from tests.e2e.catalog.conftest import unique_name
 
 from tests.core.grpc_client import GRPCClient
 from tests.core.helpers import wait_for_cr, wait_for_deletion, wait_for_restart, wait_for_running

--- a/tests/e2e/vmaas/test_compute_instance_restart_negative.py
+++ b/tests/e2e/vmaas/test_compute_instance_restart_negative.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import time
 from datetime import UTC, datetime
 
-from tests.catalog.conftest import unique_name
+from tests.e2e.catalog.conftest import unique_name
 from tests.core.grpc_client import GRPCClient
 from tests.core.helpers import wait_for_cr, wait_for_deletion, wait_for_restart, wait_for_running
 from tests.core.k8s_client import K8sClient

--- a/tests/e2e/vmaas/test_compute_instance_short_lived_metering.py
+++ b/tests/e2e/vmaas/test_compute_instance_short_lived_metering.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from tests.catalog.conftest import unique_name
+from tests.e2e.catalog.conftest import unique_name
 from tests.core.grpc_client import GRPCClient
 from tests.core.helpers import wait_for_cr, wait_for_deletion, wait_for_grpc_removal
 from tests.core.k8s_client import K8sClient

--- a/tests/e2e/vmaas/test_compute_instance_stop_metering.py
+++ b/tests/e2e/vmaas/test_compute_instance_stop_metering.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 
 import pytest
 
-from tests.catalog.conftest import unique_name
+from tests.e2e.catalog.conftest import unique_name
 from tests.core.grpc_client import GRPCClient
 from tests.core.helpers import (
     wait_for_cr,

--- a/tests/e2e/vmaas/test_compute_instance_storage_tier.py
+++ b/tests/e2e/vmaas/test_compute_instance_storage_tier.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import pytest
 
-from tests.catalog.conftest import unique_name
+from tests.e2e.catalog.conftest import unique_name
 from tests.core.grpc_client import GRPCClient
 from tests.core.helpers import (
     assert_grpc_rejected,
@@ -438,7 +438,7 @@ def test_compute_instance_boot_disk_tier_from_template_default() -> None:
     is written verbatim into the CR and used by AAP as the role name to include
     (playbook_osac_create_compute_instance.yml), and only AAP-published templates have a backing
     role, so the CI can neither provision nor delete. This constraint is documented on the sibling
-    test tests/vmaas/test_compute_instance_disk_image.py::test_template_disk_image_default, which
+    test tests/e2e/vmaas/test_compute_instance_disk_image.py::test_template_disk_image_default, which
     hit the same limitation and works around it by asserting on the template object only.
     """
 

--- a/tests/e2e/vmaas/test_console.py
+++ b/tests/e2e/vmaas/test_console.py
@@ -16,7 +16,7 @@ from typing import Any
 import pytest
 import websocket
 
-from tests.catalog.conftest import unique_name
+from tests.e2e.catalog.conftest import unique_name
 from tests.core.grpc_client import GRPCClient
 from tests.core.helpers import (
     assert_grpc_rejected,


### PR DESCRIPTION
## Summary

Follow-up to #650 — fixes all stale Python imports and comment-path references
left behind after relocating the e2e test suites from `tests/` to `tests/e2e/`.

This is part of [OSAC-3593](https://redhat.atlassian.net/browse/OSAC-3593) (Migrate e2e test suite from osac-test-infra into osac),
child of the mono-repo consolidation epic OSAC-4255.

## What this PR fixes

### 1. Package marker restored (1 file)
- `tests/__init__.py` — recreated (empty). Git's rename detection moved it to
  `tests/e2e/__init__.py` during #650; both locations need the marker so
  `from tests.core.*` resolves correctly.

### 2. Stale imports updated (22 files)

| Category | Files | Old path → New path |
|----------|-------|---------------------|
| `unique_name` | 20 | `from tests.catalog.conftest` → `from tests.e2e.catalog.conftest` |
| `bmi_ssh` | 1 | `from tests.bmaas.networking` → `from tests.e2e.bmaas.networking` |
| `DEFAULT_IT_*` | 1 | `from tests.vmaas.conftest` → `from tests.e2e.vmaas.conftest` |
| `external_ip helpers` | 2 | `from tests.vmaas.external_ip.helpers` → `from tests.e2e.vmaas.external_ip.helpers` |

### 3. Stale comment paths updated (2 files)
- `tests/core/grpc_client.py:215` — `tests/vmaas/external_ip/conftest.py`
  → `tests/e2e/vmaas/external_ip/conftest.py`
- `tests/e2e/vmaas/test_compute_instance_storage_tier.py:441` —
  `tests/vmaas/test_compute_instance_disk_image.py`
  → `tests/e2e/vmaas/test_compute_instance_disk_image.py`

### Verification
```sh
# Zero stale imports remaining
git grep 'from tests\.' -- tests/ | grep -v 'from tests\.core' | grep -v 'from tests\.e2e'

# Zero stale comment paths remaining
git grep 'tests/vmaas/\|tests/bmaas/\|tests/caas/\|tests/catalog/\|tests/storage/' -- tests/
```