### PR TITLE
NO-ISSUE: Fix Go module cache misses and outdated azure/setup-helm pin

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -25,6 +25,11 @@ runs:
   - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6
     with:
       go-version: '1.26.3'
+      # Without this, setup-go looks for go.sum at the repo root by
+      # default -- this is a mono-repo, every component's go.sum lives in
+      # its own subdirectory, so the built-in module cache silently never
+      # hit ("Restore cache failed: Dependencies file is not found").
+      cache-dependency-path: ${{ inputs.working-directory }}/go.sum
   - name: Download Go modules
     shell: bash
     working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -150,7 +150,7 @@ jobs:
 
     - name: Set up Helm
       if: steps.should-run.outputs.run
-      uses: azure/setup-helm@v5
+      uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
       with:
         version: v3.21.4
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -88,7 +88,7 @@ jobs:
       with:
         install_only: true
     - name: Install Helm
-      uses: azure/setup-helm@v4
+      uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
     - name: Install ginkgo
       run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.32.0  # keep in sync with go.mod's github.com/onsi/ginkgo/v2 version
     - name: Install infrastructure on Kind
@@ -147,7 +147,7 @@ jobs:
           install_only: true
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
 
       - name: Install ginkgo
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.32.0  # keep in sync with go.mod's github.com/onsi/ginkgo/v2 version
@@ -198,7 +198,7 @@ jobs:
           install_only: true
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
 
       - name: Install ginkgo
         run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.32.0  # keep in sync with go.mod's github.com/onsi/ginkgo/v2 version


### PR DESCRIPTION
## Summary

Looked at all the warning annotations on nightly run [33426760686](https://github.com/osac-project/osac/actions/runs/33426760686) (which otherwise passed end-to-end — first fully green nightly since #627). Two of the four warning types are fixable here; the other two live in `osac-test-infra`.

## Fixed here

- **"Restore cache failed: Dependencies file is not found... Supported file pattern: go.mod"** (5x) — the shared `setup-go` composite action calls `actions/setup-go` without `cache-dependency-path`, so its built-in module cache looks for `go.sum` at the repo root by default. This is a mono-repo — every component's `go.sum` lives in its own subdirectory — so the cache silently never hit for *any* caller (fulfillment-service, osac-metering's 3 modules). Pointed it at `${{ inputs.working-directory }}/go.sum`.
- **"Node.js 20 is deprecated... azure/setup-helm@v4"** — `integration-tests.yml` had 3 unpinned `@v4` references (an old major version whose Node runtime hasn't been bumped), inconsistent with every other `azure/setup-helm` usage in this repo, already pinned to v5.0.1's SHA. Bumped to match. Also fixed `helm-lint.yaml`'s one remaining unpinned `@v5` tag for the same reason.

## Not fixed here (out of scope — different repo)

- The remaining Node20-deprecation warnings (stale `actions/checkout`/`actions/upload-artifact`/`actions/download-artifact` pins) come from `osac-test-infra`'s reusable E2E workflows, which pin much older action SHAs across ~18 files — a real but separate, larger cleanup.
- A gitleaks pre-upload redaction pass on a real E2E run doesn't fully converge to 0 findings within its 3-pass cap on one large single-line `jobs-page-1.json` (drops 1601 → 7 → 6 → 4, still trending down). It already has an explicit "post-upload scanner will cover" fallback and only ever flags AAP session-token JWTs scoped to that run's own ephemeral cluster, not real long-lived secrets — but the redaction loop itself lives in `osac-test-infra/.github/actions/gather-artifacts`, not here.

## Test plan

- [x] YAML syntax validated for all 3 changed files
- [x] Confirmed every `setup-go` caller's `working-directory` has its own `go.sum`
- [ ] Confirm cache hits and no Node20 warning on the next nightly/PR run

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dependency caching for Go-based components in monorepo workflows.
  * Stabilized Helm-related linting and integration-test workflows by using fixed, verified tooling versions.
  * Improved consistency and reproducibility across automated validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->