### PR TITLE
OSAC-3593: Move tests/core/  tests/projects and tests/conftest.py into tests/e2e/

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -15,6 +15,6 @@ When changing one repo, check all dependent repos in this table before submittin
 |-----------|-----------|-----|
 | `osac-operator` CRD types | `fulfillment-service` reconciler registration | New CRD types must be registered in the fulfillment-service reconciler (in-repo change, same PR) |
 | `osac-operator` CRD spec changes | `osac-aap` roles that read CRD fields | Adding a field to `ClusterOrderSpec` requires the AAP playbook to extract and use it |
-| `fulfillment-service` CLI flag changes | `tests/core/osac_cli.py` | Keep the shared E2E CLI helper aligned with tenant-facing flags |
+| `fulfillment-service` CLI flag changes | `tests/e2e/core/osac_cli.py` | Keep the shared E2E CLI helper aligned with tenant-facing flags |
 
 Evidence: MGMT-24226 eval scored 3/5 because the agent fixed `fulfillment-service` and `osac-aap` but missed updating `osac-installer`'s pinned image version — this was pre-mono-repo-merge (OSAC-1739), when these were still separate repos and image tags were pinned per-commit. That specific mechanism (a separate pinned tag needing a manual re-sync via `sync-image-tags.sh`) no longer exists post-mono-repo — `osac/osac-installer/scripts/sync-image-tags.sh` was removed upstream (`OSAC-3367`) and `osac/osac-installer/values/*/values.yaml` now leaves mono-repo-resident components' image tags unpinned. See the CRD-registration and CLI-flag rows above for what still needs a cross-file check today.

--- a/tests/e2e/bmaas/conftest.py
+++ b/tests/e2e/bmaas/conftest.py
@@ -8,8 +8,8 @@ from pathlib import Path
 
 import pytest
 
-from tests.core.grpc_client import GRPCClient
-from tests.core.runner import env
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.runner import env
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/bmaas/networking/bmi_ssh.py
+++ b/tests/e2e/bmaas/networking/bmi_ssh.py
@@ -70,9 +70,7 @@ def ping(bmc_ip: str, target_ip: str, count: int = 3, wait: int = 3) -> bool:
 
 def curl_status(bmc_ip: str, url: str, timeout: int = 15) -> int:
     output, rc = ssh_bmi_unchecked(
-        bmc_ip,
-        f"curl -s -o /dev/null -w '%{{http_code}}' --connect-timeout {timeout} {url}",
-        timeout=timeout + 30,
+        bmc_ip, f"curl -s -o /dev/null -w '%{{http_code}}' --connect-timeout {timeout} {url}", timeout=timeout + 30
     )
     log.info("curl_status(%s, %s): ssh_rc=%d, output=%r", bmc_ip, url, rc, output[-200:])
     for line in output.strip().splitlines():

--- a/tests/e2e/bmaas/networking/conftest.py
+++ b/tests/e2e/bmaas/networking/conftest.py
@@ -5,8 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.core.grpc_client import GRPCClient
-from tests.core.runner import env
+from tests.e2e.core.runner import env
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/bmaas/networking/test_bmaas_networking.py
+++ b/tests/e2e/bmaas/networking/test_bmaas_networking.py
@@ -6,8 +6,8 @@ from typing import Any, ClassVar
 import pytest
 
 from tests.e2e.bmaas.networking import bmi_ssh
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import (
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import (
     wait_for_bmh_available,
     wait_for_bmi_cr,
     wait_for_bmi_deletion,
@@ -33,9 +33,9 @@ from tests.core.helpers import (
     wait_for_virtual_network_deletion,
     wait_for_virtual_network_ready,
 )
-from tests.core.k8s_client import K8sClient
-from tests.core.osac_cli import OsacCLI
-from tests.core.runner import poll_until
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.osac_cli import OsacCLI
+from tests.e2e.core.runner import poll_until
 
 
 def _require(state: dict[str, Any], *keys: str) -> None:
@@ -57,9 +57,7 @@ class TestBmaasNetworking:
         external_ip_pool_cidr: str,
     ) -> None:
         pool_id = private_grpc.create_external_ip_pool(
-            name=external_ip_pool_name,
-            cidrs=[external_ip_pool_cidr],
-            implementation_strategy="netris",
+            name=external_ip_pool_name, cidrs=[external_ip_pool_cidr], implementation_strategy="netris"
         )
         pool_cr = wait_for_external_ip_pool_cr(k8s=k8s_hub_client, uuid=pool_id)
         wait_for_external_ip_pool_ready(k8s=k8s_hub_client, name=pool_cr)
@@ -70,9 +68,7 @@ class TestBmaasNetworking:
 
     # ── Phase 1: Build the Network ──────────────────────────────────────
 
-    def test_01_create_virtual_network(
-        self, grpc: GRPCClient, k8s_hub_client: K8sClient, net_test_run_id: str
-    ) -> None:
+    def test_01_create_virtual_network(self, grpc: GRPCClient, k8s_hub_client: K8sClient, net_test_run_id: str) -> None:
         name = f"net-{net_test_run_id}"
         vnet_id = grpc.create_virtual_network(name=name, ipv4_cidr="10.100.0.0/16")
         vnet_cr = wait_for_virtual_network_cr(k8s=k8s_hub_client, uuid=vnet_id)
@@ -121,9 +117,7 @@ class TestBmaasNetworking:
 
         self.__class__.state.update(sg_id=sg_id, sg_cr=sg_cr, sg_name=sg_name)
 
-    def test_04_create_nat_gateway(
-        self, grpc: GRPCClient, k8s_hub_client: K8sClient, net_test_run_id: str
-    ) -> None:
+    def test_04_create_nat_gateway(self, grpc: GRPCClient, k8s_hub_client: K8sClient, net_test_run_id: str) -> None:
         _require(self.state, "vnet_name", "pool_id")
 
         nat_eip_name = f"nat-eip-{net_test_run_id}"
@@ -323,9 +317,7 @@ class TestBmaasNetworking:
             description=f"NAT gateway egress curl quay.io (bmc_ip={bmi1['bmc_ip']}, tenant_ip={bmi1['ip']})",
         )
 
-    def test_12_external_ip_ingress(
-        self, grpc: GRPCClient, k8s_hub_client: K8sClient, net_test_run_id: str
-    ) -> None:
+    def test_12_external_ip_ingress(self, grpc: GRPCClient, k8s_hub_client: K8sClient, net_test_run_id: str) -> None:
         _require(self.state, "bmi1", "pool_id")
         bmi1 = self.state["bmi1"]
 
@@ -351,12 +343,8 @@ class TestBmaasNetworking:
             except subprocess.CalledProcessError:
                 return ""
 
