### PR TITLE
OSAC-3593: Pass test-ref to e2e reusable workflows

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -142,6 +142,8 @@ jobs:
       # Checkout osac-test-infra for tests/Containerfile (not the caller repo)
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+      # Pull e2e tests from this PR's commit so test changes are exercised
+      test-ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
   e2e-bmaas-gate:
     if: always()

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -153,6 +153,8 @@ jobs:
       # Checkout osac-test-infra for tests/Containerfile (not the caller repo)
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+      # Pull e2e tests from this PR's commit so test changes are exercised
+      test-ref: ${{ github.event.pull_request.head.sha || github.sha }}
       # CaaS-specific inputs (cluster-template, caas-domain, flavor-image,
       # flavor-name, namespace, etc.) are left at the reusable workflow's own
       # defaults -- none are required and this caller has no need to override

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -149,6 +149,8 @@ jobs:
       # Checkout osac-test-infra for tests/Containerfile (not the caller repo)
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+      # Pull e2e tests from this PR's commit so test changes are exercised
+      test-ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
   e2e-vmaas-gate:
     if: always()


### PR DESCRIPTION
Companion to the [osac-test-infra hard cutover](https://github.com/osac-project/osac-test-infra/pull/432): each caller now passes test-ref pointing to the PR's head SHA so the reusable workflow checks out this commit's tests/ instead of main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * End-to-end installation tests now run against the correct pull request or workflow commit.
  * Updated BMaaS, CaaS, and VMaaS test workflows to use the triggering revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->