### PR TITLE
OSAC-4741: Pass enable-ai-diagnostic through to scheduled E2E full-install runs

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -157,6 +157,13 @@ jobs:
       test-source: "osac"
       test-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       test-ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      # AI failure diagnosis only for scheduled runs: those always run
+      # against main in this repo's own context (no fork involved), unlike
+      # pull_request/merge_group runs from PRs, which come from genuine
+      # forks and cannot get OIDC/WIF access at all regardless of this
+      # input (a GitHub Actions security policy, not something this input
+      # can override).
+      enable-ai-diagnostic: ${{ github.event_name == 'schedule' }}
 
   e2e-bmaas-gate:
     if: always()

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -169,6 +169,13 @@ jobs:
       # flavor-name, namespace, etc.) are left at the reusable workflow's own
       # defaults -- none are required and this caller has no need to override
       # them today.
+      # AI failure diagnosis only for scheduled runs: those always run
+      # against main in this repo's own context (no fork involved), unlike
+      # pull_request/merge_group runs from PRs, which come from genuine
+      # forks and cannot get OIDC/WIF access at all regardless of this
+      # input (a GitHub Actions security policy, not something this input
+      # can override).
+      enable-ai-diagnostic: ${{ github.event_name == 'schedule' }}
 
   e2e-caas-gate:
     if: always()

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -165,6 +165,13 @@ jobs:
       test-source: "osac"
       test-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       test-ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      # AI failure diagnosis only for scheduled runs: those always run
+      # against main in this repo's own context (no fork involved), unlike
+      # pull_request/merge_group runs from PRs, which come from genuine
+      # forks and cannot get OIDC/WIF access at all regardless of this
+      # input (a GitHub Actions security policy, not something this input
+      # can override).
+      enable-ai-diagnostic: ${{ github.event_name == 'schedule' }}
 
   e2e-vmaas-gate:
     if: always()


### PR DESCRIPTION
## Summary

Companion to [osac-test-infra#435](https://github.com/osac-project/osac-test-infra/pull/435), which adds the `enable-ai-diagnostic` input (AI-powered root-cause diagnosis on failure, written to the job summary) to the three reusable E2E full-install workflows. This PR passes that input through from the mono-repo's own callers, true only for `schedule`-triggered runs — matching the existing `notify-on-failure` pattern already used by
`osac-test-infra`'s own callers (this mono-repo's callers never wired that one up either; pre-existing asymmetry, not touched here).

## ⚠️ Merge-order dependency — do not merge before osac-test-infra#435

This repo's callers pin to `osac-test-infra/...@main`. GitHub validates `workflow_call` inputs strictly — passing `enable-ai-diagnostic` here before the reusable workflow on `osac-test-infra`'s `main` actually defines it would break **every** scheduled (and PR-triggered) E2E run in this repo immediately with an "unexpected input" error.

**[osac-test-infra#435](https://github.com/osac-project/osac-test-infra/pull/435)
must merge and be confirmed live on `main` before this PR merges.**

## Test plan

- [x] YAML syntax validated on all three changed workflow files
- [ ] Blocked on osac-test-infra#435 landing first — then confirm a real scheduled run picks this up cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * AI-powered failure diagnostics are now enabled for scheduled end-to-end test runs.
  * Pull request and merge-group test runs continue without AI diagnostics, ensuring compatibility with forked execution environments.
  * End-to-end test workflows now consistently use the appropriate repository and revision when sourcing shared tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->