### PR TITLE
POC: test Vertex AI WIF auth on osac-1 (throwaway, do not merge)

### DIFF
--- a/.github/workflows/llm-capability-poc.yaml
+++ b/.github/workflows/llm-capability-poc.yaml
@@ -1,32 +1,51 @@
-name: LLM Capability POC (fleet-wide, non-osac-ci-1)
+name: LLM Capability POC (fleet-wide)
 
 # Throwaway validation, not a real capability: proves whether the existing
 # WIF auth to the osac-ci GCP project (already used by
 # graphify-brain-refresh-vertex-poc.yaml, which only ever runs on
-# osac-ci-1) works "out of the box" on a different fleet host with zero
-# new GCP-side configuration -- since WIF trust is based on the calling
-# job's OIDC identity (repo/ref), not on which physical runner executes
-# it, this should just work. Deliberately has nothing to do with
+# osac-ci-1) works "out of the box" on every fleet host with zero new
+# GCP-side configuration -- since WIF trust is based on the calling job's
+# OIDC identity (repo/ref), not on which physical runner executes it,
+# this should just work on main. Deliberately has nothing to do with
 # graphify -- tests the general Vertex AI capability in isolation.
+#
+# Host list is hardcoded here rather than read from
+# osac-test-infra's fleet/inventory/hosts.yml (source of truth for the
+# real fleet) -- that file lives in a different repo, and a throwaway
+# POC isn't worth a cross-repo checkout for. Keep in sync manually if the
+# fleet changes before this file is deleted.
 #
 # Delete this file once the answer is confirmed either way.
 
 on:
   workflow_dispatch: {}
-  # pull_request so this can run and be validated entirely on this PR's
-  # own branch, without ever landing on main -- workflow_dispatch alone
-  # requires the workflow file to already exist on the default branch to
-  # be dispatchable, which a throwaway POC shouldn't need.
-  pull_request:
-    paths:
-      - .github/workflows/llm-capability-poc.yaml
 
 permissions: {}
 
 jobs:
   test:
-    name: Call Vertex AI from osac-1
-    runs-on: [self-hosted, osac-1]
+    name: Call Vertex AI (${{ matrix.host }})
+    strategy:
+      fail-fast: false
+      matrix:
+        host:
+          - osac-ci-1
+          - osac-1
+          - osac-2
+          - osac-3
+          - osac-4
+          - osac-5
+          - osac-6
+          - osac-7
+          - osac-8
+          - osac-9
+          - osac-10
+          - osac-11
+          - osac-12
+          - osac-13
+          - osac-14
+          - osac-15
+    runs-on: [self-hosted, "${{ matrix.host }}"]
     timeout-minutes: 10
     permissions:
       id-token: write

--- a/.github/workflows/llm-capability-poc.yaml
+++ b/.github/workflows/llm-capability-poc.yaml
@@ -13,6 +13,13 @@ name: LLM Capability POC (fleet-wide, non-osac-ci-1)
 
 on:
   workflow_dispatch: {}
+  # pull_request so this can run and be validated entirely on this PR's
+  # own branch, without ever landing on main -- workflow_dispatch alone
+  # requires the workflow file to already exist on the default branch to
+  # be dispatchable, which a throwaway POC shouldn't need.
+  pull_request:
+    paths:
+      - .github/workflows/llm-capability-poc.yaml
 
 permissions: {}
 

--- a/.github/workflows/llm-capability-poc.yaml
+++ b/.github/workflows/llm-capability-poc.yaml
@@ -1,0 +1,57 @@
+name: LLM Capability POC (fleet-wide, non-osac-ci-1)
+
+# Throwaway validation, not a real capability: proves whether the existing
+# WIF auth to the osac-ci GCP project (already used by
+# graphify-brain-refresh-vertex-poc.yaml, which only ever runs on
+# osac-ci-1) works "out of the box" on a different fleet host with zero
+# new GCP-side configuration -- since WIF trust is based on the calling
+# job's OIDC identity (repo/ref), not on which physical runner executes
+# it, this should just work. Deliberately has nothing to do with
+# graphify -- tests the general Vertex AI capability in isolation.
+#
+# Delete this file once the answer is confirmed either way.
+
+on:
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  test:
+    name: Call Vertex AI from osac-1
+    runs-on: [self-hosted, osac-1]
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+    env:
+      GOOGLE_CLOUD_PROJECT: osac-ci
+      GOOGLE_CLOUD_LOCATION: us-central1
+    steps:
+      - name: Authenticate to Google Cloud (Vertex AI)
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
+        with:
+          workload_identity_provider: projects/1008600636152/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider
+          service_account: osac-ci@osac-ci.iam.gserviceaccount.com
+
+      - name: Install google-genai SDK
+        run: pip install --user --quiet google-genai
+
+      - name: Call Vertex AI Gemini (minimal smoke test)
+        run: |
+          set -euo pipefail
+          python3 - <<'PYEOF'
+          import os
+          from google import genai
+
+          client = genai.Client(
+              vertexai=True,
+              project=os.environ["GOOGLE_CLOUD_PROJECT"],
+              location=os.environ["GOOGLE_CLOUD_LOCATION"],
+          )
+          resp = client.models.generate_content(
+              model="gemini-2.5-flash",
+              contents="Reply with exactly one word: WORKS",
+          )
+          print("Response:", resp.text)
+          print("Hostname check: this ran on", os.uname().nodename)
+          PYEOF


### PR DESCRIPTION
Throwaway validation only -- **not meant to be merged**.

Tests whether the existing WIF auth to the \`osac-ci\` GCP project (used
today only by \`graphify-brain-refresh-vertex-poc.yaml\`, which always
runs on \`osac-ci-1\`) works out of the box on a different fleet host
(\`osac-1\`) with zero new GCP-side configuration. Deliberately has
nothing to do with graphify.

Will close this PR without merging once the run result is confirmed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered and pull-request validation workflow for Vertex AI access.
  * Runs a lightweight Gemini smoke test on the designated self-hosted runner.
  * Uses secure, short-lived cloud authentication for the validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->