### PR TITLE
OSAC-2486: Add E2E tests for default networking and auto ExternalIP

### DIFF
--- a/tests/core/grpc_client.py
+++ b/tests/core/grpc_client.py
@@ -43,9 +43,20 @@ class GRPCClient:
     def call(self, *, service: str, data: dict[str, Any] | None = None) -> dict[str, Any]:
         return json.loads(run(*self._build_args(service=service, data=data)))
 
-    def create_compute_instance(self, *, catalog_item: str, subnet_ids: list[str], name: str | None = None) -> str:
-        attachments = [{"subnet": {"id": sid}} for sid in subnet_ids]
-        obj: dict[str, Any] = {"spec": {"catalog_item": {"id": catalog_item}, "network_attachments": attachments}}
+    def create_compute_instance(
+        self,
+        *,
+        catalog_item: str,
+        subnet_ids: list[str] | None = None,
+        name: str | None = None,
+        auto_external_ip_attachment: bool = False,
+    ) -> str:
+        spec: dict[str, Any] = {"catalog_item": {"id": catalog_item}}
+        if subnet_ids is not None:
+            spec["network_attachments"] = [{"subnet": {"id": sid}} for sid in subnet_ids]
+        if auto_external_ip_attachment:
+            spec["auto_external_ip_attachment"] = True
+        obj: dict[str, Any] = {"spec": spec}
         if name is not None:
             obj["metadata"] = {"name": name}
         response: dict[str, Any] = self.call(service=f"{PUBLIC_API}.ComputeInstances/Create", data={"object": obj})
@@ -84,6 +95,10 @@ class GRPCClient:
 
     # VirtualNetwork operations
 
