### PR TITLE
OSAC-3593: Switch e2e callers to use osac mono-repo tests

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -142,6 +142,9 @@ jobs:
       # Checkout osac-test-infra for tests/Containerfile (not the caller repo)
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+      # OSAC-3593: Use tests from osac mono-repo instead of osac-test-infra
+      test-source: "osac"
+      test-ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
   e2e-bmaas-gate:
     if: always()

--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -144,6 +144,7 @@ jobs:
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
       # OSAC-3593: Use tests from osac mono-repo instead of osac-test-infra
       test-source: "osac"
+      test-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       test-ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
   e2e-bmaas-gate:

--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -25,7 +25,7 @@ on:
         required: false
         default: "bmaas"
       test-filter:
-        description: "pytest -k filter"
+        description: "pytest -k filter (GHA always also excludes TestBmaasNetworking)"
         required: false
         default: ""
       test-infra-ref:
@@ -120,7 +120,10 @@ jobs:
     uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-full-install.yml@main
     with:
       test-suite: ${{ inputs.test-suite || 'bmaas' }}
-      test-filter: ${{ inputs.test-filter || '' }}
+      # Networking is Netris-lab only (eth9, virsh, 3 BMIs). GHA never ran it
+      # (test-infra tree has lifecycle+inventory only). Overlay of tests/e2e
+      # would collect it; deselect so the job matches the periodic 3-test set.
+      test-filter: ${{ inputs.test-filter && format('{0} and not TestBmaasNetworking', inputs.test-filter) || 'not TestBmaasNetworking' }}
       # osac-installer now lives as a subdirectory of this same monorepo checkout
       # (its Chart.yaml deps resolve fulfillment-service/osac-operator/osac-aap/BMF
       # as ../../../<name> siblings within it), so a PR touching those components

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -155,6 +155,7 @@ jobs:
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
       # OSAC-3593: Use tests from osac mono-repo instead of osac-test-infra
       test-source: "osac"
+      test-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       test-ref: ${{ github.event.pull_request.head.sha || github.sha }}
       # CaaS-specific inputs (cluster-template, caas-domain, flavor-image,
       # flavor-name, namespace, etc.) are left at the reusable workflow's own

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -153,6 +153,9 @@ jobs:
       # Checkout osac-test-infra for tests/Containerfile (not the caller repo)
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+      # OSAC-3593: Use tests from osac mono-repo instead of osac-test-infra
+      test-source: "osac"
+      test-ref: ${{ github.event.pull_request.head.sha || github.sha }}
       # CaaS-specific inputs (cluster-template, caas-domain, flavor-image,
       # flavor-name, namespace, etc.) are left at the reusable workflow's own
       # defaults -- none are required and this caller has no need to override

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -151,6 +151,7 @@ jobs:
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
       # OSAC-3593: Use tests from osac mono-repo instead of osac-test-infra
       test-source: "osac"
+      test-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       test-ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
   e2e-vmaas-gate:

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -149,6 +149,9 @@ jobs:
       # Checkout osac-test-infra for tests/Containerfile (not the caller repo)
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+      # OSAC-3593: Use tests from osac mono-repo instead of osac-test-infra
+      test-source: "osac"
+      test-ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
   e2e-vmaas-gate:
     if: always()


### PR DESCRIPTION
Pass test-source="osac" and test-ref pointing to the current commit SHA in all three e2e caller workflows. This switches osac's own CI to run tests from the mono-repo's tests/e2e/ directory instead of osac-test-infra's tests/ directory.

See [ #433  [OSAC-3593](https://redhat.atlassian.net/browse/OSAC-3593): Add dual-source test support to e2e reusable workflows ](https://github.com/osac-project/osac-test-infra/pull/433)- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * End-to-end installation workflows now run tests from the matching pull request revision.
  * Non-pull-request runs use the workflow’s revision for test selection.
  * Coverage is aligned across bare-metal, container, and virtual-machine installation scenarios.
  * Existing test infrastructure remains available where required for building test containers.
  * Bare-metal networking tests now use configured catalog items consistently.
  * Public key paths are validated, and required Ed25519 SSH keys are automatically created or refreshed when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->