-        hostname = poll_until(
-            fn=_try_ssh_eip,
-            until=lambda h: bool(h),
-            retries=5,
-            delay=15,
-            description=f"SSH via external IP {ext_addr}",
+        poll_until(
+            fn=_try_ssh_eip, until=lambda h: bool(h), retries=5, delay=15, description=f"SSH via external IP {ext_addr}"
         )
 
         self.__class__.state.update(

--- a/tests/e2e/bmaas/test_baremetal_instance_inventory_exhausted.py
+++ b/tests/e2e/bmaas/test_baremetal_instance_inventory_exhausted.py
@@ -5,8 +5,8 @@ import subprocess
 
 import pytest
 
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import (
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import (
     assert_bmi_does_not_become_running,
     assert_bmi_lifecycle_on_running,
     wait_for_bmi_cr,
@@ -15,9 +15,9 @@ from tests.core.helpers import (
     wait_for_bmi_running,
     wait_for_bmi_running_after_recovery,
 )
-from tests.core.k8s_client import K8sClient
-from tests.core.osac_cli import OsacCLI
-from tests.core.runner import poll_until
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.osac_cli import OsacCLI
+from tests.e2e.core.runner import poll_until
 
 _AVAILABLE_BMH_STATES = {"available", "ready"}
 _NOT_FOUND_RE = re.compile(r"Code:\s*NotFound|baremetalinstance\b.*\bnot found", re.IGNORECASE)
@@ -91,12 +91,7 @@ def test_baremetal_instance_inventory_exhausted(
             wait_for_bmi_running(grpc=grpc, bmi_id=bmi_id)
 
         # Lifecycle checks after all claim BMIs are up (not interleaved with creates).
-        assert_bmi_lifecycle_on_running(
-            grpc=grpc,
-            k8s=k8s_hub_client,
-            bmi_id=bmi_ids[0],
-            bmh_namespace=bmh_namespace,
-        )
+        assert_bmi_lifecycle_on_running(grpc=grpc, k8s=k8s_hub_client, bmi_id=bmi_ids[0], bmh_namespace=bmh_namespace)
 
         available_after_claim: int = k8s_hub_client.count_bmhs_by_provisioning_state(
             bmh_namespace=bmh_namespace, states=_AVAILABLE_BMH_STATES

--- a/tests/e2e/bmaas/test_baremetal_instance_lifecycle.py
+++ b/tests/e2e/bmaas/test_baremetal_instance_lifecycle.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-import pytest
 import logging
 import re
 from typing import Any
 
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import (
+import pytest
+
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import (
     wait_for_bmh_available,
     wait_for_bmh_provisioned,
     wait_for_bmi_cr,
@@ -14,9 +15,9 @@ from tests.core.helpers import (
     wait_for_bmi_grpc_removal,
     wait_for_bmi_running,
 )
-from tests.core.k8s_client import K8sClient
-from tests.core.osac_cli import OsacCLI
-from tests.core.runner import poll_until
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.osac_cli import OsacCLI
+from tests.e2e.core.runner import poll_until
 
 logger = logging.getLogger(__name__)
 
@@ -45,8 +46,7 @@ def _assert_nic_metadata(
     cr_macs: set[str] = set(k8s.get_bmi_hardware_nics(name=bmi_cr_name))
     assert cr_macs, f"BareMetalInstance CR {bmi_cr_name} has no status.hardware.nics"
     assert cr_macs == bmh_macs, (
-        f"BMI CR status.hardware.nics {sorted(cr_macs)} does not match "
-        f"BareMetalHost hardware.nics {sorted(bmh_macs)}"
+        f"BMI CR status.hardware.nics {sorted(cr_macs)} does not match BareMetalHost hardware.nics {sorted(bmh_macs)}"
     )
 
     # 3. gRPC API response must match the BMI CR
@@ -64,11 +64,9 @@ def _assert_nic_metadata(
     assert "Network Interfaces:" in describe_output, (
         "osac describe baremetalinstance output missing 'Network Interfaces:' section"
     )
-    ni_section = describe_output[describe_output.index("Network Interfaces:"):]
+    ni_section = describe_output[describe_output.index("Network Interfaces:") :]
     for mac in bmh_macs:
-        assert mac in ni_section, (
-            f"osac describe baremetalinstance 'Network Interfaces:' section missing MAC '{mac}'"
-        )
+        assert mac in ni_section, f"osac describe baremetalinstance 'Network Interfaces:' section missing MAC '{mac}'"
 
 
 def _get_condition_status(grpc: GRPCClient, bmi_id: str, condition_type: str) -> str:

--- a/tests/e2e/caas/conftest.py
+++ b/tests/e2e/caas/conftest.py
@@ -5,8 +5,8 @@ from collections.abc import Iterator
 
 import pytest
 
-from tests.core.osac_cli import OsacCLI
-from tests.core.runner import env
+from tests.e2e.core.osac_cli import OsacCLI
+from tests.e2e.core.runner import env
 
 
 # TODO(OSAC-1060): Remove this override once the osac-operator storage controller

--- a/tests/e2e/caas/test_cluster_create.py
+++ b/tests/e2e/caas/test_cluster_create.py
@@ -7,8 +7,8 @@ from pathlib import Path
 import pytest
 
 from tests.e2e.catalog.conftest import unique_name
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import (
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import (
     wait_for_cluster_deleting,
     wait_for_cluster_deletion,
     wait_for_cluster_grpc_deleting_or_archived,
@@ -17,10 +17,10 @@ from tests.core.helpers import (
     wait_for_cluster_progressing,
     wait_for_cluster_ready,
 )
-from tests.core.k8s_client import K8sClient
-from tests.core.metering import MeteringCollector
-from tests.core.osac_cli import OsacCLI
-from tests.core.runner import poll_until, run
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.metering import MeteringCollector
+from tests.e2e.core.osac_cli import OsacCLI
+from tests.e2e.core.runner import poll_until, run
 
 # Real OCP release image used to provision the ClusterVersion(s) created by these
 # tests. Fixed (not randomly generated) so repeated runs reuse the same

--- a/tests/e2e/caas/test_cluster_delete_feedback_light.py
+++ b/tests/e2e/caas/test_cluster_delete_feedback_light.py
@@ -5,8 +5,8 @@ import subprocess
 from pathlib import Path
 
 from tests.e2e.catalog.conftest import unique_name
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import (
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import (
     wait_for_cluster_deleting,
     wait_for_cluster_deletion,
     wait_for_cluster_grpc_deleting_or_archived,
@@ -14,8 +14,8 @@ from tests.core.helpers import (
     wait_for_cluster_order_cr,
     wait_for_cluster_progressing,
 )
-from tests.core.k8s_client import K8sClient
-from tests.core.osac_cli import OsacCLI
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.osac_cli import OsacCLI
 
 
 def test_cluster_delete_reports_deleting_state_without_provisioning(

--- a/tests/e2e/catalog/conftest.py
+++ b/tests/e2e/catalog/conftest.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import logging
 import re
 import subprocess
-from typing import Generator
+from collections.abc import Generator
 from uuid import uuid4
 
 import pytest
 
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import (
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import (
     wait_for_subnet_cr,
     wait_for_subnet_deletion,
     wait_for_subnet_ready,
@@ -17,8 +17,8 @@ from tests.core.helpers import (
     wait_for_virtual_network_deletion,
     wait_for_virtual_network_ready,
 )
-from tests.core.k8s_client import K8sClient
-from tests.core.runner import env
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.runner import env
 
 logger = logging.getLogger(__name__)
 
@@ -37,13 +37,7 @@ def compute_instance_template() -> str:
     return env("OSAC_VM_TEMPLATE", "ocp-virt-vm")
 
 
-def _delete_subnet_teardown(
-    grpc: GRPCClient,
-    k8s: K8sClient,
-    *,
-    subnet_id: str,
-    subnet_cr_name: str,
-) -> None:
+def _delete_subnet_teardown(grpc: GRPCClient, k8s: K8sClient, *, subnet_id: str, subnet_cr_name: str) -> None:
     try:
         grpc.delete_subnet(subnet_id=subnet_id)
     except subprocess.CalledProcessError as exc:
@@ -57,13 +51,7 @@ def _delete_subnet_teardown(
         wait_for_subnet_deletion(k8s=k8s, name=subnet_cr_name)
 
 
-def _delete_virtual_network_teardown(
-    grpc: GRPCClient,
-    k8s: K8sClient,
-    *,
-    vn_id: str,
-    vn_cr_name: str,
-) -> None:
+def _delete_virtual_network_teardown(grpc: GRPCClient, k8s: K8sClient, *, vn_id: str, vn_cr_name: str) -> None:
     try:
         grpc.delete_virtual_network(vn_id=vn_id)
     except subprocess.CalledProcessError as exc:
@@ -78,10 +66,7 @@ def _delete_virtual_network_teardown(
 
 
 @pytest.fixture(scope="module")
-def catalog_networking(
-    grpc: GRPCClient,
-    k8s_hub_client: K8sClient,
-) -> Generator[dict[str, str], None, None]:
+def catalog_networking(grpc: GRPCClient, k8s_hub_client: K8sClient) -> Generator[dict[str, str], None, None]:
     """Create VirtualNetwork + Subnet for compute instance catalog item tests."""
     tag = uuid4().hex[:8]
     vn_id: str | None = None
@@ -90,18 +75,11 @@ def catalog_networking(
     subnet_cr_name: str | None = None
 
     try:
-        vn_id = grpc.create_virtual_network(
-            name=f"e2e-cat-vn-{tag}",
-            ipv4_cidr="10.200.0.0/16",
-        )
+        vn_id = grpc.create_virtual_network(name=f"e2e-cat-vn-{tag}", ipv4_cidr="10.200.0.0/16")
         vn_cr_name = wait_for_virtual_network_cr(k8s=k8s_hub_client, uuid=vn_id)
         wait_for_virtual_network_ready(k8s=k8s_hub_client, name=vn_cr_name)
 
-        subnet_id = grpc.create_subnet(
-            name=f"e2e-cat-subnet-{tag}",
-            virtual_network=vn_id,
-            ipv4_cidr="10.200.100.0/24",
-        )
+        subnet_id = grpc.create_subnet(name=f"e2e-cat-subnet-{tag}", virtual_network=vn_id, ipv4_cidr="10.200.100.0/24")
         subnet_cr_name = wait_for_subnet_cr(k8s=k8s_hub_client, uuid=subnet_id)
         wait_for_subnet_ready(k8s=k8s_hub_client, name=subnet_cr_name)
 
@@ -123,19 +101,9 @@ def catalog_networking(
     finally:
         # Normal cleanup runs regardless of setup success/failure
         if subnet_id and subnet_cr_name:
-            _delete_subnet_teardown(
-                grpc,
-                k8s_hub_client,
-                subnet_id=subnet_id,
-                subnet_cr_name=subnet_cr_name,
-            )
+            _delete_subnet_teardown(grpc, k8s_hub_client, subnet_id=subnet_id, subnet_cr_name=subnet_cr_name)
         if vn_id and vn_cr_name:
-            _delete_virtual_network_teardown(
-                grpc,
-                k8s_hub_client,
-                vn_id=vn_id,
-                vn_cr_name=vn_cr_name,
-            )
+            _delete_virtual_network_teardown(grpc, k8s_hub_client, vn_id=vn_id, vn_cr_name=vn_cr_name)
 
 
 @pytest.fixture(scope="module")

--- a/tests/e2e/catalog/test_catalog_item_lifecycle.py
+++ b/tests/e2e/catalog/test_catalog_item_lifecycle.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import subprocess
-
 from tests.e2e.catalog.conftest import unique_name
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import wait_for_cluster_order_cr
-from tests.core.k8s_client import K8sClient
-from tests.core.osac_cli import OsacCLI
-from tests.core.runner import poll_until
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import wait_for_cluster_order_cr
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.osac_cli import OsacCLI
+from tests.e2e.core.runner import poll_until
 
 # Fixed (not randomly generated) so repeated runs reuse the same ClusterVersion
 # via GRPCClient.ensure_cluster_version instead of accumulating duplicates on
@@ -38,9 +36,7 @@ def test_catalog_item_crud(grpc: GRPCClient, cluster_template: str) -> None:
 
         assert catalog_item_id not in grpc.list_cluster_catalog_item_ids()
 
-        output, rc = grpc.call_unchecked(
-            service="osac.public.v1.ClusterCatalogItems/Get", data={"id": catalog_item_id}
-        )
+        output, rc = grpc.call_unchecked(service="osac.public.v1.ClusterCatalogItems/Get", data={"id": catalog_item_id})
         assert rc != 0, f"Expected Get to fail after deletion, got: {output}"
 
         catalog_item_id = ""
@@ -72,9 +68,7 @@ def test_catalog_item_unpublish_transition(grpc: GRPCClient, cluster_template: s
 
         assert catalog_item_id not in grpc.list_cluster_catalog_item_ids()
 
-        output, rc = grpc.call_unchecked(
-            service="osac.public.v1.ClusterCatalogItems/Get", data={"id": catalog_item_id}
-        )
+        output, rc = grpc.call_unchecked(service="osac.public.v1.ClusterCatalogItems/Get", data={"id": catalog_item_id})
         assert rc != 0, f"Expected Get to fail after unpublishing, got: {output}"
     finally:
         grpc.delete_cluster_catalog_item(catalog_item_id=catalog_item_id)
@@ -82,12 +76,7 @@ def test_catalog_item_unpublish_transition(grpc: GRPCClient, cluster_template: s
 
 def test_catalog_item_field_definitions(grpc: GRPCClient, cluster_template: str) -> None:
     field_defs = [
-        {
-            "path": "spec.network.pod_cidr",
-            "display_name": "Pod CIDR",
-            "editable": True,
-            "default": "10.128.0.0/14",
-        },
+        {"path": "spec.network.pod_cidr", "display_name": "Pod CIDR", "editable": True, "default": "10.128.0.0/14"},
         {
             "path": "spec.network.service_cidr",
             "display_name": "Service CIDR",
@@ -140,7 +129,7 @@ def test_catalog_item_field_definitions(grpc: GRPCClient, cluster_template: str)
                 "display_name": "Pod Network CIDR",
                 "editable": True,
                 "default": "10.128.0.0/14",
-            },
+            }
         ]
         grpc.update_cluster_catalog_item(catalog_item_id=catalog_item_id, field_definitions=reduced_fds)
 
@@ -177,9 +166,7 @@ def test_create_cluster_with_catalog_item(grpc: GRPCClient, cli: OsacCLI, cluste
         grpc.delete_cluster_catalog_item(catalog_item_id=catalog_item_id)
 
 
-def test_create_cluster_with_unpublished_catalog_item_fails(
-    grpc: GRPCClient, cluster_template: str
-) -> None:
+def test_create_cluster_with_unpublished_catalog_item_fails(grpc: GRPCClient, cluster_template: str) -> None:
     name = unique_name("e2e-unpub")
     catalog_item_id = grpc.create_cluster_catalog_item(name=name, template=cluster_template, published=False)
     try:
@@ -232,12 +219,7 @@ def test_create_cluster_with_catalog_item_version(
         template=cluster_template,
         published=True,
         field_definitions=[
-            {
-                "path": "version",
-                "display_name": "Version",
-                "editable": True,
-                "default": version["name"],
-            }
+            {"path": "version", "display_name": "Version", "editable": True, "default": version["name"]}
         ],
     )
     cluster_id = ""

--- a/tests/e2e/catalog/test_compute_instance_catalog_item_disk_image.py
+++ b/tests/e2e/catalog/test_compute_instance_catalog_item_disk_image.py
@@ -5,8 +5,8 @@ import subprocess
 import pytest
 
 from tests.e2e.catalog.conftest import unique_name
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import assert_grpc_rejected, wait_for_grpc_removal
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import assert_grpc_rejected, wait_for_grpc_removal
 
 SOURCE_REF = "quay.io/containerdisks/fedora:41"
 
@@ -76,9 +76,7 @@ def test_disk_image_deletion_protection_catalog_item(grpc: GRPCClient, compute_i
 
         # Same field_definition shape as the default-application test: prefix-less
         # "disk_image" + DiskImage name.
-        field_defs = [
-            {"path": "disk_image", "display_name": "Disk Image", "editable": True, "default": di_name}
-        ]
+        field_defs = [{"path": "disk_image", "display_name": "Disk Image", "editable": True, "default": di_name}]
         catalog_item_id = grpc.create_compute_instance_catalog_item(
             name=unique_name("e2e-cidi-cat"),
             template=compute_instance_template,

--- a/tests/e2e/catalog/test_compute_instance_catalog_item_lifecycle.py
+++ b/tests/e2e/catalog/test_compute_instance_catalog_item_lifecycle.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from tests.e2e.catalog.conftest import unique_name
-from tests.core.grpc_client import GRPCClient
-from tests.core.runner import poll_until
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.runner import poll_until
 
 
 def test_compute_instance_catalog_item_crud(grpc: GRPCClient, compute_instance_template: str) -> None:
@@ -59,9 +59,7 @@ def test_unpublished_compute_instance_catalog_item_not_visible_in_public_api(
         grpc.delete_compute_instance_catalog_item(catalog_item_id=catalog_item_id)
 
 
-def test_compute_instance_catalog_item_unpublish_transition(
-    grpc: GRPCClient, compute_instance_template: str
-) -> None:
+def test_compute_instance_catalog_item_unpublish_transition(grpc: GRPCClient, compute_instance_template: str) -> None:
     name = unique_name("e2e-ci-trans")
     catalog_item_id = grpc.create_compute_instance_catalog_item(
         name=name, template=compute_instance_template, published=True
@@ -81,16 +79,9 @@ def test_compute_instance_catalog_item_unpublish_transition(
         grpc.delete_compute_instance_catalog_item(catalog_item_id=catalog_item_id)
 
 
-def test_compute_instance_catalog_item_field_definitions(
-    grpc: GRPCClient, compute_instance_template: str
-) -> None:
+def test_compute_instance_catalog_item_field_definitions(grpc: GRPCClient, compute_instance_template: str) -> None:
     field_defs = [
-        {
-            "path": "spec.instance_type",
-            "display_name": "Instance Type",
-            "editable": True,
-            "default": "standard-2x4",
-        },
+        {"path": "spec.instance_type", "display_name": "Instance Type", "editable": True, "default": "standard-2x4"}
     ]
     name = unique_name("e2e-ci-fd")
     catalog_item_id = grpc.create_compute_instance_catalog_item(
@@ -106,12 +97,7 @@ def test_compute_instance_catalog_item_field_definitions(
         assert it_fd["editable"] is True
 
         updated_fds = [
-            {
-                "path": "spec.instance_type",
-                "display_name": "VM Size",
-                "editable": True,
-                "default": "standard-2x4",
-            },
+            {"path": "spec.instance_type", "display_name": "VM Size", "editable": True, "default": "standard-2x4"}
         ]
         grpc.update_compute_instance_catalog_item(catalog_item_id=catalog_item_id, field_definitions=updated_fds)
 
@@ -122,12 +108,7 @@ def test_compute_instance_catalog_item_field_definitions(
         assert it_fd["displayName"] == "VM Size"
 
         updated_fds_v2 = [
-            {
-                "path": "spec.instance_type",
-                "display_name": "VM Size",
-                "editable": False,
-                "default": "standard-4x8",
-            },
+            {"path": "spec.instance_type", "display_name": "VM Size", "editable": False, "default": "standard-4x8"}
         ]
         grpc.update_compute_instance_catalog_item(catalog_item_id=catalog_item_id, field_definitions=updated_fds_v2)
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -9,10 +9,10 @@ from pathlib import Path
 
 import pytest
 
-from tests.core.grpc_client import PRIVATE_API, GRPCClient
-from tests.core.k8s_client import K8sClient
-from tests.core.keycloak import get_jwt
-from tests.core.keycloak_admin import (
+from tests.e2e.core.grpc_client import PRIVATE_API, GRPCClient
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.keycloak import get_jwt
+from tests.e2e.core.keycloak_admin import (
     add_user_to_organization,
     add_user_to_organization_group,
     ensure_organization_group,
@@ -20,9 +20,9 @@ from tests.core.keycloak_admin import (
     get_user_id,
     wait_for_organization,
 )
-from tests.core.metering import MeteringCollector
-from tests.core.osac_cli import OsacCLI
-from tests.core.runner import env, run
+from tests.e2e.core.metering import MeteringCollector
+from tests.e2e.core.osac_cli import OsacCLI
+from tests.e2e.core.runner import env, run
 
 
 @pytest.fixture(scope="session")
@@ -153,9 +153,7 @@ def keycloak_admin_password() -> str:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def setup_organization_memberships(
-    ensure_tenants: None, keycloak_url: str, keycloak_admin_password: str
-) -> None:
+def setup_organization_memberships(ensure_tenants: None, keycloak_url: str, keycloak_admin_password: str) -> None:
     """
     Add test users to their corresponding Keycloak organizations.
     This runs after ensure_tenants creates the Tenant resources, which the
@@ -165,10 +163,7 @@ def setup_organization_memberships(
     admin_token = get_admin_token(keycloak_url=keycloak_url, username="admin", password=keycloak_admin_password)
 
     # Map of organization name -> list of usernames
-    org_users = {
-        "tenant1": ["tenant1_user", "tenant1_admin"],
-        "tenant2": ["tenant2_user", "tenant2_admin"],
-    }
+    org_users = {"tenant1": ["tenant1_user", "tenant1_admin"], "tenant2": ["tenant2_user", "tenant2_admin"]}
 
     for org_name, usernames in org_users.items():
         # Wait for the organization to be synced to Keycloak by the tenant controller
@@ -247,7 +242,9 @@ def ensure_k8s_only_network_class(private_grpc: GRPCClient, k8s_hub_client: K8sC
 
 
 @pytest.fixture(scope="session")
-def cli(namespace: str, fulfillment_address: str, keycloak_url: str, jwt_username: str, jwt_password: str) -> Iterator[OsacCLI]:  # noqa: E501
+def cli(
+    namespace: str, fulfillment_address: str, keycloak_url: str, jwt_username: str, jwt_password: str
+) -> Iterator[OsacCLI]:  # noqa: E501
     instance = OsacCLI(
         binary=env("OSAC_CLI_PATH", "osac"),
         address=f"https://{fulfillment_address.rsplit(':', 1)[0]}",

--- a/tests/e2e/core/grpc_client.py
+++ b/tests/e2e/core/grpc_client.py
@@ -7,7 +7,7 @@ import time
 from collections.abc import Callable
 from typing import Any
 
-from tests.core.runner import run, run_unchecked
+from tests.e2e.core.runner import run, run_unchecked
 
 PUBLIC_API: str = "osac.public.v1"
 PRIVATE_API: str = "osac.private.v1"
@@ -239,12 +239,7 @@ class GRPCClient:
     # ExternalIPPool operations (private API only)
 
     def create_external_ip_pool(
-        self,
-        *,
-        name: str,
-        cidrs: list[str],
-        ip_family: str = "IP_FAMILY_IPV4",
-        implementation_strategy: str = "",
+        self, *, name: str, cidrs: list[str], ip_family: str = "IP_FAMILY_IPV4", implementation_strategy: str = ""
     ) -> str:
         response: dict[str, Any] = self.call(
             service=f"{PRIVATE_API}.ExternalIPPools/Create",
@@ -349,7 +344,7 @@ class GRPCClient:
         response: dict[str, Any] = self.call(service=f"{PUBLIC_API}.ClusterCatalogItems/List")
         return [item["id"] for item in response.get("items", [])]
 
-    def update_cluster_catalog_item(self, *, catalog_item_id: str, **fields: Any) -> dict[str, Any]:
+    def update_cluster_catalog_item(self, *, catalog_item_id: str, **fields: Any) -> dict[str, Any]:  # noqa: ANN401
         if not fields:
             raise ValueError("update_cluster_catalog_item requires at least one field to update")
         obj: dict[str, Any] = {"id": catalog_item_id, **fields}
@@ -384,7 +379,7 @@ class GRPCClient:
         response: dict[str, Any] = self.call(service=f"{PUBLIC_API}.ComputeInstanceCatalogItems/List")
         return [item["id"] for item in response.get("items", [])]
 
-    def update_compute_instance_catalog_item(self, *, catalog_item_id: str, **fields: Any) -> dict[str, Any]:
+    def update_compute_instance_catalog_item(self, *, catalog_item_id: str, **fields: Any) -> dict[str, Any]:  # noqa: ANN401
         if not fields:
             raise ValueError("update_compute_instance_catalog_item requires at least one field to update")
         obj: dict[str, Any] = {"id": catalog_item_id, **fields}
@@ -458,7 +453,7 @@ class GRPCClient:
         response: dict[str, Any] = self.call(service=f"{PRIVATE_API}.ClusterVersions/List")
         return [item["id"] for item in response.get("items", [])]
 
-    def update_cluster_version(self, *, version_id: str, **fields: Any) -> dict[str, Any]:
+    def update_cluster_version(self, *, version_id: str, **fields: Any) -> dict[str, Any]:  # noqa: ANN401
         if not fields:
             raise ValueError("update_cluster_version requires at least one field to update")
         return self.call(
@@ -727,7 +722,7 @@ class GRPCClient:
         response: dict[str, Any] = self.call(service=f"{PRIVATE_API}.NetworkClasses/List")
         return response.get("items", [])
 
-    def update_network_class(self, *, network_class_id: str, **fields: Any) -> dict[str, Any]:
+    def update_network_class(self, *, network_class_id: str, **fields: Any) -> dict[str, Any]:  # noqa: ANN401
         if not fields:
             raise ValueError("update_network_class requires at least one field to update")
         obj: dict[str, Any] = {"id": network_class_id, **fields}

--- a/tests/e2e/core/helpers.py
+++ b/tests/e2e/core/helpers.py
@@ -7,9 +7,9 @@ from typing import Any
 
 import pytest
 
-from tests.core.grpc_client import GRPCClient
-from tests.core.k8s_client import K8sClient
-from tests.core.runner import poll_until, run_unchecked
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.runner import poll_until, run_unchecked
 
 _POOL_READY_STATE = "EXTERNAL_IP_POOL_STATE_READY"
 
@@ -675,12 +675,7 @@ def wait_for_bmi_running(*, grpc: GRPCClient, bmi_id: str) -> None:
 
 
 def assert_bmi_lifecycle_on_running(
-    *,
-    grpc: GRPCClient,
-    k8s: K8sClient,
-    bmi_id: str,
-    bmh_namespace: str,
-    power_cycle: bool = True,
+    *, grpc: GRPCClient, k8s: K8sClient, bmi_id: str, bmh_namespace: str, power_cycle: bool = True
 ) -> tuple[str, str]:
     """Assert BMH binding/provisioning on an already-RUNNING BMI.
 

--- a/tests/e2e/core/k8s_client.py
+++ b/tests/e2e/core/k8s_client.py
@@ -4,7 +4,7 @@ import json
 import subprocess
 from typing import Any
 
-from tests.core.runner import run, run_unchecked
+from tests.e2e.core.runner import run, run_unchecked
 
 
 class K8sClient:

--- a/tests/e2e/core/keycloak.py
+++ b/tests/e2e/core/keycloak.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 
-from tests.core.runner import poll_until, run_unchecked
+from tests.e2e.core.runner import poll_until, run_unchecked
 
 
 def get_jwt(*, keycloak_url: str, realm: str, client_id: str, username: str, password: str) -> str:

--- a/tests/e2e/core/keycloak_admin.py
+++ b/tests/e2e/core/keycloak_admin.py
@@ -5,7 +5,7 @@ import time
 from typing import Any
 from urllib.parse import urlencode
 
-from tests.core.runner import run
+from tests.e2e.core.runner import run
 
 
 def get_admin_token(*, keycloak_url: str, username: str, password: str) -> str:
@@ -36,7 +36,12 @@ def get_admin_token(*, keycloak_url: str, username: str, password: str) -> str:
 
 
 def keycloak_admin_request(
-    *, keycloak_url: str, admin_token: str, method: str, path: str, data: Any = None
+    *,
+    keycloak_url: str,
+    admin_token: str,
+    method: str,
+    path: str,
+    data: Any = None,  # noqa: ANN401
 ) -> tuple[int, bytes]:
     """
     Make an authenticated request to the Keycloak admin API for the 'osac' realm.
@@ -72,9 +77,7 @@ def keycloak_admin_request(
     return status_code, body
 
 
-def wait_for_organization(
-    *, keycloak_url: str, admin_token: str, org_name: str, timeout_seconds: int = 60
-) -> str:
+def wait_for_organization(*, keycloak_url: str, admin_token: str, org_name: str, timeout_seconds: int = 60) -> str:
     """
     Wait for an organization to be synced to Keycloak and return its ID.
     Polls with exponential backoff until the organization exists or timeout is reached.
@@ -86,10 +89,7 @@ def wait_for_organization(
     while time.time() - start_time < timeout_seconds:
         query = urlencode({"exact": "true", "search": org_name})
         status, body = keycloak_admin_request(
-            keycloak_url=keycloak_url,
-            admin_token=admin_token,
-            method="GET",
-            path=f"/organizations?{query}",
+            keycloak_url=keycloak_url, admin_token=admin_token, method="GET", path=f"/organizations?{query}"
         )
 
         if status != 200:
@@ -217,6 +217,7 @@ def add_user_to_organization_group(
             f"Failed to add user '{username}' to group in organization '{org_name}': "
             f"status={status} body={body.decode()}"
         )
+
 
 def wait_for_project_in_keycloak(
     *, keycloak_url: str, admin_token: str, org_id: str, project_name: str, timeout_seconds: int = 300

--- a/tests/e2e/core/metering.py
+++ b/tests/e2e/core/metering.py
@@ -10,7 +10,7 @@ from typing import Any
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
-from tests.core.runner import poll_until
+from tests.e2e.core.runner import poll_until
 
 logger = logging.getLogger(__name__)
 
@@ -84,12 +84,16 @@ class MeteringCollector:
         events = self._fetch_events(event_type, resource_id)
         since_dt = datetime.fromisoformat(since)
         matching = [
-            ev for ev in events
+            ev
+            for ev in events
             if ev.get("type") == event_type
-            and (ev.get("resource_id") == resource_id
-                 or ev.get("osacresourceid") == resource_id
-                 or ev.get("data", {}).get("resource_id") == resource_id)
-            and _parse_time(ev.get("time", "")) >= since_dt
+            and (
+                ev.get("resource_id") == resource_id
+                or ev.get("osacresourceid") == resource_id
+                or ev.get("data", {}).get("resource_id") == resource_id
+            )
+            and ev.get("time")
+            and _parse_time(ev["time"]) >= since_dt
         ]
         assert not matching, (
             f"Expected no {event_type} events for {resource_id} after {since}, "
@@ -101,17 +105,13 @@ class MeteringCollector:
         return self._fetch_events(event_type, resource_id)
 
     def _fetch_events(self, event_type: str, resource_id: str) -> list[dict[str, Any]]:
-        params = urlencode({
-            "type": event_type,
-            "resource_id": resource_id,
-            "since": self._start_time,
-        })
+        params = urlencode({"type": event_type, "resource_id": resource_id, "since": self._start_time})
         url = f"{self._base_url}/events?{params}"
         last_exc: OSError | None = None
         for attempt in range(3):
             try:
                 req = Request(url)
-                with urlopen(req, timeout=10) as resp:  # noqa: S310
+                with urlopen(req, timeout=10) as resp:
                     return json.loads(resp.read().decode("utf-8"))
             except (urllib.error.URLError, OSError) as exc:
                 last_exc = exc
@@ -155,14 +155,17 @@ class MeteringCollector:
     @staticmethod
     def _validate_structure(event: dict[str, Any], expected: ExpectedEvent) -> None:
         assert event.get("specversion") == "1.0", f"Wrong specversion: {event.get('specversion')}"
-        assert event.get("source") in ("osac-metering", "osac-metering/reconciler"), \
+        assert event.get("source") in ("osac-metering", "osac-metering/reconciler"), (
             f"Wrong source: {event.get('source')}"
+        )
         assert event.get("id"), "Missing event id"
         assert event.get("time"), "Missing event time"
-        assert event.get("osacresourceid") == expected.resource_id, \
+        assert event.get("osacresourceid") == expected.resource_id, (
             f"Wrong osacresourceid: {event.get('osacresourceid')}"
-        assert event.get("osacresourcetype") in ("compute_instance", "cluster_order"), \
+        )
+        assert event.get("osacresourcetype") in ("compute_instance", "cluster_order"), (
             f"Wrong osacresourcetype: {event.get('osacresourcetype')}"
+        )
         assert event.get("osactenant"), "Missing osactenant"
 
         data = event.get("data", {})
@@ -180,11 +183,7 @@ class MeteringCollector:
             except (ValueError, TypeError) as exc:
                 raise AssertionError(f"Invalid RFC3339 transition_time: {data.get('transition_time')}") from exc
 
-        transition_types = {
-            "osac.resource.started.v1",
-            "osac.resource.suspended.v1",
-            "osac.resource.resumed.v1",
-        }
+        transition_types = {"osac.resource.started.v1", "osac.resource.suspended.v1", "osac.resource.resumed.v1"}
         if expected.event_type in transition_types:
             assert "previous_state" in data, f"Missing previous_state in {expected.event_type}"
             assert "duration_seconds" in data, f"Missing duration_seconds in {expected.event_type}"
@@ -192,15 +191,13 @@ class MeteringCollector:
         if expected.event_type == "osac.resource.suspended.v1":
             valid = ("RUNNING", "STOPPING", "STARTING", "PROGRESSING", "READY")
             assert data.get("previous_state") in valid, (
-                f"suspended.v1 previous_state should be one of {valid}, "
-                f"got {data.get('previous_state')!r}"
+                f"suspended.v1 previous_state should be one of {valid}, got {data.get('previous_state')!r}"
             )
 
         if expected.event_type == "osac.resource.resumed.v1":
             valid = ("STOPPED", "PAUSED", "FAILED", "DELETE_FAILED")
             assert data.get("previous_state") in valid, (
-                f"resumed.v1 previous_state should be one of {valid}, "
-                f"got {data.get('previous_state')!r}"
+                f"resumed.v1 previous_state should be one of {valid}, got {data.get('previous_state')!r}"
             )
 
         resource_type = event.get("osacresourcetype")
@@ -215,9 +212,9 @@ def _validate_vmaas_billing(event: dict[str, Any]) -> None:
     assert bd.get("instance_type"), "Missing or empty instance_type in billing_dimensions"
     assert bd.get("image_ref"), "Missing or empty image_ref in billing_dimensions"
     assert "boot_disk_size_gib" in bd, "Missing boot_disk_size_gib in billing_dimensions"
-    assert isinstance(
-        bd["boot_disk_size_gib"], (int, float)
-    ), f"boot_disk_size_gib should be numeric, got {type(bd['boot_disk_size_gib']).__name__}"
+    assert isinstance(bd["boot_disk_size_gib"], (int, float)), (
+        f"boot_disk_size_gib should be numeric, got {type(bd['boot_disk_size_gib']).__name__}"
+    )
 
 
 def _validate_caas_billing(event: dict[str, Any], event_type: str) -> None:
@@ -228,9 +225,11 @@ def _validate_caas_billing(event: dict[str, Any], event_type: str) -> None:
     if event_type in ("osac.resource.created.v1", "osac.resource.deleted.v1"):
         assert bd.get("release_image"), "Missing release_image in billing_dimensions"
         return
-    assert bd.get("component") in ("control_plane", "worker"), \
+    assert bd.get("component") in ("control_plane", "worker"), (
         f"component should be control_plane or worker, got {bd.get('component')!r}"
+    )
     assert bd.get("node_set"), "Missing node_set in billing_dimensions"
     assert bd.get("host_type"), "Missing host_type in billing_dimensions"
-    assert isinstance(bd.get("node_count"), (int, float)) and bd["node_count"] > 0, \
+    assert isinstance(bd.get("node_count"), (int, float)) and bd["node_count"] > 0, (
         f"node_count should be positive number, got {bd.get('node_count')!r}"
+    )

--- a/tests/e2e/core/osac_cli.py
+++ b/tests/e2e/core/osac_cli.py
@@ -5,7 +5,7 @@ import shutil
 import tempfile
 from typing import Any
 
-from tests.core.runner import run, run_unchecked
+from tests.e2e.core.runner import run, run_unchecked
 
 
 class OsacCLI:
@@ -125,9 +125,7 @@ class OsacCLI:
 
                 storage_tier = disk.get("storage_tier")
                 if storage_tier is None:
-                    raise ValueError(
-                        f"additional_disks[{idx}]: 'storage_tier' is required, got None"
-                    )
+                    raise ValueError(f"additional_disks[{idx}]: 'storage_tier' is required, got None")
 
                 # Build --additional-disk flag value: size=<GiB>,storage-tier=<name>
                 disk_spec = f"size={size},storage-tier={storage_tier}"

--- a/tests/e2e/core/runner.py
+++ b/tests/e2e/core/runner.py
@@ -78,12 +78,13 @@ def poll_until(
                 f", last error: {last_error}" if last_error else "",
             )
             last_logged = now
-        time.sleep(delay)
+        if attempt + 1 < retries:
+            time.sleep(delay)
     if last_error is not None:
         raise TimeoutError(
-            f"{description} — timeout after {retries * delay}s, last call failed: {last_error}"
+            f"{description} — timeout after {max(retries - 1, 0) * delay}s, last call failed: {last_error}"
         ) from last_error
-    raise TimeoutError(f"{description} — timeout after {retries * delay}s, last value: {value!r}")
+    raise TimeoutError(f"{description} — timeout after {max(retries - 1, 0) * delay}s, last value: {value!r}")
 
 
 def env(name: str, default: str | None = None) -> str:

--- a/tests/e2e/projects/README.md
+++ b/tests/e2e/projects/README.md
@@ -23,7 +23,7 @@ Full lifecycle test that validates:
 
 - **Keycloak**: Must be accessible for organization/group verification
 - **Multiple Tenants**: tenant1 and tenant2 must exist
-- **JWT Authentication**: tenant1_admin, tenant1_user, tenant2_user must be configured
+- **JWT Authentication**: tenant1_admin, tenant1_user, tenant2_admin, tenant2_user must be configured
 - **Environment Variables**:
   - `OSAC_KEYCLOAK_URL`: Keycloak base URL
   - `OSAC_KEYCLOAK_ADMIN_PASSWORD`: Keycloak admin password (default: "admin")

--- a/tests/e2e/projects/conftest.py
+++ b/tests/e2e/projects/conftest.py
@@ -4,13 +4,13 @@ import logging
 import os
 import re
 import subprocess
-from typing import Generator
+from collections.abc import Generator
 from uuid import uuid4
 
 import pytest
 
-from tests.core.grpc_client import GRPCClient
-from tests.core.keycloak_admin import (
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.keycloak_admin import (
     get_admin_token,
     wait_for_organization,
     wait_for_project_in_keycloak,
@@ -34,12 +34,7 @@ def unique_name(prefix: str) -> str:
     return f"{prefix}-{uuid4().hex[:8]}"
 
 
-def _delete_project_teardown(
-    grpc: GRPCClient,
-    *,
-    project_id: str,
-    project_name: str,
-) -> None:
+def _delete_project_teardown(grpc: GRPCClient, *, project_id: str, project_name: str) -> None:
     """Delete a project, handling common errors gracefully."""
     try:
         grpc.delete_project(project_id=project_id)
@@ -51,12 +46,7 @@ def _delete_project_teardown(
             logger.warning("Project %s (%s) teardown delete failed: %s", project_name, project_id, combined.strip())
 
 
-def _delete_project_membership_teardown(
-    grpc: GRPCClient,
-    *,
-    membership_id: str,
-    membership_name: str,
-) -> None:
+def _delete_project_membership_teardown(grpc: GRPCClient, *, membership_id: str, membership_name: str) -> None:
     """Delete a project membership, handling common errors gracefully."""
     try:
         grpc.delete_project_membership(membership_id=membership_id)
@@ -72,10 +62,7 @@ def _delete_project_membership_teardown(
 
 @pytest.fixture(scope="function")
 def project_lifecycle_resources(
-    jwt_grpc_tenant1_admin: GRPCClient,
-    keycloak_url: str,
-    keycloak_admin_password: str,
-    skip_keycloak_sync_checks: bool,
+    jwt_grpc_tenant1_admin: GRPCClient, keycloak_url: str, keycloak_admin_password: str, skip_keycloak_sync_checks: bool
 ) -> Generator[dict[str, str | bool], None, None]:
     """
     Create parent project, child project, and project membership for lifecycle tests.
@@ -147,9 +134,7 @@ def project_lifecycle_resources(
         if child_project_id:
             _delete_project_teardown(jwt_grpc_tenant1_admin, project_id=child_project_id, project_name=child_name)
         if parent_project_id:
-            _delete_project_teardown(
-                jwt_grpc_tenant1_admin, project_id=parent_project_id, project_name=parent_name
-            )
+            _delete_project_teardown(jwt_grpc_tenant1_admin, project_id=parent_project_id, project_name=parent_name)
         raise
     finally:
         # Normal cleanup runs regardless of setup success/failure
@@ -177,9 +162,7 @@ def project_lifecycle_resources(
                     logger.warning("Child project %s still exists in Keycloak after deletion", child_name)
 
         if parent_project_id:
-            _delete_project_teardown(
-                jwt_grpc_tenant1_admin, project_id=parent_project_id, project_name=parent_name
-            )
+            _delete_project_teardown(jwt_grpc_tenant1_admin, project_id=parent_project_id, project_name=parent_name)
             # Verify parent removed from Keycloak with polling
             if not skip_keycloak_sync_checks and admin_token and org_id:
                 try:

--- a/tests/e2e/projects/test_project_e2e.py
+++ b/tests/e2e/projects/test_project_e2e.py
@@ -4,9 +4,9 @@ import subprocess
 
 import pytest
 
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import assert_grpc_rejected
-from tests.core.keycloak_admin import wait_for_project_not_in_keycloak
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import assert_grpc_rejected
+from tests.e2e.core.keycloak_admin import wait_for_project_not_in_keycloak
 
 
 def test_project_full_lifecycle(

--- a/tests/e2e/references/conftest.py
+++ b/tests/e2e/references/conftest.py
@@ -9,8 +9,8 @@ from uuid import uuid4
 
 import pytest
 
-from tests.core.grpc_client import PUBLIC_API, GRPCClient
-from tests.core.helpers import (
+from tests.e2e.core.grpc_client import PUBLIC_API, GRPCClient
+from tests.e2e.core.helpers import (
     wait_for_security_group_cr,
     wait_for_security_group_deletion,
     wait_for_security_group_ready,
@@ -21,7 +21,7 @@ from tests.core.helpers import (
     wait_for_virtual_network_deletion,
     wait_for_virtual_network_ready,
 )
-from tests.core.k8s_client import K8sClient
+from tests.e2e.core.k8s_client import K8sClient
 
 logger = logging.getLogger(__name__)
 

--- a/tests/e2e/references/test_cluster_baremetal_references.py
+++ b/tests/e2e/references/test_cluster_baremetal_references.py
@@ -9,10 +9,10 @@ from uuid import uuid4
 
 import pytest
 
-from tests.core.grpc_client import PRIVATE_API, PUBLIC_API, GRPCClient
-from tests.core.helpers import assert_grpc_field_violation
-from tests.core.osac_cli import OsacCLI
-from tests.core.runner import env
+from tests.e2e.core.grpc_client import PRIVATE_API, PUBLIC_API, GRPCClient
+from tests.e2e.core.helpers import assert_grpc_field_violation
+from tests.e2e.core.osac_cli import OsacCLI
+from tests.e2e.core.runner import env
 
 logger = logging.getLogger(__name__)
 
@@ -160,7 +160,11 @@ class TestClusterBareMetalReferences:
                 logger.warning("Failed to cleanup BMI catalog item %s", cat_id)
 
     def test_cross_tenant_cluster_template_reference(
-        self, private_grpc: GRPCClient, jwt_grpc_tenant1: GRPCClient, jwt_cli_user: OsacCLI, cluster_template: str,
+        self,
+        private_grpc: GRPCClient,
+        jwt_grpc_tenant1: GRPCClient,
+        jwt_cli_user: OsacCLI,
+        cluster_template: str,
         cluster_version: str,
     ):
         tag = uuid4().hex[:8]

--- a/tests/e2e/references/test_compute_references.py
+++ b/tests/e2e/references/test_compute_references.py
@@ -8,16 +8,16 @@ from uuid import uuid4
 
 import pytest
 
-from tests.core.grpc_client import PRIVATE_API, PUBLIC_API, GRPCClient
-from tests.core.helpers import (
+from tests.e2e.core.grpc_client import PRIVATE_API, PUBLIC_API, GRPCClient
+from tests.e2e.core.helpers import (
     assert_grpc_field_violation,
     wait_for_cr,
     wait_for_deletion,
     wait_for_provision,
     wait_for_running,
 )
-from tests.core.k8s_client import K8sClient
-from tests.core.runner import env
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.runner import env
 
 logger = logging.getLogger(__name__)
 

--- a/tests/e2e/references/test_iam_references.py
+++ b/tests/e2e/references/test_iam_references.py
@@ -8,9 +8,9 @@ from uuid import uuid4
 
 import pytest
 
-from tests.core.grpc_client import PUBLIC_API, GRPCClient
-from tests.core.helpers import assert_grpc_field_violation
-from tests.core.osac_cli import OsacCLI
+from tests.e2e.core.grpc_client import PUBLIC_API, GRPCClient
+from tests.e2e.core.helpers import assert_grpc_field_violation
+from tests.e2e.core.osac_cli import OsacCLI
 
 logger = logging.getLogger(__name__)
 
@@ -41,9 +41,7 @@ class TestIAMReferences:
         rb_name = f"ref-rb-{tag}"
 
         try:
-            rb_id = grpc.create_role_binding(
-                name=rb_name, role_name=TENANT_ADMIN_ROLE, user_names=[TENANT_ADMIN_USER]
-            )
+            rb_id = grpc.create_role_binding(name=rb_name, role_name=TENANT_ADMIN_ROLE, user_names=[TENANT_ADMIN_USER])
         except subprocess.CalledProcessError as exc:
             _skip_if_users_not_found(exc)
             raise
@@ -76,9 +74,7 @@ class TestIAMReferences:
             _skip_if_users_not_found(exc)
             raise
         try:
-            response: dict[str, Any] = grpc.call(
-                service=f"{PUBLIC_API}.ProjectMemberships/Get", data={"id": pm_id}
-            )
+            response: dict[str, Any] = grpc.call(service=f"{PUBLIC_API}.ProjectMemberships/Get", data={"id": pm_id})
             spec = response["object"]["spec"]
 
             users = spec["users"]

--- a/tests/e2e/references/test_ip_management_references.py
+++ b/tests/e2e/references/test_ip_management_references.py
@@ -7,8 +7,8 @@ from uuid import uuid4
 
 import pytest
 
-from tests.core.grpc_client import PRIVATE_API, PUBLIC_API, GRPCClient
-from tests.core.helpers import assert_grpc_field_violation
+from tests.e2e.core.grpc_client import PRIVATE_API, PUBLIC_API, GRPCClient
+from tests.e2e.core.helpers import assert_grpc_field_violation
 
 logger = logging.getLogger(__name__)
 

--- a/tests/e2e/references/test_networking_references.py
+++ b/tests/e2e/references/test_networking_references.py
@@ -5,15 +5,15 @@ import subprocess
 
 import pytest
 
-from tests.core.grpc_client import PUBLIC_API, GRPCClient
-from tests.core.helpers import (
+from tests.e2e.core.grpc_client import PUBLIC_API, GRPCClient
+from tests.e2e.core.helpers import (
     assert_grpc_field_violation,
     wait_for_security_group_cr,
     wait_for_security_group_deletion,
     wait_for_subnet_cr,
     wait_for_subnet_deletion,
 )
-from tests.core.k8s_client import K8sClient
+from tests.e2e.core.k8s_client import K8sClient
 
 logger = logging.getLogger(__name__)
 

--- a/tests/e2e/storage/conftest.py
+++ b/tests/e2e/storage/conftest.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-from tests.core.runner import env, run_unchecked
+from tests.e2e.core.runner import env, run_unchecked
 
 
 def _storage_controller_configured(namespace: str) -> bool:

--- a/tests/e2e/storage/test_caas_cluster_storage.py
+++ b/tests/e2e/storage/test_caas_cluster_storage.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from uuid import uuid4
 
 from tests.e2e.catalog.conftest import unique_name
-from tests.core.helpers import (
+from tests.e2e.core.helpers import (
     wait_for_cluster_deletion,
     wait_for_cluster_order_condition,
     wait_for_cluster_order_cr,
@@ -32,9 +32,9 @@ from tests.core.helpers import (
     wait_for_tenant_cr,
     wait_for_tenant_deletion,
 )
-from tests.core.k8s_client import K8sClient
-from tests.core.osac_cli import OsacCLI
-from tests.core.runner import poll_until
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.osac_cli import OsacCLI
+from tests.e2e.core.runner import poll_until
 
 _NAMESPACE_MANIFEST = textwrap.dedent("""\
     apiVersion: v1
@@ -54,11 +54,7 @@ _TENANT_MANIFEST = textwrap.dedent("""\
 
 
 def test_caas_cluster_storage_lifecycle(
-    k8s_hub_client: K8sClient,
-    cli: OsacCLI,
-    cluster_template: str,
-    pull_secret_path: str,
-    ssh_public_key_path: str,
+    k8s_hub_client: K8sClient, cli: OsacCLI, cluster_template: str, pull_secret_path: str, ssh_public_key_path: str
 ) -> None:
     tenant_name: str = f"test-caas-storage-{uuid4().hex[:8]}"
     namespace: str = k8s_hub_client.namespace

--- a/tests/e2e/storage/test_tenant_storage_lifecycle.py
+++ b/tests/e2e/storage/test_tenant_storage_lifecycle.py
@@ -12,14 +12,9 @@ from __future__ import annotations
 import textwrap
 from uuid import uuid4
 
-from tests.core.helpers import (
-    wait_for_tenant_condition,
-    wait_for_tenant_cr,
-    wait_for_tenant_deletion,
-)
-from tests.core.k8s_client import K8sClient
-from tests.core.runner import poll_until
-
+from tests.e2e.core.helpers import wait_for_tenant_condition, wait_for_tenant_cr, wait_for_tenant_deletion
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.runner import poll_until
 
 _NAMESPACE_MANIFEST = textwrap.dedent("""\
     apiVersion: v1
@@ -38,9 +33,7 @@ _TENANT_MANIFEST = textwrap.dedent("""\
 """)
 
 
-def test_tenant_storage_lifecycle(
-    k8s_hub_client: K8sClient, storage_config_namespace: str
-) -> None:
+def test_tenant_storage_lifecycle(k8s_hub_client: K8sClient, storage_config_namespace: str) -> None:
     tenant_name: str = f"test-storage-{uuid4().hex[:8]}"
     namespace: str = k8s_hub_client.namespace
 

--- a/tests/e2e/vmaas/conftest.py
+++ b/tests/e2e/vmaas/conftest.py
@@ -8,8 +8,8 @@ from collections.abc import Iterator
 
 import pytest
 
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import (
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import (
     wait_for_subnet_cr,
     wait_for_subnet_deletion,
     wait_for_subnet_ready,
@@ -18,9 +18,9 @@ from tests.core.helpers import (
     wait_for_virtual_network_deletion,
     wait_for_virtual_network_ready,
 )
-from tests.core.k8s_client import K8sClient
-from tests.core.osac_cli import OsacCLI
-from tests.core.runner import env
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.osac_cli import OsacCLI
+from tests.e2e.core.runner import env
 
 DEFAULT_IT_CORES: int = 2
 DEFAULT_IT_MEMORY_GIB: int = 4

--- a/tests/e2e/vmaas/external_ip/conftest.py
+++ b/tests/e2e/vmaas/external_ip/conftest.py
@@ -8,8 +8,8 @@ from uuid import uuid4
 import pytest
 
 from tests.e2e.catalog.conftest import unique_name
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import (
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import (
     wait_for_cr,
     wait_for_deletion,
     wait_for_external_ip_attachment_deletion,
@@ -20,17 +20,15 @@ from tests.core.helpers import (
     wait_for_external_ip_pool_ready,
     wait_for_running,
 )
-from tests.core.k8s_client import K8sClient
-from tests.core.osac_cli import OsacCLI
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.osac_cli import OsacCLI
 from tests.e2e.vmaas.external_ip.helpers import allocate_worker_subnet, create_ip
 
 logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="class")
-def make_pool(
-    grpc: GRPCClient, private_grpc: GRPCClient, k8s_hub_client: K8sClient
-) -> Generator[..., None, None]:
+def make_pool(grpc: GRPCClient, private_grpc: GRPCClient, k8s_hub_client: K8sClient) -> Generator[..., None, None]:
     created: list[tuple[str, str]] = []
 
     def _make(*, prefix: int = 24, name_prefix: str = "test-pool") -> tuple[str, str]:
@@ -135,10 +133,7 @@ def external_ip(
 
 @pytest.fixture(scope="class")
 def make_compute_instances(
-    cli: OsacCLI,
-    k8s_hub_client: K8sClient,
-    vm_template: str,
-    default_subnet: str,
+    cli: OsacCLI, k8s_hub_client: K8sClient, vm_template: str, default_subnet: str
 ) -> Generator[Callable[..., tuple[tuple[str, str], ...]], None, None]:
     created: list[tuple[str, str]] = []
 
@@ -147,9 +142,7 @@ def make_compute_instances(
         for _ in range(count):
             name = unique_name("e2e-ci")
             uuid = cli.create_compute_instance(
-                name=name,
-                template=vm_template,
-                network_attachments=[{"subnet": default_subnet}],
+                name=name, template=vm_template, network_attachments=[{"subnet": default_subnet}]
             )
             name = wait_for_cr(k8s=k8s_hub_client, uuid=uuid)
             created.append((uuid, name))

--- a/tests/e2e/vmaas/external_ip/helpers.py
+++ b/tests/e2e/vmaas/external_ip/helpers.py
@@ -6,9 +6,9 @@ import os
 from typing import Any
 from uuid import uuid4
 
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import wait_for_external_ip_allocated, wait_for_external_ip_cr
-from tests.core.k8s_client import K8sClient
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import wait_for_external_ip_allocated, wait_for_external_ip_cr
+from tests.e2e.core.k8s_client import K8sClient
 
 logger = logging.getLogger(__name__)
 
@@ -79,9 +79,7 @@ def pool_status(private_grpc: GRPCClient, pool_id: str) -> dict[str, Any]:
     }
 
 
-def create_ip(
-    grpc: GRPCClient, k8s: K8sClient, pool_id: str
-) -> tuple[str, str]:
+def create_ip(grpc: GRPCClient, k8s: K8sClient, pool_id: str) -> tuple[str, str]:
     ip_name: str = f"test-ip-{uuid4().hex[:8]}"
     ip_id: str = grpc.create_external_ip(name=ip_name, pool=pool_id)
     ip_cr_name: str = wait_for_external_ip_cr(k8s=k8s, uuid=ip_id)

--- a/tests/e2e/vmaas/external_ip/test_external_ip_pool_capacity.py
+++ b/tests/e2e/vmaas/external_ip/test_external_ip_pool_capacity.py
@@ -5,10 +5,10 @@ from uuid import uuid4
 
 import pytest
 
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import assert_grpc_rejected, wait_for_external_ip_pool_deletion
-from tests.core.k8s_client import K8sClient
-from tests.core.runner import poll_until
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import assert_grpc_rejected, wait_for_external_ip_pool_deletion
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.runner import poll_until
 from tests.e2e.vmaas.external_ip.helpers import create_ip, delete_ip, pool_status
 
 
@@ -20,11 +20,7 @@ class TestPoolCapacity:
     purposeful tradeoff to greatly reduce test execution time.
     """
 
-    def test_capacity_initialized_from_cidr(
-        self,
-        small_pool: tuple[str, str],
-        private_grpc: GRPCClient,
-    ) -> None:
+    def test_capacity_initialized_from_cidr(self, small_pool: tuple[str, str], private_grpc: GRPCClient) -> None:
         pool_id, _ = small_pool
         status = pool_status(private_grpc, pool_id)
         assert status["total"] == 2, f"Expected small pool to have 2 usable IPs, got {status['total']}"
@@ -90,9 +86,7 @@ class TestPoolCapacity:
         assert status["available"] == 0
 
     def test_pool_deletion_blocked_while_ips_allocated(
-        self,
-        small_pool: tuple[str, str],
-        private_grpc: GRPCClient,
+        self, small_pool: tuple[str, str], private_grpc: GRPCClient
     ) -> None:
         pool_id, _ = small_pool
         with pytest.raises(subprocess.CalledProcessError) as exc_info:

--- a/tests/e2e/vmaas/external_ip/test_external_ip_pool_lifecycle.py
+++ b/tests/e2e/vmaas/external_ip/test_external_ip_pool_lifecycle.py
@@ -6,8 +6,8 @@ from uuid import uuid4
 
 import pytest
 
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import (
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import (
     assert_grpc_rejected,
     wait_for_external_ip_allocated,
     wait_for_external_ip_attachment_cr,
@@ -16,8 +16,8 @@ from tests.core.helpers import (
     wait_for_external_ip_deletion,
     wait_for_external_ip_pool_deletion,
 )
-from tests.core.k8s_client import K8sClient
-from tests.core.runner import poll_until
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.runner import poll_until
 
 
 class TestExternalIPPoolLifecycle:
@@ -40,9 +40,7 @@ class TestExternalIPPoolLifecycle:
 
         # --- Attach ExternalIP to ComputeInstance 1 ---
         att_id: str = grpc.create_external_ip_attachment(
-            name=f"test-att-{uuid4().hex[:8]}",
-            external_ip=ip_id,
-            compute_instance=ci1_uuid,
+            name=f"test-att-{uuid4().hex[:8]}", external_ip=ip_id, compute_instance=ci1_uuid
         )
         att_cr_name: str = wait_for_external_ip_attachment_cr(k8s=k8s_hub_client, uuid=att_id)
         wait_for_external_ip_attachment_ready(k8s=k8s_hub_client, name=att_cr_name)
@@ -66,9 +64,7 @@ class TestExternalIPPoolLifecycle:
 
         # --- Re-attach same IP to ComputeInstance 2 ---
         att2_id: str = grpc.create_external_ip_attachment(
-            name=f"test-att-{uuid4().hex[:8]}",
-            external_ip=ip_id,
-            compute_instance=ci2_uuid,
+            name=f"test-att-{uuid4().hex[:8]}", external_ip=ip_id, compute_instance=ci2_uuid
         )
         att2_cr_name: str = wait_for_external_ip_attachment_cr(k8s=k8s_hub_client, uuid=att2_id)
         wait_for_external_ip_attachment_ready(k8s=k8s_hub_client, name=att2_cr_name)
@@ -120,9 +116,7 @@ class TestExternalIPPoolLifecycle:
         fake_ci_uuid: str = str(uuid4())
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
             grpc.create_external_ip_attachment(
-                name=f"test-att-{uuid4().hex[:8]}",
-                external_ip=ip_id,
-                compute_instance=fake_ci_uuid,
+                name=f"test-att-{uuid4().hex[:8]}", external_ip=ip_id, compute_instance=fake_ci_uuid
             )
         assert_grpc_rejected(exc_info, "InvalidArgument")
 
@@ -130,26 +124,20 @@ class TestExternalIPPoolLifecycle:
         fake_ip_uuid: str = str(uuid4())
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
             grpc.create_external_ip_attachment(
-                name=f"test-att-{uuid4().hex[:8]}",
-                external_ip=fake_ip_uuid,
-                compute_instance=ci1_uuid,
+                name=f"test-att-{uuid4().hex[:8]}", external_ip=fake_ip_uuid, compute_instance=ci1_uuid
             )
         assert_grpc_rejected(exc_info, "InvalidArgument")
 
         # Duplicate attachment — attach same ExternalIP twice
         att_id: str = grpc.create_external_ip_attachment(
-            name=f"test-att-{uuid4().hex[:8]}",
-            external_ip=ip_id,
-            compute_instance=ci1_uuid,
+            name=f"test-att-{uuid4().hex[:8]}", external_ip=ip_id, compute_instance=ci1_uuid
         )
         att_cr_name: str = wait_for_external_ip_attachment_cr(k8s=k8s_hub_client, uuid=att_id)
         wait_for_external_ip_attachment_ready(k8s=k8s_hub_client, name=att_cr_name)
 
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
             grpc.create_external_ip_attachment(
-                name=f"test-att-{uuid4().hex[:8]}",
-                external_ip=ip_id,
-                compute_instance=ci1_uuid,
+                name=f"test-att-{uuid4().hex[:8]}", external_ip=ip_id, compute_instance=ci1_uuid
             )
         assert_grpc_rejected(exc_info, "FailedPrecondition")
 

--- a/tests/e2e/vmaas/test_compute_instance_api_fields.py
+++ b/tests/e2e/vmaas/test_compute_instance_api_fields.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from tests.e2e.catalog.conftest import unique_name
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import wait_for_cr, wait_for_deletion, wait_for_provision, wait_for_running
-from tests.core.k8s_client import K8sClient
-from tests.core.osac_cli import OsacCLI
-from tests.core.runner import poll_until
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import wait_for_cr, wait_for_deletion, wait_for_provision, wait_for_running
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.osac_cli import OsacCLI
+from tests.e2e.core.runner import poll_until
 
 TEST_BOOT_DISK_SIZE: int = 20
 TEST_RUN_STRATEGY: str = "Always"
@@ -73,16 +73,12 @@ def test_compute_instance_api_fields(
     assert vm_status == "Running", f"VM should be Running, got {vm_status}"
 
     # Immutability: cores
-    output, rc = k8s_hub_client.patch(
-        resource="computeinstance", name=instance_name, patch='{"spec":{"cores":8}}'
-    )
+    output, rc = k8s_hub_client.patch(resource="computeinstance", name=instance_name, patch='{"spec":{"cores":8}}')
     assert rc != 0, "cores field should be immutable"
     assert "cores is immutable" in output, f"Expected immutability error, got: {output}"
 
     # Immutability: memoryGiB
-    output, rc = k8s_hub_client.patch(
-        resource="computeinstance", name=instance_name, patch='{"spec":{"memoryGiB":16}}'
-    )
+    output, rc = k8s_hub_client.patch(resource="computeinstance", name=instance_name, patch='{"spec":{"memoryGiB":16}}')
     assert rc != 0, "memoryGiB field should be immutable"
     assert "memoryGiB is immutable" in output, f"Expected immutability error, got: {output}"
 

--- a/tests/e2e/vmaas/test_compute_instance_cli_fields.py
+++ b/tests/e2e/vmaas/test_compute_instance_cli_fields.py
@@ -4,10 +4,10 @@ import base64
 from typing import Any
 
 from tests.e2e.catalog.conftest import unique_name
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import wait_for_cr, wait_for_deletion, wait_for_provision, wait_for_running
-from tests.core.k8s_client import K8sClient
-from tests.core.osac_cli import OsacCLI
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import wait_for_cr, wait_for_deletion, wait_for_provision, wait_for_running
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.osac_cli import OsacCLI
 from tests.e2e.vmaas.conftest import DEFAULT_IT_CORES, DEFAULT_IT_MEMORY_GIB
 
 TEST_BOOT_DISK_SIZE: int = 20
@@ -16,11 +16,7 @@ TEST_USER_DATA: str = "#cloud-config\npackages:\n  - vim\n"
 
 
 def test_compute_instance_cli_explicit_fields(
-    cli: OsacCLI,
-    grpc: GRPCClient,
-    k8s_hub_client: K8sClient,
-    default_subnet: str,
-    vm_template: str,
+    cli: OsacCLI, grpc: GRPCClient, k8s_hub_client: K8sClient, default_subnet: str, vm_template: str
 ) -> None:
     name = unique_name("e2e-ci")
     uuid: str = cli.create_compute_instance(
@@ -39,17 +35,15 @@ def test_compute_instance_cli_explicit_fields(
     ci_spec: dict[str, Any] = k8s_hub_client.get_json(resource="computeinstance", name=ci_name)
     spec: dict[str, Any] = ci_spec["spec"]
     assert spec["cores"] == DEFAULT_IT_CORES, f"cores mismatch: {spec['cores']} != {DEFAULT_IT_CORES}"
-    assert spec["memoryGiB"] == DEFAULT_IT_MEMORY_GIB, f"memoryGiB mismatch: {spec['memoryGiB']} != {DEFAULT_IT_MEMORY_GIB}"
+    assert spec["memoryGiB"] == DEFAULT_IT_MEMORY_GIB, (
+        f"memoryGiB mismatch: {spec['memoryGiB']} != {DEFAULT_IT_MEMORY_GIB}"
+    )
 
     # Verify osac.openshift.io/instance-type-name label is set by reconciler
     labels: dict[str, str] = ci_spec["metadata"].get("labels", {})
     it_label: str | None = labels.get("osac.openshift.io/instance-type-name")
-    assert it_label is not None, (
-        f"osac.openshift.io/instance-type-name label should be set, got: {it_label!r}"
-    )
-    assert len(it_label) > 0, (
-        f"osac.openshift.io/instance-type-name label should be non-empty, got: {it_label!r}"
-    )
+    assert it_label is not None, f"osac.openshift.io/instance-type-name label should be set, got: {it_label!r}"
+    assert len(it_label) > 0, f"osac.openshift.io/instance-type-name label should be non-empty, got: {it_label!r}"
 
     assert spec["bootDisk"]["sizeGiB"] == TEST_BOOT_DISK_SIZE, (
         f"bootDisk.sizeGiB mismatch: {spec['bootDisk']['sizeGiB']} != {TEST_BOOT_DISK_SIZE}"

--- a/tests/e2e/vmaas/test_compute_instance_creation.py
+++ b/tests/e2e/vmaas/test_compute_instance_creation.py
@@ -3,18 +3,17 @@ from __future__ import annotations
 import pytest
 
 from tests.e2e.catalog.conftest import unique_name
-
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import (
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import (
     wait_for_cr,
     wait_for_deletion,
     wait_for_grpc_removal,
     wait_for_provision,
     wait_for_running,
 )
-from tests.core.k8s_client import K8sClient
-from tests.core.metering import MeteringCollector
-from tests.core.osac_cli import OsacCLI
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.metering import MeteringCollector
+from tests.e2e.core.osac_cli import OsacCLI
 
 
 @pytest.mark.metering
@@ -29,9 +28,7 @@ def test_compute_instance_lifecycle(
 ) -> None:
     name = unique_name("e2e-ci")
     uuid: str = cli.create_compute_instance(
-        name=name,
-        template=vm_template,
-        network_attachments=[{"subnet": default_subnet}],
+        name=name, template=vm_template, network_attachments=[{"subnet": default_subnet}]
     )
     metering.expect("osac.resource.created.v1", resource_id=uuid)
 
@@ -48,8 +45,7 @@ def test_compute_instance_lifecycle(
     created_event = metering.get_event("osac.resource.created.v1", resource_id=uuid)
     bd = created_event.get("data", {}).get("billing_dimensions", {})
     assert bd.get("instance_type") == cli.default_instance_type, (
-        f"billing_dimensions.instance_type mismatch: "
-        f"{bd.get('instance_type')!r} != {cli.default_instance_type!r}"
+        f"billing_dimensions.instance_type mismatch: {bd.get('instance_type')!r} != {cli.default_instance_type!r}"
     )
 
     # Verify VM exists on virt cluster

--- a/tests/e2e/vmaas/test_compute_instance_delete_during_provision.py
+++ b/tests/e2e/vmaas/test_compute_instance_delete_during_provision.py
@@ -5,13 +5,12 @@ import time
 import pytest
 
 from tests.e2e.catalog.conftest import unique_name
-
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import wait_for_cr, wait_for_deletion, wait_for_grpc_removal
-from tests.core.k8s_client import K8sClient
-from tests.core.metering import MeteringCollector
-from tests.core.osac_cli import OsacCLI
-from tests.core.runner import poll_until
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import wait_for_cr, wait_for_deletion, wait_for_grpc_removal
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.metering import MeteringCollector
+from tests.e2e.core.osac_cli import OsacCLI
+from tests.e2e.core.runner import poll_until
 
 TERMINAL_JOB_STATES: tuple[str, ...] = ("Canceled", "Failed", "Succeeded")
 
@@ -20,7 +19,6 @@ def _get_deprovision_status(k8s: K8sClient, *, name: str) -> str:
     if not k8s.is_present(resource="computeinstance", name=name):
         return "cr_deleted"
     return k8s.get_compute_instance_latest_job_state(name=name, job_type="deprovision", checked=False)
-
 
 
 def _wait_for_provision_termination(k8s: K8sClient, *, name: str) -> None:
@@ -68,9 +66,7 @@ def test_compute_instance_delete_during_provision(
 ) -> None:
     name = unique_name("e2e-ci")
     uuid: str = cli.create_compute_instance(
-        name=name,
-        template=vm_template,
-        network_attachments=[{"subnet": default_subnet}],
+        name=name, template=vm_template, network_attachments=[{"subnet": default_subnet}]
     )
     metering.expect("osac.resource.created.v1", resource_id=uuid)
 

--- a/tests/e2e/vmaas/test_compute_instance_disk_image.py
+++ b/tests/e2e/vmaas/test_compute_instance_disk_image.py
@@ -5,8 +5,8 @@ from uuid import uuid4
 
 import pytest
 
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import (
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import (
     assert_grpc_rejected,
     wait_for_cr,
     wait_for_deletion,
@@ -14,7 +14,7 @@ from tests.core.helpers import (
     wait_for_provision,
     wait_for_running,
 )
-from tests.core.k8s_client import K8sClient
+from tests.e2e.core.k8s_client import K8sClient
 
 SOURCE_REF = "quay.io/containerdisks/fedora:41"
 

--- a/tests/e2e/vmaas/test_compute_instance_gpu.py
+++ b/tests/e2e/vmaas/test_compute_instance_gpu.py
@@ -5,11 +5,11 @@ import subprocess
 from typing import Any
 
 from tests.e2e.catalog.conftest import unique_name
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import wait_for_cr, wait_for_deletion, wait_for_grpc_removal
-from tests.core.k8s_client import K8sClient
-from tests.core.osac_cli import OsacCLI
-from tests.core.runner import poll_until
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import wait_for_cr, wait_for_deletion, wait_for_grpc_removal
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.osac_cli import OsacCLI
+from tests.e2e.core.runner import poll_until
 
 GPU_IT_CORES: int = 2
 GPU_IT_MEMORY_GIB: int = 4

--- a/tests/e2e/vmaas/test_compute_instance_heartbeat.py
+++ b/tests/e2e/vmaas/test_compute_instance_heartbeat.py
@@ -3,12 +3,17 @@ from __future__ import annotations
 import pytest
 
 from tests.e2e.catalog.conftest import unique_name
-
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import wait_for_cr, wait_for_deletion, wait_for_grpc_removal, wait_for_provision, wait_for_running
-from tests.core.k8s_client import K8sClient
-from tests.core.metering import MeteringCollector
-from tests.core.osac_cli import OsacCLI
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import (
+    wait_for_cr,
+    wait_for_deletion,
+    wait_for_grpc_removal,
+    wait_for_provision,
+    wait_for_running,
+)
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.metering import MeteringCollector
+from tests.e2e.core.osac_cli import OsacCLI
 
 
 @pytest.mark.metering
@@ -30,9 +35,7 @@ def test_compute_instance_heartbeat(
     """
     name = unique_name("e2e-ci")
     uuid: str = cli.create_compute_instance(
-        name=name,
-        template=vm_template,
-        network_attachments=[{"subnet": default_subnet}],
+        name=name, template=vm_template, network_attachments=[{"subnet": default_subnet}]
     )
 
     ci_name: str = wait_for_cr(k8s=k8s_hub_client, uuid=uuid)

--- a/tests/e2e/vmaas/test_compute_instance_instance_type.py
+++ b/tests/e2e/vmaas/test_compute_instance_instance_type.py
@@ -2,40 +2,42 @@ from __future__ import annotations
 
 import re
 import subprocess
-from typing import Any, Iterator
+from collections.abc import Iterator
+from typing import Any
 from uuid import uuid4
 
 import pytest
 
 from tests.e2e.catalog.conftest import unique_name
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import wait_for_cr, wait_for_deletion
-from tests.core.k8s_client import K8sClient
-from tests.core.osac_cli import OsacCLI
-from tests.core.runner import run_unchecked
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import wait_for_cr, wait_for_deletion
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.osac_cli import OsacCLI
+from tests.e2e.core.runner import run_unchecked
 
 IT_CORES: int = 2
 IT_MEMORY_GIB: int = 4
 
 
 def _build_create_ci_args(
-    cli: OsacCLI,
-    vm_template: str,
-    default_subnet: str,
-    it_name: str,
-    disk_image: str,
-    ci_name: str | None = None,
+    cli: OsacCLI, vm_template: str, default_subnet: str, it_name: str, disk_image: str, ci_name: str | None = None
 ) -> list[str]:
     args = [cli.binary, "--config", cli.config_dir, "create", "computeinstance"]
     if ci_name is not None:
         args += ["--name", ci_name]
     args += [
-        "--template", vm_template,
-        "--network-attachment", f"subnet={default_subnet}",
-        "--instance-type", it_name,
-        "--boot-disk-size", "20",
-        "--disk-image", disk_image,
-        "--run-strategy", "Always",
+        "--template",
+        vm_template,
+        "--network-attachment",
+        f"subnet={default_subnet}",
+        "--instance-type",
+        it_name,
+        "--boot-disk-size",
+        "20",
+        "--disk-image",
+        disk_image,
+        "--run-strategy",
+        "Always",
     ]
     return args
 
@@ -45,10 +47,7 @@ def active_instance_type(private_grpc: GRPCClient) -> Iterator[str]:
     """Create an ACTIVE instance type for testing; clean up after."""
     it_name = f"e2e-ci-it-{uuid4().hex[:8]}"
     private_grpc.create_instance_type(
-        name=it_name,
-        cores=IT_CORES,
-        memory_gib=IT_MEMORY_GIB,
-        description="E2E compute instance test type",
+        name=it_name, cores=IT_CORES, memory_gib=IT_MEMORY_GIB, description="E2E compute instance test type"
     )
     yield it_name
     try:
@@ -78,9 +77,7 @@ def test_compute_instance_happy_path(
             network_attachments=[{"subnet": default_subnet}],
             instance_type=active_instance_type,
         )
-        assert ci_uuid in grpc.list_compute_instance_ids(), (
-            f"ComputeInstance {ci_uuid} not found in list after create"
-        )
+        assert ci_uuid in grpc.list_compute_instance_ids(), f"ComputeInstance {ci_uuid} not found in list after create"
 
         # Wait for CR and verify reconciler expansion
         ci_name = wait_for_cr(k8s=k8s_hub_client, uuid=ci_uuid)
@@ -126,19 +123,17 @@ def test_compute_instance_deletion_protection(
             network_attachments=[{"subnet": default_subnet}],
             instance_type=active_instance_type,
         )
-        assert ci_uuid in grpc.list_compute_instance_ids(), (
-            f"ComputeInstance {ci_uuid} not found in list after create"
-        )
+        assert ci_uuid in grpc.list_compute_instance_ids(), f"ComputeInstance {ci_uuid} not found in list after create"
         ci_name = wait_for_cr(k8s=k8s_hub_client, uuid=ci_uuid)
 
         output, rc = run_unchecked(
-            private_cli.binary, "--config", private_cli.config_dir, "delete", "instancetype", active_instance_type,
+            private_cli.binary, "--config", private_cli.config_dir, "delete", "instancetype", active_instance_type
         )
         assert rc != 0, "delete should be rejected when ComputeInstance references instance type"
         error_lower = output.lower()
-        assert any(term in error_lower for term in [
-            "409", "conflict", "referenced", "failedprecondition", "in use",
-        ]), f"Expected conflict/reference error, got: {output}"
+        assert any(term in error_lower for term in ["409", "conflict", "referenced", "failedprecondition", "in use"]), (
+            f"Expected conflict/reference error, got: {output}"
+        )
     finally:
         if ci_uuid is not None:
             cli.delete_compute_instance(uuid=ci_uuid)
@@ -159,15 +154,17 @@ def test_compute_instance_deprecated_warning(
     deprecated_ci_name: str | None = None
 
     try:
-        private_grpc.update_instance_type(
-            name=active_instance_type, state="INSTANCE_TYPE_STATE_DEPRECATED",
-        )
+        private_grpc.update_instance_type(name=active_instance_type, state="INSTANCE_TYPE_STATE_DEPRECATED")
 
         dep_output, dep_rc = run_unchecked(
             *_build_create_ci_args(
-                cli, vm_template, default_subnet, active_instance_type, default_disk_image,
+                cli,
+                vm_template,
+                default_subnet,
+                active_instance_type,
+                default_disk_image,
                 ci_name=unique_name("e2e-ci"),
-            ),
+            )
         )
         assert dep_rc == 0, f"create with DEPRECATED type should succeed, got: {dep_output}"
         assert "deprecat" in dep_output.lower() or "warning" in dep_output.lower(), (
@@ -186,18 +183,12 @@ def test_compute_instance_deprecated_warning(
 
 
 def test_compute_instance_nonexistent_instance_type(
-    cli: OsacCLI,
-    k8s_hub_client: K8sClient,
-    default_subnet: str,
-    vm_template: str,
-    default_disk_image: str,
+    cli: OsacCLI, k8s_hub_client: K8sClient, default_subnet: str, vm_template: str, default_disk_image: str
 ) -> None:
     missing_it_name = f"nonexistent-it-{uuid4().hex[:8]}"
     ci_name = f"e2e-neg-{uuid4().hex[:8]}"
     output, rc = run_unchecked(
-        *_build_create_ci_args(
-            cli, vm_template, default_subnet, missing_it_name, default_disk_image, ci_name=ci_name,
-        ),
+        *_build_create_ci_args(cli, vm_template, default_subnet, missing_it_name, default_disk_image, ci_name=ci_name)
     )
     if rc == 0:
         uuid_match = re.search(r"'([^']+)'", output)
@@ -207,14 +198,12 @@ def test_compute_instance_nonexistent_instance_type(
             cli.delete_compute_instance(uuid=ci_uuid)
             wait_for_deletion(k8s=k8s_hub_client, name=cr_name)
         elif k8s_hub_client.is_present(resource="computeinstance", name=ci_name):
-            pytest.fail(
-                f"ComputeInstance CR {ci_name} leaked but UUID could not be parsed from output: {output}"
-            )
+            pytest.fail(f"ComputeInstance CR {ci_name} leaked but UUID could not be parsed from output: {output}")
     assert rc != 0, f"create with nonexistent instance type should fail, got: {output}"
     error_lower = output.lower()
-    assert any(term in error_lower for term in [
-        "not found", "404", "notfound",
-    ]), f"Expected not-found error, got: {output}"
+    assert any(term in error_lower for term in ["not found", "404", "notfound"]), (
+        f"Expected not-found error, got: {output}"
+    )
 
 
 def test_compute_instance_obsolete_instance_type(
@@ -226,18 +215,14 @@ def test_compute_instance_obsolete_instance_type(
     active_instance_type: str,
     default_disk_image: str,
 ) -> None:
-    private_grpc.update_instance_type(
-        name=active_instance_type, state="INSTANCE_TYPE_STATE_DEPRECATED",
-    )
-    private_grpc.update_instance_type(
-        name=active_instance_type, state="INSTANCE_TYPE_STATE_OBSOLETE",
-    )
+    private_grpc.update_instance_type(name=active_instance_type, state="INSTANCE_TYPE_STATE_DEPRECATED")
+    private_grpc.update_instance_type(name=active_instance_type, state="INSTANCE_TYPE_STATE_OBSOLETE")
 
     ci_name = f"e2e-obs-{uuid4().hex[:8]}"
     output, rc = run_unchecked(
         *_build_create_ci_args(
-            cli, vm_template, default_subnet, active_instance_type, default_disk_image, ci_name=ci_name,
-        ),
+            cli, vm_template, default_subnet, active_instance_type, default_disk_image, ci_name=ci_name
+        )
     )
     if rc == 0:
         uuid_match = re.search(r"'([^']+)'", output)
@@ -247,11 +232,9 @@ def test_compute_instance_obsolete_instance_type(
             cli.delete_compute_instance(uuid=ci_uuid)
             wait_for_deletion(k8s=k8s_hub_client, name=cr_name)
         elif k8s_hub_client.is_present(resource="computeinstance", name=ci_name):
-            pytest.fail(
-                f"ComputeInstance CR {ci_name} leaked but UUID could not be parsed from output: {output}"
-            )
+            pytest.fail(f"ComputeInstance CR {ci_name} leaked but UUID could not be parsed from output: {output}")
     assert rc != 0, f"create with OBSOLETE instance type should be rejected, got: {output}"
     error_lower = output.lower()
-    assert any(term in error_lower for term in [
-        "obsolete", "rejected", "failedprecondition", "409", "conflict",
-    ]), f"Expected rejection error for obsolete instance type, got: {output}"
+    assert any(term in error_lower for term in ["obsolete", "rejected", "failedprecondition", "409", "conflict"]), (
+        f"Expected rejection error for obsolete instance type, got: {output}"
+    )

--- a/tests/e2e/vmaas/test_compute_instance_restart.py
+++ b/tests/e2e/vmaas/test_compute_instance_restart.py
@@ -5,13 +5,12 @@ from datetime import UTC, datetime
 import pytest
 
 from tests.e2e.catalog.conftest import unique_name
-
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import wait_for_cr, wait_for_deletion, wait_for_restart, wait_for_running
-from tests.core.k8s_client import K8sClient
-from tests.core.metering import MeteringCollector
-from tests.core.osac_cli import OsacCLI
-from tests.core.runner import poll_until
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import wait_for_cr, wait_for_deletion, wait_for_restart, wait_for_running
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.metering import MeteringCollector
+from tests.e2e.core.osac_cli import OsacCLI
+from tests.e2e.core.runner import poll_until
 
 
 def _wait_for_new_vmi(k8s_virt: K8sClient, *, vmi_namespace: str, ci_name: str, original_ts: str) -> str:
@@ -37,9 +36,7 @@ def test_compute_instance_restart(
 ) -> None:
     name = unique_name("e2e-ci")
     uuid: str = cli.create_compute_instance(
-        name=name,
-        template=vm_template,
-        network_attachments=[{"subnet": default_subnet}],
+        name=name, template=vm_template, network_attachments=[{"subnet": default_subnet}]
     )
     metering.expect("osac.resource.created.v1", resource_id=uuid)
 

--- a/tests/e2e/vmaas/test_compute_instance_restart_negative.py
+++ b/tests/e2e/vmaas/test_compute_instance_restart_negative.py
@@ -4,24 +4,18 @@ import time
 from datetime import UTC, datetime
 
 from tests.e2e.catalog.conftest import unique_name
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import wait_for_cr, wait_for_deletion, wait_for_restart, wait_for_running
-from tests.core.k8s_client import K8sClient
-from tests.core.osac_cli import OsacCLI
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import wait_for_cr, wait_for_deletion, wait_for_restart, wait_for_running
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.osac_cli import OsacCLI
 
 
 def test_compute_instance_restart_past_timestamp_ignored(
-    cli: OsacCLI,
-    grpc: GRPCClient,
-    k8s_hub_client: K8sClient,
-    vm_template: str,
-    default_subnet: str,
+    cli: OsacCLI, grpc: GRPCClient, k8s_hub_client: K8sClient, vm_template: str, default_subnet: str
 ) -> None:
     name = unique_name("e2e-ci")
     uuid: str = cli.create_compute_instance(
-        template=vm_template,
-        name=name,
-        network_attachments=[{"subnet": default_subnet}],
+        template=vm_template, name=name, network_attachments=[{"subnet": default_subnet}]
     )
     ci_name: str = wait_for_cr(k8s=k8s_hub_client, uuid=uuid)
     wait_for_running(k8s=k8s_hub_client, name=ci_name)

--- a/tests/e2e/vmaas/test_compute_instance_short_lived_metering.py
+++ b/tests/e2e/vmaas/test_compute_instance_short_lived_metering.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import pytest
 
 from tests.e2e.catalog.conftest import unique_name
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import wait_for_cr, wait_for_deletion, wait_for_grpc_removal
-from tests.core.k8s_client import K8sClient
-from tests.core.metering import MeteringCollector
-from tests.core.osac_cli import OsacCLI
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import wait_for_cr, wait_for_deletion, wait_for_grpc_removal
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.metering import MeteringCollector
+from tests.e2e.core.osac_cli import OsacCLI
 
 
 @pytest.mark.metering
@@ -26,9 +26,7 @@ def test_short_lived_vm_metering(
     without waiting for it to reach Running.
     """
     uuid: str = cli.create_compute_instance(
-        name=unique_name("e2e-ci"),
-        template=vm_template,
-        network_attachments=[{"subnet": default_subnet}],
+        name=unique_name("e2e-ci"), template=vm_template, network_attachments=[{"subnet": default_subnet}]
     )
     metering.expect("osac.resource.created.v1", resource_id=uuid)
 

--- a/tests/e2e/vmaas/test_compute_instance_stop_metering.py
+++ b/tests/e2e/vmaas/test_compute_instance_stop_metering.py
@@ -6,18 +6,18 @@ from datetime import UTC, datetime
 import pytest
 
 from tests.e2e.catalog.conftest import unique_name
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import (
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import (
     wait_for_cr,
     wait_for_deletion,
     wait_for_grpc_removal,
     wait_for_provision,
     wait_for_running,
 )
-from tests.core.k8s_client import K8sClient
-from tests.core.metering import MeteringCollector
-from tests.core.osac_cli import OsacCLI
-from tests.core.runner import poll_until
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.metering import MeteringCollector
+from tests.e2e.core.osac_cli import OsacCLI
+from tests.e2e.core.runner import poll_until
 
 
 @pytest.mark.metering
@@ -36,9 +36,7 @@ def test_compute_instance_stop_metering(
     """
     name = unique_name("e2e-ci")
     uuid: str = cli.create_compute_instance(
-        name=name,
-        template=vm_template,
-        network_attachments=[{"subnet": default_subnet}],
+        name=name, template=vm_template, network_attachments=[{"subnet": default_subnet}]
     )
 
     ci_name: str = wait_for_cr(k8s=k8s_hub_client, uuid=uuid)
@@ -71,9 +69,7 @@ def test_compute_instance_stop_metering(
         f"Stop from RUNNING should have previous_state=RUNNING, got {suspended_data.get('previous_state')!r}"
     )
     ds = suspended_data.get("duration_seconds")
-    assert isinstance(ds, (int, float)) and ds > 0, (
-        f"Stop from RUNNING should have positive duration_seconds, got {ds}"
-    )
+    assert isinstance(ds, (int, float)) and ds > 0, f"Stop from RUNNING should have positive duration_seconds, got {ds}"
 
     # Verify heartbeats stop after VM becomes non-billable.
     # The heartbeat generator queries the projection DB, which is updated
@@ -82,12 +78,7 @@ def test_compute_instance_stop_metering(
     # interval so in-flight heartbeats drain, then assert silence.
     time.sleep(90)
     no_more_after = datetime.now(UTC).isoformat()
-    metering.assert_no_events(
-        "osac.resource.heartbeat.v1",
-        resource_id=uuid,
-        since=no_more_after,
-        within=90,
-    )
+    metering.assert_no_events("osac.resource.heartbeat.v1", resource_id=uuid, since=no_more_after, within=90)
 
     cli.delete_compute_instance(uuid=uuid)
     metering.expect("osac.resource.deleted.v1", resource_id=uuid)

--- a/tests/e2e/vmaas/test_compute_instance_storage_tier.py
+++ b/tests/e2e/vmaas/test_compute_instance_storage_tier.py
@@ -6,22 +6,14 @@ from typing import Any
 import pytest
 
 from tests.e2e.catalog.conftest import unique_name
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import (
-    assert_grpc_rejected,
-    wait_for_cr,
-    wait_for_deletion,
-    wait_for_provision,
-)
-from tests.core.k8s_client import K8sClient
-from tests.core.osac_cli import OsacCLI
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import assert_grpc_rejected, wait_for_cr, wait_for_deletion, wait_for_provision
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.osac_cli import OsacCLI
 
 
 def verify_datavolume_storage_classes(
-    k8s_hub_client: K8sClient,
-    k8s_virt_client: K8sClient,
-    ci_name: str,
-    cr: dict[str, Any],
+    k8s_hub_client: K8sClient, k8s_virt_client: K8sClient, ci_name: str, cr: dict[str, Any]
 ) -> None:
     """Verify that DataVolumes were created with correct StorageClasses.
 
@@ -29,7 +21,7 @@ def verify_datavolume_storage_classes(
     AAP currently uses global _requested_storage_tier and ignores per-disk storageTier fields.
     After PR #257 merges, uncomment the verify_datavolume_storage_classes() calls in tests.
     """
-    vmi_ns = k8s_hub_client.get_compute_instance_vm_namespace(name=ci_name)
+    _ = k8s_hub_client.get_compute_instance_vm_namespace(name=ci_name)
 
     # Verify boot disk
     boot_tier = cr["spec"]["bootDisk"]["storageTier"]
@@ -80,8 +72,7 @@ def test_compute_instance_explicit_boot_disk_tier(
         # Verify CR has the correct storage tier
         cr = k8s_hub_client.get_json(resource="computeinstance", name=ci_name)
         assert cr["spec"]["bootDisk"]["storageTier"] == default_storage_tier, (
-            f"Boot disk tier mismatch: "
-            f"{cr['spec']['bootDisk']['storageTier']!r} != {default_storage_tier!r}"
+            f"Boot disk tier mismatch: {cr['spec']['bootDisk']['storageTier']!r} != {default_storage_tier!r}"
         )
 
         # E2E: Verify DataVolume StorageClass (commented out until osac PR #257)
@@ -151,11 +142,7 @@ def test_compute_instance_multiple_disks_different_tiers(
 
 
 def test_compute_instance_nonexistent_tier_rejected(
-    private_grpc: GRPCClient,
-    vm_template: str,
-    default_subnet: str,
-    default_instance_type: str,
-    default_disk_image: str,
+    private_grpc: GRPCClient, vm_template: str, default_subnet: str, default_instance_type: str, default_disk_image: str
 ) -> None:
     """Verify that requesting a nonexistent storage tier returns INVALID_ARGUMENT."""
     nonexistent_tier = f"nonexistent-tier-{unique_name('test')}"
@@ -180,9 +167,9 @@ def test_compute_instance_nonexistent_tier_rejected(
 
     assert_grpc_rejected(exc_info, "InvalidArgument")
     error_lower = str(exc_info.value.stderr).lower()
-    assert any(term in error_lower for term in [
-        "not found", "does not exist", "notfound",
-    ]), f"Expected not-found/does-not-exist error, got: {exc_info.value.stderr}"
+    assert any(term in error_lower for term in ["not found", "does not exist", "notfound"]), (
+        f"Expected not-found/does-not-exist error, got: {exc_info.value.stderr}"
+    )
 
 
 def test_compute_instance_tier_immutability(
@@ -227,21 +214,16 @@ def test_compute_instance_tier_immutability(
 
         # Attempt to update the storage tier via K8s
         import json
+
         patch_json = json.dumps({"spec": {"bootDisk": {"storageTier": fast_tier}}})
-        output, rc = k8s_hub_client.patch(
-            resource="computeinstance",
-            name=ci_name,
-            patch=patch_json,
-        )
+        output, rc = k8s_hub_client.patch(resource="computeinstance", name=ci_name, patch=patch_json)
 
         # Verify patch was rejected
         assert rc != 0, "storage tier should be immutable"
 
         # Verify error mentions immutability
         error_output = output.lower()
-        assert "immutable" in error_output or "invalid" in error_output, (
-            f"Expected immutability error, got: {output}"
-        )
+        assert "immutable" in error_output or "invalid" in error_output, f"Expected immutability error, got: {output}"
     finally:
         grpc.delete_compute_instance(ci_id=uuid)
         if ci_name is not None:
@@ -252,11 +234,7 @@ def test_compute_instance_tier_immutability(
     reason="Requires mandatory storage_tier validation (follow-up osac PR after this test infrastructure lands)"
 )
 def test_compute_instance_boot_disk_tier_required(
-    private_grpc: GRPCClient,
-    vm_template: str,
-    default_subnet: str,
-    default_instance_type: str,
-    default_disk_image: str,
+    private_grpc: GRPCClient, vm_template: str, default_subnet: str, default_instance_type: str, default_disk_image: str
 ) -> None:
     """Verify that missing boot disk tier returns INVALID_ARGUMENT.
 
@@ -343,37 +321,14 @@ def test_compute_instance_boot_disk_tier_from_catalog_item_default(
             "editable": True,
             "default": default_storage_tier,
         },
-        {
-            "path": "boot_disk.size_gib",
-            "display_name": "Boot Disk Size",
-            "editable": True,
-        },
-        {
-            "path": "network_attachments",
-            "display_name": "Network Attachments",
-            "editable": True,
-        },
-        {
-            "path": "disk_image",
-            "display_name": "Disk Image",
-            "editable": True,
-        },
-        {
-            "path": "instance_type",
-            "display_name": "Instance Type",
-            "editable": True,
-        },
-        {
-            "path": "run_strategy",
-            "display_name": "Run Strategy",
-            "editable": True,
-        },
+        {"path": "boot_disk.size_gib", "display_name": "Boot Disk Size", "editable": True},
+        {"path": "network_attachments", "display_name": "Network Attachments", "editable": True},
+        {"path": "disk_image", "display_name": "Disk Image", "editable": True},
+        {"path": "instance_type", "display_name": "Instance Type", "editable": True},
+        {"path": "run_strategy", "display_name": "Run Strategy", "editable": True},
     ]
     catalog_item_id = private_grpc.create_compute_instance_catalog_item(
-        name=unique_name("e2e-cat-tier"),
-        template=vm_template,
-        published=True,
-        field_definitions=field_defs,
+        name=unique_name("e2e-cat-tier"), template=vm_template, published=True, field_definitions=field_defs
     )
 
     try:
@@ -465,37 +420,14 @@ def test_compute_instance_user_tier_overrides_catalog_item_default(
             "editable": True,
             "default": default_storage_tier,
         },
-        {
-            "path": "boot_disk.size_gib",
-            "display_name": "Boot Disk Size",
-            "editable": True,
-        },
-        {
-            "path": "network_attachments",
-            "display_name": "Network Attachments",
-            "editable": True,
-        },
-        {
-            "path": "disk_image",
-            "display_name": "Disk Image",
-            "editable": True,
-        },
-        {
-            "path": "instance_type",
-            "display_name": "Instance Type",
-            "editable": True,
-        },
-        {
-            "path": "run_strategy",
-            "display_name": "Run Strategy",
-            "editable": True,
-        },
+        {"path": "boot_disk.size_gib", "display_name": "Boot Disk Size", "editable": True},
+        {"path": "network_attachments", "display_name": "Network Attachments", "editable": True},
+        {"path": "disk_image", "display_name": "Disk Image", "editable": True},
+        {"path": "instance_type", "display_name": "Instance Type", "editable": True},
+        {"path": "run_strategy", "display_name": "Run Strategy", "editable": True},
     ]
     catalog_item_id = private_grpc.create_compute_instance_catalog_item(
-        name=unique_name("e2e-cat-override"),
-        template=vm_template,
-        published=True,
-        field_definitions=field_defs,
+        name=unique_name("e2e-cat-override"), template=vm_template, published=True, field_definitions=field_defs
     )
 
     try:
@@ -566,42 +498,15 @@ def test_compute_instance_explicit_additional_disks_without_catalog_item_default
             "editable": True,
             "default": default_storage_tier,
         },
-        {
-            "path": "boot_disk.size_gib",
-            "display_name": "Boot Disk Size",
-            "editable": True,
-        },
-        {
-            "path": "additional_disks",
-            "display_name": "Additional Disks",
-            "editable": True,
-        },
-        {
-            "path": "network_attachments",
-            "display_name": "Network Attachments",
-            "editable": True,
-        },
-        {
-            "path": "disk_image",
-            "display_name": "Disk Image",
-            "editable": True,
-        },
-        {
-            "path": "instance_type",
-            "display_name": "Instance Type",
-            "editable": True,
-        },
-        {
-            "path": "run_strategy",
-            "display_name": "Run Strategy",
-            "editable": True,
-        },
+        {"path": "boot_disk.size_gib", "display_name": "Boot Disk Size", "editable": True},
+        {"path": "additional_disks", "display_name": "Additional Disks", "editable": True},
+        {"path": "network_attachments", "display_name": "Network Attachments", "editable": True},
+        {"path": "disk_image", "display_name": "Disk Image", "editable": True},
+        {"path": "instance_type", "display_name": "Instance Type", "editable": True},
+        {"path": "run_strategy", "display_name": "Run Strategy", "editable": True},
     ]
     catalog_item_id = private_grpc.create_compute_instance_catalog_item(
-        name=unique_name("e2e-cat-no-add-def"),
-        template=vm_template,
-        published=True,
-        field_definitions=field_defs,
+        name=unique_name("e2e-cat-no-add-def"), template=vm_template, published=True, field_definitions=field_defs
     )
 
     try:
@@ -678,42 +583,15 @@ def test_compute_instance_additional_disks_from_catalog_item_default(
             "editable": True,
             "default": [{"size_gib": 10, "storage_tier": fast_tier}],
         },
-        {
-            "path": "boot_disk.size_gib",
-            "display_name": "Boot Disk Size",
-            "editable": True,
-        },
-        {
-            "path": "boot_disk.storage_tier",
-            "display_name": "Boot Disk Storage Tier",
-            "editable": True,
-        },
-        {
-            "path": "network_attachments",
-            "display_name": "Network Attachments",
-            "editable": True,
-        },
-        {
-            "path": "disk_image",
-            "display_name": "Disk Image",
-            "editable": True,
-        },
-        {
-            "path": "instance_type",
-            "display_name": "Instance Type",
-            "editable": True,
-        },
-        {
-            "path": "run_strategy",
-            "display_name": "Run Strategy",
-            "editable": True,
-        },
+        {"path": "boot_disk.size_gib", "display_name": "Boot Disk Size", "editable": True},
+        {"path": "boot_disk.storage_tier", "display_name": "Boot Disk Storage Tier", "editable": True},
+        {"path": "network_attachments", "display_name": "Network Attachments", "editable": True},
+        {"path": "disk_image", "display_name": "Disk Image", "editable": True},
+        {"path": "instance_type", "display_name": "Instance Type", "editable": True},
+        {"path": "run_strategy", "display_name": "Run Strategy", "editable": True},
     ]
     catalog_item_id = private_grpc.create_compute_instance_catalog_item(
-        name=unique_name("e2e-cat-add-disks"),
-        template=vm_template,
-        published=True,
-        field_definitions=field_defs,
+        name=unique_name("e2e-cat-add-disks"), template=vm_template, published=True, field_definitions=field_defs
     )
 
     try:
@@ -785,42 +663,15 @@ def test_compute_instance_user_additional_disks_override_catalog_item_default(
             "editable": True,
             "default": [{"size_gib": 10, "storage_tier": fast_tier}],
         },
-        {
-            "path": "boot_disk.size_gib",
-            "display_name": "Boot Disk Size",
-            "editable": True,
-        },
-        {
-            "path": "boot_disk.storage_tier",
-            "display_name": "Boot Disk Storage Tier",
-            "editable": True,
-        },
-        {
-            "path": "network_attachments",
-            "display_name": "Network Attachments",
-            "editable": True,
-        },
-        {
-            "path": "disk_image",
-            "display_name": "Disk Image",
-            "editable": True,
-        },
-        {
-            "path": "instance_type",
-            "display_name": "Instance Type",
-            "editable": True,
-        },
-        {
-            "path": "run_strategy",
-            "display_name": "Run Strategy",
-            "editable": True,
-        },
+        {"path": "boot_disk.size_gib", "display_name": "Boot Disk Size", "editable": True},
+        {"path": "boot_disk.storage_tier", "display_name": "Boot Disk Storage Tier", "editable": True},
+        {"path": "network_attachments", "display_name": "Network Attachments", "editable": True},
+        {"path": "disk_image", "display_name": "Disk Image", "editable": True},
+        {"path": "instance_type", "display_name": "Instance Type", "editable": True},
+        {"path": "run_strategy", "display_name": "Run Strategy", "editable": True},
     ]
     catalog_item_id = private_grpc.create_compute_instance_catalog_item(
-        name=unique_name("e2e-cat-add-override"),
-        template=vm_template,
-        published=True,
-        field_definitions=field_defs,
+        name=unique_name("e2e-cat-add-override"), template=vm_template, published=True, field_definitions=field_defs
     )
 
     try:
@@ -896,42 +747,15 @@ def test_compute_instance_empty_additional_disks_opts_out_of_catalog_item_defaul
             "editable": True,
             "default": [{"size_gib": 10, "storage_tier": fast_tier}],
         },
-        {
-            "path": "boot_disk.size_gib",
-            "display_name": "Boot Disk Size",
-            "editable": True,
-        },
-        {
-            "path": "boot_disk.storage_tier",
-            "display_name": "Boot Disk Storage Tier",
-            "editable": True,
-        },
-        {
-            "path": "network_attachments",
-            "display_name": "Network Attachments",
-            "editable": True,
-        },
-        {
-            "path": "disk_image",
-            "display_name": "Disk Image",
-            "editable": True,
-        },
-        {
-            "path": "instance_type",
-            "display_name": "Instance Type",
-            "editable": True,
-        },
-        {
-            "path": "run_strategy",
-            "display_name": "Run Strategy",
-            "editable": True,
-        },
+        {"path": "boot_disk.size_gib", "display_name": "Boot Disk Size", "editable": True},
+        {"path": "boot_disk.storage_tier", "display_name": "Boot Disk Storage Tier", "editable": True},
+        {"path": "network_attachments", "display_name": "Network Attachments", "editable": True},
+        {"path": "disk_image", "display_name": "Disk Image", "editable": True},
+        {"path": "instance_type", "display_name": "Instance Type", "editable": True},
+        {"path": "run_strategy", "display_name": "Run Strategy", "editable": True},
     ]
     catalog_item_id = private_grpc.create_compute_instance_catalog_item(
-        name=unique_name("e2e-cat-add-empty"),
-        template=vm_template,
-        published=True,
-        field_definitions=field_defs,
+        name=unique_name("e2e-cat-add-empty"), template=vm_template, published=True, field_definitions=field_defs
     )
 
     try:

--- a/tests/e2e/vmaas/test_console.py
+++ b/tests/e2e/vmaas/test_console.py
@@ -17,16 +17,16 @@ import pytest
 import websocket
 
 from tests.e2e.catalog.conftest import unique_name
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import (
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import (
     assert_grpc_rejected,
     wait_for_cr,
     wait_for_deletion,
     wait_for_provision,
     wait_for_running,
 )
-from tests.core.k8s_client import K8sClient
-from tests.core.osac_cli import OsacCLI
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.osac_cli import OsacCLI
 
 logger = logging.getLogger(__name__)
 

--- a/tests/e2e/vmaas/test_disk_image_lifecycle.py
+++ b/tests/e2e/vmaas/test_disk_image_lifecycle.py
@@ -5,8 +5,8 @@ from uuid import uuid4
 
 import pytest
 
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import assert_grpc_rejected
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import assert_grpc_rejected
 
 SOURCE_REF = "quay.io/containerdisks/fedora:41"
 

--- a/tests/e2e/vmaas/test_instance_type_lifecycle.py
+++ b/tests/e2e/vmaas/test_instance_type_lifecycle.py
@@ -4,8 +4,8 @@ import subprocess
 from typing import Any
 from uuid import uuid4
 
-from tests.core.grpc_client import GRPCClient, PRIVATE_API
-from tests.core.osac_cli import OsacCLI
+from tests.e2e.core.grpc_client import PRIVATE_API, GRPCClient
+from tests.e2e.core.osac_cli import OsacCLI
 
 TEST_CORES: int = 4
 TEST_MEMORY_GIB: int = 8
@@ -13,16 +13,12 @@ TEST_MEMORY_GIB: int = 8
 TEST_GPU: dict[str, Any] = {"pci_device_selector": "10DE:20B0", "resource_name": "nvidia.com/A100", "count": 1}
 
 
-def _assert_state_transition(
-    private_grpc: GRPCClient, it_name: str, target_state: str,
-) -> None:
+def _assert_state_transition(private_grpc: GRPCClient, it_name: str, target_state: str) -> None:
     """Update an InstanceType to *target_state* and verify the transition."""
     private_grpc.update_instance_type(name=it_name, state=target_state)
     response = private_grpc.get_instance_type(name=it_name)
     actual = response["object"]["spec"]["state"]
-    assert actual == target_state, (
-        f"state transition to {target_state}: {actual} != {target_state}"
-    )
+    assert actual == target_state, f"state transition to {target_state}: {actual} != {target_state}"
 
 
 def test_instance_type_lifecycle(cli: OsacCLI, private_grpc: GRPCClient) -> None:
@@ -31,10 +27,7 @@ def test_instance_type_lifecycle(cli: OsacCLI, private_grpc: GRPCClient) -> None
     try:
         # 1. CREATE via private gRPC (admin operation)
         private_grpc.create_instance_type(
-            name=it_name,
-            cores=TEST_CORES,
-            memory_gib=TEST_MEMORY_GIB,
-            description="Lifecycle test type",
+            name=it_name, cores=TEST_CORES, memory_gib=TEST_MEMORY_GIB, description="Lifecycle test type"
         )
         names: list[str] = private_grpc.list_instance_type_names()
         assert it_name in names, f"InstanceType {it_name} not found in list after create: {names}"
@@ -42,18 +35,14 @@ def test_instance_type_lifecycle(cli: OsacCLI, private_grpc: GRPCClient) -> None
         # 2. GET via gRPC (verify API fields)
         response: dict = private_grpc.get_instance_type(name=it_name)
         obj: dict = response["object"]
-        assert obj["spec"]["cores"] == TEST_CORES, (
-            f"spec.cores mismatch: {obj['spec']['cores']} != {TEST_CORES}"
-        )
+        assert obj["spec"]["cores"] == TEST_CORES, f"spec.cores mismatch: {obj['spec']['cores']} != {TEST_CORES}"
         assert obj["spec"]["memoryGib"] == TEST_MEMORY_GIB, (
             f"spec.memoryGib mismatch: {obj['spec']['memoryGib']} != {TEST_MEMORY_GIB}"
         )
         assert obj["spec"]["state"] == "INSTANCE_TYPE_STATE_ACTIVE", (
             f"spec.state mismatch: {obj['spec']['state']} != INSTANCE_TYPE_STATE_ACTIVE"
         )
-        assert obj["metadata"]["name"] == it_name, (
-            f"metadata.name mismatch: {obj['metadata']['name']} != {it_name}"
-        )
+        assert obj["metadata"]["name"] == it_name, f"metadata.name mismatch: {obj['metadata']['name']} != {it_name}"
 
         # Verify CLI describe works
         cli_output = cli.describe_instance_type(name=it_name)
@@ -74,14 +63,12 @@ def test_instance_type_lifecycle(cli: OsacCLI, private_grpc: GRPCClient) -> None
         assert it_name not in names, f"InstanceType {it_name} still in list after delete: {names}"
 
         # 7. NEGATIVE: get after delete should fail
-        output, rc = private_grpc.call_unchecked(
-            service=f"{PRIVATE_API}.InstanceTypes/Get", data={"id": it_name},
-        )
+        output, rc = private_grpc.call_unchecked(service=f"{PRIVATE_API}.InstanceTypes/Get", data={"id": it_name})
         assert rc != 0, f"get after delete should fail, but rc={rc}, output: {output}"
         error_lower = output.lower()
-        assert any(term in error_lower for term in [
-            "not found", "404", "notfound",
-        ]), f"Expected not-found error after delete, got: {output}"
+        assert any(term in error_lower for term in ["not found", "404", "notfound"]), (
+            f"Expected not-found error after delete, got: {output}"
+        )
 
     finally:
         try:
@@ -159,10 +146,7 @@ def test_gpu_instance_type(private_grpc: GRPCClient) -> None:
 
         # 2. LIST: GPU types are distinguishable from non-GPU types
         private_grpc.create_instance_type(
-            name=nogpu_name,
-            cores=TEST_CORES,
-            memory_gib=TEST_MEMORY_GIB,
-            description="Non-GPU lifecycle test type",
+            name=nogpu_name, cores=TEST_CORES, memory_gib=TEST_MEMORY_GIB, description="Non-GPU lifecycle test type"
         )
 
         list_response: dict[str, Any] = private_grpc.call(service=f"{PRIVATE_API}.InstanceTypes/List")
@@ -173,9 +157,7 @@ def test_gpu_instance_type(private_grpc: GRPCClient) -> None:
         assert len(gpu_items) == 1, f"GPU InstanceType {gpu_name} not found in list"
         assert len(nogpu_items) == 1, f"Non-GPU InstanceType {nogpu_name} not found in list"
         assert "gpu" in gpu_items[0]["spec"], f"GPU type should have gpu field: {gpu_items[0]['spec']}"
-        assert "gpu" not in nogpu_items[0]["spec"], (
-            f"Non-GPU type should not have gpu field: {nogpu_items[0]['spec']}"
-        )
+        assert "gpu" not in nogpu_items[0]["spec"], f"Non-GPU type should not have gpu field: {nogpu_items[0]['spec']}"
 
         # 3. IMMUTABILITY: update attempt with different GPU is rejected
         output, rc = private_grpc.call_unchecked(
@@ -184,11 +166,7 @@ def test_gpu_instance_type(private_grpc: GRPCClient) -> None:
                 "object": {
                     "id": gpu_name,
                     "spec": {
-                        "gpu": {
-                            "pci_device_selector": "10DE:2204",
-                            "resource_name": "nvidia.com/A10",
-                            "count": 2,
-                        }
+                        "gpu": {"pci_device_selector": "10DE:2204", "resource_name": "nvidia.com/A10", "count": 2}
                     },
                 }
             },
@@ -197,9 +175,7 @@ def test_gpu_instance_type(private_grpc: GRPCClient) -> None:
         assert "immutable" in output.lower(), f"Expected immutability error, got: {output}"
 
         response = private_grpc.get_instance_type(name=gpu_name)
-        assert response["object"]["spec"]["gpu"] == gpu, (
-            "GPU fields should be unchanged after rejected update"
-        )
+        assert response["object"]["spec"]["gpu"] == gpu, "GPU fields should be unchanged after rejected update"
 
     finally:
         for name in (gpu_name, nogpu_name):

--- a/tests/e2e/vmaas/test_jwt_auth_smoke.py
+++ b/tests/e2e/vmaas/test_jwt_auth_smoke.py
@@ -5,9 +5,9 @@ from uuid import uuid4
 
 import pytest
 
-from tests.core.grpc_client import GRPCClient
-from tests.core.osac_cli import OsacCLI
-from tests.core.runner import run_unchecked
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.osac_cli import OsacCLI
+from tests.e2e.core.runner import run_unchecked
 
 CLIENT_LISTABLE_RESOURCES = [
     "clustertemplates",
@@ -94,9 +94,7 @@ def test_jwt_security_group_lifecycle(jwt_grpc_tenant1: GRPCClient) -> None:
         pytest.fail(f"VirtualNetwork {vn_id} did not reach READY state within 180s")
 
     subnet_name: str = f"jwt-sg-subnet-{uuid4().hex[:8]}"
-    subnet_id: str = jwt_grpc_tenant1.create_subnet(
-        name=subnet_name, virtual_network=vn_id, ipv4_cidr="10.202.1.0/24",
-    )
+    subnet_id: str = jwt_grpc_tenant1.create_subnet(name=subnet_name, virtual_network=vn_id, ipv4_cidr="10.202.1.0/24")
     for _ in range(90):
         sn = jwt_grpc_tenant1.get_subnet(subnet_id=subnet_id)
         if sn["object"].get("status", {}).get("state") == "SUBNET_STATE_READY":

--- a/tests/e2e/vmaas/test_metadata_name_validation.py
+++ b/tests/e2e/vmaas/test_metadata_name_validation.py
@@ -6,15 +6,15 @@ import uuid
 
 import pytest
 
-from tests.core.grpc_client import PUBLIC_API, GRPCClient
-from tests.core.helpers import (
+from tests.e2e.core.grpc_client import PUBLIC_API, GRPCClient
+from tests.e2e.core.helpers import (
     assert_grpc_rejected,
     wait_for_virtual_network_cr,
     wait_for_virtual_network_deletion,
     wait_for_virtual_network_ready,
 )
-from tests.core.k8s_client import K8sClient
-from tests.core.runner import poll_until
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.runner import poll_until
 
 
 def _grpc_error_message(exc: subprocess.CalledProcessError) -> str:

--- a/tests/e2e/vmaas/test_name_immutability.py
+++ b/tests/e2e/vmaas/test_name_immutability.py
@@ -5,8 +5,8 @@ import uuid
 
 import pytest
 
-from tests.core.grpc_client import PUBLIC_API, GRPCClient
-from tests.core.helpers import assert_grpc_rejected
+from tests.e2e.core.grpc_client import PUBLIC_API, GRPCClient
+from tests.e2e.core.helpers import assert_grpc_rejected
 
 
 def _grpc_error_output(exc: subprocess.CalledProcessError) -> str:

--- a/tests/e2e/vmaas/test_name_uniqueness.py
+++ b/tests/e2e/vmaas/test_name_uniqueness.py
@@ -6,14 +6,14 @@ import uuid
 
 import pytest
 
-from tests.core.grpc_client import PUBLIC_API, GRPCClient
-from tests.core.helpers import (
+from tests.e2e.core.grpc_client import PUBLIC_API, GRPCClient
+from tests.e2e.core.helpers import (
     assert_grpc_rejected,
     wait_for_virtual_network_cr,
     wait_for_virtual_network_deletion,
     wait_for_virtual_network_ready,
 )
-from tests.core.k8s_client import K8sClient
+from tests.e2e.core.k8s_client import K8sClient
 
 
 def _grpc_error_message(exc: subprocess.CalledProcessError) -> str:

--- a/tests/e2e/vmaas/test_security_group_lifecycle.py
+++ b/tests/e2e/vmaas/test_security_group_lifecycle.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from uuid import uuid4
 
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import (
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import (
     wait_for_security_group_cr,
     wait_for_security_group_deletion,
     wait_for_security_group_ready,
@@ -14,8 +14,8 @@ from tests.core.helpers import (
     wait_for_virtual_network_deletion,
     wait_for_virtual_network_ready,
 )
-from tests.core.k8s_client import K8sClient
-from tests.core.runner import poll_until
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.runner import poll_until
 
 
 def test_security_group_lifecycle(grpc: GRPCClient, k8s_hub_client: K8sClient) -> None:

--- a/tests/e2e/vmaas/test_subnet_lifecycle.py
+++ b/tests/e2e/vmaas/test_subnet_lifecycle.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from uuid import uuid4
 
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import (
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import (
     wait_for_subnet_cr,
     wait_for_subnet_deletion,
     wait_for_subnet_ready,
@@ -11,8 +11,8 @@ from tests.core.helpers import (
     wait_for_virtual_network_deletion,
     wait_for_virtual_network_ready,
 )
-from tests.core.k8s_client import K8sClient
-from tests.core.runner import poll_until
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.runner import poll_until
 
 
 def test_subnet_lifecycle(grpc: GRPCClient, k8s_hub_client: K8sClient) -> None:

--- a/tests/e2e/vmaas/test_virtual_network_lifecycle.py
+++ b/tests/e2e/vmaas/test_virtual_network_lifecycle.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from uuid import uuid4
 
-from tests.core.grpc_client import GRPCClient
-from tests.core.helpers import (
+from tests.e2e.core.grpc_client import GRPCClient
+from tests.e2e.core.helpers import (
     wait_for_virtual_network_cr,
     wait_for_virtual_network_deletion,
     wait_for_virtual_network_ready,
 )
-from tests.core.k8s_client import K8sClient
-from tests.core.runner import poll_until
+from tests.e2e.core.k8s_client import K8sClient
+from tests.e2e.core.runner import poll_until
 
 
 def test_virtual_network_lifecycle(grpc: GRPCClient, k8s_hub_client: K8sClient) -> None:


### PR DESCRIPTION
- Moves shared test utilities (grpc_client, k8s_client, keycloak, osac_cli, runner, helpers, metering) into tests/e2e/core/ and updates all imports.
- Moves projects directory and conftest.py into tests/e2e directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded validation of boot-disk storage tiers during compute instance creation.
  * Improved end-to-end coverage across compute, networking, storage, catalog, project, and reference workflows.
  * Improved polling timeout reporting and handling of incomplete metering events.
  * Standardized shared test utilities across end-to-end scenarios.

* **Documentation**
  * Updated Projects API end-to-end testing prerequisites, including the required test account configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->