+    def list_virtual_networks(self) -> list[dict[str, Any]]:
+        response: dict[str, Any] = self.call(service=f"{PUBLIC_API}.VirtualNetworks/List")
+        return response.get("items", [])
+
     def create_virtual_network(self, *, name: str, ipv4_cidr: str) -> str:
         response: dict[str, Any] = self.call(
             service=f"{PUBLIC_API}.VirtualNetworks/Create",
@@ -102,6 +117,10 @@ class GRPCClient:
         self.call(service=f"{PUBLIC_API}.VirtualNetworks/Delete", data={"id": vn_id})
 
     # Subnet operations
+
+    def list_subnets(self) -> list[dict[str, Any]]:
+        response: dict[str, Any] = self.call(service=f"{PUBLIC_API}.Subnets/List")
+        return response.get("items", [])
 
     def create_subnet(self, *, name: str, virtual_network: str, ipv4_cidr: str) -> str:
         response: dict[str, Any] = self.call(
@@ -138,6 +157,10 @@ class GRPCClient:
         return self.call(service=f"{PUBLIC_API}.Clusters/Get", data={"id": cluster_id})
 
     # SecurityGroup operations
+
+    def list_security_groups(self) -> list[dict[str, Any]]:
+        response: dict[str, Any] = self.call(service=f"{PUBLIC_API}.SecurityGroups/List")
+        return response.get("items", [])
 
     def create_security_group(self, *, name: str, virtual_network: str) -> str:
         response: dict[str, Any] = self.call(
@@ -226,15 +249,41 @@ class GRPCClient:
                     continue
                 raise RuntimeError(f"Failed to create tenant '{name}': {output}") from e
 
+    def get_tenant_condition_status(self, *, name: str, condition_type: str) -> str:
+        proto_type = "TENANT_CONDITION_TYPE_" + re.sub(r"(?<!^)(?=[A-Z])", "_", condition_type).upper()
+        response = self.call(
+            service=f"{PRIVATE_API}.Tenants/List", data={"filter": f'this.metadata.name == "{name}"', "limit": 1}
+        )
+        items = response.get("items", [])
+        if not items:
+            return ""
+        for cond in items[0].get("status", {}).get("conditions", []):
+            if cond.get("type") == proto_type:
+                raw = cond.get("status", "")
+                if raw == "CONDITION_STATUS_TRUE":
+                    return "True"
+                if raw == "CONDITION_STATUS_FALSE":
+                    return "False"
+                return raw
+        return ""
+
+    def get_tenant_condition_reason(self, *, name: str, condition_type: str) -> str:
+        proto_type = "TENANT_CONDITION_TYPE_" + re.sub(r"(?<!^)(?=[A-Z])", "_", condition_type).upper()
+        response = self.call(
+            service=f"{PRIVATE_API}.Tenants/List", data={"filter": f'this.metadata.name == "{name}"', "limit": 1}
+        )
+        items = response.get("items", [])
+        if not items:
+            return ""
+        for cond in items[0].get("status", {}).get("conditions", []):
+            if cond.get("type") == proto_type:
+                return cond.get("reason", "")
+        return ""
+
     # ExternalIPPool operations (private API only)
 
     def create_external_ip_pool(
-        self,
-        *,
-        name: str,
-        cidrs: list[str],
-        ip_family: str = "IP_FAMILY_IPV4",
-        implementation_strategy: str = "",
+        self, *, name: str, cidrs: list[str], ip_family: str = "IP_FAMILY_IPV4", implementation_strategy: str = ""
     ) -> str:
         response: dict[str, Any] = self.call(
             service=f"{PRIVATE_API}.ExternalIPPools/Create",
@@ -263,6 +312,10 @@ class GRPCClient:
 
     # ExternalIP operations (public API)
 
+    def list_external_ips(self) -> list[dict[str, Any]]:
+        response: dict[str, Any] = self.call(service=f"{PUBLIC_API}.ExternalIPs/List")
+        return response.get("items", [])
+
     def create_external_ip(self, *, name: str, pool: str) -> str:
         response: dict[str, Any] = self.call(
             service=f"{PUBLIC_API}.ExternalIPs/Create",
@@ -281,6 +334,10 @@ class GRPCClient:
         self.call(service=f"{PUBLIC_API}.ExternalIPs/Delete", data={"id": external_ip_id})
 
     # ExternalIPAttachment operations (public API)
+
+    def list_external_ip_attachments(self) -> list[dict[str, Any]]:
+        response: dict[str, Any] = self.call(service=f"{PUBLIC_API}.ExternalIPAttachments/List")
+        return response.get("items", [])
 
     def create_external_ip_attachment(self, *, name: str, external_ip: str, compute_instance: str) -> str:
         response: dict[str, Any] = self.call(
@@ -650,6 +707,13 @@ class GRPCClient:
         return response.get("items", [])
 
     # NATGateway operations (public API)
+
+    def list_nat_gateways(self) -> list[dict[str, Any]]:
+        response: dict[str, Any] = self.call(service=f"{PUBLIC_API}.NATGateways/List")
+        return response.get("items", [])
+
+    def get_nat_gateway(self, *, nat_gateway_id: str) -> dict[str, Any]:
+        return self.call(service=f"{PUBLIC_API}.NATGateways/Get", data={"id": nat_gateway_id})
 
     def create_nat_gateway(self, *, name: str, virtual_network_name: str, external_ip_name: str) -> str:
         response: dict[str, Any] = self.call(

--- a/tests/core/helpers.py
+++ b/tests/core/helpers.py
@@ -266,6 +266,16 @@ def wait_for_external_ip_attachment_deletion(*, k8s: K8sClient, name: str) -> No
     )
 
 
+def wait_for_nat_gateway_cr(*, k8s: K8sClient, uuid: str) -> str:
+    return poll_until(
+        fn=lambda: k8s.get_nat_gateway_name(uuid=uuid, checked=False),
+        until=lambda v: v != "",
+        retries=30,
+        delay=2,
+        description=f"NATGateway CR for {uuid}",
+    )
+
+
 # NATGateway helpers
 
 
@@ -549,6 +559,18 @@ def wait_for_tenant_condition(*, k8s: K8sClient, name: str, condition_type: str,
     )
 
 
+def wait_for_grpc_tenant_condition(
+    *, grpc: GRPCClient, name: str, condition_type: str, expected_status: str = "True"
+) -> None:
+    poll_until(
+        fn=lambda: grpc.get_tenant_condition_status(name=name, condition_type=condition_type),
+        until=lambda v: v == expected_status,
+        retries=120,
+        delay=5,
+        description=f"Tenant {name} {condition_type}={expected_status} (gRPC)",
+    )
+
+
 def wait_for_tenant_deletion(*, k8s: K8sClient, name: str) -> None:
     poll_until(
         fn=lambda: not k8s.is_present(resource="tenant", name=name),
@@ -675,12 +697,7 @@ def wait_for_bmi_running(*, grpc: GRPCClient, bmi_id: str) -> None:
 
 
 def assert_bmi_lifecycle_on_running(
-    *,
-    grpc: GRPCClient,
-    k8s: K8sClient,
-    bmi_id: str,
-    bmh_namespace: str,
-    power_cycle: bool = True,
+    *, grpc: GRPCClient, k8s: K8sClient, bmi_id: str, bmh_namespace: str, power_cycle: bool = True
 ) -> tuple[str, str]:
     """Assert BMH binding/provisioning on an already-RUNNING BMI.
 

--- a/tests/core/k8s_client.py
+++ b/tests/core/k8s_client.py
@@ -215,6 +215,28 @@ class K8sClient:
         dv = self.get_json(resource="datavolume", name=name)
         return dv.get("spec", {}).get("pvc", {}).get("storageClassName", "")
 
+    # NATGateway queries
+
+    def get_nat_gateway_name(self, *, uuid: str, checked: bool = True) -> str:
+        output, rc = self._get(
+            "get",
+            "natgateway",
+            "-n",
+            self.namespace,
+            "-l",
+            f"osac.openshift.io/natgateway-uuid={uuid}",
+            "-o",
+            "jsonpath={.items[0].metadata.name}",
+            checked=checked,
+        )
+        return output if rc == 0 else ""
+
+    def get_nat_gateway_phase(self, *, name: str, checked: bool = True) -> str:
+        output, rc = self._get(
+            "get", "natgateway", name, "-n", self.namespace, "-o", "jsonpath={.status.phase}", checked=checked
+        )
+        return output if rc == 0 else ""
+
     # ExternalIPPool queries
 
     def get_external_ip_pool_name(self, *, uuid: str, checked: bool = True) -> str:

--- a/tests/core/osac_cli.py
+++ b/tests/core/osac_cli.py
@@ -79,6 +79,7 @@ class OsacCLI:
         run_strategy: str = "Always",
         user_data_secret_ref: str | None = None,
         instance_type: str | None = None,
+        external_ip_attachment: bool = False,
     ) -> str:
         args: list[str] = [
             "create",
@@ -125,9 +126,7 @@ class OsacCLI:
 
                 storage_tier = disk.get("storage_tier")
                 if storage_tier is None:
-                    raise ValueError(
-                        f"additional_disks[{idx}]: 'storage_tier' is required, got None"
-                    )
+                    raise ValueError(f"additional_disks[{idx}]: 'storage_tier' is required, got None")
 
                 # Build --additional-disk flag value: size=<GiB>,storage-tier=<name>
                 disk_spec = f"size={size},storage-tier={storage_tier}"
@@ -161,6 +160,9 @@ class OsacCLI:
 
         if user_data_secret_ref is not None:
             args.extend(["--user-data", user_data_secret_ref])
+
+        if external_ip_attachment:
+            args.append("--external-ip-attachment")
 
         return self._parse_uuid(self._run(*args))
 

--- a/tests/e2e/vmaas/test_auto_external_ip.py
+++ b/tests/e2e/vmaas/test_auto_external_ip.py
@@ -1,0 +1,227 @@
+"""E2E tests for OSAC-2486: Auto ExternalIP attachment lifecycle.
+
+Tests:
+1. Auto ExternalIP + ExternalIPAttachment created with correct labels on CI creation
+2. Auto-cleanup on ComputeInstance deletion (resources removed, pool capacity restored)
+3. Pool exhaustion returns FailedPrecondition
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from collections.abc import Iterator
+from uuid import uuid4
+
+import pytest
+
+from tests.catalog.conftest import unique_name
+from tests.core.grpc_client import GRPCClient
+from tests.core.helpers import (
+    assert_grpc_rejected,
+    wait_for_cr,
+    wait_for_deletion,
+    wait_for_external_ip_pool_cr,
+    wait_for_external_ip_pool_deletion,
+    wait_for_external_ip_pool_grpc_ready,
+    wait_for_external_ip_pool_ready,
+    wait_for_running,
+)
+from tests.core.k8s_client import K8sClient
+from tests.core.osac_cli import OsacCLI
+from tests.core.runner import poll_until
+from tests.vmaas.external_ip.helpers import allocate_worker_subnet, pool_status
+
+logger = logging.getLogger(__name__)
+
+_AUTO_CREATED_LABEL = "osac.openshift.io/auto-created"
+_AUTO_CREATED_FOR_LABEL = "osac.openshift.io/auto-created-for"
+
+
+def _find_auto_created_resources(items: list[dict], ci_id: str) -> list[dict]:
+    return [item for item in items if item.get("metadata", {}).get("labels", {}).get(_AUTO_CREATED_FOR_LABEL) == ci_id]
+
+
+@pytest.fixture(scope="module")
+def auto_eip_pool(private_grpc: GRPCClient, k8s_hub_client: K8sClient) -> Iterator[tuple[str, str]]:
+    pool_name = f"test-auto-eip-{uuid4().hex[:8]}"
+    subnet = allocate_worker_subnet(prefix=24)
+    pool_id = private_grpc.create_external_ip_pool(name=pool_name, cidrs=[str(subnet)])
+    pool_cr_name = wait_for_external_ip_pool_cr(k8s=k8s_hub_client, uuid=pool_id)
+    wait_for_external_ip_pool_ready(k8s=k8s_hub_client, name=pool_cr_name)
+    wait_for_external_ip_pool_grpc_ready(private_grpc=private_grpc, pool_id=pool_id)
+    print(f"\nExternalIPPool ready: {pool_name} ({pool_id})")
+
+    yield pool_id, pool_cr_name
+
+    if not k8s_hub_client.is_present(resource="externalippool", name=pool_cr_name):
+        return
+    try:
+        private_grpc.delete_external_ip_pool(pool_id=pool_id)
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr or ""
+        if "NotFound" not in stderr:
+            logger.warning("ExternalIPPool %s teardown failed: %s", pool_id, stderr.strip())
+            return
+    wait_for_external_ip_pool_deletion(k8s=k8s_hub_client, name=pool_cr_name)
+
+
+def test_auto_external_ip_lifecycle(
+    auto_eip_pool: tuple[str, str],
+    cli: OsacCLI,
+    grpc: GRPCClient,
+    private_grpc: GRPCClient,
+    k8s_hub_client: K8sClient,
+    vm_template: str,
+) -> None:
+    pool_id, _pool_cr_name = auto_eip_pool
+
+    condition = private_grpc.get_tenant_condition_status(name="tenant1", condition_type="DefaultNetworkingReady")
+    reason = private_grpc.get_tenant_condition_reason(name="tenant1", condition_type="DefaultNetworkingReady")
+    if condition != "True" or reason == "NoDefaultNetworking":
+        pytest.skip(
+            f"DefaultNetworkingReady is {condition!r} (reason={reason!r}) for tenant1"
+            " — default networking not ready in this environment"
+        )
+
+    initial_status = pool_status(private_grpc, pool_id)
+    initial_available: int = initial_status["available"]
+    print(f"Pool initial status: {initial_status}")
+
+    # --- Create ComputeInstance with --external-ip-attachment ---
+    ci_name = unique_name("e2e-ci-auto-eip")
+    ci_uuid: str = cli.create_compute_instance(name=ci_name, template=vm_template, external_ip_attachment=True)
+    cr_name: str = wait_for_cr(k8s=k8s_hub_client, uuid=ci_uuid)
+    wait_for_running(k8s=k8s_hub_client, name=cr_name)
+    print(f"ComputeInstance {cr_name} is Running")
+
+    # --- Verify auto-created ExternalIP ---
+    auto_eips = _find_auto_created_resources(grpc.list_external_ips(), ci_uuid)
+    assert len(auto_eips) == 1, f"Expected 1 auto-created ExternalIP for {ci_uuid}, found {len(auto_eips)}"
+    eip = auto_eips[0]
+    assert eip["metadata"]["labels"].get(_AUTO_CREATED_LABEL) == "true"
+    assert eip["status"].get("attached") is True, "Auto-created ExternalIP should be attached"
+    eip_id: str = eip["id"]
+    print(f"Auto-created ExternalIP: {eip_id}")
+
+    # --- Verify auto-created ExternalIPAttachment ---
+    auto_atts = _find_auto_created_resources(grpc.list_external_ip_attachments(), ci_uuid)
+    assert len(auto_atts) == 1, f"Expected 1 auto-created ExternalIPAttachment for {ci_uuid}, found {len(auto_atts)}"
+    att = auto_atts[0]
+    assert att["metadata"]["labels"].get(_AUTO_CREATED_LABEL) == "true"
+    att_id: str = att["id"]
+    print(f"Auto-created ExternalIPAttachment: {att_id}")
+
+    # --- Verify pool capacity decremented ---
+    after_create_status = pool_status(private_grpc, pool_id)
+    assert after_create_status["available"] == initial_available - 1, (
+        f"Pool available should have decremented by 1: {initial_status} -> {after_create_status}"
+    )
+
+    # --- Delete ComputeInstance and verify auto-cleanup ---
+    cli.delete_compute_instance(uuid=ci_uuid)
+    wait_for_deletion(k8s=k8s_hub_client, name=cr_name)
+    print(f"ComputeInstance {cr_name} deleted")
+
+    # Verify ExternalIPAttachment cleaned up
+    poll_until(
+        fn=lambda: att_id not in [a["id"] for a in grpc.list_external_ip_attachments()],
+        until=lambda v: v is True,
+        retries=30,
+        delay=5,
+        description=f"ExternalIPAttachment {att_id} auto-cleanup",
+    )
+    print("Auto-created ExternalIPAttachment cleaned up")
+
+    # Verify ExternalIP cleaned up
+    poll_until(
+        fn=lambda: eip_id not in grpc.list_external_ip_ids(),
+        until=lambda v: v is True,
+        retries=30,
+        delay=5,
+        description=f"ExternalIP {eip_id} auto-cleanup",
+    )
+    print("Auto-created ExternalIP cleaned up")
+
+    # Verify pool capacity restored
+    poll_until(
+        fn=lambda: pool_status(private_grpc, pool_id)["available"],
+        until=lambda v: v == initial_available,
+        retries=30,
+        delay=5,
+        description="Pool capacity restored",
+    )
+    print(f"Pool capacity restored: {pool_status(private_grpc, pool_id)}")
+
+
+def test_auto_external_ip_pool_exhaustion(
+    private_grpc: GRPCClient, grpc: GRPCClient, k8s_hub_client: K8sClient
+) -> None:
+    condition = private_grpc.get_tenant_condition_status(name="tenant1", condition_type="DefaultNetworkingReady")
+    reason = private_grpc.get_tenant_condition_reason(name="tenant1", condition_type="DefaultNetworkingReady")
+    if condition != "True" or reason == "NoDefaultNetworking":
+        pytest.skip(
+            f"DefaultNetworkingReady is {condition!r} (reason={reason!r}) for tenant1"
+            " — default networking not ready in this environment"
+        )
+
+    # --- Create a tiny /30 pool (2 usable IPs) ---
+    pool_name = f"test-exhaust-{uuid4().hex[:8]}"
+    subnet = allocate_worker_subnet(prefix=30)
+    pool_id = private_grpc.create_external_ip_pool(name=pool_name, cidrs=[str(subnet)])
+    pool_cr_name = wait_for_external_ip_pool_cr(k8s=k8s_hub_client, uuid=pool_id)
+    wait_for_external_ip_pool_ready(k8s=k8s_hub_client, name=pool_cr_name)
+    wait_for_external_ip_pool_grpc_ready(private_grpc=private_grpc, pool_id=pool_id)
+
+    status = pool_status(private_grpc, pool_id)
+    total_capacity: int = status["total"]
+    print(f"\nExhaustion pool ready: {pool_name} (total={total_capacity})")
+
+    created_ci_ids: list[str] = []
+    created_ci_names: list[str] = []
+
+    try:
+        # --- Exhaust all pool capacity ---
+        for i in range(total_capacity):
+            ci_uuid = grpc.create_compute_instance(
+                catalog_item=_get_any_catalog_item(grpc), auto_external_ip_attachment=True
+            )
+            ci_name = wait_for_cr(k8s=k8s_hub_client, uuid=ci_uuid)
+            created_ci_ids.append(ci_uuid)
+            created_ci_names.append(ci_name)
+            print(f"Created CI {i + 1}/{total_capacity}: {ci_uuid}")
+
+        remaining = pool_status(private_grpc, pool_id)
+        assert remaining["available"] == 0, f"Pool should be exhausted, but available={remaining['available']}"
+
+        # --- Attempt creation when pool is exhausted ---
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            grpc.create_compute_instance(catalog_item=_get_any_catalog_item(grpc), auto_external_ip_attachment=True)
+        assert_grpc_rejected(exc_info, "FailedPrecondition")
+        print("Pool exhaustion correctly returned FailedPrecondition")
+
+    finally:
+        # --- Cleanup: delete CIs (auto-cleanup restores pool) ---
+        for ci_uuid, ci_name in zip(created_ci_ids, created_ci_names, strict=True):
+            try:
+                grpc.delete_compute_instance(ci_id=ci_uuid)
+            except subprocess.CalledProcessError:
+                logger.warning("Failed to delete CI %s during cleanup", ci_uuid)
+                continue
+            wait_for_deletion(k8s=k8s_hub_client, name=ci_name)
+
+        # --- Cleanup pool ---
+        try:
+            private_grpc.delete_external_ip_pool(pool_id=pool_id)
+        except subprocess.CalledProcessError as exc:
+            stderr = exc.stderr or ""
+            if "NotFound" not in stderr:
+                logger.warning("Pool %s cleanup failed: %s", pool_id, stderr.strip())
+        if k8s_hub_client.is_present(resource="externalippool", name=pool_cr_name):
+            wait_for_external_ip_pool_deletion(k8s=k8s_hub_client, name=pool_cr_name)
+
+
+def _get_any_catalog_item(grpc: GRPCClient) -> str:
+    items = grpc.list_compute_instance_catalog_item_ids()
+    assert items, "No ComputeInstanceCatalogItems found — cannot create compute instance"
+    return items[0]

--- a/tests/e2e/vmaas/test_default_networking.py
+++ b/tests/e2e/vmaas/test_default_networking.py
@@ -1,0 +1,165 @@
+"""E2E tests for OSAC-2486: Default networking tenant onboarding.
+
+Tests:
+1. Tenant onboarding auto-creates default VN, Subnet(s), SG, and optionally NATGateway
+2. ComputeInstance lifecycle using default networking (no explicit network_attachments)
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from tests.catalog.conftest import unique_name
+from tests.core.grpc_client import GRPCClient
+from tests.core.helpers import (
+    wait_for_cr,
+    wait_for_deletion,
+    wait_for_grpc_removal,
+    wait_for_grpc_tenant_condition,
+    wait_for_provision,
+    wait_for_running,
+    wait_for_tenant_cr,
+    wait_for_tenant_deletion,
+)
+from tests.core.k8s_client import K8sClient
+from tests.core.osac_cli import OsacCLI
+
+_DEFAULT_LABEL = "osac.openshift.io/default=true"
+_TENANT_ANNOTATION = "osac.openshift.io/tenant"
+
+
+def _get_default_resources(k8s: K8sClient, resource: str) -> list[dict[str, str]]:
+    raw = k8s.get_by_label(
+        resource=resource,
+        label=_DEFAULT_LABEL,
+        jsonpath=(
+            "{range .items[*]}{.metadata.name},{.metadata.annotations['osac\\.openshift\\.io/tenant']}{\"\\n\"}{end}"
+        ),
+    )
+    results: list[dict[str, str]] = []
+    for line in raw.strip().splitlines():
+        if not line.strip():
+            continue
+        parts = line.split(",", 1)
+        results.append({"name": parts[0], "tenant": parts[1] if len(parts) > 1 else ""})
+    return results
+
+
+def _filter_by_tenant(resources: list[dict[str, str]], tenant: str) -> list[dict[str, str]]:
+    return [r for r in resources if r["tenant"] == tenant]
+
+
+def test_default_networking_onboarding(private_grpc: GRPCClient, k8s_hub_client: K8sClient) -> None:
+    tenant_name: str = f"test-defnet-{uuid4().hex[:8]}"
+
+    print(f"\nCreating tenant: {tenant_name}")
+    private_grpc.ensure_tenant(name=tenant_name)
+
+    try:
+        _verify_default_networking(k8s=k8s_hub_client, private_grpc=private_grpc, tenant_name=tenant_name)
+    finally:
+        _cleanup_tenant(k8s=k8s_hub_client, tenant_name=tenant_name)
+
+
+def _verify_default_networking(*, k8s: K8sClient, private_grpc: GRPCClient, tenant_name: str) -> None:
+    wait_for_tenant_cr(k8s=k8s, name=tenant_name)
+    print(f"Waiting for DefaultNetworkingReady on {tenant_name}...")
+    try:
+        wait_for_grpc_tenant_condition(grpc=private_grpc, name=tenant_name, condition_type="DefaultNetworkingReady")
+    except TimeoutError:
+        reason = private_grpc.get_tenant_condition_reason(name=tenant_name, condition_type="DefaultNetworkingReady")
+        pytest.skip(
+            f"DefaultNetworkingReady did not reach True for {tenant_name} (reason={reason!r})"
+            " — default networking not provisioned in this environment"
+        )
+
+    reason = private_grpc.get_tenant_condition_reason(name=tenant_name, condition_type="DefaultNetworkingReady")
+    if reason == "NoDefaultNetworking":
+        pytest.skip(
+            f"Tenant {tenant_name} has DefaultNetworkingReady=True with reason NoDefaultNetworking — "
+            "no default NetworkClass with defaults configured in this environment"
+        )
+    print(f"DefaultNetworkingReady=True for {tenant_name} (reason={reason})")
+
+    vns = _filter_by_tenant(_get_default_resources(k8s, "virtualnetwork"), tenant_name)
+    assert len(vns) >= 1, f"Expected at least 1 default VirtualNetwork for {tenant_name}, found {vns}"
+    for vn in vns:
+        phase = k8s.get_virtual_network_phase(name=vn["name"])
+        assert phase == "Ready", f"Default VirtualNetwork {vn['name']} phase is {phase}, expected Ready"
+    print(f"Default VirtualNetwork(s): {[v['name'] for v in vns]}")
+
+    subnets = _filter_by_tenant(_get_default_resources(k8s, "subnet"), tenant_name)
+    assert len(subnets) >= 1, f"Expected at least 1 default Subnet for {tenant_name}, found {subnets}"
+    for subnet in subnets:
+        phase = k8s.get_subnet_phase(name=subnet["name"])
+        assert phase == "Ready", f"Default Subnet {subnet['name']} phase is {phase}, expected Ready"
+    print(f"Default Subnet(s): {[s['name'] for s in subnets]}")
+
+    sgs = _filter_by_tenant(_get_default_resources(k8s, "securitygroup"), tenant_name)
+    assert len(sgs) >= 1, f"Expected at least 1 default SecurityGroup for {tenant_name}, found {sgs}"
+    for sg in sgs:
+        phase = k8s.get_security_group_phase(name=sg["name"])
+        assert phase == "Ready", f"Default SecurityGroup {sg['name']} phase is {phase}, expected Ready"
+    print(f"Default SecurityGroup(s): {[s['name'] for s in sgs]}")
+
+    nat_gws = _filter_by_tenant(_get_default_resources(k8s, "natgateway"), tenant_name)
+    if nat_gws:
+        for ng in nat_gws:
+            phase = k8s.get_nat_gateway_phase(name=ng["name"])
+            assert phase == "Ready", f"Default NATGateway {ng['name']} phase is {phase}, expected Ready"
+        print(f"Default NATGateway(s): {[n['name'] for n in nat_gws]}")
+    else:
+        print("No default NATGateway found (NetworkClass may not have enable_nat_gateway=true)")
+
+
+def _cleanup_tenant(*, k8s: K8sClient, tenant_name: str) -> None:
+    print(f"\nCleaning up tenant: {tenant_name}")
+    if k8s.is_present(resource="tenant", name=tenant_name):
+        k8s.delete(resource="tenant", name=tenant_name, wait=False)
+        wait_for_tenant_deletion(k8s=k8s, name=tenant_name)
+        print(f"Tenant {tenant_name} deleted")
+
+    if k8s.is_present(resource="namespace", name=tenant_name):
+        k8s.delete(resource="namespace", name=tenant_name, wait=False)
+        print(f"Namespace {tenant_name} cleanup initiated")
+
+
+def test_compute_instance_lifecycle_default_networking(
+    cli: OsacCLI,
+    grpc: GRPCClient,
+    private_grpc: GRPCClient,
+    k8s_hub_client: K8sClient,
+    k8s_virt_client: K8sClient,
+    vm_template: str,
+) -> None:
+    condition = private_grpc.get_tenant_condition_status(name="tenant1", condition_type="DefaultNetworkingReady")
+    reason = private_grpc.get_tenant_condition_reason(name="tenant1", condition_type="DefaultNetworkingReady")
+    if condition != "True" or reason == "NoDefaultNetworking":
+        pytest.skip(
+            f"DefaultNetworkingReady is {condition!r} (reason={reason!r}) for tenant1"
+            " — default networking not ready in this environment"
+        )
+
+    name = unique_name("e2e-ci-defnet")
+    uuid: str = cli.create_compute_instance(name=name, template=vm_template)
+    assert uuid in grpc.list_compute_instance_ids()
+
+    ci_name: str = wait_for_cr(k8s=k8s_hub_client, uuid=uuid)
+
+    cr = k8s_hub_client.get_json(resource="computeinstance", name=ci_name)
+    attachments = cr.get("spec", {}).get("networkAttachments", [])
+    assert len(attachments) >= 1, f"Expected auto-injected networkAttachments, got {attachments}"
+    print(f"Auto-injected {len(attachments)} network attachment(s)")
+
+    wait_for_provision(k8s=k8s_hub_client, name=ci_name)
+    wait_for_running(k8s=k8s_hub_client, name=ci_name)
+
+    vmi_ns: str = k8s_hub_client.get_compute_instance_vm_namespace(name=ci_name)
+    vmi_ts: str = k8s_virt_client.get_vmi_creation_timestamp(vmi_namespace=vmi_ns, compute_instance_name=ci_name)
+    assert vmi_ts != "", f"No VMI found on virt cluster for {ci_name}"
+
+    cli.delete_compute_instance(uuid=uuid)
+    wait_for_deletion(k8s=k8s_hub_client, name=ci_name)
+    wait_for_grpc_removal(grpc=grpc, uuid=uuid)


### PR DESCRIPTION
Port of [osac-test-infra PR #338 ](https://github.com/osac-project/osac-test-infra/pull/338)to the osac repo tests/ directory.

- test_default_networking_onboarding: verifies tenant creation auto-provisions default VN, Subnet(s), SG, and NATGateway
- test_compute_instance_lifecycle_default_networking: full CI lifecycle using default network injection (no explicit network_attachments)
- test_auto_external_ip_lifecycle: verifies auto ExternalIP/Attachment creation via --external-ip-attachment and auto-cleanup on CI deletion
- test_auto_external_ip_pool_exhaustion: verifies FailedPrecondition when no pool capacity remains

Infrastructure additions (ported to osac tests/core/):
- NATGateway gRPC client methods (list, get) and K8s queries
- Full-object list methods for VN, Subnet, SG, ExternalIP, Attachment
- --external-ip-attachment flag support in OsacCLI.create_compute_instance
- wait_for_nat_gateway_cr, wait_for_grpc_tenant_condition in helpers.py
- get_tenant_condition_status/reason in GRPCClient
- auto_external_ip_attachment param in GRPCClient.create_compute_instance
- ensure_k8s_only_network_class session fixture in conftest.py (already present; ensure_tenants now depends on it)

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Compute instances can optionally use specified subnets or receive automatic external IP attachments.
  - Added visibility into virtual networks, subnets, security groups, external IPs, attachments, and NAT gateways.
  - Added tenant condition status and reason checks.
  - Added NAT gateway discovery and status monitoring.

- **Tests**
  - Added end-to-end coverage for automatic external IP lifecycle and pool exhaustion.
  - Added coverage for default networking setup and compute instance lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->