### PR TITLE
OSAC-4677: per-service enablement via global.services.* Helm values

### DIFF
--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -191,7 +191,7 @@ jobs:
   #
   # bare-metal-fulfillment-operator's image override (bmf.image.repository)
   # is currently a no-op in this flow specifically: values/caas-ci/values.yaml
-  # sets bmf.enabled: false, so the chart isn't deployed here at all. Still
+  # sets global.services.bmaas.enabled: false, so the chart isn't deployed here at all. Still
   # built from source for consistency with the other components -- revisit
   # if caas ever needs BMF enabled.
   e2e-caas-full-install:

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -186,7 +186,7 @@ jobs:
   #
   # bare-metal-fulfillment-operator's image override (bmf.image.repository)
   # is currently a no-op in this flow specifically: values/vmaas-ci/values.yaml
-  # sets bmf.enabled: false, so the chart isn't deployed here at all. Still
+  # sets global.services.bmaas.enabled: false, so the chart isn't deployed here at all. Still
   # built from source for consistency with the other 3 components (all 4
   # should build from the PR in every e2e flow, even where one isn't
   # currently deployed) -- revisit if vmaas ever needs BMF enabled.

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -327,10 +327,19 @@ jobs:
         CONTAINER_TOOL: docker
       run: make -C osac-installer install-infra PLATFORM=kind PROFILE=dev NS=osac
 
+    - name: Build fulfillment-service image from PR
+      env:
+        CONTAINER_TOOL: docker
+      run: |
+        docker build -t localhost/fulfillment-service:it -f fulfillment-service/Containerfile .
+        kind load docker-image localhost/fulfillment-service:it --name osac-dev
+
     - name: Deploy charts
       env:
         CONTAINER_TOOL: docker
-      run: make -C osac-installer install-osac PLATFORM=kind PROFILE=dev NS=osac
+      run: >-
+        make -C osac-installer install-osac PLATFORM=kind PROFILE=dev NS=osac
+        EXTRA_HELM_ARGS="--set service.images.service=localhost/fulfillment-service:it"
 
     - name: Collect diagnostic logs
       if: always()
@@ -382,4 +391,6 @@ jobs:
     - name: Test idempotency (helm upgrade with no changes)
       env:
         CONTAINER_TOOL: docker
-      run: make -C osac-installer install-osac PLATFORM=kind PROFILE=dev NS=osac
+      run: >-
+        make -C osac-installer install-osac PLATFORM=kind PROFILE=dev NS=osac
+        EXTRA_HELM_ARGS="--set service.images.service=localhost/fulfillment-service:it"

--- a/fulfillment-service/charts/service/templates/_helpers.tpl
+++ b/fulfillment-service/charts/service/templates/_helpers.tpl
@@ -38,3 +38,26 @@ Return the hostname for the fulfillment internal API. Fails if 'internalHostname
 {{- define "fulfillment-internal-api.hostname" -}}
 {{- required "internalHostname is required" .Values.internalHostname -}}
 {{- end -}}
+
+{{/*
+Check if a service tier is enabled via global.services.<key>.enabled.
+Args: list of [context, serviceKey]
+Falls back to true when global.services is not set.
+Returns non-empty string for enabled, empty for disabled (for use in {{- if include ... }}).
+*/}}
+{{- define "fulfillment-service.serviceEnabled" -}}
+{{- $ctx := index . 0 -}}
+{{- $svcKey := index . 1 -}}
+{{- $enabled := true -}}
+{{- if $ctx.Values.global -}}
+{{- if $ctx.Values.global.services -}}
+{{- $svc := index $ctx.Values.global.services $svcKey -}}
+{{- if $svc -}}
+{{- if hasKey $svc "enabled" -}}
+{{- $enabled = $svc.enabled -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if $enabled -}}true{{- end -}}
+{{- end }}

--- a/fulfillment-service/charts/service/templates/grpc-server/deployment.yaml
+++ b/fulfillment-service/charts/service/templates/grpc-server/deployment.yaml
@@ -172,16 +172,16 @@ spec:
         - --token-encryption-crt=/etc/fulfillment-token-encryption/tls.crt
         - --token-issuer={{ include "fulfillment-api.tokenIssuerUrl" . }}
         - --metrics-listener-address=0.0.0.0:8002
-        {{- if .Values.services.caas.enabled }}
+        {{- if include "fulfillment-service.serviceEnabled" (list . "caas") }}
         - --enable-caas
         {{- end }}
-        {{- if .Values.services.vmaas.enabled }}
+        {{- if include "fulfillment-service.serviceEnabled" (list . "vmaas") }}
         - --enable-vmaas
         {{- end }}
-        {{- if .Values.services.bmaas.enabled }}
+        {{- if include "fulfillment-service.serviceEnabled" (list . "bmaas") }}
         - --enable-bmaas
         {{- end }}
-        {{- if .Values.services.maas.enabled }}
+        {{- if include "fulfillment-service.serviceEnabled" (list . "maas") }}
         - --enable-maas
         {{- end }}
         {{- if and .Values.vault.endpoint .Values.vault.credentials }}

--- a/fulfillment-service/charts/service/templates/grpc-server/deployment.yaml
+++ b/fulfillment-service/charts/service/templates/grpc-server/deployment.yaml
@@ -172,6 +172,18 @@ spec:
         - --token-encryption-crt=/etc/fulfillment-token-encryption/tls.crt
         - --token-issuer={{ include "fulfillment-api.tokenIssuerUrl" . }}
         - --metrics-listener-address=0.0.0.0:8002
+        {{- if .Values.services.caas.enabled }}
+        - --enable-caas
+        {{- end }}
+        {{- if .Values.services.vmaas.enabled }}
+        - --enable-vmaas
+        {{- end }}
+        {{- if .Values.services.bmaas.enabled }}
+        - --enable-bmaas
+        {{- end }}
+        {{- if .Values.services.maas.enabled }}
+        - --enable-maas
+        {{- end }}
         {{- if and .Values.vault.endpoint .Values.vault.credentials }}
         - --vault-endpoint={{ tpl .Values.vault.endpoint . }}
         - --vault-namespace={{ .Values.vault.namespace }}

--- a/fulfillment-service/charts/service/templates/rest-gateway/deployment.yaml
+++ b/fulfillment-service/charts/service/templates/rest-gateway/deployment.yaml
@@ -72,6 +72,18 @@ spec:
         - --grpc-server-address=fulfillment-internal-api:8001
         - --grpc-keep-alive=5m
         - --metrics-listener-address=0.0.0.0:8002
+        {{- if .Values.services.caas.enabled }}
+        - --enable-caas
+        {{- end }}
+        {{- if .Values.services.vmaas.enabled }}
+        - --enable-vmaas
+        {{- end }}
+        {{- if .Values.services.bmaas.enabled }}
+        - --enable-bmaas
+        {{- end }}
+        {{- if .Values.services.maas.enabled }}
+        - --enable-maas
+        {{- end }}
         ports:
         - name: api
           containerPort: 8000

--- a/fulfillment-service/charts/service/templates/rest-gateway/deployment.yaml
+++ b/fulfillment-service/charts/service/templates/rest-gateway/deployment.yaml
@@ -72,16 +72,16 @@ spec:
         - --grpc-server-address=fulfillment-internal-api:8001
         - --grpc-keep-alive=5m
         - --metrics-listener-address=0.0.0.0:8002
-        {{- if .Values.services.caas.enabled }}
+        {{- if include "fulfillment-service.serviceEnabled" (list . "caas") }}
         - --enable-caas
         {{- end }}
-        {{- if .Values.services.vmaas.enabled }}
+        {{- if include "fulfillment-service.serviceEnabled" (list . "vmaas") }}
         - --enable-vmaas
         {{- end }}
-        {{- if .Values.services.bmaas.enabled }}
+        {{- if include "fulfillment-service.serviceEnabled" (list . "bmaas") }}
         - --enable-bmaas
         {{- end }}
-        {{- if .Values.services.maas.enabled }}
+        {{- if include "fulfillment-service.serviceEnabled" (list . "maas") }}
         - --enable-maas
         {{- end }}
         ports:

--- a/fulfillment-service/charts/service/values.yaml
+++ b/fulfillment-service/charts/service/values.yaml
@@ -225,5 +225,17 @@ vault:
   # Volume sources for the Keycloak client secret used for Vault authentication.
   credentials: []
 
+# Service tier enablement flags. When all are true (the default), OSAC operates as a full-stack cloud.
+# The umbrella chart overrides these via the service.services values path.
+services:
+  caas:
+    enabled: true
+  vmaas:
+    enabled: true
+  bmaas:
+    enabled: true
+  maas:
+    enabled: true
+
 consoleProxy:
   disabled: false

--- a/fulfillment-service/charts/service/values.yaml
+++ b/fulfillment-service/charts/service/values.yaml
@@ -225,17 +225,5 @@ vault:
   # Volume sources for the Keycloak client secret used for Vault authentication.
   credentials: []
 
-# Service tier enablement flags. When all are true (the default), OSAC operates as a full-stack cloud.
-# The umbrella chart overrides these via the service.services values path.
-services:
-  caas:
-    enabled: true
-  vmaas:
-    enabled: true
-  bmaas:
-    enabled: true
-  maas:
-    enabled: true
-
 consoleProxy:
   disabled: false

--- a/fulfillment-service/internal/cmd/service/start/grpcserver/register_servers.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/register_servers.go
@@ -170,8 +170,6 @@ func RegisterResourceServers(ctx context.Context, registrar grpc.ServiceRegistra
 			SetAttributionLogic(deps.PublicAttributionLogic).
 			SetTenancyLogic(deps.TenancyLogic).
 			SetMetricsRegisterer(deps.MetricsRegisterer).
-			SetScheme(deps.HubScheme).
-			SetSecretStore(deps.SecretStore).
 			Build()
 		if err != nil {
 			return nil, fmt.Errorf("failed to create clusters server: %w", err)

--- a/fulfillment-service/internal/cmd/service/start/grpcserver/register_servers.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/register_servers.go
@@ -29,6 +29,7 @@ import (
 	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/osac/fulfillment-service/internal/events"
 	"github.com/osac-project/osac/fulfillment-service/internal/servers"
+	"github.com/osac-project/osac/fulfillment-service/internal/services"
 	"github.com/osac-project/osac/fulfillment-service/internal/vault"
 )
 
@@ -49,6 +50,8 @@ type ResourceServerDeps struct {
 	// before the gRPC server's interceptor chain is built, which happens before RegisterResourceServers is
 	// called. It's threaded through here so registration still happens in one place.
 	PrivateUsersServer privatev1.UsersServer
+
+	Services *services.Flags
 }
 
 // ResourceServers exposes the constructed servers and shared infrastructure that code outside the
@@ -72,117 +75,122 @@ func RegisterResourceServers(ctx context.Context, registrar grpc.ServiceRegistra
 		return nil, fmt.Errorf("notifier must be a *database.Notifier, got %T", deps.Notifier)
 	}
 
-	// Create the cluster templates server:
-	deps.Logger.InfoContext(ctx, "Creating cluster templates server")
-	clusterTemplatesServer, err := servers.NewClusterTemplatesServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PublicAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create cluster templates server: %w", err)
-	}
-	publicv1.RegisterClusterTemplatesServer(registrar, clusterTemplatesServer)
+	// CaaS: public cluster templates and catalog items
+	if deps.Services.CaaS {
+		deps.Logger.InfoContext(ctx, "Creating cluster templates server")
+		clusterTemplatesServer, err := servers.NewClusterTemplatesServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PublicAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create cluster templates server: %w", err)
+		}
+		publicv1.RegisterClusterTemplatesServer(registrar, clusterTemplatesServer)
 
-	// Create the cluster catalog items server:
-	deps.Logger.InfoContext(ctx, "Creating cluster catalog items server")
-	clusterCatalogItemsServer, err := servers.NewClusterCatalogItemsServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PublicAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create cluster catalog items server: %w", err)
+		deps.Logger.InfoContext(ctx, "Creating cluster catalog items server")
+		clusterCatalogItemsServer, err := servers.NewClusterCatalogItemsServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PublicAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create cluster catalog items server: %w", err)
+		}
+		publicv1.RegisterClusterCatalogItemsServer(registrar, clusterCatalogItemsServer)
 	}
-	publicv1.RegisterClusterCatalogItemsServer(registrar, clusterCatalogItemsServer)
 
-	// Create the compute instance catalog items server:
-	deps.Logger.InfoContext(ctx, "Creating compute instance catalog items server")
-	computeInstanceCatalogItemsServer, err := servers.NewComputeInstanceCatalogItemsServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PublicAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create compute instance catalog items server: %w", err)
+	if deps.Services.VMaaS {
+		deps.Logger.InfoContext(ctx, "Creating compute instance catalog items server")
+		computeInstanceCatalogItemsServer, err := servers.NewComputeInstanceCatalogItemsServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PublicAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create compute instance catalog items server: %w", err)
+		}
+		publicv1.RegisterComputeInstanceCatalogItemsServer(registrar, computeInstanceCatalogItemsServer)
 	}
-	publicv1.RegisterComputeInstanceCatalogItemsServer(registrar, computeInstanceCatalogItemsServer)
 
-	// Create the private cluster templates server:
-	deps.Logger.InfoContext(ctx, "Creating private cluster templates server")
-	privateClusterTemplatesServer, err := servers.NewPrivateClusterTemplatesServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PrivateAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create private cluster templates server: %w", err)
-	}
-	privatev1.RegisterClusterTemplatesServer(registrar, privateClusterTemplatesServer)
+	if deps.Services.CaaS {
+		deps.Logger.InfoContext(ctx, "Creating private cluster templates server")
+		privateClusterTemplatesServer, err := servers.NewPrivateClusterTemplatesServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PrivateAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create private cluster templates server: %w", err)
+		}
+		privatev1.RegisterClusterTemplatesServer(registrar, privateClusterTemplatesServer)
 
-	// Create the private cluster catalog items server:
-	deps.Logger.InfoContext(ctx, "Creating private cluster catalog items server")
-	privateClusterCatalogItemsServer, err := servers.NewPrivateClusterCatalogItemsServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PrivateAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create private cluster catalog items server: %w", err)
+		deps.Logger.InfoContext(ctx, "Creating private cluster catalog items server")
+		privateClusterCatalogItemsServer, err := servers.NewPrivateClusterCatalogItemsServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PrivateAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create private cluster catalog items server: %w", err)
+		}
+		privatev1.RegisterClusterCatalogItemsServer(registrar, privateClusterCatalogItemsServer)
 	}
-	privatev1.RegisterClusterCatalogItemsServer(registrar, privateClusterCatalogItemsServer)
 
-	// Create the private compute instance catalog items server:
-	deps.Logger.InfoContext(ctx, "Creating private compute instance catalog items server")
-	privateComputeInstanceCatalogItemsServer, err := servers.NewPrivateComputeInstanceCatalogItemsServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PrivateAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create private compute instance catalog items server: %w", err)
+	if deps.Services.VMaaS {
+		deps.Logger.InfoContext(ctx, "Creating private compute instance catalog items server")
+		privateComputeInstanceCatalogItemsServer, err := servers.NewPrivateComputeInstanceCatalogItemsServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PrivateAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create private compute instance catalog items server: %w", err)
+		}
+		privatev1.RegisterComputeInstanceCatalogItemsServer(registrar, privateComputeInstanceCatalogItemsServer)
 	}
-	privatev1.RegisterComputeInstanceCatalogItemsServer(registrar, privateComputeInstanceCatalogItemsServer)
 
-	// Create the clusters server:
-	deps.Logger.InfoContext(ctx, "Creating clusters server")
-	clustersServer, err := servers.NewClustersServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PublicAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create clusters server: %w", err)
-	}
-	publicv1.RegisterClustersServer(registrar, clustersServer)
+	if deps.Services.CaaS {
+		deps.Logger.InfoContext(ctx, "Creating clusters server")
+		clustersServer, err := servers.NewClustersServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PublicAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			SetScheme(deps.HubScheme).
+			SetSecretStore(deps.SecretStore).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create clusters server: %w", err)
+		}
+		publicv1.RegisterClustersServer(registrar, clustersServer)
 
-	// Create the private clusters server:
-	deps.Logger.InfoContext(ctx, "Creating private clusters server")
-	privateClustersServer, err := servers.NewPrivateClustersServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PrivateAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create private clusters server: %w", err)
+		deps.Logger.InfoContext(ctx, "Creating private clusters server")
+		privateClustersServer, err := servers.NewPrivateClustersServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PrivateAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create private clusters server: %w", err)
+		}
+		privatev1.RegisterClustersServer(registrar, privateClustersServer)
 	}
-	privatev1.RegisterClustersServer(registrar, privateClustersServer)
 
 	// Create the host types server:
 	deps.Logger.InfoContext(ctx, "Creating host types server")
@@ -212,173 +220,168 @@ func RegisterResourceServers(ctx context.Context, registrar grpc.ServiceRegistra
 	}
 	privatev1.RegisterHostTypesServer(registrar, privateHostTypesServer)
 
-	// Create the compute instance templates server:
-	deps.Logger.InfoContext(ctx, "Creating compute instance templates server")
-	computeInstanceTemplatesServer, err := servers.NewComputeInstanceTemplatesServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PublicAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create compute instance templates server: %w", err)
-	}
-	publicv1.RegisterComputeInstanceTemplatesServer(registrar, computeInstanceTemplatesServer)
+	// VMaaS: compute instance templates, compute instances, disk images
+	var privateComputeInstancesServer privatev1.ComputeInstancesServer
+	if deps.Services.VMaaS {
+		deps.Logger.InfoContext(ctx, "Creating compute instance templates server")
+		computeInstanceTemplatesServer, err := servers.NewComputeInstanceTemplatesServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PublicAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create compute instance templates server: %w", err)
+		}
+		publicv1.RegisterComputeInstanceTemplatesServer(registrar, computeInstanceTemplatesServer)
 
-	// Create the private compute instance templates server:
-	deps.Logger.InfoContext(ctx, "Creating private compute instance templates server")
-	privateComputeInstanceTemplatesServer, err := servers.NewPrivateComputeInstanceTemplatesServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PrivateAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create private compute instance templates server: %w", err)
-	}
-	privatev1.RegisterComputeInstanceTemplatesServer(registrar, privateComputeInstanceTemplatesServer)
+		deps.Logger.InfoContext(ctx, "Creating private compute instance templates server")
+		privateComputeInstanceTemplatesServer, err := servers.NewPrivateComputeInstanceTemplatesServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PrivateAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create private compute instance templates server: %w", err)
+		}
+		privatev1.RegisterComputeInstanceTemplatesServer(registrar, privateComputeInstanceTemplatesServer)
 
-	// Create the compute instances server:
-	deps.Logger.InfoContext(ctx, "Creating compute instances server")
-	computeInstancesServer, err := servers.NewComputeInstancesServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PublicAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create compute instances server: %w", err)
-	}
-	publicv1.RegisterComputeInstancesServer(registrar, computeInstancesServer)
+		deps.Logger.InfoContext(ctx, "Creating compute instances server")
+		computeInstancesServer, err := servers.NewComputeInstancesServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PublicAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create compute instances server: %w", err)
+		}
+		publicv1.RegisterComputeInstancesServer(registrar, computeInstancesServer)
 
-	// Create the private compute instances server:
-	deps.Logger.InfoContext(ctx, "Creating private compute instances server")
-	privateComputeInstancesServer, err := servers.NewPrivateComputeInstancesServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PrivateAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create private compute instances server: %w", err)
-	}
-	privatev1.RegisterComputeInstancesServer(registrar, privateComputeInstancesServer)
+		deps.Logger.InfoContext(ctx, "Creating private compute instances server")
+		var ciErr error
+		privateComputeInstancesServer, ciErr = servers.NewPrivateComputeInstancesServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PrivateAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if ciErr != nil {
+			return nil, fmt.Errorf("failed to create private compute instances server: %w", ciErr)
+		}
+		privatev1.RegisterComputeInstancesServer(registrar, privateComputeInstancesServer)
 
-	// Create the disk images server:
-	deps.Logger.InfoContext(ctx, "Creating disk images server")
-	diskImagesServer, err := servers.NewDiskImagesServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PublicAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create disk images server: %w", err)
-	}
-	publicv1.RegisterDiskImagesServer(registrar, diskImagesServer)
+		deps.Logger.InfoContext(ctx, "Creating disk images server")
+		diskImagesServer, err := servers.NewDiskImagesServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PublicAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create disk images server: %w", err)
+		}
+		publicv1.RegisterDiskImagesServer(registrar, diskImagesServer)
 
-	// Create the private disk images server:
-	deps.Logger.InfoContext(ctx, "Creating private disk images server")
-	privateDiskImagesServer, err := servers.NewPrivateDiskImagesServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PrivateAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create private disk images server: %w", err)
+		deps.Logger.InfoContext(ctx, "Creating private disk images server")
+		privateDiskImagesServer, err := servers.NewPrivateDiskImagesServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PrivateAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create private disk images server: %w", err)
+		}
+		privatev1.RegisterDiskImagesServer(registrar, privateDiskImagesServer)
 	}
-	privatev1.RegisterDiskImagesServer(registrar, privateDiskImagesServer)
 
-	// Create the bare metal instance templates server:
-	deps.Logger.InfoContext(ctx, "Creating bare metal instance templates server")
-	bareMetalInstanceTemplatesServer, err := servers.NewBareMetalInstanceTemplatesServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PublicAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create bare metal instance templates server: %w", err)
-	}
-	publicv1.RegisterBareMetalInstanceTemplatesServer(registrar, bareMetalInstanceTemplatesServer)
+	if deps.Services.BMaaS {
+		deps.Logger.InfoContext(ctx, "Creating bare metal instance templates server")
+		bareMetalInstanceTemplatesServer, err := servers.NewBareMetalInstanceTemplatesServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PublicAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create bare metal instance templates server: %w", err)
+		}
+		publicv1.RegisterBareMetalInstanceTemplatesServer(registrar, bareMetalInstanceTemplatesServer)
 
-	// Create the bare metal instance catalog items server:
-	deps.Logger.InfoContext(ctx, "Creating bare metal instance catalog items server")
-	bareMetalInstanceCatalogItemsServer, err := servers.NewBareMetalInstanceCatalogItemsServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PublicAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create bare metal instance catalog items server: %w", err)
-	}
-	publicv1.RegisterBareMetalInstanceCatalogItemsServer(registrar, bareMetalInstanceCatalogItemsServer)
+		deps.Logger.InfoContext(ctx, "Creating bare metal instance catalog items server")
+		bareMetalInstanceCatalogItemsServer, err := servers.NewBareMetalInstanceCatalogItemsServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PublicAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create bare metal instance catalog items server: %w", err)
+		}
+		publicv1.RegisterBareMetalInstanceCatalogItemsServer(registrar, bareMetalInstanceCatalogItemsServer)
 
-	// Create the bare metal instances server:
-	deps.Logger.InfoContext(ctx, "Creating bare metal instances server")
-	bareMetalInstancesServer, err := servers.NewBareMetalInstancesServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PublicAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create bare metal instances server: %w", err)
-	}
-	publicv1.RegisterBareMetalInstancesServer(registrar, bareMetalInstancesServer)
+		deps.Logger.InfoContext(ctx, "Creating bare metal instances server")
+		bareMetalInstancesServer, err := servers.NewBareMetalInstancesServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PublicAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create bare metal instances server: %w", err)
+		}
+		publicv1.RegisterBareMetalInstancesServer(registrar, bareMetalInstancesServer)
 
-	// Create the private bare metal instance templates server:
-	deps.Logger.InfoContext(ctx, "Creating private bare metal instance templates server")
-	privateBareMetalInstanceTemplatesServer, err := servers.NewPrivateBareMetalInstanceTemplatesServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PrivateAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create private bare metal instance templates server: %w", err)
-	}
-	privatev1.RegisterBareMetalInstanceTemplatesServer(registrar, privateBareMetalInstanceTemplatesServer)
+		deps.Logger.InfoContext(ctx, "Creating private bare metal instance templates server")
+		privateBareMetalInstanceTemplatesServer, err := servers.NewPrivateBareMetalInstanceTemplatesServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PrivateAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create private bare metal instance templates server: %w", err)
+		}
+		privatev1.RegisterBareMetalInstanceTemplatesServer(registrar, privateBareMetalInstanceTemplatesServer)
 
-	// Create the private bare metal instance catalog items server:
-	deps.Logger.InfoContext(ctx, "Creating private bare metal instance catalog items server")
-	privateBareMetalInstanceCatalogItemsServer, err := servers.NewPrivateBareMetalInstanceCatalogItemsServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PrivateAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create private bare metal instance catalog items server: %w", err)
-	}
-	privatev1.RegisterBareMetalInstanceCatalogItemsServer(registrar, privateBareMetalInstanceCatalogItemsServer)
+		deps.Logger.InfoContext(ctx, "Creating private bare metal instance catalog items server")
+		privateBareMetalInstanceCatalogItemsServer, err := servers.NewPrivateBareMetalInstanceCatalogItemsServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PrivateAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create private bare metal instance catalog items server: %w", err)
+		}
+		privatev1.RegisterBareMetalInstanceCatalogItemsServer(registrar, privateBareMetalInstanceCatalogItemsServer)
 
-	// Create the private bare metal instances server:
-	deps.Logger.InfoContext(ctx, "Creating private bare metal instances server")
-	privateBareMetalInstancesServer, err := servers.NewPrivateBareMetalInstancesServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PrivateAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create private bare metal instances server: %w", err)
+		deps.Logger.InfoContext(ctx, "Creating private bare metal instances server")
+		privateBareMetalInstancesServer, err := servers.NewPrivateBareMetalInstancesServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PrivateAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create private bare metal instances server: %w", err)
+		}
+		privatev1.RegisterBareMetalInstancesServer(registrar, privateBareMetalInstancesServer)
 	}
-	privatev1.RegisterBareMetalInstancesServer(registrar, privateBareMetalInstancesServer)
 
 	// Create the private hubs server:
 	deps.Logger.InfoContext(ctx, "Creating private hubs server")
@@ -519,89 +522,91 @@ func RegisterResourceServers(ctx context.Context, registrar grpc.ServiceRegistra
 	}
 	privatev1.RegisterNetworkClassesServer(registrar, privateNetworkClassesServer)
 
-	// Create the instance types server:
-	deps.Logger.InfoContext(ctx, "Creating instance types server")
-	instanceTypesServer, err := servers.NewInstanceTypesServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PublicAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create instance types server: %w", err)
-	}
-	publicv1.RegisterInstanceTypesServer(registrar, instanceTypesServer)
+	// VMaaS: instance types
+	if deps.Services.VMaaS {
+		deps.Logger.InfoContext(ctx, "Creating instance types server")
+		instanceTypesServer, err := servers.NewInstanceTypesServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PublicAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create instance types server: %w", err)
+		}
+		publicv1.RegisterInstanceTypesServer(registrar, instanceTypesServer)
 
-	// Create the private instance types server:
-	deps.Logger.InfoContext(ctx, "Creating private instance types server")
-	privateInstanceTypesServer, err := servers.NewPrivateInstanceTypesServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PrivateAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create private instance types server: %w", err)
+		deps.Logger.InfoContext(ctx, "Creating private instance types server")
+		privateInstanceTypesServer, err := servers.NewPrivateInstanceTypesServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PrivateAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create private instance types server: %w", err)
+		}
+		privatev1.RegisterInstanceTypesServer(registrar, privateInstanceTypesServer)
 	}
-	privatev1.RegisterInstanceTypesServer(registrar, privateInstanceTypesServer)
 
-	// Create the bare metal instance types server:
-	deps.Logger.InfoContext(ctx, "Creating bare metal instance types server")
-	bareMetalInstanceTypesServer, err := servers.NewBareMetalInstanceTypesServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PublicAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create bare metal instance types server: %w", err)
-	}
-	publicv1.RegisterBareMetalInstanceTypesServer(registrar, bareMetalInstanceTypesServer)
+	// BMaaS: bare metal instance types
+	if deps.Services.BMaaS {
+		deps.Logger.InfoContext(ctx, "Creating bare metal instance types server")
+		bareMetalInstanceTypesServer, err := servers.NewBareMetalInstanceTypesServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PublicAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create bare metal instance types server: %w", err)
+		}
+		publicv1.RegisterBareMetalInstanceTypesServer(registrar, bareMetalInstanceTypesServer)
 
-	// Create the private bare metal instance types server:
-	deps.Logger.InfoContext(ctx, "Creating private bare metal instance types server")
-	privateBareMetalInstanceTypesServer, err := servers.NewPrivateBareMetalInstanceTypesServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PrivateAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create private bare metal instance types server: %w", err)
+		deps.Logger.InfoContext(ctx, "Creating private bare metal instance types server")
+		privateBareMetalInstanceTypesServer, err := servers.NewPrivateBareMetalInstanceTypesServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PrivateAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create private bare metal instance types server: %w", err)
+		}
+		privatev1.RegisterBareMetalInstanceTypesServer(registrar, privateBareMetalInstanceTypesServer)
 	}
-	privatev1.RegisterBareMetalInstanceTypesServer(registrar, privateBareMetalInstanceTypesServer)
 
-	// Create the cluster versions server:
-	deps.Logger.InfoContext(ctx, "Creating cluster versions server")
-	clusterVersionsServer, err := servers.NewClusterVersionsServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PublicAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create cluster versions server: %w", err)
-	}
-	publicv1.RegisterClusterVersionsServer(registrar, clusterVersionsServer)
+	if deps.Services.CaaS {
+		deps.Logger.InfoContext(ctx, "Creating cluster versions server")
+		clusterVersionsServer, err := servers.NewClusterVersionsServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PublicAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create cluster versions server: %w", err)
+		}
+		publicv1.RegisterClusterVersionsServer(registrar, clusterVersionsServer)
 
-	// Create the private cluster versions server:
-	deps.Logger.InfoContext(ctx, "Creating private cluster versions server")
-	privateClusterVersionsServer, err := servers.NewPrivateClusterVersionsServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PrivateAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create private cluster versions server: %w", err)
+		deps.Logger.InfoContext(ctx, "Creating private cluster versions server")
+		privateClusterVersionsServer, err := servers.NewPrivateClusterVersionsServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PrivateAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create private cluster versions server: %w", err)
+		}
+		privatev1.RegisterClusterVersionsServer(registrar, privateClusterVersionsServer)
 	}
-	privatev1.RegisterClusterVersionsServer(registrar, privateClusterVersionsServer)
 
 	// Create the private storage backends server:
 	deps.Logger.InfoContext(ctx, "Creating private storage backends server")
@@ -983,20 +988,22 @@ func RegisterResourceServers(ctx context.Context, registrar grpc.ServiceRegistra
 	}
 	privatev1.RegisterProjectsServer(registrar, privateProjectsServer)
 
-	// Create the private volumes server:
-	deps.Logger.InfoContext(ctx, "Creating private volumes server")
-	privateVolumesServer, err := servers.NewPrivateVolumesServer().
-		SetLogger(deps.Logger).
-		SetNotifier(deps.Notifier).
-		SetAttributionLogic(deps.PrivateAttributionLogic).
-		SetTenancyLogic(deps.TenancyLogic).
-		SetMetricsRegisterer(deps.MetricsRegisterer).
-		SetTierResolver(deps.TierResolver).
-		Build()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create private volumes server: %w", err)
+	// VMaaS: volumes
+	if deps.Services.VMaaS {
+		deps.Logger.InfoContext(ctx, "Creating private volumes server")
+		privateVolumesServer, err := servers.NewPrivateVolumesServer().
+			SetLogger(deps.Logger).
+			SetNotifier(deps.Notifier).
+			SetAttributionLogic(deps.PrivateAttributionLogic).
+			SetTenancyLogic(deps.TenancyLogic).
+			SetMetricsRegisterer(deps.MetricsRegisterer).
+			SetTierResolver(deps.TierResolver).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create private volumes server: %w", err)
+		}
+		privatev1.RegisterVolumesServer(registrar, privateVolumesServer)
 	}
-	privatev1.RegisterVolumesServer(registrar, privateVolumesServer)
 
 	// Create the public users server:
 	deps.Logger.InfoContext(ctx, "Creating public users server")

--- a/fulfillment-service/internal/cmd/service/start/grpcserver/register_servers_test.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/register_servers_test.go
@@ -179,7 +179,7 @@ var _ = BeforeSuite(func() {
 		SetTenancyLogic(tenancy).
 		Build()
 	Expect(err).ToNot(HaveOccurred())
-	tierResolver := newDAOTierResolver(storageTiersDAO, storageBackendsDAO)
+	tierResolver = newDAOTierResolver(storageTiersDAO, storageBackendsDAO)
 
 	// Create the private users server, exactly as production does in start_grpc_server_cmd.go's run(). It's
 	// constructed outside RegisterResourceServers there because the JIT provisioning interceptor needs it before

--- a/fulfillment-service/internal/cmd/service/start/grpcserver/register_servers_test.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/register_servers_test.go
@@ -41,6 +41,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/auth"
@@ -51,6 +52,7 @@ import (
 	"github.com/osac-project/osac/fulfillment-service/internal/packages"
 	"github.com/osac-project/osac/fulfillment-service/internal/recovery"
 	"github.com/osac-project/osac/fulfillment-service/internal/servers"
+	"github.com/osac-project/osac/fulfillment-service/internal/services"
 	itesting "github.com/osac-project/osac/fulfillment-service/internal/testing"
 )
 
@@ -60,13 +62,16 @@ func TestRegisterServers(t *testing.T) {
 }
 
 var (
-	ctx         context.Context
-	ctrl        *gomock.Controller
-	logger      *slog.Logger
-	dbContainer *database.Container
-	attribution *auth.MockAttributionLogic
-	tenancy     *auth.MockTenancyLogic
-	conn        *grpc.ClientConn
+	ctx          context.Context
+	ctrl         *gomock.Controller
+	logger       *slog.Logger
+	dbContainer  *database.Container
+	dbNotifier   *database.Notifier
+	attribution  *auth.MockAttributionLogic
+	tenancy      *auth.MockTenancyLogic
+	conn         *grpc.ClientConn
+	hubScheme    *k8sruntime.Scheme
+	tierResolver servers.TierResolverFunc
 )
 
 var _ = BeforeSuite(func() {
@@ -149,16 +154,16 @@ var _ = BeforeSuite(func() {
 	// Create the notifier. ExternalIPPoolsServerBuilder, ProjectsServerBuilder, and PrivateProjectsServerBuilder
 	// require a concrete *database.Notifier (see register_servers.go), so this can't be nil or a different
 	// events.Notifier implementation.
-	notifier, err := database.NewNotifier().
+	dbNotifier, err = database.NewNotifier().
 		SetLogger(logger).
 		SetChannel("events").
 		SetPool(pool).
 		Build()
 	Expect(err).ToNot(HaveOccurred())
-	err = notifier.Start(ctx)
+	err = dbNotifier.Start(ctx)
 	Expect(err).ToNot(HaveOccurred())
 
-	hubScheme, err := hubscheme.NewHub()
+	hubScheme, err = hubscheme.NewHub()
 	Expect(err).ToNot(HaveOccurred())
 	metricsRegisterer := prometheus.NewRegistry()
 
@@ -181,7 +186,7 @@ var _ = BeforeSuite(func() {
 	// the interceptor chain is built — see ResourceServerDeps.PrivateUsersServer's doc comment.
 	privateUsersServer, err := servers.NewPrivateUsersServer().
 		SetLogger(logger).
-		SetNotifier(notifier).
+		SetNotifier(dbNotifier).
 		SetAttributionLogic(attribution).
 		SetTenancyLogic(tenancy).
 		SetMetricsRegisterer(metricsRegisterer).
@@ -197,7 +202,7 @@ var _ = BeforeSuite(func() {
 	DeferCleanup(server.Stop)
 	_, err = RegisterResourceServers(ctx, server.Registrar(), ResourceServerDeps{
 		Logger:                  logger,
-		Notifier:                notifier,
+		Notifier:                dbNotifier,
 		PrivateAttributionLogic: attribution,
 		PublicAttributionLogic:  attribution,
 		TenancyLogic:            tenancy,
@@ -205,6 +210,7 @@ var _ = BeforeSuite(func() {
 		HubScheme:               hubScheme,
 		TierResolver:            tierResolver,
 		PrivateUsersServer:      privateUsersServer,
+		Services:                &services.Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true},
 	})
 	Expect(err).ToNot(HaveOccurred())
 	server.Start()
@@ -452,3 +458,167 @@ func dedupeByResource(cases []filterOracleCase) []filterOracleCase {
 	}
 	return result
 }
+
+// registerWithFlags creates a gRPC server, registers resource servers with the given service flags,
+// and returns the registered service names via GetServiceInfo.
+func registerWithFlags(svcFlags *services.Flags) (map[string]grpc.ServiceInfo, *ResourceServers, error) {
+	srv := grpc.NewServer()
+	rs, err := RegisterResourceServers(ctx, srv, ResourceServerDeps{
+		Logger:                  logger,
+		Notifier:                dbNotifier,
+		PrivateAttributionLogic: attribution,
+		PublicAttributionLogic:  attribution,
+		TenancyLogic:            tenancy,
+		MetricsRegisterer:       prometheus.NewRegistry(),
+		HubScheme:               hubScheme,
+		TierResolver:            tierResolver,
+		PrivateUsersServer:      nil,
+		Services:                svcFlags,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return srv.GetServiceInfo(), rs, nil
+}
+
+var _ = Describe("Conditional service registration", func() {
+	// CaaS service names (both public and private)
+	caasServices := []string{
+		"osac.public.v1.ClusterTemplates",
+		"osac.public.v1.ClusterCatalogItems",
+		"osac.public.v1.Clusters",
+		"osac.public.v1.ClusterVersions",
+		"osac.private.v1.ClusterTemplates",
+		"osac.private.v1.ClusterCatalogItems",
+		"osac.private.v1.Clusters",
+		"osac.private.v1.ClusterVersions",
+	}
+
+	// VMaaS service names
+	vmaasServices := []string{
+		"osac.public.v1.ComputeInstanceTemplates",
+		"osac.public.v1.ComputeInstanceCatalogItems",
+		"osac.public.v1.ComputeInstances",
+		"osac.public.v1.DiskImages",
+		"osac.public.v1.InstanceTypes",
+		"osac.private.v1.ComputeInstanceTemplates",
+		"osac.private.v1.ComputeInstanceCatalogItems",
+		"osac.private.v1.ComputeInstances",
+		"osac.private.v1.DiskImages",
+		"osac.private.v1.InstanceTypes",
+		"osac.private.v1.Volumes",
+	}
+
+	// BMaaS service names
+	bmaasServices := []string{
+		"osac.public.v1.BareMetalInstanceTemplates",
+		"osac.public.v1.BareMetalInstanceCatalogItems",
+		"osac.public.v1.BareMetalInstances",
+		"osac.public.v1.BareMetalInstanceTypes",
+		"osac.private.v1.BareMetalInstanceTemplates",
+		"osac.private.v1.BareMetalInstanceCatalogItems",
+		"osac.private.v1.BareMetalInstances",
+		"osac.private.v1.BareMetalInstanceTypes",
+	}
+
+	// Shared infrastructure services (always registered regardless of flags)
+	sharedServices := []string{
+		"osac.public.v1.HostTypes",
+		"osac.public.v1.VirtualNetworks",
+		"osac.public.v1.Subnets",
+		"osac.public.v1.SecurityGroups",
+		"osac.public.v1.Roles",
+		"osac.public.v1.RoleBindings",
+		"osac.public.v1.ProjectMemberships",
+		"osac.public.v1.ExternalIPPools",
+		"osac.public.v1.ExternalIPs",
+		"osac.public.v1.ExternalIPAttachments",
+		"osac.public.v1.NATGateways",
+		"osac.public.v1.Tenants",
+		"osac.public.v1.IdentityProviders",
+		"osac.public.v1.Projects",
+		"osac.public.v1.Users",
+		"osac.public.v1.Secrets",
+		"osac.public.v1.StorageTiers",
+		"osac.private.v1.HostTypes",
+		"osac.private.v1.Hubs",
+		"osac.private.v1.VirtualNetworks",
+		"osac.private.v1.Subnets",
+		"osac.private.v1.SecurityGroups",
+		"osac.private.v1.NetworkClasses",
+		"osac.private.v1.Roles",
+		"osac.private.v1.RoleBindings",
+		"osac.private.v1.ProjectMemberships",
+		"osac.private.v1.ExternalIPPools",
+		"osac.private.v1.ExternalIPs",
+		"osac.private.v1.ExternalIPAttachments",
+		"osac.private.v1.NATGateways",
+		"osac.private.v1.Tenants",
+		"osac.private.v1.IdentityProviders",
+		"osac.private.v1.Projects",
+		"osac.private.v1.Users",
+		"osac.private.v1.StorageBackends",
+		"osac.private.v1.Secrets",
+		"osac.private.v1.StorageTiers",
+	}
+
+	It("registers all services when all flags are enabled", func() {
+		info, _, err := registerWithFlags(&services.Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true})
+		Expect(err).ToNot(HaveOccurred())
+
+		for _, svc := range append(append(append(caasServices, vmaasServices...), bmaasServices...), sharedServices...) {
+			Expect(info).To(HaveKey(svc), "expected service %s to be registered", svc)
+		}
+	})
+
+	It("excludes BMaaS services when BMaaS is disabled", func() {
+		info, _, err := registerWithFlags(&services.Flags{CaaS: true, VMaaS: true, BMaaS: false, MaaS: false})
+		Expect(err).ToNot(HaveOccurred())
+
+		for _, svc := range bmaasServices {
+			Expect(info).ToNot(HaveKey(svc), "expected BMaaS service %s to NOT be registered", svc)
+		}
+		for _, svc := range caasServices {
+			Expect(info).To(HaveKey(svc), "expected CaaS service %s to be registered", svc)
+		}
+		for _, svc := range vmaasServices {
+			Expect(info).To(HaveKey(svc), "expected VMaaS service %s to be registered", svc)
+		}
+	})
+
+	It("excludes CaaS and BMaaS services when only VMaaS is enabled", func() {
+		info, _, err := registerWithFlags(&services.Flags{CaaS: false, VMaaS: true, BMaaS: false, MaaS: false})
+		Expect(err).ToNot(HaveOccurred())
+
+		for _, svc := range caasServices {
+			Expect(info).ToNot(HaveKey(svc), "expected CaaS service %s to NOT be registered", svc)
+		}
+		for _, svc := range bmaasServices {
+			Expect(info).ToNot(HaveKey(svc), "expected BMaaS service %s to NOT be registered", svc)
+		}
+		for _, svc := range vmaasServices {
+			Expect(info).To(HaveKey(svc), "expected VMaaS service %s to be registered", svc)
+		}
+	})
+
+	It("always registers shared infrastructure regardless of flags", func() {
+		info, _, err := registerWithFlags(&services.Flags{CaaS: false, VMaaS: false, BMaaS: false, MaaS: false})
+		Expect(err).ToNot(HaveOccurred())
+
+		for _, svc := range sharedServices {
+			Expect(info).To(HaveKey(svc), "expected shared service %s to always be registered", svc)
+		}
+	})
+
+	It("returns nil PrivateComputeInstancesServer when VMaaS is disabled", func() {
+		_, rs, err := registerWithFlags(&services.Flags{CaaS: true, VMaaS: false, BMaaS: true, MaaS: false})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rs.PrivateComputeInstancesServer).To(BeNil())
+	})
+
+	It("returns non-nil PrivateComputeInstancesServer when VMaaS is enabled", func() {
+		_, rs, err := registerWithFlags(&services.Flags{CaaS: true, VMaaS: true, BMaaS: false, MaaS: false})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(rs.PrivateComputeInstancesServer).ToNot(BeNil())
+	})
+})

--- a/fulfillment-service/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -512,6 +512,14 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 		return fmt.Errorf("failed to read gRPC keepalive configuration: %w", err)
 	}
 
+	// Create the disabled-service request counter and unknown service handler:
+	disabledServiceCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "fulfillment_disabled_service_requests_total",
+		Help: "Total requests to disabled services.",
+	}, []string{"service", "method"})
+	metricsRegisterer.MustRegister(disabledServiceCounter)
+	unknownHandler := NewUnknownServiceHandler(c.args.services, disabledServiceCounter)
+
 	// Create the gRPC server:
 	c.logger.InfoContext(ctx, "Creating gRPC server")
 	grpcServer := grpc.NewServer(
@@ -523,6 +531,7 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 			MinTime:             keepaliveConfig.MinTime,
 			PermitWithoutStream: true,
 		}),
+		grpc.UnknownServiceHandler(unknownHandler),
 		grpc.ChainUnaryInterceptor(
 			panicInterceptor.UnaryServer,
 			metricsInterceptor.UnaryServer,

--- a/fulfillment-service/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -516,7 +516,7 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 	disabledServiceCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "fulfillment_disabled_service_requests_total",
 		Help: "Total requests to disabled services.",
-	}, []string{"service", "method"})
+	}, []string{"service"})
 	metricsRegisterer.MustRegister(disabledServiceCounter)
 	unknownHandler := NewUnknownServiceHandler(c.args.services, disabledServiceCounter)
 

--- a/fulfillment-service/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -56,6 +56,7 @@ import (
 	"github.com/osac-project/osac/fulfillment-service/internal/recovery"
 	"github.com/osac-project/osac/fulfillment-service/internal/references"
 	"github.com/osac-project/osac/fulfillment-service/internal/servers"
+	"github.com/osac-project/osac/fulfillment-service/internal/services"
 	shtdwn "github.com/osac-project/osac/fulfillment-service/internal/shutdown"
 	"github.com/osac-project/osac/fulfillment-service/internal/validation"
 	"github.com/osac-project/osac/fulfillment-service/internal/vault"
@@ -189,6 +190,7 @@ func Cmd() *cobra.Command {
 	)
 	vault.AddBaseFlags(flags)
 	network.AddGrpcKeepaliveFlags(flags)
+	runner.args.services = services.RegisterFlags(flags)
 	return command
 }
 
@@ -208,16 +210,26 @@ type runnerContext struct {
 		tokenIssuer              string
 		emergencyServiceAccounts []string
 		vaultBase                vault.BaseConfig
+		services                 *services.Flags
 	}
 }
 
 // run runs the `start grpc-server` command.
 func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:gocyclo
+	// Apply service flag defaults and validate (before context creation to avoid cancel leak):
+	c.args.services.EnableAllIfNoneSet()
+	if err := c.args.services.Validate(); err != nil {
+		return fmt.Errorf("invalid service flags: %w", err)
+	}
+
 	// Get the context and create a cancellable version:
 	ctx, cancel := context.WithCancel(cmd.Context())
 
 	// Get the dependencies from the context:
 	c.logger = logging.LoggerFromContext(ctx)
+	c.logger.InfoContext(ctx, "Service enablement",
+		slog.Any("enabled", c.args.services.EnabledServices()),
+	)
 
 	// Configure the Kubernetes libraries to use the logger:
 	logrLogger := logr.FromSlogHandler(c.logger.Handler())

--- a/fulfillment-service/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/start_grpc_server_cmd.go
@@ -699,6 +699,7 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 		SecretStore:             secretStore,
 		TierResolver:            tierResolver,
 		PrivateUsersServer:      privateUsersServer,
+		Services:                c.args.services,
 	})
 	if err != nil {
 		return err
@@ -735,40 +736,42 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error { //nolint:
 	// filterable-resource-exempt: singleton JWKS fetch, no List RPC or CEL filter field
 	publicv1.RegisterJsonWebKeySetServer(grpcServer, jsonWebKeySetServer)
 
-	// Build the console target resolver (lookup/policy only):
-	hubLookup := servers.NewPrivateServerHubLookup(privateHubsServer, privateSecretsServer)
-	consoleResolver, err := servers.NewConsoleTargetResolver().
-		SetLogger(c.logger).
-		SetComputeInstanceLookup(servers.NewPrivateServerCILookup(privateComputeInstancesServer)).
-		SetHubLookup(hubLookup).
-		SetHubClientFactory(servers.NewDefaultHubClientFactory(hubScheme)).
-		Build()
-	if err != nil {
-		return fmt.Errorf("failed to create console target resolver: %w", err)
-	}
+	if c.args.services.VMaaS {
+		// Build the console target resolver (lookup/policy only):
+		hubLookup := servers.NewPrivateServerHubLookup(privateHubsServer, privateSecretsServer)
+		consoleResolver, err := servers.NewConsoleTargetResolver().
+			SetLogger(c.logger).
+			SetComputeInstanceLookup(servers.NewPrivateServerCILookup(privateComputeInstancesServer)).
+			SetHubLookup(hubLookup).
+			SetHubClientFactory(servers.NewDefaultHubClientFactory(hubScheme)).
+			Build()
+		if err != nil {
+			return fmt.Errorf("failed to create console target resolver: %w", err)
+		}
 
-	// Build the console session service (orchestration):
-	sessionService, err := console.NewSessionService().
-		SetLogger(c.logger).
-		SetResolver(consoleResolver).
-		SetSealer(ticketSealer).
-		Build()
-	if err != nil {
-		return fmt.Errorf("failed to create console session service: %w", err)
-	}
+		// Build the console session service (orchestration):
+		sessionService, err := console.NewSessionService().
+			SetLogger(c.logger).
+			SetResolver(consoleResolver).
+			SetSealer(ticketSealer).
+			Build()
+		if err != nil {
+			return fmt.Errorf("failed to create console session service: %w", err)
+		}
 
-	// Create the console sessions server (thin adapter):
-	c.logger.InfoContext(ctx, "Creating console server")
-	consoleServer, err := servers.NewConsoleServer().
-		SetLogger(c.logger).
-		SetSessionService(sessionService).
-		Build()
-	if err != nil {
-		return fmt.Errorf("failed to create console server: %w", err)
+		// Create the console sessions server (thin adapter):
+		c.logger.InfoContext(ctx, "Creating console server")
+		consoleServer, err := servers.NewConsoleServer().
+			SetLogger(c.logger).
+			SetSessionService(sessionService).
+			Build()
+		if err != nil {
+			return fmt.Errorf("failed to create console server: %w", err)
+		}
+		// filterable-resource-exempt: session/action RPC, no List RPC or CEL filter field; also depends on
+		// privateHubsServer/privateComputeInstancesServer from RegisterResourceServers, so it must be built after
+		publicv1.RegisterConsoleSessionsServer(grpcServer, consoleServer)
 	}
-	// filterable-resource-exempt: session/action RPC, no List RPC or CEL filter field; also depends on
-	// privateHubsServer/privateComputeInstancesServer from RegisterResourceServers, so it must be built after
-	publicv1.RegisterConsoleSessionsServer(grpcServer, consoleServer)
 
 	// Create the events server:
 	c.logger.InfoContext(ctx, "Creating events server")

--- a/fulfillment-service/internal/cmd/service/start/grpcserver/unknown_service_handler.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/unknown_service_handler.go
@@ -1,0 +1,112 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package grpcserver
+
+import (
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/osac-project/osac/fulfillment-service/internal/services"
+)
+
+// disabledServicePrefixes maps each service flag to its set of gRPC service full-name prefixes.
+// When a flag is false, all prefixes in that group are added to the disabled set.
+var disabledServicePrefixes = map[string][]string{
+	"CaaS": {
+		"/osac.public.v1.ClusterTemplates/",
+		"/osac.public.v1.ClusterCatalogItems/",
+		"/osac.public.v1.Clusters/",
+		"/osac.public.v1.ClusterVersions/",
+		"/osac.private.v1.ClusterTemplates/",
+		"/osac.private.v1.ClusterCatalogItems/",
+		"/osac.private.v1.Clusters/",
+		"/osac.private.v1.ClusterVersions/",
+	},
+	"VMaaS": {
+		"/osac.public.v1.ComputeInstanceTemplates/",
+		"/osac.public.v1.ComputeInstanceCatalogItems/",
+		"/osac.public.v1.ComputeInstances/",
+		"/osac.public.v1.DiskImages/",
+		"/osac.public.v1.ConsoleSessions/",
+		"/osac.public.v1.InstanceTypes/",
+		"/osac.private.v1.ComputeInstanceTemplates/",
+		"/osac.private.v1.ComputeInstanceCatalogItems/",
+		"/osac.private.v1.ComputeInstances/",
+		"/osac.private.v1.DiskImages/",
+		"/osac.private.v1.InstanceTypes/",
+		"/osac.private.v1.Volumes/",
+	},
+	"BMaaS": {
+		"/osac.public.v1.BareMetalInstanceTemplates/",
+		"/osac.public.v1.BareMetalInstanceCatalogItems/",
+		"/osac.public.v1.BareMetalInstances/",
+		"/osac.public.v1.BareMetalInstanceTypes/",
+		"/osac.private.v1.BareMetalInstanceTemplates/",
+		"/osac.private.v1.BareMetalInstanceCatalogItems/",
+		"/osac.private.v1.BareMetalInstances/",
+		"/osac.private.v1.BareMetalInstanceTypes/",
+	},
+}
+
+// buildDisabledServiceMap builds a map from gRPC method prefix to the service group name
+// (e.g. "CaaS") for every service that is currently disabled.
+func buildDisabledServiceMap(svcFlags *services.Flags) map[string]string {
+	disabled := make(map[string]string)
+	flagValues := map[string]bool{
+		"CaaS":  svcFlags.CaaS,
+		"VMaaS": svcFlags.VMaaS,
+		"BMaaS": svcFlags.BMaaS,
+	}
+	for group, prefixes := range disabledServicePrefixes {
+		if !flagValues[group] {
+			for _, prefix := range prefixes {
+				disabled[prefix] = group
+			}
+		}
+	}
+	return disabled
+}
+
+// NewUnknownServiceHandler returns a grpc.StreamHandler that returns codes.Unavailable for
+// known-but-disabled services and codes.Unimplemented for genuinely unknown services.
+func NewUnknownServiceHandler(
+	svcFlags *services.Flags,
+	counter *prometheus.CounterVec,
+) grpc.StreamHandler {
+	disabledMap := buildDisabledServiceMap(svcFlags)
+
+	return func(_ interface{}, stream grpc.ServerStream) error {
+		method, ok := grpc.MethodFromServerStream(stream)
+		if !ok {
+			return status.Error(codes.Unimplemented, "unknown service")
+		}
+
+		for prefix, group := range disabledMap {
+			if strings.HasPrefix(method, prefix) {
+				counter.WithLabelValues(group, method).Inc()
+				return status.Errorf(
+					codes.Unavailable,
+					"the %s service is not enabled on this server",
+					group,
+				)
+			}
+		}
+
+		return status.Errorf(codes.Unimplemented, "unknown service %s", method)
+	}
+}

--- a/fulfillment-service/internal/cmd/service/start/grpcserver/unknown_service_handler.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/unknown_service_handler.go
@@ -98,7 +98,7 @@ func NewUnknownServiceHandler(
 
 		for prefix, group := range disabledMap {
 			if strings.HasPrefix(method, prefix) {
-				counter.WithLabelValues(group, method).Inc()
+				counter.WithLabelValues(group).Inc()
 				return status.Errorf(
 					codes.Unavailable,
 					"the %s service is not enabled on this server",

--- a/fulfillment-service/internal/cmd/service/start/grpcserver/unknown_service_handler_test.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/unknown_service_handler_test.go
@@ -16,8 +16,9 @@ package grpcserver
 import (
 	"context"
 	"net"
-	"testing"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"google.golang.org/grpc"
@@ -36,25 +37,24 @@ func newTestCounter(reg *prometheus.Registry) *prometheus.CounterVec {
 	return counter
 }
 
-func startTestServer(t *testing.T, handler grpc.StreamHandler) *grpc.ClientConn {
-	t.Helper()
+func startTestServer(handler grpc.StreamHandler) (*grpc.ClientConn, func()) {
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("failed to listen: %v", err)
-	}
+	Expect(err).ToNot(HaveOccurred())
+
 	srv := grpc.NewServer(grpc.UnknownServiceHandler(handler))
-	t.Cleanup(srv.Stop)
 	go func() { _ = srv.Serve(lis) }()
 
 	conn, err := grpc.NewClient(
 		lis.Addr().String(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
-	if err != nil {
-		t.Fatalf("failed to dial: %v", err)
+	Expect(err).ToNot(HaveOccurred())
+
+	cleanup := func() {
+		conn.Close()
+		srv.Stop()
 	}
-	t.Cleanup(func() { conn.Close() })
-	return conn
+	return conn, cleanup
 }
 
 func invokeMethod(conn *grpc.ClientConn, fullMethod string) error {
@@ -74,122 +74,94 @@ func getCounterValue(counter *prometheus.CounterVec, labels ...string) float64 {
 	return *m.Counter.Value
 }
 
-func TestUnknownServiceHandler_DisabledService(t *testing.T) {
-	reg := prometheus.NewRegistry()
-	counter := newTestCounter(reg)
-	flags := &services.Flags{CaaS: false, VMaaS: true, BMaaS: true, MaaS: false}
-	handler := NewUnknownServiceHandler(flags, counter)
-	conn := startTestServer(t, handler)
+var _ = Describe("UnknownServiceHandler", func() {
+	It("returns Unavailable for a disabled service", func() {
+		reg := prometheus.NewRegistry()
+		counter := newTestCounter(reg)
+		flags := &services.Flags{CaaS: false, VMaaS: true, BMaaS: true, MaaS: false}
+		handler := NewUnknownServiceHandler(flags, counter)
+		conn, cleanup := startTestServer(handler)
+		DeferCleanup(cleanup)
 
-	err := invokeMethod(conn, "/osac.public.v1.Clusters/List")
-	if err == nil {
-		t.Fatal("expected error for disabled CaaS service")
-	}
-	st, ok := status.FromError(err)
-	if !ok {
-		t.Fatalf("expected gRPC status error, got: %v", err)
-	}
-	if st.Code() != codes.Unavailable {
-		t.Errorf("expected Unavailable, got %v", st.Code())
-	}
-	if got := st.Message(); got != "the CaaS service is not enabled on this server" {
-		t.Errorf("unexpected message: %s", got)
-	}
-}
+		err := invokeMethod(conn, "/osac.public.v1.Clusters/List")
+		Expect(err).To(HaveOccurred())
 
-func TestUnknownServiceHandler_UnknownService(t *testing.T) {
-	reg := prometheus.NewRegistry()
-	counter := newTestCounter(reg)
-	flags := &services.Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true}
-	handler := NewUnknownServiceHandler(flags, counter)
-	conn := startTestServer(t, handler)
-
-	err := invokeMethod(conn, "/osac.public.v1.NonExistent/Get")
-	if err == nil {
-		t.Fatal("expected error for unknown service")
-	}
-	st, ok := status.FromError(err)
-	if !ok {
-		t.Fatalf("expected gRPC status error, got: %v", err)
-	}
-	if st.Code() != codes.Unimplemented {
-		t.Errorf("expected Unimplemented, got %v", st.Code())
-	}
-}
-
-func TestUnknownServiceHandler_PrometheusCounter(t *testing.T) {
-	reg := prometheus.NewRegistry()
-	counter := newTestCounter(reg)
-	flags := &services.Flags{CaaS: false, VMaaS: true, BMaaS: false, MaaS: false}
-	handler := NewUnknownServiceHandler(flags, counter)
-	conn := startTestServer(t, handler)
-
-	_ = invokeMethod(conn, "/osac.public.v1.Clusters/List")
-	_ = invokeMethod(conn, "/osac.public.v1.Clusters/Get")
-	_ = invokeMethod(conn, "/osac.private.v1.BareMetalInstances/List")
-
-	caasCount := getCounterValue(counter, "CaaS", "/osac.public.v1.Clusters/List")
-	if caasCount != 1 {
-		t.Errorf("expected CaaS List counter = 1, got %v", caasCount)
-	}
-	caasGetCount := getCounterValue(counter, "CaaS", "/osac.public.v1.Clusters/Get")
-	if caasGetCount != 1 {
-		t.Errorf("expected CaaS Get counter = 1, got %v", caasGetCount)
-	}
-	bmaasCount := getCounterValue(counter, "BMaaS", "/osac.private.v1.BareMetalInstances/List")
-	if bmaasCount != 1 {
-		t.Errorf("expected BMaaS counter = 1, got %v", bmaasCount)
-	}
-}
-
-func TestUnknownServiceHandler_EnabledServiceNotBlocked(t *testing.T) {
-	reg := prometheus.NewRegistry()
-	counter := newTestCounter(reg)
-	flags := &services.Flags{CaaS: false, VMaaS: true, BMaaS: true, MaaS: false}
-	handler := NewUnknownServiceHandler(flags, counter)
-	conn := startTestServer(t, handler)
-
-	err := invokeMethod(conn, "/osac.public.v1.ComputeInstances/List")
-	if err == nil {
-		t.Fatal("expected error (service not actually registered)")
-	}
-	st, ok := status.FromError(err)
-	if !ok {
-		t.Fatalf("expected gRPC status error, got: %v", err)
-	}
-	if st.Code() != codes.Unimplemented {
-		t.Errorf("expected Unimplemented for enabled-but-not-registered service, got %v", st.Code())
-	}
-}
-
-func TestBuildDisabledServiceMap(t *testing.T) {
-	t.Run("all enabled means empty map", func(t *testing.T) {
-		m := buildDisabledServiceMap(&services.Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true})
-		if len(m) != 0 {
-			t.Errorf("expected empty map, got %d entries", len(m))
-		}
+		st, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(st.Code()).To(Equal(codes.Unavailable))
+		Expect(st.Message()).To(Equal("the CaaS service is not enabled on this server"))
 	})
 
-	t.Run("all disabled populates all prefixes", func(t *testing.T) {
+	It("returns Unimplemented for an unknown service", func() {
+		reg := prometheus.NewRegistry()
+		counter := newTestCounter(reg)
+		flags := &services.Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true}
+		handler := NewUnknownServiceHandler(flags, counter)
+		conn, cleanup := startTestServer(handler)
+		DeferCleanup(cleanup)
+
+		err := invokeMethod(conn, "/osac.public.v1.NonExistent/Get")
+		Expect(err).To(HaveOccurred())
+
+		st, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(st.Code()).To(Equal(codes.Unimplemented))
+	})
+
+	It("increments the Prometheus counter for disabled services", func() {
+		reg := prometheus.NewRegistry()
+		counter := newTestCounter(reg)
+		flags := &services.Flags{CaaS: false, VMaaS: true, BMaaS: false, MaaS: false}
+		handler := NewUnknownServiceHandler(flags, counter)
+		conn, cleanup := startTestServer(handler)
+		DeferCleanup(cleanup)
+
+		_ = invokeMethod(conn, "/osac.public.v1.Clusters/List")
+		_ = invokeMethod(conn, "/osac.public.v1.Clusters/Get")
+		_ = invokeMethod(conn, "/osac.private.v1.BareMetalInstances/List")
+
+		Expect(getCounterValue(counter, "CaaS", "/osac.public.v1.Clusters/List")).To(Equal(1.0))
+		Expect(getCounterValue(counter, "CaaS", "/osac.public.v1.Clusters/Get")).To(Equal(1.0))
+		Expect(getCounterValue(counter, "BMaaS", "/osac.private.v1.BareMetalInstances/List")).To(Equal(1.0))
+	})
+
+	It("returns Unimplemented for an enabled but not registered service", func() {
+		reg := prometheus.NewRegistry()
+		counter := newTestCounter(reg)
+		flags := &services.Flags{CaaS: false, VMaaS: true, BMaaS: true, MaaS: false}
+		handler := NewUnknownServiceHandler(flags, counter)
+		conn, cleanup := startTestServer(handler)
+		DeferCleanup(cleanup)
+
+		err := invokeMethod(conn, "/osac.public.v1.ComputeInstances/List")
+		Expect(err).To(HaveOccurred())
+
+		st, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(st.Code()).To(Equal(codes.Unimplemented))
+	})
+})
+
+var _ = Describe("buildDisabledServiceMap", func() {
+	It("returns an empty map when all services are enabled", func() {
+		m := buildDisabledServiceMap(&services.Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true})
+		Expect(m).To(BeEmpty())
+	})
+
+	It("populates all prefixes when all services are disabled", func() {
 		m := buildDisabledServiceMap(&services.Flags{CaaS: false, VMaaS: false, BMaaS: false, MaaS: false})
 		totalPrefixes := 0
 		for _, prefixes := range disabledServicePrefixes {
 			totalPrefixes += len(prefixes)
 		}
-		if len(m) != totalPrefixes {
-			t.Errorf("expected %d entries, got %d", totalPrefixes, len(m))
-		}
+		Expect(m).To(HaveLen(totalPrefixes))
 	})
 
-	t.Run("partial disable only includes disabled groups", func(t *testing.T) {
+	It("only includes disabled groups for partial disable", func() {
 		m := buildDisabledServiceMap(&services.Flags{CaaS: true, VMaaS: false, BMaaS: true, MaaS: false})
 		for prefix := range m {
-			if group := m[prefix]; group != "VMaaS" {
-				t.Errorf("expected only VMaaS in disabled map, got %s for %s", group, prefix)
-			}
+			Expect(m[prefix]).To(Equal("VMaaS"))
 		}
-		if len(m) != len(disabledServicePrefixes["VMaaS"]) {
-			t.Errorf("expected %d VMaaS entries, got %d", len(disabledServicePrefixes["VMaaS"]), len(m))
-		}
+		Expect(m).To(HaveLen(len(disabledServicePrefixes["VMaaS"])))
 	})
-}
+})

--- a/fulfillment-service/internal/cmd/service/start/grpcserver/unknown_service_handler_test.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/unknown_service_handler_test.go
@@ -32,7 +32,7 @@ import (
 func newTestCounter(reg *prometheus.Registry) *prometheus.CounterVec {
 	counter := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "fulfillment_disabled_service_requests_total",
-	}, []string{"service", "method"})
+	}, []string{"service"})
 	reg.MustRegister(counter)
 	return counter
 }
@@ -120,9 +120,8 @@ var _ = Describe("UnknownServiceHandler", func() {
 		_ = invokeMethod(conn, "/osac.public.v1.Clusters/Get")
 		_ = invokeMethod(conn, "/osac.private.v1.BareMetalInstances/List")
 
-		Expect(getCounterValue(counter, "CaaS", "/osac.public.v1.Clusters/List")).To(Equal(1.0))
-		Expect(getCounterValue(counter, "CaaS", "/osac.public.v1.Clusters/Get")).To(Equal(1.0))
-		Expect(getCounterValue(counter, "BMaaS", "/osac.private.v1.BareMetalInstances/List")).To(Equal(1.0))
+		Expect(getCounterValue(counter, "CaaS")).To(Equal(2.0))
+		Expect(getCounterValue(counter, "BMaaS")).To(Equal(1.0))
 	})
 
 	It("returns Unimplemented for an enabled but not registered service", func() {

--- a/fulfillment-service/internal/cmd/service/start/grpcserver/unknown_service_handler_test.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/unknown_service_handler_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package grpcserver
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+
+	"github.com/osac-project/osac/fulfillment-service/internal/services"
+)
+
+func newTestCounter(reg *prometheus.Registry) *prometheus.CounterVec {
+	counter := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "fulfillment_disabled_service_requests_total",
+	}, []string{"service", "method"})
+	reg.MustRegister(counter)
+	return counter
+}
+
+func startTestServer(t *testing.T, handler grpc.StreamHandler) *grpc.ClientConn {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	srv := grpc.NewServer(grpc.UnknownServiceHandler(handler))
+	t.Cleanup(srv.Stop)
+	go func() { _ = srv.Serve(lis) }()
+
+	conn, err := grpc.NewClient(
+		lis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	return conn
+}
+
+func invokeMethod(conn *grpc.ClientConn, fullMethod string) error {
+	return conn.Invoke(context.Background(), fullMethod, nil, &struct{}{})
+}
+
+func getCounterValue(counter *prometheus.CounterVec, labels ...string) float64 {
+	m := &dto.Metric{}
+	c, err := counter.GetMetricWithLabelValues(labels...)
+	if err != nil {
+		return 0
+	}
+	_ = c.Write(m)
+	if m.Counter == nil {
+		return 0
+	}
+	return *m.Counter.Value
+}
+
+func TestUnknownServiceHandler_DisabledService(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	counter := newTestCounter(reg)
+	flags := &services.Flags{CaaS: false, VMaaS: true, BMaaS: true, MaaS: false}
+	handler := NewUnknownServiceHandler(flags, counter)
+	conn := startTestServer(t, handler)
+
+	err := invokeMethod(conn, "/osac.public.v1.Clusters/List")
+	if err == nil {
+		t.Fatal("expected error for disabled CaaS service")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got: %v", err)
+	}
+	if st.Code() != codes.Unavailable {
+		t.Errorf("expected Unavailable, got %v", st.Code())
+	}
+	if got := st.Message(); got != "the CaaS service is not enabled on this server" {
+		t.Errorf("unexpected message: %s", got)
+	}
+}
+
+func TestUnknownServiceHandler_UnknownService(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	counter := newTestCounter(reg)
+	flags := &services.Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true}
+	handler := NewUnknownServiceHandler(flags, counter)
+	conn := startTestServer(t, handler)
+
+	err := invokeMethod(conn, "/osac.public.v1.NonExistent/Get")
+	if err == nil {
+		t.Fatal("expected error for unknown service")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got: %v", err)
+	}
+	if st.Code() != codes.Unimplemented {
+		t.Errorf("expected Unimplemented, got %v", st.Code())
+	}
+}
+
+func TestUnknownServiceHandler_PrometheusCounter(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	counter := newTestCounter(reg)
+	flags := &services.Flags{CaaS: false, VMaaS: true, BMaaS: false, MaaS: false}
+	handler := NewUnknownServiceHandler(flags, counter)
+	conn := startTestServer(t, handler)
+
+	_ = invokeMethod(conn, "/osac.public.v1.Clusters/List")
+	_ = invokeMethod(conn, "/osac.public.v1.Clusters/Get")
+	_ = invokeMethod(conn, "/osac.private.v1.BareMetalInstances/List")
+
+	caasCount := getCounterValue(counter, "CaaS", "/osac.public.v1.Clusters/List")
+	if caasCount != 1 {
+		t.Errorf("expected CaaS List counter = 1, got %v", caasCount)
+	}
+	caasGetCount := getCounterValue(counter, "CaaS", "/osac.public.v1.Clusters/Get")
+	if caasGetCount != 1 {
+		t.Errorf("expected CaaS Get counter = 1, got %v", caasGetCount)
+	}
+	bmaasCount := getCounterValue(counter, "BMaaS", "/osac.private.v1.BareMetalInstances/List")
+	if bmaasCount != 1 {
+		t.Errorf("expected BMaaS counter = 1, got %v", bmaasCount)
+	}
+}
+
+func TestUnknownServiceHandler_EnabledServiceNotBlocked(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	counter := newTestCounter(reg)
+	flags := &services.Flags{CaaS: false, VMaaS: true, BMaaS: true, MaaS: false}
+	handler := NewUnknownServiceHandler(flags, counter)
+	conn := startTestServer(t, handler)
+
+	err := invokeMethod(conn, "/osac.public.v1.ComputeInstances/List")
+	if err == nil {
+		t.Fatal("expected error (service not actually registered)")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got: %v", err)
+	}
+	if st.Code() != codes.Unimplemented {
+		t.Errorf("expected Unimplemented for enabled-but-not-registered service, got %v", st.Code())
+	}
+}
+
+func TestBuildDisabledServiceMap(t *testing.T) {
+	t.Run("all enabled means empty map", func(t *testing.T) {
+		m := buildDisabledServiceMap(&services.Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true})
+		if len(m) != 0 {
+			t.Errorf("expected empty map, got %d entries", len(m))
+		}
+	})
+
+	t.Run("all disabled populates all prefixes", func(t *testing.T) {
+		m := buildDisabledServiceMap(&services.Flags{CaaS: false, VMaaS: false, BMaaS: false, MaaS: false})
+		totalPrefixes := 0
+		for _, prefixes := range disabledServicePrefixes {
+			totalPrefixes += len(prefixes)
+		}
+		if len(m) != totalPrefixes {
+			t.Errorf("expected %d entries, got %d", totalPrefixes, len(m))
+		}
+	})
+
+	t.Run("partial disable only includes disabled groups", func(t *testing.T) {
+		m := buildDisabledServiceMap(&services.Flags{CaaS: true, VMaaS: false, BMaaS: true, MaaS: false})
+		for prefix := range m {
+			if group := m[prefix]; group != "VMaaS" {
+				t.Errorf("expected only VMaaS in disabled map, got %s for %s", group, prefix)
+			}
+		}
+		if len(m) != len(disabledServicePrefixes["VMaaS"]) {
+			t.Errorf("expected %d VMaaS entries, got %d", len(disabledServicePrefixes["VMaaS"]), len(m))
+		}
+	})
+}

--- a/fulfillment-service/internal/cmd/service/start/restgateway/restgateway_suite_test.go
+++ b/fulfillment-service/internal/cmd/service/start/restgateway/restgateway_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package restgateway
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestRestgatewaySuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "REST gateway")
+}

--- a/fulfillment-service/internal/cmd/service/start/restgateway/start_rest_gateway_cmd.go
+++ b/fulfillment-service/internal/cmd/service/start/restgateway/start_rest_gateway_cmd.go
@@ -37,6 +37,7 @@ import (
 	"github.com/osac-project/osac/fulfillment-service/internal/logging"
 	"github.com/osac-project/osac/fulfillment-service/internal/network"
 	"github.com/osac-project/osac/fulfillment-service/internal/servers"
+	"github.com/osac-project/osac/fulfillment-service/internal/services"
 	shtdwn "github.com/osac-project/osac/fulfillment-service/internal/shutdown"
 	"github.com/osac-project/osac/fulfillment-service/internal/version"
 )
@@ -63,6 +64,7 @@ func Cmd() *cobra.Command {
 		[]string{},
 		caFileFlagHelp,
 	)
+	runner.args.services = services.RegisterFlags(flags)
 	return command
 }
 
@@ -75,16 +77,26 @@ type runnerContext struct {
 	args         struct {
 		caFiles   []string
 		tokenFile string
+		services  *services.Flags
 	}
 }
 
 // run runs the `start rest-gateway` command.
 func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
+	// Apply service flag defaults and validate (before context creation to avoid cancel leak):
+	c.args.services.EnableAllIfNoneSet()
+	if err := c.args.services.Validate(); err != nil {
+		return fmt.Errorf("invalid service flags: %w", err)
+	}
+
 	// Get the context:
 	ctx, cancel := context.WithCancel(cmd.Context())
 
 	// Get the dependencies from the context:
 	c.logger = logging.LoggerFromContext(ctx)
+	c.logger.InfoContext(ctx, "Service enablement",
+		slog.Any("enabled", c.args.services.EnabledServices()),
+	)
 
 	// Save the flags:
 	c.flags = cmd.Flags()

--- a/fulfillment-service/internal/cmd/service/start/restgateway/start_rest_gateway_cmd.go
+++ b/fulfillment-service/internal/cmd/service/start/restgateway/start_rest_gateway_cmd.go
@@ -297,21 +297,23 @@ type handlerRegistrar func(context.Context, *runtime.ServeMux, *grpc.ClientConn)
 
 // registerHandlers registers all public and private API service handlers on the gateway mux.
 func (c *runnerContext) registerHandlers(ctx context.Context, mux *runtime.ServeMux) error {
-	handlers := []handlerRegistrar{
-		// Public API:
+	for _, register := range buildHandlerList(c.args.services) {
+		if err := register(ctx, mux, c.grpcClient); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// buildHandlerList returns the set of grpc-gateway handler registrars to register,
+// filtered by which services are enabled.
+func buildHandlerList(svcFlags *services.Flags) []handlerRegistrar {
+	var handlers []handlerRegistrar
+
+	// Shared public API (always registered):
+	handlers = append(handlers,
 		publicv1.RegisterCapabilitiesHandler,
-		publicv1.RegisterClusterTemplatesHandler,
-		publicv1.RegisterClusterCatalogItemsHandler,
-		publicv1.RegisterClustersHandler,
-		publicv1.RegisterClusterVersionsHandler,
 		publicv1.RegisterHostTypesHandler,
-		publicv1.RegisterComputeInstanceTemplatesHandler,
-		publicv1.RegisterComputeInstanceCatalogItemsHandler,
-		publicv1.RegisterComputeInstancesHandler,
-		publicv1.RegisterDiskImagesHandler,
-		publicv1.RegisterBareMetalInstanceTemplatesHandler,
-		publicv1.RegisterBareMetalInstanceCatalogItemsHandler,
-		publicv1.RegisterBareMetalInstancesHandler,
 		publicv1.RegisterVirtualNetworksHandler,
 		publicv1.RegisterSubnetsHandler,
 		publicv1.RegisterSecurityGroupsHandler,
@@ -321,33 +323,20 @@ func (c *runnerContext) registerHandlers(ctx context.Context, mux *runtime.Serve
 		publicv1.RegisterExternalIPAttachmentsHandler,
 		publicv1.RegisterRolesHandler,
 		publicv1.RegisterRoleBindingsHandler,
-		publicv1.RegisterConsoleSessionsHandler,
 		publicv1.RegisterJsonWebKeySetHandler,
-		publicv1.RegisterInstanceTypesHandler,
-		publicv1.RegisterBareMetalInstanceTypesHandler,
 		publicv1.RegisterStorageTiersHandler,
+	)
 
-		// Private API:
+	// Shared private API (always registered):
+	handlers = append(handlers,
 		privatev1.RegisterCapabilitiesHandler,
-		privatev1.RegisterClusterTemplatesHandler,
-		privatev1.RegisterClusterCatalogItemsHandler,
-		privatev1.RegisterClustersHandler,
-		privatev1.RegisterClusterVersionsHandler,
 		privatev1.RegisterEventsHandler,
 		privatev1.RegisterHostTypesHandler,
 		privatev1.RegisterHubsHandler,
-		privatev1.RegisterComputeInstanceTemplatesHandler,
-		privatev1.RegisterComputeInstanceCatalogItemsHandler,
-		privatev1.RegisterComputeInstancesHandler,
-		privatev1.RegisterDiskImagesHandler,
-		privatev1.RegisterBareMetalInstanceTemplatesHandler,
-		privatev1.RegisterBareMetalInstanceCatalogItemsHandler,
-		privatev1.RegisterBareMetalInstancesHandler,
 		privatev1.RegisterNetworkClassesHandler,
 		privatev1.RegisterSecretsHandler,
 		privatev1.RegisterStorageBackendsHandler,
 		privatev1.RegisterStorageTiersHandler,
-		privatev1.RegisterVolumesHandler,
 		privatev1.RegisterVirtualNetworksHandler,
 		privatev1.RegisterSubnetsHandler,
 		privatev1.RegisterSecurityGroupsHandler,
@@ -357,15 +346,55 @@ func (c *runnerContext) registerHandlers(ctx context.Context, mux *runtime.Serve
 		privatev1.RegisterExternalIPAttachmentsHandler,
 		privatev1.RegisterRolesHandler,
 		privatev1.RegisterRoleBindingsHandler,
-		privatev1.RegisterInstanceTypesHandler,
-		privatev1.RegisterBareMetalInstanceTypesHandler,
+	)
+
+	// CaaS handlers:
+	if svcFlags.CaaS {
+		handlers = append(handlers,
+			publicv1.RegisterClusterTemplatesHandler,
+			publicv1.RegisterClusterCatalogItemsHandler,
+			publicv1.RegisterClustersHandler,
+			publicv1.RegisterClusterVersionsHandler,
+			privatev1.RegisterClusterTemplatesHandler,
+			privatev1.RegisterClusterCatalogItemsHandler,
+			privatev1.RegisterClustersHandler,
+			privatev1.RegisterClusterVersionsHandler,
+		)
 	}
-	for _, register := range handlers {
-		if err := register(ctx, mux, c.grpcClient); err != nil {
-			return err
-		}
+
+	// VMaaS handlers:
+	if svcFlags.VMaaS {
+		handlers = append(handlers,
+			publicv1.RegisterComputeInstanceTemplatesHandler,
+			publicv1.RegisterComputeInstanceCatalogItemsHandler,
+			publicv1.RegisterComputeInstancesHandler,
+			publicv1.RegisterDiskImagesHandler,
+			publicv1.RegisterConsoleSessionsHandler,
+			publicv1.RegisterInstanceTypesHandler,
+			privatev1.RegisterComputeInstanceTemplatesHandler,
+			privatev1.RegisterComputeInstanceCatalogItemsHandler,
+			privatev1.RegisterComputeInstancesHandler,
+			privatev1.RegisterDiskImagesHandler,
+			privatev1.RegisterInstanceTypesHandler,
+			privatev1.RegisterVolumesHandler,
+		)
 	}
-	return nil
+
+	// BMaaS handlers:
+	if svcFlags.BMaaS {
+		handlers = append(handlers,
+			publicv1.RegisterBareMetalInstanceTemplatesHandler,
+			publicv1.RegisterBareMetalInstanceCatalogItemsHandler,
+			publicv1.RegisterBareMetalInstancesHandler,
+			publicv1.RegisterBareMetalInstanceTypesHandler,
+			privatev1.RegisterBareMetalInstanceTemplatesHandler,
+			privatev1.RegisterBareMetalInstanceCatalogItemsHandler,
+			privatev1.RegisterBareMetalInstancesHandler,
+			privatev1.RegisterBareMetalInstanceTypesHandler,
+		)
+	}
+
+	return handlers
 }
 
 // userAgent is the user agent string for the REST gateway.

--- a/fulfillment-service/internal/cmd/service/start/restgateway/start_rest_gateway_cmd_test.go
+++ b/fulfillment-service/internal/cmd/service/start/restgateway/start_rest_gateway_cmd_test.go
@@ -17,12 +17,13 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/osac-project/osac/fulfillment-service/internal/services"
 )
 
-// handlerName extracts the short function name from a handlerRegistrar function pointer.
 func handlerName(h handlerRegistrar) string {
 	name := runtime.FuncForPC(reflect.ValueOf(h).Pointer()).Name()
 	if idx := strings.LastIndex(name, "/"); idx >= 0 {
@@ -132,60 +133,39 @@ var sharedHandlers = []string{
 	"private/v1.RegisterRoleBindingsHandler",
 }
 
-func TestBuildHandlerList_AllEnabled(t *testing.T) {
-	handlers := buildHandlerList(&services.Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true})
-	names := handlerNames(handlers)
+var _ = Describe("buildHandlerList", func() {
+	It("includes all service groups when all are enabled", func() {
+		handlers := buildHandlerList(&services.Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true})
+		names := handlerNames(handlers)
 
-	for _, group := range []struct {
-		label    string
-		expected []string
-	}{
-		{"CaaS", caasHandlers},
-		{"VMaaS", vmaasHandlers},
-		{"BMaaS", bmaasHandlers},
-		{"shared", sharedHandlers},
-	} {
-		if missing := containsAll(names, group.expected); len(missing) > 0 {
-			t.Errorf("all-enabled: missing %s handlers: %v", group.label, missing)
-		}
-	}
-}
+		Expect(containsAll(names, caasHandlers)).To(BeEmpty(), "missing CaaS handlers")
+		Expect(containsAll(names, vmaasHandlers)).To(BeEmpty(), "missing VMaaS handlers")
+		Expect(containsAll(names, bmaasHandlers)).To(BeEmpty(), "missing BMaaS handlers")
+		Expect(containsAll(names, sharedHandlers)).To(BeEmpty(), "missing shared handlers")
+	})
 
-func TestBuildHandlerList_BMaaSDisabled(t *testing.T) {
-	handlers := buildHandlerList(&services.Flags{CaaS: true, VMaaS: true, BMaaS: false, MaaS: false})
-	names := handlerNames(handlers)
+	It("excludes BMaaS handlers when BMaaS is disabled", func() {
+		handlers := buildHandlerList(&services.Flags{CaaS: true, VMaaS: true, BMaaS: false, MaaS: false})
+		names := handlerNames(handlers)
 
-	if found := containsNone(names, bmaasHandlers); len(found) > 0 {
-		t.Errorf("BMaaS disabled: found BMaaS handlers that should be absent: %v", found)
-	}
-	if missing := containsAll(names, caasHandlers); len(missing) > 0 {
-		t.Errorf("BMaaS disabled: missing CaaS handlers: %v", missing)
-	}
-	if missing := containsAll(names, vmaasHandlers); len(missing) > 0 {
-		t.Errorf("BMaaS disabled: missing VMaaS handlers: %v", missing)
-	}
-}
+		Expect(containsNone(names, bmaasHandlers)).To(BeEmpty(), "BMaaS handlers should be absent")
+		Expect(containsAll(names, caasHandlers)).To(BeEmpty(), "missing CaaS handlers")
+		Expect(containsAll(names, vmaasHandlers)).To(BeEmpty(), "missing VMaaS handlers")
+	})
 
-func TestBuildHandlerList_OnlyVMaaS(t *testing.T) {
-	handlers := buildHandlerList(&services.Flags{CaaS: false, VMaaS: true, BMaaS: false, MaaS: false})
-	names := handlerNames(handlers)
+	It("includes only VMaaS and shared handlers when only VMaaS is enabled", func() {
+		handlers := buildHandlerList(&services.Flags{CaaS: false, VMaaS: true, BMaaS: false, MaaS: false})
+		names := handlerNames(handlers)
 
-	if found := containsNone(names, caasHandlers); len(found) > 0 {
-		t.Errorf("only VMaaS: found CaaS handlers that should be absent: %v", found)
-	}
-	if found := containsNone(names, bmaasHandlers); len(found) > 0 {
-		t.Errorf("only VMaaS: found BMaaS handlers that should be absent: %v", found)
-	}
-	if missing := containsAll(names, vmaasHandlers); len(missing) > 0 {
-		t.Errorf("only VMaaS: missing VMaaS handlers: %v", missing)
-	}
-}
+		Expect(containsNone(names, caasHandlers)).To(BeEmpty(), "CaaS handlers should be absent")
+		Expect(containsNone(names, bmaasHandlers)).To(BeEmpty(), "BMaaS handlers should be absent")
+		Expect(containsAll(names, vmaasHandlers)).To(BeEmpty(), "missing VMaaS handlers")
+	})
 
-func TestBuildHandlerList_SharedAlwaysPresent(t *testing.T) {
-	handlers := buildHandlerList(&services.Flags{CaaS: false, VMaaS: false, BMaaS: false, MaaS: false})
-	names := handlerNames(handlers)
+	It("always includes shared handlers even when all services are disabled", func() {
+		handlers := buildHandlerList(&services.Flags{CaaS: false, VMaaS: false, BMaaS: false, MaaS: false})
+		names := handlerNames(handlers)
 
-	if missing := containsAll(names, sharedHandlers); len(missing) > 0 {
-		t.Errorf("all disabled: missing shared handlers: %v", missing)
-	}
-}
+		Expect(containsAll(names, sharedHandlers)).To(BeEmpty(), "missing shared handlers")
+	})
+})

--- a/fulfillment-service/internal/cmd/service/start/restgateway/start_rest_gateway_cmd_test.go
+++ b/fulfillment-service/internal/cmd/service/start/restgateway/start_rest_gateway_cmd_test.go
@@ -26,6 +26,9 @@ import (
 func handlerName(h handlerRegistrar) string {
 	name := runtime.FuncForPC(reflect.ValueOf(h).Pointer()).Name()
 	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		if prev := strings.LastIndex(name[:idx], "/"); prev >= 0 {
+			idx = prev
+		}
 		name = name[idx+1:]
 	}
 	return name
@@ -68,41 +71,65 @@ func containsNone(names []string, excluded []string) []string {
 }
 
 var caasHandlers = []string{
-	"v1.RegisterClusterTemplatesHandler",
-	"v1.RegisterClusterCatalogItemsHandler",
-	"v1.RegisterClustersHandler",
-	"v1.RegisterClusterVersionsHandler",
+	"public/v1.RegisterClusterTemplatesHandler",
+	"public/v1.RegisterClusterCatalogItemsHandler",
+	"public/v1.RegisterClustersHandler",
+	"public/v1.RegisterClusterVersionsHandler",
+	"private/v1.RegisterClusterTemplatesHandler",
+	"private/v1.RegisterClusterCatalogItemsHandler",
+	"private/v1.RegisterClustersHandler",
+	"private/v1.RegisterClusterVersionsHandler",
 }
 
 var vmaasHandlers = []string{
-	"v1.RegisterComputeInstanceTemplatesHandler",
-	"v1.RegisterComputeInstanceCatalogItemsHandler",
-	"v1.RegisterComputeInstancesHandler",
-	"v1.RegisterDiskImagesHandler",
-	"v1.RegisterConsoleSessionsHandler",
-	"v1.RegisterInstanceTypesHandler",
-	"v1.RegisterVolumesHandler",
+	"public/v1.RegisterComputeInstanceTemplatesHandler",
+	"public/v1.RegisterComputeInstanceCatalogItemsHandler",
+	"public/v1.RegisterComputeInstancesHandler",
+	"public/v1.RegisterDiskImagesHandler",
+	"public/v1.RegisterConsoleSessionsHandler",
+	"public/v1.RegisterInstanceTypesHandler",
+	"private/v1.RegisterComputeInstanceTemplatesHandler",
+	"private/v1.RegisterComputeInstanceCatalogItemsHandler",
+	"private/v1.RegisterComputeInstancesHandler",
+	"private/v1.RegisterDiskImagesHandler",
+	"private/v1.RegisterInstanceTypesHandler",
+	"private/v1.RegisterVolumesHandler",
 }
 
 var bmaasHandlers = []string{
-	"v1.RegisterBareMetalInstanceTemplatesHandler",
-	"v1.RegisterBareMetalInstanceCatalogItemsHandler",
-	"v1.RegisterBareMetalInstancesHandler",
-	"v1.RegisterBareMetalInstanceTypesHandler",
+	"public/v1.RegisterBareMetalInstanceTemplatesHandler",
+	"public/v1.RegisterBareMetalInstanceCatalogItemsHandler",
+	"public/v1.RegisterBareMetalInstancesHandler",
+	"public/v1.RegisterBareMetalInstanceTypesHandler",
+	"private/v1.RegisterBareMetalInstanceTemplatesHandler",
+	"private/v1.RegisterBareMetalInstanceCatalogItemsHandler",
+	"private/v1.RegisterBareMetalInstancesHandler",
+	"private/v1.RegisterBareMetalInstanceTypesHandler",
 }
 
 var sharedHandlers = []string{
-	"v1.RegisterCapabilitiesHandler",
-	"v1.RegisterHostTypesHandler",
-	"v1.RegisterVirtualNetworksHandler",
-	"v1.RegisterSubnetsHandler",
-	"v1.RegisterSecurityGroupsHandler",
-	"v1.RegisterNATGatewaysHandler",
-	"v1.RegisterExternalIPPoolsHandler",
-	"v1.RegisterExternalIPsHandler",
-	"v1.RegisterExternalIPAttachmentsHandler",
-	"v1.RegisterRolesHandler",
-	"v1.RegisterRoleBindingsHandler",
+	"public/v1.RegisterCapabilitiesHandler",
+	"public/v1.RegisterHostTypesHandler",
+	"public/v1.RegisterVirtualNetworksHandler",
+	"public/v1.RegisterSubnetsHandler",
+	"public/v1.RegisterSecurityGroupsHandler",
+	"public/v1.RegisterNATGatewaysHandler",
+	"public/v1.RegisterExternalIPPoolsHandler",
+	"public/v1.RegisterExternalIPsHandler",
+	"public/v1.RegisterExternalIPAttachmentsHandler",
+	"public/v1.RegisterRolesHandler",
+	"public/v1.RegisterRoleBindingsHandler",
+	"private/v1.RegisterCapabilitiesHandler",
+	"private/v1.RegisterHostTypesHandler",
+	"private/v1.RegisterVirtualNetworksHandler",
+	"private/v1.RegisterSubnetsHandler",
+	"private/v1.RegisterSecurityGroupsHandler",
+	"private/v1.RegisterNATGatewaysHandler",
+	"private/v1.RegisterExternalIPPoolsHandler",
+	"private/v1.RegisterExternalIPsHandler",
+	"private/v1.RegisterExternalIPAttachmentsHandler",
+	"private/v1.RegisterRolesHandler",
+	"private/v1.RegisterRoleBindingsHandler",
 }
 
 func TestBuildHandlerList_AllEnabled(t *testing.T) {

--- a/fulfillment-service/internal/cmd/service/start/restgateway/start_rest_gateway_cmd_test.go
+++ b/fulfillment-service/internal/cmd/service/start/restgateway/start_rest_gateway_cmd_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package restgateway
+
+import (
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/osac-project/osac/fulfillment-service/internal/services"
+)
+
+// handlerName extracts the short function name from a handlerRegistrar function pointer.
+func handlerName(h handlerRegistrar) string {
+	name := runtime.FuncForPC(reflect.ValueOf(h).Pointer()).Name()
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		name = name[idx+1:]
+	}
+	return name
+}
+
+func handlerNames(handlers []handlerRegistrar) []string {
+	names := make([]string, len(handlers))
+	for i, h := range handlers {
+		names[i] = handlerName(h)
+	}
+	return names
+}
+
+func containsAll(names []string, expected []string) []string {
+	set := make(map[string]bool, len(names))
+	for _, n := range names {
+		set[n] = true
+	}
+	var missing []string
+	for _, e := range expected {
+		if !set[e] {
+			missing = append(missing, e)
+		}
+	}
+	return missing
+}
+
+func containsNone(names []string, excluded []string) []string {
+	set := make(map[string]bool, len(names))
+	for _, n := range names {
+		set[n] = true
+	}
+	var found []string
+	for _, e := range excluded {
+		if set[e] {
+			found = append(found, e)
+		}
+	}
+	return found
+}
+
+var caasHandlers = []string{
+	"v1.RegisterClusterTemplatesHandler",
+	"v1.RegisterClusterCatalogItemsHandler",
+	"v1.RegisterClustersHandler",
+	"v1.RegisterClusterVersionsHandler",
+}
+
+var vmaasHandlers = []string{
+	"v1.RegisterComputeInstanceTemplatesHandler",
+	"v1.RegisterComputeInstanceCatalogItemsHandler",
+	"v1.RegisterComputeInstancesHandler",
+	"v1.RegisterDiskImagesHandler",
+	"v1.RegisterConsoleSessionsHandler",
+	"v1.RegisterInstanceTypesHandler",
+	"v1.RegisterVolumesHandler",
+}
+
+var bmaasHandlers = []string{
+	"v1.RegisterBareMetalInstanceTemplatesHandler",
+	"v1.RegisterBareMetalInstanceCatalogItemsHandler",
+	"v1.RegisterBareMetalInstancesHandler",
+	"v1.RegisterBareMetalInstanceTypesHandler",
+}
+
+var sharedHandlers = []string{
+	"v1.RegisterCapabilitiesHandler",
+	"v1.RegisterHostTypesHandler",
+	"v1.RegisterVirtualNetworksHandler",
+	"v1.RegisterSubnetsHandler",
+	"v1.RegisterSecurityGroupsHandler",
+	"v1.RegisterNATGatewaysHandler",
+	"v1.RegisterExternalIPPoolsHandler",
+	"v1.RegisterExternalIPsHandler",
+	"v1.RegisterExternalIPAttachmentsHandler",
+	"v1.RegisterRolesHandler",
+	"v1.RegisterRoleBindingsHandler",
+}
+
+func TestBuildHandlerList_AllEnabled(t *testing.T) {
+	handlers := buildHandlerList(&services.Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true})
+	names := handlerNames(handlers)
+
+	for _, group := range []struct {
+		label    string
+		expected []string
+	}{
+		{"CaaS", caasHandlers},
+		{"VMaaS", vmaasHandlers},
+		{"BMaaS", bmaasHandlers},
+		{"shared", sharedHandlers},
+	} {
+		if missing := containsAll(names, group.expected); len(missing) > 0 {
+			t.Errorf("all-enabled: missing %s handlers: %v", group.label, missing)
+		}
+	}
+}
+
+func TestBuildHandlerList_BMaaSDisabled(t *testing.T) {
+	handlers := buildHandlerList(&services.Flags{CaaS: true, VMaaS: true, BMaaS: false, MaaS: false})
+	names := handlerNames(handlers)
+
+	if found := containsNone(names, bmaasHandlers); len(found) > 0 {
+		t.Errorf("BMaaS disabled: found BMaaS handlers that should be absent: %v", found)
+	}
+	if missing := containsAll(names, caasHandlers); len(missing) > 0 {
+		t.Errorf("BMaaS disabled: missing CaaS handlers: %v", missing)
+	}
+	if missing := containsAll(names, vmaasHandlers); len(missing) > 0 {
+		t.Errorf("BMaaS disabled: missing VMaaS handlers: %v", missing)
+	}
+}
+
+func TestBuildHandlerList_OnlyVMaaS(t *testing.T) {
+	handlers := buildHandlerList(&services.Flags{CaaS: false, VMaaS: true, BMaaS: false, MaaS: false})
+	names := handlerNames(handlers)
+
+	if found := containsNone(names, caasHandlers); len(found) > 0 {
+		t.Errorf("only VMaaS: found CaaS handlers that should be absent: %v", found)
+	}
+	if found := containsNone(names, bmaasHandlers); len(found) > 0 {
+		t.Errorf("only VMaaS: found BMaaS handlers that should be absent: %v", found)
+	}
+	if missing := containsAll(names, vmaasHandlers); len(missing) > 0 {
+		t.Errorf("only VMaaS: missing VMaaS handlers: %v", missing)
+	}
+}
+
+func TestBuildHandlerList_SharedAlwaysPresent(t *testing.T) {
+	handlers := buildHandlerList(&services.Flags{CaaS: false, VMaaS: false, BMaaS: false, MaaS: false})
+	names := handlerNames(handlers)
+
+	if missing := containsAll(names, sharedHandlers); len(missing) > 0 {
+		t.Errorf("all disabled: missing shared handlers: %v", missing)
+	}
+}

--- a/fulfillment-service/internal/services/flags.go
+++ b/fulfillment-service/internal/services/flags.go
@@ -1,0 +1,79 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package services
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+)
+
+type Flags struct {
+	CaaS  bool
+	VMaaS bool
+	BMaaS bool
+	MaaS  bool
+}
+
+func RegisterFlags(flags *pflag.FlagSet) *Flags {
+	f := &Flags{}
+	flags.BoolVar(&f.CaaS, "enable-caas", false,
+		"Enable the CaaS (Container as a Service) endpoints.")
+	flags.BoolVar(&f.VMaaS, "enable-vmaas", false,
+		"Enable the VMaaS (Virtual Machine as a Service) endpoints.")
+	flags.BoolVar(&f.BMaaS, "enable-bmaas", false,
+		"Enable the BMaaS (Bare Metal as a Service) endpoints.")
+	flags.BoolVar(&f.MaaS, "enable-maas", false,
+		"Enable the MaaS (Metal as a Service) endpoints.")
+	return f
+}
+
+func (f *Flags) EnableAllIfNoneSet() {
+	if !f.CaaS && !f.VMaaS && !f.BMaaS && !f.MaaS {
+		f.CaaS = true
+		f.VMaaS = true
+		f.BMaaS = true
+		f.MaaS = true
+	}
+}
+
+func (f *Flags) Validate() error {
+	if f.CaaS && !f.VMaaS && !f.BMaaS {
+		return fmt.Errorf("CaaS requires at least one of VMaaS or BMaaS")
+	}
+	if f.MaaS && !f.CaaS {
+		return fmt.Errorf("MaaS requires CaaS")
+	}
+	return nil
+}
+
+func (f *Flags) EnabledServices() []string {
+	var result []string
+	if f.CaaS {
+		result = append(result, "caas")
+	}
+	if f.VMaaS {
+		result = append(result, "vmaas")
+	}
+	if f.BMaaS {
+		result = append(result, "bmaas")
+	}
+	if f.MaaS {
+		result = append(result, "maas")
+	}
+	if result == nil {
+		return []string{}
+	}
+	return result
+}

--- a/fulfillment-service/internal/services/flags_test.go
+++ b/fulfillment-service/internal/services/flags_test.go
@@ -252,4 +252,3 @@ func TestEnabledServices(t *testing.T) {
 		})
 	}
 }
-

--- a/fulfillment-service/internal/services/flags_test.go
+++ b/fulfillment-service/internal/services/flags_test.go
@@ -14,241 +14,141 @@ language governing permissions and limitations under the License.
 package services
 
 import (
-	"strings"
-	"testing"
-
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/ginkgo/v2/dsl/table"
+	. "github.com/onsi/gomega"
 	"github.com/spf13/pflag"
 )
 
-func TestEnableAllIfNoneSet(t *testing.T) {
-	tests := []struct {
-		name     string
-		initial  Flags
-		expected Flags
-	}{
-		{
-			name:    "all false enables all",
-			initial: Flags{},
-			expected: Flags{
-				CaaS:  true,
-				VMaaS: true,
-				BMaaS: true,
-				MaaS:  true,
+var _ = Describe("Service flags", func() {
+	Describe("EnableAllIfNoneSet", func() {
+		DescribeTable("enables all services when none are set",
+			func(initial, expected Flags) {
+				initial.EnableAllIfNoneSet()
+				Expect(initial).To(Equal(expected))
 			},
-		},
-		{
-			name:    "one set preserves explicit flags",
-			initial: Flags{CaaS: true, VMaaS: true},
-			expected: Flags{
-				CaaS:  true,
-				VMaaS: true,
-				BMaaS: false,
-				MaaS:  false,
-			},
-		},
-		{
-			name:    "only BMaaS set preserves",
-			initial: Flags{BMaaS: true},
-			expected: Flags{
-				CaaS:  false,
-				VMaaS: false,
-				BMaaS: true,
-				MaaS:  false,
-			},
-		},
-		{
-			name:    "all already set remains unchanged",
-			initial: Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true},
-			expected: Flags{
-				CaaS:  true,
-				VMaaS: true,
-				BMaaS: true,
-				MaaS:  true,
-			},
-		},
-	}
+			Entry("all false enables all",
+				Flags{},
+				Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true},
+			),
+			Entry("one set preserves explicit flags",
+				Flags{CaaS: true, VMaaS: true},
+				Flags{CaaS: true, VMaaS: true, BMaaS: false, MaaS: false},
+			),
+			Entry("only BMaaS set preserves",
+				Flags{BMaaS: true},
+				Flags{CaaS: false, VMaaS: false, BMaaS: true, MaaS: false},
+			),
+			Entry("all already set remains unchanged",
+				Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true},
+				Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true},
+			),
+		)
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			f := tt.initial
+	Describe("Validate", func() {
+		DescribeTable("validates service flag combinations",
+			func(flags Flags, valid bool, errSubstring string) {
+				err := flags.Validate()
+				if valid {
+					Expect(err).ToNot(HaveOccurred())
+				} else {
+					Expect(err).To(HaveOccurred())
+					if errSubstring != "" {
+						Expect(err.Error()).To(ContainSubstring(errSubstring))
+					}
+				}
+			},
+			Entry("all enabled is valid",
+				Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true}, true, "",
+			),
+			Entry("CaaS with VMaaS is valid",
+				Flags{CaaS: true, VMaaS: true}, true, "",
+			),
+			Entry("CaaS with BMaaS is valid",
+				Flags{CaaS: true, BMaaS: true}, true, "",
+			),
+			Entry("VMaaS only is valid",
+				Flags{VMaaS: true}, true, "",
+			),
+			Entry("BMaaS only is valid",
+				Flags{BMaaS: true}, true, "",
+			),
+			Entry("CaaS without VMaaS or BMaaS is invalid",
+				Flags{CaaS: true}, false, "CaaS requires at least one of VMaaS or BMaaS",
+			),
+			Entry("CaaS with MaaS but no VMaaS or BMaaS is invalid",
+				Flags{CaaS: true, MaaS: true}, false, "CaaS requires at least one of VMaaS or BMaaS",
+			),
+			Entry("MaaS without CaaS is invalid",
+				Flags{MaaS: true, VMaaS: true}, false, "MaaS requires CaaS",
+			),
+			Entry("MaaS alone is invalid",
+				Flags{MaaS: true}, false, "",
+			),
+		)
+
+		It("validates after EnableAllIfNoneSet", func() {
+			f := Flags{}
 			f.EnableAllIfNoneSet()
-			if f != tt.expected {
-				t.Errorf("got %+v, want %+v", f, tt.expected)
-			}
+			Expect(f.Validate()).ToNot(HaveOccurred())
 		})
-	}
-}
-
-func TestValidate(t *testing.T) {
-	tests := []struct {
-		name    string
-		flags   Flags
-		wantErr bool
-		errMsg  string
-	}{
-		{
-			name:    "all enabled is valid",
-			flags:   Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true},
-			wantErr: false,
-		},
-		{
-			name:    "CaaS with VMaaS is valid",
-			flags:   Flags{CaaS: true, VMaaS: true},
-			wantErr: false,
-		},
-		{
-			name:    "CaaS with BMaaS is valid",
-			flags:   Flags{CaaS: true, BMaaS: true},
-			wantErr: false,
-		},
-		{
-			name:    "VMaaS only is valid",
-			flags:   Flags{VMaaS: true},
-			wantErr: false,
-		},
-		{
-			name:    "BMaaS only is valid",
-			flags:   Flags{BMaaS: true},
-			wantErr: false,
-		},
-		{
-			name:    "CaaS without VMaaS or BMaaS is invalid",
-			flags:   Flags{CaaS: true},
-			wantErr: true,
-			errMsg:  "CaaS requires at least one of VMaaS or BMaaS",
-		},
-		{
-			name:    "CaaS with MaaS but no VMaaS or BMaaS is invalid",
-			flags:   Flags{CaaS: true, MaaS: true},
-			wantErr: true,
-			errMsg:  "CaaS requires at least one of VMaaS or BMaaS",
-		},
-		{
-			name:    "MaaS without CaaS is invalid",
-			flags:   Flags{MaaS: true, VMaaS: true},
-			wantErr: true,
-			errMsg:  "MaaS requires CaaS",
-		},
-		{
-			name:    "all disabled is valid after EnableAllIfNoneSet",
-			flags:   Flags{},
-			wantErr: false,
-		},
-		{
-			name:    "MaaS alone is invalid for both rules",
-			flags:   Flags{MaaS: true},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			f := tt.flags
-			if tt.name == "all disabled is valid after EnableAllIfNoneSet" {
-				f.EnableAllIfNoneSet()
-			}
-			err := f.Validate()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if tt.wantErr && tt.errMsg != "" {
-				if err == nil || !strings.Contains(err.Error(), tt.errMsg) {
-					t.Errorf("error message %q should contain %q", err, tt.errMsg)
-				}
-			}
-		})
-	}
-}
-
-func TestRegisterFlags(t *testing.T) {
-	t.Run("flags register and parse correctly", func(t *testing.T) {
-		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-		flags := RegisterFlags(fs)
-
-		err := fs.Parse([]string{"--enable-caas", "--enable-vmaas"})
-		if err != nil {
-			t.Fatalf("failed to parse flags: %v", err)
-		}
-
-		if !flags.CaaS {
-			t.Error("CaaS should be true")
-		}
-		if !flags.VMaaS {
-			t.Error("VMaaS should be true")
-		}
-		if flags.BMaaS {
-			t.Error("BMaaS should be false")
-		}
-		if flags.MaaS {
-			t.Error("MaaS should be false")
-		}
 	})
 
-	t.Run("no flags means all false", func(t *testing.T) {
-		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-		flags := RegisterFlags(fs)
+	Describe("RegisterFlags", func() {
+		It("registers and parses flags correctly", func() {
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			flags := RegisterFlags(fs)
 
-		err := fs.Parse([]string{})
-		if err != nil {
-			t.Fatalf("failed to parse flags: %v", err)
-		}
-
-		if flags.CaaS || flags.VMaaS || flags.BMaaS || flags.MaaS {
-			t.Errorf("all flags should be false by default, got %+v", flags)
-		}
-	})
-
-	t.Run("all flags can be set", func(t *testing.T) {
-		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-		flags := RegisterFlags(fs)
-
-		err := fs.Parse([]string{"--enable-caas", "--enable-vmaas", "--enable-bmaas", "--enable-maas"})
-		if err != nil {
-			t.Fatalf("failed to parse flags: %v", err)
-		}
-
-		if !flags.CaaS || !flags.VMaaS || !flags.BMaaS || !flags.MaaS {
-			t.Errorf("all flags should be true, got %+v", flags)
-		}
-	})
-}
-
-func TestEnabledServices(t *testing.T) {
-	tests := []struct {
-		name     string
-		flags    Flags
-		expected []string
-	}{
-		{
-			name:     "all enabled",
-			flags:    Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true},
-			expected: []string{"caas", "vmaas", "bmaas", "maas"},
-		},
-		{
-			name:     "none enabled",
-			flags:    Flags{},
-			expected: []string{},
-		},
-		{
-			name:     "partial",
-			flags:    Flags{CaaS: true, BMaaS: true},
-			expected: []string{"caas", "bmaas"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.flags.EnabledServices()
-			if len(got) != len(tt.expected) {
-				t.Errorf("EnabledServices() = %v, want %v", got, tt.expected)
-				return
-			}
-			for i, v := range got {
-				if v != tt.expected[i] {
-					t.Errorf("EnabledServices()[%d] = %q, want %q", i, v, tt.expected[i])
-				}
-			}
+			Expect(fs.Parse([]string{"--enable-caas", "--enable-vmaas"})).To(Succeed())
+			Expect(flags.CaaS).To(BeTrue())
+			Expect(flags.VMaaS).To(BeTrue())
+			Expect(flags.BMaaS).To(BeFalse())
+			Expect(flags.MaaS).To(BeFalse())
 		})
-	}
-}
+
+		It("defaults all flags to false", func() {
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			flags := RegisterFlags(fs)
+
+			Expect(fs.Parse([]string{})).To(Succeed())
+			Expect(flags.CaaS).To(BeFalse())
+			Expect(flags.VMaaS).To(BeFalse())
+			Expect(flags.BMaaS).To(BeFalse())
+			Expect(flags.MaaS).To(BeFalse())
+		})
+
+		It("allows all flags to be set", func() {
+			fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			flags := RegisterFlags(fs)
+
+			Expect(fs.Parse([]string{
+				"--enable-caas", "--enable-vmaas", "--enable-bmaas", "--enable-maas",
+			})).To(Succeed())
+			Expect(flags.CaaS).To(BeTrue())
+			Expect(flags.VMaaS).To(BeTrue())
+			Expect(flags.BMaaS).To(BeTrue())
+			Expect(flags.MaaS).To(BeTrue())
+		})
+	})
+
+	Describe("EnabledServices", func() {
+		DescribeTable("returns enabled service names",
+			func(flags Flags, expected []string) {
+				Expect(flags.EnabledServices()).To(Equal(expected))
+			},
+			Entry("all enabled",
+				Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true},
+				[]string{"caas", "vmaas", "bmaas", "maas"},
+			),
+			Entry("none enabled",
+				Flags{},
+				[]string{},
+			),
+			Entry("partial",
+				Flags{CaaS: true, BMaaS: true},
+				[]string{"caas", "bmaas"},
+			),
+		)
+	})
+})

--- a/fulfillment-service/internal/services/flags_test.go
+++ b/fulfillment-service/internal/services/flags_test.go
@@ -1,0 +1,255 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package services
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func TestEnableAllIfNoneSet(t *testing.T) {
+	tests := []struct {
+		name     string
+		initial  Flags
+		expected Flags
+	}{
+		{
+			name:    "all false enables all",
+			initial: Flags{},
+			expected: Flags{
+				CaaS:  true,
+				VMaaS: true,
+				BMaaS: true,
+				MaaS:  true,
+			},
+		},
+		{
+			name:    "one set preserves explicit flags",
+			initial: Flags{CaaS: true, VMaaS: true},
+			expected: Flags{
+				CaaS:  true,
+				VMaaS: true,
+				BMaaS: false,
+				MaaS:  false,
+			},
+		},
+		{
+			name:    "only BMaaS set preserves",
+			initial: Flags{BMaaS: true},
+			expected: Flags{
+				CaaS:  false,
+				VMaaS: false,
+				BMaaS: true,
+				MaaS:  false,
+			},
+		},
+		{
+			name:    "all already set remains unchanged",
+			initial: Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true},
+			expected: Flags{
+				CaaS:  true,
+				VMaaS: true,
+				BMaaS: true,
+				MaaS:  true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := tt.initial
+			f.EnableAllIfNoneSet()
+			if f != tt.expected {
+				t.Errorf("got %+v, want %+v", f, tt.expected)
+			}
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		flags   Flags
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "all enabled is valid",
+			flags:   Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true},
+			wantErr: false,
+		},
+		{
+			name:    "CaaS with VMaaS is valid",
+			flags:   Flags{CaaS: true, VMaaS: true},
+			wantErr: false,
+		},
+		{
+			name:    "CaaS with BMaaS is valid",
+			flags:   Flags{CaaS: true, BMaaS: true},
+			wantErr: false,
+		},
+		{
+			name:    "VMaaS only is valid",
+			flags:   Flags{VMaaS: true},
+			wantErr: false,
+		},
+		{
+			name:    "BMaaS only is valid",
+			flags:   Flags{BMaaS: true},
+			wantErr: false,
+		},
+		{
+			name:    "CaaS without VMaaS or BMaaS is invalid",
+			flags:   Flags{CaaS: true},
+			wantErr: true,
+			errMsg:  "CaaS requires at least one of VMaaS or BMaaS",
+		},
+		{
+			name:    "CaaS with MaaS but no VMaaS or BMaaS is invalid",
+			flags:   Flags{CaaS: true, MaaS: true},
+			wantErr: true,
+			errMsg:  "CaaS requires at least one of VMaaS or BMaaS",
+		},
+		{
+			name:    "MaaS without CaaS is invalid",
+			flags:   Flags{MaaS: true, VMaaS: true},
+			wantErr: true,
+			errMsg:  "MaaS requires CaaS",
+		},
+		{
+			name:    "all disabled is valid after EnableAllIfNoneSet",
+			flags:   Flags{},
+			wantErr: false,
+		},
+		{
+			name:    "MaaS alone is invalid for both rules",
+			flags:   Flags{MaaS: true},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := tt.flags
+			if tt.name == "all disabled is valid after EnableAllIfNoneSet" {
+				f.EnableAllIfNoneSet()
+			}
+			err := f.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.errMsg != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("error message %q should contain %q", err, tt.errMsg)
+				}
+			}
+		})
+	}
+}
+
+func TestRegisterFlags(t *testing.T) {
+	t.Run("flags register and parse correctly", func(t *testing.T) {
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		flags := RegisterFlags(fs)
+
+		err := fs.Parse([]string{"--enable-caas", "--enable-vmaas"})
+		if err != nil {
+			t.Fatalf("failed to parse flags: %v", err)
+		}
+
+		if !flags.CaaS {
+			t.Error("CaaS should be true")
+		}
+		if !flags.VMaaS {
+			t.Error("VMaaS should be true")
+		}
+		if flags.BMaaS {
+			t.Error("BMaaS should be false")
+		}
+		if flags.MaaS {
+			t.Error("MaaS should be false")
+		}
+	})
+
+	t.Run("no flags means all false", func(t *testing.T) {
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		flags := RegisterFlags(fs)
+
+		err := fs.Parse([]string{})
+		if err != nil {
+			t.Fatalf("failed to parse flags: %v", err)
+		}
+
+		if flags.CaaS || flags.VMaaS || flags.BMaaS || flags.MaaS {
+			t.Errorf("all flags should be false by default, got %+v", flags)
+		}
+	})
+
+	t.Run("all flags can be set", func(t *testing.T) {
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		flags := RegisterFlags(fs)
+
+		err := fs.Parse([]string{"--enable-caas", "--enable-vmaas", "--enable-bmaas", "--enable-maas"})
+		if err != nil {
+			t.Fatalf("failed to parse flags: %v", err)
+		}
+
+		if !flags.CaaS || !flags.VMaaS || !flags.BMaaS || !flags.MaaS {
+			t.Errorf("all flags should be true, got %+v", flags)
+		}
+	})
+}
+
+func TestEnabledServices(t *testing.T) {
+	tests := []struct {
+		name     string
+		flags    Flags
+		expected []string
+	}{
+		{
+			name:     "all enabled",
+			flags:    Flags{CaaS: true, VMaaS: true, BMaaS: true, MaaS: true},
+			expected: []string{"caas", "vmaas", "bmaas", "maas"},
+		},
+		{
+			name:     "none enabled",
+			flags:    Flags{},
+			expected: []string{},
+		},
+		{
+			name:     "partial",
+			flags:    Flags{CaaS: true, BMaaS: true},
+			expected: []string{"caas", "bmaas"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.flags.EnabledServices()
+			if len(got) != len(tt.expected) {
+				t.Errorf("EnabledServices() = %v, want %v", got, tt.expected)
+				return
+			}
+			for i, v := range got {
+				if v != tt.expected[i] {
+					t.Errorf("EnabledServices()[%d] = %q, want %q", i, v, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+

--- a/fulfillment-service/internal/services/services_suite_test.go
+++ b/fulfillment-service/internal/services/services_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package services
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+)
+
+func TestServices(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Services")
+}

--- a/osac-aap/collections/ansible_collections/osac/service/roles/publish_templates/tasks/bare_metal_instances.yaml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/publish_templates/tasks/bare_metal_instances.yaml
@@ -4,7 +4,13 @@
     validate_certs: "{{ publish_templates_validate_certs | default(true) | bool }}"
     headers:
       authorization: Bearer {{ osac_fulfillment_service_token }}
+    status_code: [200, 404]
   register: bare_metal_instance_template_check
+
+- name: Skip BareMetalInstance templates when service is disabled
+  ansible.builtin.debug:
+    msg: "BMaaS service not available (HTTP 404) — skipping bare metal instance template publishing"
+  when: bare_metal_instance_template_check.status == 404
 
 - name: Create list of existing BareMetalInstance template IDs
   ansible.builtin.set_fact:
@@ -12,14 +18,17 @@
       {{
       bare_metal_instance_template_check | json_query("json.items[].id")
       }}
-  when: bare_metal_instance_template_check is success and bare_metal_instance_template_check.json.get('items', []) | length > 0
+  when: >-
+    bare_metal_instance_template_check.status != 404
+    and bare_metal_instance_template_check is success
+    and bare_metal_instance_template_check.json.get('items', []) | length > 0
 
 - name: Update existing BareMetalInstance template
   loop: "{{ osac_bare_metal_instance_templates }}"
   loop_control:
     label: "{{ template.id }}"
     loop_var: template
-  when: bare_metal_instance_template_ids is defined and template.id in bare_metal_instance_template_ids
+  when: bare_metal_instance_template_check.status != 404 and bare_metal_instance_template_ids is defined and template.id in bare_metal_instance_template_ids
   ansible.builtin.uri:
     url: "{{ publish_templates_bare_metal_instance_api_endpoint }}/{{ template.id }}"
     validate_certs: "{{ publish_templates_validate_certs | default(true) | bool }}"
@@ -34,7 +43,9 @@
   loop_control:
     label: "{{ template.id }}"
     loop_var: template
-  when: bare_metal_instance_template_ids is not defined or template.id not in bare_metal_instance_template_ids
+  when: >-
+    bare_metal_instance_template_check.status != 404
+    and (bare_metal_instance_template_ids is not defined or template.id not in bare_metal_instance_template_ids)
   ansible.builtin.uri:
     url: "{{ publish_templates_bare_metal_instance_api_endpoint }}"
     validate_certs: "{{ publish_templates_validate_certs | default(true) | bool }}"

--- a/osac-aap/collections/ansible_collections/osac/service/roles/publish_templates/tasks/clusters.yaml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/publish_templates/tasks/clusters.yaml
@@ -4,7 +4,13 @@
     validate_certs: "{{ publish_templates_validate_certs | default(true) | bool }}"
     headers:
       authorization: Bearer {{ osac_fulfillment_service_token }}
+    status_code: [200, 404]
   register: cluster_template_check
+
+- name: Skip cluster templates when service is disabled
+  ansible.builtin.debug:
+    msg: "CaaS service not available (HTTP 404) — skipping cluster template publishing"
+  when: cluster_template_check.status == 404
 
 - name: Create list of existing cluster template template ids    # noqa: jinja[invalid]
   ansible.builtin.set_fact:
@@ -12,14 +18,14 @@
       {{
       cluster_template_check | json_query("json.items[].id")
       }}
-  when: cluster_template_check is success and cluster_template_check.json.get('items', []) | length > 0
+  when: cluster_template_check.status != 404 and cluster_template_check is success and cluster_template_check.json.get('items', []) | length > 0
 
 - name: Update existing cluster template
   loop: "{{ osac_cluster_templates }}"
   loop_control:
     label: "{{ template.id }}"
     loop_var: template
-  when: cluster_template_ids is defined and template.id in cluster_template_ids
+  when: cluster_template_check.status != 404 and cluster_template_ids is defined and template.id in cluster_template_ids
   ansible.builtin.uri:
     url: "{{ publish_templates_cluster_api_endpoint }}/{{ template.id }}"
     validate_certs: "{{ publish_templates_validate_certs | default(true) | bool }}"
@@ -34,7 +40,7 @@
   loop_control:
     label: "{{ template.id }}"
     loop_var: template
-  when: cluster_template_ids is not defined or template.id not in cluster_template_ids
+  when: cluster_template_check.status != 404 and (cluster_template_ids is not defined or template.id not in cluster_template_ids)
   ansible.builtin.uri:
     url: "{{ publish_templates_cluster_api_endpoint }}"
     validate_certs: "{{ publish_templates_validate_certs | default(true) | bool }}"

--- a/osac-aap/collections/ansible_collections/osac/service/roles/publish_templates/tasks/compute_instances.yaml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/publish_templates/tasks/compute_instances.yaml
@@ -4,7 +4,13 @@
     validate_certs: "{{ publish_templates_validate_certs | default(true) | bool }}"
     headers:
       authorization: Bearer {{ osac_fulfillment_service_token }}
+    status_code: [200, 404]
   register: compute_instance_template_check
+
+- name: Skip ComputeInstance templates when service is disabled
+  ansible.builtin.debug:
+    msg: "VMaaS service not available (HTTP 404) — skipping compute instance template publishing"
+  when: compute_instance_template_check.status == 404
 
 - name: Create list of existing ComputeInstance template IDs
   ansible.builtin.set_fact:
@@ -12,14 +18,17 @@
       {{
       compute_instance_template_check | json_query("json.items[].id")
       }}
-  when: compute_instance_template_check is success and compute_instance_template_check.json.get('items', []) | length > 0
+  when: >-
+    compute_instance_template_check.status != 404
+    and compute_instance_template_check is success
+    and compute_instance_template_check.json.get('items', []) | length > 0
 
 - name: Update existing ComputeInstance template
   loop: "{{ osac_compute_instance_templates }}"
   loop_control:
     label: "{{ template.id }}"
     loop_var: template
-  when: compute_instance_template_ids is defined and template.id in compute_instance_template_ids
+  when: compute_instance_template_check.status != 404 and compute_instance_template_ids is defined and template.id in compute_instance_template_ids
   ansible.builtin.uri:
     url: "{{ publish_templates_compute_instance_api_endpoint }}/{{ template.id }}"
     validate_certs: "{{ publish_templates_validate_certs | default(true) | bool }}"
@@ -34,7 +43,7 @@
   loop_control:
     label: "{{ template.id }}"
     loop_var: template
-  when: compute_instance_template_ids is not defined or template.id not in compute_instance_template_ids
+  when: compute_instance_template_check.status != 404 and (compute_instance_template_ids is not defined or template.id not in compute_instance_template_ids)
   ansible.builtin.uri:
     url: "{{ publish_templates_compute_instance_api_endpoint }}"
     validate_certs: "{{ publish_templates_validate_certs | default(true) | bool }}"

--- a/osac-aap/collections/ansible_collections/osac/service/roles/publish_templates/tasks/main.yaml
+++ b/osac-aap/collections/ansible_collections/osac/service/roles/publish_templates/tasks/main.yaml
@@ -3,7 +3,7 @@
   ansible.builtin.include_tasks: clusters.yaml
 
 - name: Apply templates for compute instances
-  ansible.builtin.import_tasks: compute_instances.yaml
+  ansible.builtin.include_tasks: compute_instances.yaml
 
 - name: Apply templates for bare metal instances
-  ansible.builtin.import_tasks: bare_metal_instances.yaml
+  ansible.builtin.include_tasks: bare_metal_instances.yaml

--- a/osac-installer/Makefile
+++ b/osac-installer/Makefile
@@ -301,7 +301,7 @@ ifeq ($(SUITE),bmf)
 	$(call kind-load-image,localhost/bmf-operator:it)
 	kubectl apply --server-side --force-conflicts -f ../bare-metal-fulfillment-operator/test/crds/
 	$(MAKE) install-osac PLATFORM=$(PLATFORM) PROFILE=$(PROFILE) NS=$(NS) \
-		EXTRA_HELM_ARGS="--set bmf.enabled=true --set bmf.image.repository=localhost/bmf-operator --set bmf.image.tag=it --set bmf.image.pullPolicy=Never --set operator.enabled=false --set service.enabled=false --set hubAccess.enabled=false --set validation.enabled=false --set networkClass.enabled=false"
+		EXTRA_HELM_ARGS="--set global.services.bmaas.enabled=true --set bmf.replicaCount=1 --set bmf.image.repository=localhost/bmf-operator --set bmf.image.tag=it --set bmf.image.pullPolicy=Never --set operator.enabled=false --set service.enabled=false --set hubAccess.enabled=false --set validation.enabled=false --set networkClass.enabled=false"
 	cd ../bare-metal-fulfillment-operator && ginkgo run --timeout 30m -v test/integration
 endif
 

--- a/osac-installer/charts/osac/Chart.yaml
+++ b/osac-installer/charts/osac/Chart.yaml
@@ -31,7 +31,7 @@ dependencies:
     version: ">=0.0.0-0"
     repository: "file://../../../bare-metal-fulfillment-operator/charts/operator"
     alias: bmf
-    condition: bmf.enabled
+    condition: global.services.bmaas.enabled
   - name: osac-ui
     version: "0.0.6"
     repository: "oci://ghcr.io/osac-project/charts"

--- a/osac-installer/charts/osac/templates/bmf-metal3-test-secrets.yaml
+++ b/osac-installer/charts/osac/templates/bmf-metal3-test-secrets.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.bmf.enabled .Values.bmf.testBackend.metal3.enabled }}
+{{- if and .Values.global.services.bmaas.enabled .Values.bmf.testBackend.metal3.enabled }}
 # Kind/IT only: seeds a fake metal3-backend inventory/management config so the BMF
 # manager can start without a real OpenStack/Ironic deployment. Fake BareMetalHost
 # objects (see bare-metal-fulfillment-operator's test/integration suite) stand in

--- a/osac-installer/charts/osac/values.schema.json
+++ b/osac-installer/charts/osac/values.schema.json
@@ -265,18 +265,8 @@
         },
         "controllers": {
           "type": "object",
-          "description": "Enable or disable individual operator controllers",
+          "description": "Enable or disable shared-infrastructure operator controllers (service-tier controllers are driven by operator.services.*)",
           "properties": {
-            "clusterOrder": {
-              "type": "boolean",
-              "description": "Enable ClusterOrder controller",
-              "default": true
-            },
-            "computeInstance": {
-              "type": "boolean",
-              "description": "Enable ComputeInstance controller",
-              "default": true
-            },
             "tenant": {
               "type": "boolean",
               "description": "Enable Tenant controller",
@@ -290,11 +280,6 @@
             "networkingProvisioning": {
               "type": "boolean",
               "description": "Dispatch AAP jobs to provision networking resources. Set false for Kind dev (no fabric): controllers reconcile VirtualNetwork/Subnet/SecurityGroup to READY without provisioning.",
-              "default": true
-            },
-            "bareMetalInstance": {
-              "type": "boolean",
-              "description": "Enable BareMetalInstance controller",
               "default": true
             },
             "storage": {

--- a/osac-installer/charts/osac/values.schema.json
+++ b/osac-installer/charts/osac/values.schema.json
@@ -1249,11 +1249,6 @@
       "type": "object",
       "description": "Bare Metal Fulfillment Operator configuration",
       "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "Enable or disable the BMF operator subchart",
-          "default": true
-        },
         "image": {
           "type": "object",
           "properties": {
@@ -1845,39 +1840,6 @@
                     }
                   }
                 }
-              }
-            }
-          }
-        }
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "global": {
-            "properties": {
-              "services": {
-                "properties": {
-                  "bmaas": {
-                    "properties": {
-                      "enabled": {
-                        "const": false
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "required": ["global"]
-      },
-      "then": {
-        "properties": {
-          "bmf": {
-            "properties": {
-              "enabled": {
-                "const": false
               }
             }
           }

--- a/osac-installer/charts/osac/values.schema.json
+++ b/osac-installer/charts/osac/values.schema.json
@@ -227,6 +227,42 @@
             }
           }
         },
+        "services": {
+          "type": "object",
+          "description": "Service tier enablement flags passed to the operator",
+          "properties": {
+            "caas": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable CaaS tier (gates Cluster controller)",
+                  "default": true
+                }
+              }
+            },
+            "vmaas": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable VMaaS tier (gates ComputeInstance controller)",
+                  "default": true
+                }
+              }
+            },
+            "bmaas": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable BMaaS tier (gates BareMetalInstance controller)",
+                  "default": true
+                }
+              }
+            }
+          }
+        },
         "controllers": {
           "type": "object",
           "description": "Enable or disable individual operator controllers",
@@ -1880,6 +1916,35 @@
                     "const": true
                   }
                 }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "services": {
+            "properties": {
+              "bmaas": {
+                "properties": {
+                  "enabled": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "required": ["services"]
+      },
+      "then": {
+        "properties": {
+          "bmf": {
+            "properties": {
+              "enabled": {
+                "const": false
               }
             }
           }

--- a/osac-installer/charts/osac/values.schema.json
+++ b/osac-installer/charts/osac/values.schema.json
@@ -51,51 +51,57 @@
         }
       }
     },
-    "services": {
+    "global": {
       "type": "object",
-      "description": "Service tier enablement flags. Controls which tiers are active across all OSAC components.",
+      "description": "Global values propagated to all subcharts via Helm's built-in global mechanism",
       "properties": {
-        "caas": {
+        "services": {
           "type": "object",
-          "description": "Container-as-a-Service (managed Kubernetes clusters)",
+          "description": "Service tier enablement flags. Controls which tiers are active across all OSAC components.",
           "properties": {
-            "enabled": {
-              "type": "boolean",
-              "description": "Enable CaaS tier (ClusterOrders, ClusterTemplates, ClusterCatalogItems, ClusterVersions)",
-              "default": true
-            }
-          }
-        },
-        "vmaas": {
-          "type": "object",
-          "description": "Virtual-Machine-as-a-Service (KubeVirt compute instances)",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "description": "Enable VMaaS tier (ComputeInstances, DiskImages, InstanceTypes, Volumes, ConsoleSessions)",
-              "default": true
-            }
-          }
-        },
-        "bmaas": {
-          "type": "object",
-          "description": "Bare-Metal-as-a-Service (bare metal host provisioning)",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "description": "Enable BMaaS tier (BareMetalInstances, BareMetalInstanceTypes)",
-              "default": true
-            }
-          }
-        },
-        "maas": {
-          "type": "object",
-          "description": "Metal-as-a-Service (raw metal access)",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "description": "Enable MaaS tier",
-              "default": true
+            "caas": {
+              "type": "object",
+              "description": "Container-as-a-Service (managed Kubernetes clusters)",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable CaaS tier (ClusterOrders, ClusterTemplates, ClusterCatalogItems, ClusterVersions)",
+                  "default": true
+                }
+              }
+            },
+            "vmaas": {
+              "type": "object",
+              "description": "Virtual-Machine-as-a-Service (KubeVirt compute instances)",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable VMaaS tier (ComputeInstances, DiskImages, InstanceTypes, Volumes, ConsoleSessions)",
+                  "default": true
+                }
+              }
+            },
+            "bmaas": {
+              "type": "object",
+              "description": "Bare-Metal-as-a-Service (bare metal host provisioning)",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable BMaaS tier (BareMetalInstances, BareMetalInstanceTypes)",
+                  "default": true
+                }
+              }
+            },
+            "maas": {
+              "type": "object",
+              "description": "Metal-as-a-Service (raw metal access)",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable MaaS tier",
+                  "default": true
+                }
+              }
             }
           }
         }
@@ -227,45 +233,9 @@
             }
           }
         },
-        "services": {
-          "type": "object",
-          "description": "Service tier enablement flags passed to the operator",
-          "properties": {
-            "caas": {
-              "type": "object",
-              "properties": {
-                "enabled": {
-                  "type": "boolean",
-                  "description": "Enable CaaS tier (gates Cluster controller)",
-                  "default": true
-                }
-              }
-            },
-            "vmaas": {
-              "type": "object",
-              "properties": {
-                "enabled": {
-                  "type": "boolean",
-                  "description": "Enable VMaaS tier (gates ComputeInstance controller)",
-                  "default": true
-                }
-              }
-            },
-            "bmaas": {
-              "type": "object",
-              "properties": {
-                "enabled": {
-                  "type": "boolean",
-                  "description": "Enable BMaaS tier (gates BareMetalInstance controller)",
-                  "default": true
-                }
-              }
-            }
-          }
-        },
         "controllers": {
           "type": "object",
-          "description": "Enable or disable shared-infrastructure operator controllers (service-tier controllers are driven by operator.services.*)",
+          "description": "Enable or disable shared-infrastructure operator controllers (service-tier controllers are driven by global.services.*)",
           "properties": {
             "tenant": {
               "type": "boolean",
@@ -527,52 +497,6 @@
             "credentials": {
               "type": "array",
               "description": "Volume sources for the Keycloak client secret used for Vault authentication"
-            }
-          }
-        },
-        "services": {
-          "type": "object",
-          "description": "Service tier enablement flags passed to the fulfillment-service",
-          "properties": {
-            "caas": {
-              "type": "object",
-              "properties": {
-                "enabled": {
-                  "type": "boolean",
-                  "description": "Enable CaaS tier",
-                  "default": true
-                }
-              }
-            },
-            "vmaas": {
-              "type": "object",
-              "properties": {
-                "enabled": {
-                  "type": "boolean",
-                  "description": "Enable VMaaS tier",
-                  "default": true
-                }
-              }
-            },
-            "bmaas": {
-              "type": "object",
-              "properties": {
-                "enabled": {
-                  "type": "boolean",
-                  "description": "Enable BMaaS tier",
-                  "default": true
-                }
-              }
-            },
-            "maas": {
-              "type": "object",
-              "properties": {
-                "enabled": {
-                  "type": "boolean",
-                  "description": "Enable MaaS tier",
-                  "default": true
-                }
-              }
             }
           }
         }
@@ -1827,12 +1751,16 @@
     {
       "if": {
         "properties": {
-          "services": {
+          "global": {
             "properties": {
-              "caas": {
+              "services": {
                 "properties": {
-                  "enabled": {
-                    "const": true
+                  "caas": {
+                    "properties": {
+                      "enabled": {
+                        "const": true
+                      }
+                    }
                   }
                 }
               }
@@ -1844,12 +1772,16 @@
         "anyOf": [
           {
             "properties": {
-              "services": {
+              "global": {
                 "properties": {
-                  "vmaas": {
+                  "services": {
                     "properties": {
-                      "enabled": {
-                        "const": true
+                      "vmaas": {
+                        "properties": {
+                          "enabled": {
+                            "const": true
+                          }
+                        }
                       }
                     }
                   }
@@ -1859,12 +1791,16 @@
           },
           {
             "properties": {
-              "services": {
+              "global": {
                 "properties": {
-                  "bmaas": {
+                  "services": {
                     "properties": {
-                      "enabled": {
-                        "const": true
+                      "bmaas": {
+                        "properties": {
+                          "enabled": {
+                            "const": true
+                          }
+                        }
                       }
                     }
                   }
@@ -1878,12 +1814,16 @@
     {
       "if": {
         "properties": {
-          "services": {
+          "global": {
             "properties": {
-              "maas": {
+              "services": {
                 "properties": {
-                  "enabled": {
-                    "const": true
+                  "maas": {
+                    "properties": {
+                      "enabled": {
+                        "const": true
+                      }
+                    }
                   }
                 }
               }
@@ -1893,12 +1833,16 @@
       },
       "then": {
         "properties": {
-          "services": {
+          "global": {
             "properties": {
-              "caas": {
+              "services": {
                 "properties": {
-                  "enabled": {
-                    "const": true
+                  "caas": {
+                    "properties": {
+                      "enabled": {
+                        "const": true
+                      }
+                    }
                   }
                 }
               }
@@ -1910,19 +1854,23 @@
     {
       "if": {
         "properties": {
-          "services": {
+          "global": {
             "properties": {
-              "bmaas": {
+              "services": {
                 "properties": {
-                  "enabled": {
-                    "const": false
+                  "bmaas": {
+                    "properties": {
+                      "enabled": {
+                        "const": false
+                      }
+                    }
                   }
                 }
               }
             }
           }
         },
-        "required": ["services"]
+        "required": ["global"]
       },
       "then": {
         "properties": {

--- a/osac-installer/charts/osac/values.schema.json
+++ b/osac-installer/charts/osac/values.schema.json
@@ -1276,8 +1276,8 @@
         },
         "replicaCount": {
           "type": "integer",
-          "description": "Number of operator replicas",
-          "minimum": 1,
+          "description": "Number of operator replicas (0 disables the pod without removing the subchart)",
+          "minimum": 0,
           "default": 1
         },
         "resources": {

--- a/osac-installer/charts/osac/values.schema.json
+++ b/osac-installer/charts/osac/values.schema.json
@@ -51,6 +51,56 @@
         }
       }
     },
+    "services": {
+      "type": "object",
+      "description": "Service tier enablement flags. Controls which tiers are active across all OSAC components.",
+      "properties": {
+        "caas": {
+          "type": "object",
+          "description": "Container-as-a-Service (managed Kubernetes clusters)",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable CaaS tier (ClusterOrders, ClusterTemplates, ClusterCatalogItems, ClusterVersions)",
+              "default": true
+            }
+          }
+        },
+        "vmaas": {
+          "type": "object",
+          "description": "Virtual-Machine-as-a-Service (KubeVirt compute instances)",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable VMaaS tier (ComputeInstances, DiskImages, InstanceTypes, Volumes, ConsoleSessions)",
+              "default": true
+            }
+          }
+        },
+        "bmaas": {
+          "type": "object",
+          "description": "Bare-Metal-as-a-Service (bare metal host provisioning)",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable BMaaS tier (BareMetalInstances, BareMetalInstanceTypes)",
+              "default": true
+            }
+          }
+        },
+        "maas": {
+          "type": "object",
+          "description": "Metal-as-a-Service (raw metal access)",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable MaaS tier",
+              "default": true
+            }
+          }
+        }
+      }
+    },
     "operatorCrds": {
       "type": "object",
       "description": "OSAC Operator CRDs configuration",
@@ -456,6 +506,52 @@
             "credentials": {
               "type": "array",
               "description": "Volume sources for the Keycloak client secret used for Vault authentication"
+            }
+          }
+        },
+        "services": {
+          "type": "object",
+          "description": "Service tier enablement flags passed to the fulfillment-service",
+          "properties": {
+            "caas": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable CaaS tier",
+                  "default": true
+                }
+              }
+            },
+            "vmaas": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable VMaaS tier",
+                  "default": true
+                }
+              }
+            },
+            "bmaas": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable BMaaS tier",
+                  "default": true
+                }
+              }
+            },
+            "maas": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable MaaS tier",
+                  "default": true
+                }
+              }
             }
           }
         }
@@ -1444,7 +1540,10 @@
       "default": [],
       "items": {
         "type": "object",
-        "required": ["name", "role"],
+        "required": [
+          "name",
+          "role"
+        ],
         "properties": {
           "name": {
             "type": "string",
@@ -1452,7 +1551,10 @@
           },
           "role": {
             "type": "string",
-            "enum": ["fabric", "k8s"],
+            "enum": [
+              "fabric",
+              "k8s"
+            ],
             "description": "Manager role: fabric or k8s"
           },
           "description": {
@@ -1530,15 +1632,27 @@
             "limits": {
               "type": "object",
               "properties": {
-                "cpu": { "type": "string", "description": "CPU limit" },
-                "memory": { "type": "string", "description": "Memory limit" }
+                "cpu": {
+                  "type": "string",
+                  "description": "CPU limit"
+                },
+                "memory": {
+                  "type": "string",
+                  "description": "Memory limit"
+                }
               }
             },
             "requests": {
               "type": "object",
               "properties": {
-                "cpu": { "type": "string", "description": "CPU request" },
-                "memory": { "type": "string", "description": "Memory request" }
+                "cpu": {
+                  "type": "string",
+                  "description": "CPU request"
+                },
+                "memory": {
+                  "type": "string",
+                  "description": "Memory request"
+                }
               }
             }
           }
@@ -1687,5 +1801,90 @@
       }
     }
   },
-  "required": []
+  "required": [],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "services": {
+            "properties": {
+              "caas": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "anyOf": [
+          {
+            "properties": {
+              "services": {
+                "properties": {
+                  "vmaas": {
+                    "properties": {
+                      "enabled": {
+                        "const": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "services": {
+                "properties": {
+                  "bmaas": {
+                    "properties": {
+                      "enabled": {
+                        "const": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "services": {
+            "properties": {
+              "maas": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "services": {
+            "properties": {
+              "caas": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
 }

--- a/osac-installer/charts/osac/values.yaml
+++ b/osac-installer/charts/osac/values.yaml
@@ -32,15 +32,16 @@ kafka:
 # When all are true (the default), OSAC operates as a full-stack cloud.
 # Disabling a tier stops its gRPC/REST endpoints, operator controllers,
 # and dependent infrastructure (e.g. BMF operator for BMaaS).
-services:
-  caas:
-    enabled: true
-  vmaas:
-    enabled: true
-  bmaas:
-    enabled: true
-  maas:
-    enabled: true
+global:
+  services:
+    caas:
+      enabled: true
+    vmaas:
+      enabled: true
+    bmaas:
+      enabled: true
+    maas:
+      enabled: true
 
 # --- Operator CRDs ---
 operatorCrds:
@@ -70,13 +71,6 @@ operator:
   fulfillment:
     serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
-  services:
-    caas:
-      enabled: true
-    vmaas:
-      enabled: true
-    bmaas:
-      enabled: true
   controllers:
     tenant: true
     networking: true
@@ -91,15 +85,6 @@ operator:
 service:
   enabled: true
   variant: openshift
-  services:
-    caas:
-      enabled: true
-    vmaas:
-      enabled: true
-    bmaas:
-      enabled: true
-    maas:
-      enabled: true
   # [REQUIRED] Hostname for the external API Route (e.g. fulfillment-api-osac.apps.mycluster.example.com)
   externalHostname: ""
   # [REQUIRED] Hostname for the internal API Route (e.g. fulfillment-internal-api-osac.apps.mycluster.example.com)

--- a/osac-installer/charts/osac/values.yaml
+++ b/osac-installer/charts/osac/values.yaml
@@ -78,11 +78,8 @@ operator:
     bmaas:
       enabled: true
   controllers:
-    clusterOrder: true
-    computeInstance: true
     tenant: true
     networking: true
-    bareMetalInstance: true
     storage: true
   configSecret:
     name: "osac-config"

--- a/osac-installer/charts/osac/values.yaml
+++ b/osac-installer/charts/osac/values.yaml
@@ -295,7 +295,6 @@ bmfCrds: {}
 
 # --- Bare Metal Fulfillment Operator ---
 bmf:
-  enabled: true
   image:
     repository: ghcr.io/osac-project/bare-metal-fulfillment-operator
     tag: latest  # PLACEHOLDER -- overwritten at release time by publish-charts.yaml

--- a/osac-installer/charts/osac/values.yaml
+++ b/osac-installer/charts/osac/values.yaml
@@ -27,6 +27,21 @@ kafka:
   clusterNamespace: osac-kafka
   replicas: 3
 
+# --- Service Enablement ---
+# Controls which service tiers are active across all OSAC components.
+# When all are true (the default), OSAC operates as a full-stack cloud.
+# Disabling a tier stops its gRPC/REST endpoints, operator controllers,
+# and dependent infrastructure (e.g. BMF operator for BMaaS).
+services:
+  caas:
+    enabled: true
+  vmaas:
+    enabled: true
+  bmaas:
+    enabled: true
+  maas:
+    enabled: true
+
 # --- Operator CRDs ---
 operatorCrds:
   install: true
@@ -72,6 +87,15 @@ operator:
 service:
   enabled: true
   variant: openshift
+  services:
+    caas:
+      enabled: true
+    vmaas:
+      enabled: true
+    bmaas:
+      enabled: true
+    maas:
+      enabled: true
   # [REQUIRED] Hostname for the external API Route (e.g. fulfillment-api-osac.apps.mycluster.example.com)
   externalHostname: ""
   # [REQUIRED] Hostname for the internal API Route (e.g. fulfillment-internal-api-osac.apps.mycluster.example.com)

--- a/osac-installer/charts/osac/values.yaml
+++ b/osac-installer/charts/osac/values.yaml
@@ -13,6 +13,20 @@ global:
   # OpenShift cluster. Leave empty for platforms (e.g. kind) that set these
   # three values explicitly instead.
   clusterDomain: ""
+  # --- Service Enablement ---
+  # Controls which service tiers are active across all OSAC components.
+  # When all are true (the default), OSAC operates as a full-stack cloud.
+  # Disabling a tier stops its gRPC/REST endpoints, operator controllers,
+  # and dependent infrastructure (e.g. BMF operator for BMaaS).
+  services:
+    caas:
+      enabled: true
+    vmaas:
+      enabled: true
+    bmaas:
+      enabled: true
+    maas:
+      enabled: true
 
 cliImage: quay.io/openshift/origin-cli:4.20.0
 
@@ -26,22 +40,6 @@ kafka:
   clusterName: osac-kafka
   clusterNamespace: osac-kafka
   replicas: 3
-
-# --- Service Enablement ---
-# Controls which service tiers are active across all OSAC components.
-# When all are true (the default), OSAC operates as a full-stack cloud.
-# Disabling a tier stops its gRPC/REST endpoints, operator controllers,
-# and dependent infrastructure (e.g. BMF operator for BMaaS).
-global:
-  services:
-    caas:
-      enabled: true
-    vmaas:
-      enabled: true
-    bmaas:
-      enabled: true
-    maas:
-      enabled: true
 
 # --- Operator CRDs ---
 operatorCrds:

--- a/osac-installer/charts/osac/values.yaml
+++ b/osac-installer/charts/osac/values.yaml
@@ -70,6 +70,13 @@ operator:
   fulfillment:
     serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  services:
+    caas:
+      enabled: true
+    vmaas:
+      enabled: true
+    bmaas:
+      enabled: true
   controllers:
     clusterOrder: true
     computeInstance: true

--- a/osac-installer/values/bmaas-ci/instance.yaml
+++ b/osac-installer/values/bmaas-ci/instance.yaml
@@ -1,5 +1,17 @@
 # BMaaS CI environment -- instance values for osac chart.
 
+# --- Service Enablement ---
+global:
+  services:
+    caas:
+      enabled: false
+    vmaas:
+      enabled: false
+    bmaas:
+      enabled: true
+    maas:
+      enabled: false
+
 # --- Operator ---
 operator:
   image:
@@ -16,13 +28,6 @@ operator:
   fulfillment:
     serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
-  services:
-    caas:
-      enabled: false
-    vmaas:
-      enabled: false
-    bmaas:
-      enabled: true
   controllers:
     tenant: true
     networking: true

--- a/osac-installer/values/bmaas-ci/instance.yaml
+++ b/osac-installer/values/bmaas-ci/instance.yaml
@@ -16,14 +16,18 @@ operator:
   fulfillment:
     serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  services:
+    caas:
+      enabled: false
+    vmaas:
+      enabled: false
+    bmaas:
+      enabled: true
   controllers:
-    clusterOrder: false
-    computeInstance: false
     tenant: true
     networking: true
     networkingProvisioning: false
     storage: true
-    bareMetalInstance: true
   hubAccess:
     enabled: true
   tenants:

--- a/osac-installer/values/bmaas-ci/instance.yaml
+++ b/osac-installer/values/bmaas-ci/instance.yaml
@@ -164,7 +164,6 @@ validation:
 
 # --- Bare Metal Fulfillment Operator ---
 bmf:
-  enabled: true
   image:
     repository: ghcr.io/osac-project/bare-metal-fulfillment-operator
     tag: latest

--- a/osac-installer/values/caas-ci/instance.yaml
+++ b/osac-installer/values/caas-ci/instance.yaml
@@ -6,7 +6,7 @@ global:
     caas:
       enabled: true
     vmaas:
-      enabled: false
+      enabled: true
     bmaas:
       enabled: false
     maas:

--- a/osac-installer/values/caas-ci/instance.yaml
+++ b/osac-installer/values/caas-ci/instance.yaml
@@ -16,9 +16,12 @@ operator:
   fulfillment:
     serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  services:
+    caas:
+      enabled: true
+    vmaas:
+      enabled: false
   controllers:
-    clusterOrder: true
-    computeInstance: false
     tenant: true
     networking: true
     storage: true

--- a/osac-installer/values/caas-ci/instance.yaml
+++ b/osac-installer/values/caas-ci/instance.yaml
@@ -1,5 +1,13 @@
 # CaaS CI environment -- instance values for osac chart.
 
+# --- Service Enablement ---
+global:
+  services:
+    caas:
+      enabled: true
+    vmaas:
+      enabled: false
+
 # --- Operator ---
 operator:
   image:
@@ -16,11 +24,6 @@ operator:
   fulfillment:
     serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
-  services:
-    caas:
-      enabled: true
-    vmaas:
-      enabled: false
   controllers:
     tenant: true
     networking: true

--- a/osac-installer/values/caas-ci/instance.yaml
+++ b/osac-installer/values/caas-ci/instance.yaml
@@ -7,6 +7,10 @@ global:
       enabled: true
     vmaas:
       enabled: false
+    bmaas:
+      enabled: true
+    maas:
+      enabled: false
 
 # --- Operator ---
 operator:

--- a/osac-installer/values/caas-ci/instance.yaml
+++ b/osac-installer/values/caas-ci/instance.yaml
@@ -8,7 +8,7 @@ global:
     vmaas:
       enabled: false
     bmaas:
-      enabled: true
+      enabled: false
     maas:
       enabled: false
 

--- a/osac-installer/values/caas-ci/instance.yaml
+++ b/osac-installer/values/caas-ci/instance.yaml
@@ -6,9 +6,9 @@ global:
     caas:
       enabled: true
     vmaas:
-      enabled: true
-    bmaas:
       enabled: false
+    bmaas:
+      enabled: true
     maas:
       enabled: false
 
@@ -156,7 +156,11 @@ validation:
   enabled: true
 
 # --- Bare Metal Fulfillment Operator ---
+# BMaaS is enabled (so CaaS satisfies the "requires VMaaS or BMaaS" constraint
+# and BMaaS API endpoints register), but the BMF operator runs with zero
+# replicas because the CaaS CI cluster has no Metal3 infrastructure.
 bmf:
+  replicaCount: 0
   image:
     repository: ghcr.io/osac-project/bare-metal-fulfillment-operator
     tag: latest

--- a/osac-installer/values/caas-ci/instance.yaml
+++ b/osac-installer/values/caas-ci/instance.yaml
@@ -153,7 +153,6 @@ validation:
 
 # --- Bare Metal Fulfillment Operator ---
 bmf:
-  enabled: false
   image:
     repository: ghcr.io/osac-project/bare-metal-fulfillment-operator
     tag: latest

--- a/osac-installer/values/dev/instance.yaml
+++ b/osac-installer/values/dev/instance.yaml
@@ -1,5 +1,13 @@
 # OpenShift dev environment -- instance values for osac chart.
 
+# --- Service Enablement ---
+global:
+  services:
+    caas:
+      enabled: true
+    vmaas:
+      enabled: true
+
 # --- Operator ---
 operator:
   image:
@@ -16,11 +24,6 @@ operator:
   fulfillment:
     serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
-  services:
-    caas:
-      enabled: true
-    vmaas:
-      enabled: true
   controllers:
     tenant: true
     networking: true

--- a/osac-installer/values/dev/instance.yaml
+++ b/osac-installer/values/dev/instance.yaml
@@ -16,9 +16,12 @@ operator:
   fulfillment:
     serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  services:
+    caas:
+      enabled: true
+    vmaas:
+      enabled: true
   controllers:
-    clusterOrder: true
-    computeInstance: true
     tenant: true
     networking: true
 

--- a/osac-installer/values/dev/kind-instance.yaml
+++ b/osac-installer/values/dev/kind-instance.yaml
@@ -8,7 +8,7 @@ global:
     vmaas:
       enabled: true
     bmaas:
-      enabled: false
+      enabled: true
     maas:
       enabled: false
 
@@ -127,8 +127,9 @@ aap:
     publishTemplates:
       enabled: false
 
-# --- Bare Metal Fulfillment (disabled) ---
+# --- Bare Metal Fulfillment (no Metal3 in Kind — deploy chart but 0 replicas) ---
 bmf:
+  replicaCount: 0
   secrets:
     inventoryConfig: osac-inventory-config-metal3-test
     managementConfig: osac-management-config-metal3-test

--- a/osac-installer/values/dev/kind-instance.yaml
+++ b/osac-installer/values/dev/kind-instance.yaml
@@ -17,12 +17,16 @@ operator:
   fulfillment:
     serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  services:
+    caas:
+      enabled: true
+    vmaas:
+      enabled: true
+    bmaas:
+      enabled: true
   controllers:
-    clusterOrder: true
-    computeInstance: true
     tenant: true
     networking: true
-    bareMetalInstance: true
   certs:
     issuerRef:
       name: default-ca

--- a/osac-installer/values/dev/kind-instance.yaml
+++ b/osac-installer/values/dev/kind-instance.yaml
@@ -8,7 +8,9 @@ global:
     vmaas:
       enabled: true
     bmaas:
-      enabled: true
+      enabled: false
+    maas:
+      enabled: false
 
 # --- Operator ---
 operator:

--- a/osac-installer/values/dev/kind-instance.yaml
+++ b/osac-installer/values/dev/kind-instance.yaml
@@ -127,7 +127,6 @@ aap:
 
 # --- Bare Metal Fulfillment (disabled) ---
 bmf:
-  enabled: false
   secrets:
     inventoryConfig: osac-inventory-config-metal3-test
     managementConfig: osac-management-config-metal3-test

--- a/osac-installer/values/dev/kind-instance.yaml
+++ b/osac-installer/values/dev/kind-instance.yaml
@@ -1,5 +1,15 @@
 # Kind dev environment -- instance values for osac chart.
 
+# --- Service Enablement ---
+global:
+  services:
+    caas:
+      enabled: true
+    vmaas:
+      enabled: true
+    bmaas:
+      enabled: true
+
 # --- Operator ---
 operator:
   image:
@@ -17,13 +27,6 @@ operator:
   fulfillment:
     serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
-  services:
-    caas:
-      enabled: true
-    vmaas:
-      enabled: true
-    bmaas:
-      enabled: true
   controllers:
     tenant: true
     networking: true

--- a/osac-installer/values/full-ci/instance.yaml
+++ b/osac-installer/values/full-ci/instance.yaml
@@ -16,13 +16,17 @@ operator:
   fulfillment:
     serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  services:
+    caas:
+      enabled: true
+    vmaas:
+      enabled: true
+    bmaas:
+      enabled: true
   controllers:
-    clusterOrder: true
-    computeInstance: true
     tenant: true
     networking: true
     storage: true
-    bareMetalInstance: true
   hubAccess:
     enabled: true
   tenants:

--- a/osac-installer/values/full-ci/instance.yaml
+++ b/osac-installer/values/full-ci/instance.yaml
@@ -1,5 +1,15 @@
 # Full CI environment -- instance values for osac chart.
 
+# --- Service Enablement ---
+global:
+  services:
+    caas:
+      enabled: true
+    vmaas:
+      enabled: true
+    bmaas:
+      enabled: true
+
 # --- Operator ---
 operator:
   image:
@@ -16,13 +26,6 @@ operator:
   fulfillment:
     serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
-  services:
-    caas:
-      enabled: true
-    vmaas:
-      enabled: true
-    bmaas:
-      enabled: true
   controllers:
     tenant: true
     networking: true

--- a/osac-installer/values/full-ci/instance.yaml
+++ b/osac-installer/values/full-ci/instance.yaml
@@ -9,6 +9,8 @@ global:
       enabled: true
     bmaas:
       enabled: true
+    maas:
+      enabled: true
 
 # --- Operator ---
 operator:

--- a/osac-installer/values/full-ci/instance.yaml
+++ b/osac-installer/values/full-ci/instance.yaml
@@ -164,7 +164,6 @@ validation:
 
 # --- Bare Metal Fulfillment Operator ---
 bmf:
-  enabled: true
   image:
     repository: ghcr.io/osac-project/bare-metal-fulfillment-operator
     tag: latest

--- a/osac-installer/values/vmaas-ci/instance.yaml
+++ b/osac-installer/values/vmaas-ci/instance.yaml
@@ -7,6 +7,8 @@ global:
       enabled: false
     vmaas:
       enabled: true
+    bmaas:
+      enabled: false
     maas:
       enabled: false
 

--- a/osac-installer/values/vmaas-ci/instance.yaml
+++ b/osac-installer/values/vmaas-ci/instance.yaml
@@ -20,9 +20,12 @@ operator:
   fulfillment:
     serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  services:
+    caas:
+      enabled: false
+    vmaas:
+      enabled: true
   controllers:
-    clusterOrder: false
-    computeInstance: true
     tenant: true
     networking: true
     storage: true

--- a/osac-installer/values/vmaas-ci/instance.yaml
+++ b/osac-installer/values/vmaas-ci/instance.yaml
@@ -1,5 +1,15 @@
 # VMaaS CI environment -- instance values for osac chart.
 
+# --- Service Enablement ---
+global:
+  services:
+    caas:
+      enabled: false
+    vmaas:
+      enabled: true
+    maas:
+      enabled: false
+
 # --- CSI Driver ---
 csiDriver:
   enabled: true
@@ -20,11 +30,6 @@ operator:
   fulfillment:
     serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
-  services:
-    caas:
-      enabled: false
-    vmaas:
-      enabled: true
   controllers:
     tenant: true
     networking: true

--- a/osac-installer/values/vmaas-ci/instance.yaml
+++ b/osac-installer/values/vmaas-ci/instance.yaml
@@ -177,10 +177,6 @@ aap:
 validation:
   enabled: true
 
-# --- Bare Metal Fulfillment Operator ---
-bmf:
-  enabled: false
-
 # --- Hub Access ---
 hubAccess:
   enabled: true

--- a/osac-metering/charts/osac-metering/templates/_helpers.tpl
+++ b/osac-metering/charts/osac-metering/templates/_helpers.tpl
@@ -54,3 +54,26 @@ osac-metering
 {{- define "osac-metering.kafkaReplicas" -}}
 3
 {{- end -}}
+
+{{/*
+Check if a service tier is enabled via global.services.<key>.enabled.
+Args: list of [context, serviceKey]
+Falls back to true when global.services is not set.
+Returns non-empty string for enabled, empty for disabled (for use in {{- if include ... }}).
+*/}}
+{{- define "osac-metering.serviceEnabled" -}}
+{{- $ctx := index . 0 -}}
+{{- $svcKey := index . 1 -}}
+{{- $enabled := true -}}
+{{- if $ctx.Values.global -}}
+{{- if $ctx.Values.global.services -}}
+{{- $svc := index $ctx.Values.global.services $svcKey -}}
+{{- if $svc -}}
+{{- if hasKey $svc "enabled" -}}
+{{- $enabled = $svc.enabled -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if $enabled -}}true{{- end -}}
+{{- end }}

--- a/osac-metering/charts/osac-metering/templates/deployment.yaml
+++ b/osac-metering/charts/osac-metering/templates/deployment.yaml
@@ -130,6 +130,22 @@ spec:
               value: {{ include "osac-metering.kafkaSaslUsername" . | quote }}
             - name: KAFKA_SASL_PASSWORD_FILE
               value: /etc/kafka-secrets/password
+            {{- if include "osac-metering.serviceEnabled" (list . "caas") }}
+            - name: ENABLE_CAAS
+              value: "true"
+            {{- end }}
+            {{- if include "osac-metering.serviceEnabled" (list . "vmaas") }}
+            - name: ENABLE_VMAAS
+              value: "true"
+            {{- end }}
+            {{- if include "osac-metering.serviceEnabled" (list . "bmaas") }}
+            - name: ENABLE_BMAAS
+              value: "true"
+            {{- end }}
+            {{- if include "osac-metering.serviceEnabled" (list . "maas") }}
+            - name: ENABLE_MAAS
+              value: "true"
+            {{- end }}
           volumeMounts:
             - name: kafka-secrets
               mountPath: /etc/kafka-secrets

--- a/osac-metering/metering-service/cmd/metering-service/main.go
+++ b/osac-metering/metering-service/cmd/metering-service/main.go
@@ -56,10 +56,15 @@ type config struct {
 	dbURLFile              string
 	heartbeatInterval      time.Duration
 	reconciliationInterval time.Duration
+	enableCaaS             bool
+	enableVMaaS            bool
+	enableBMaaS            bool
+	enableMaaS             bool
 }
 
 func main() {
 	cfg := configFromEnv()
+	cfg.enableAllIfNoneSet()
 	if err := cfg.validate(); err != nil {
 		fmt.Fprintf(os.Stderr, "configuration error: %v\n", err)
 		os.Exit(2)
@@ -91,6 +96,23 @@ func configFromEnv() *config {
 		dbURLFile:              envOrDefault("DB_URL_FILE", "/etc/metering/db"),
 		heartbeatInterval:      parseDurationOrDefault(os.Getenv("HEARTBEAT_INTERVAL"), 60*time.Second),
 		reconciliationInterval: parseDurationOrDefault(os.Getenv("RECONCILIATION_INTERVAL"), 60*time.Minute),
+		enableCaaS:             envBool("ENABLE_CAAS"),
+		enableVMaaS:            envBool("ENABLE_VMAAS"),
+		enableBMaaS:            envBool("ENABLE_BMAAS"),
+		enableMaaS:             envBool("ENABLE_MAAS"),
+	}
+}
+
+func envBool(key string) bool {
+	return strings.EqualFold(os.Getenv(key), "true")
+}
+
+func (c *config) enableAllIfNoneSet() {
+	if !c.enableCaaS && !c.enableVMaaS && !c.enableBMaaS && !c.enableMaaS {
+		c.enableCaaS = true
+		c.enableVMaaS = true
+		c.enableBMaaS = true
+		c.enableMaaS = true
 	}
 }
 
@@ -205,8 +227,21 @@ func run(ctx context.Context, logger logr.Logger, cfg *config) error {
 
 	publisher := kafkapub.NewPublisher(producer)
 
-	computeClient := privatev1.NewComputeInstancesClient(grpcConn)
-	clusterClient := privatev1.NewClustersClient(grpcConn)
+	logger.Info("service enablement",
+		"caas", cfg.enableCaaS,
+		"vmaas", cfg.enableVMaaS,
+		"bmaas", cfg.enableBMaaS,
+		"maas", cfg.enableMaaS,
+	)
+
+	var computeClient privatev1.ComputeInstancesClient
+	var clusterClient privatev1.ClustersClient
+	if cfg.enableVMaaS {
+		computeClient = privatev1.NewComputeInstancesClient(grpcConn)
+	}
+	if cfg.enableCaaS {
+		clusterClient = privatev1.NewClustersClient(grpcConn)
+	}
 	reconciler := reconciliation.NewReconciler(computeClient, clusterClient, store, publisher, logger, cfg.heartbeatInterval)
 
 	logger.Info("running startup reconciliation")
@@ -237,6 +272,7 @@ func run(ctx context.Context, logger logr.Logger, cfg *config) error {
 
 	eventsClient := privatev1.NewEventsClient(grpcConn)
 	consumer := watch.NewConsumer(eventsClient, publisher, store, logger)
+	consumer.Filter = watch.BuildFilter(cfg.enableVMaaS, cfg.enableCaaS)
 	err = consumer.Run(ctx)
 	runCancel()
 	wg.Wait()

--- a/osac-metering/metering-service/internal/reconciliation/reconciler.go
+++ b/osac-metering/metering-service/internal/reconciliation/reconciler.go
@@ -289,10 +289,18 @@ func (r *Reconciler) reconcileFulfillmentResources(ctx context.Context, fulfillm
 
 func (r *Reconciler) reconcileMissedDeletions(ctx context.Context, fulfillmentState map[string]fulfillmentResource, projMap map[string]projection.ResourceState, now time.Time) (int, error) {
 	corrections := 0
+	computeSkipLogged := false
 	clusterSkipLogged := false
 
 	for id, ps := range projMap {
 		if _, exists := fulfillmentState[id]; !exists {
+			if ps.ResourceType == events.ResourceTypeComputeInstance && r.computeClient == nil {
+				if !computeSkipLogged {
+					r.logger.Info("skipping compute_instance missed deletion checks, no compute client configured")
+					computeSkipLogged = true
+				}
+				continue
+			}
 			if ps.ResourceType == events.ResourceTypeClusterOrder && r.clusterClient == nil {
 				if !clusterSkipLogged {
 					r.logger.Info("skipping cluster_order missed deletion checks, no cluster client configured")
@@ -419,8 +427,10 @@ func isBillableForType(resourceType, state string) (bool, error) {
 func (r *Reconciler) loadFulfillmentState(ctx context.Context) (map[string]fulfillmentResource, error) {
 	result := make(map[string]fulfillmentResource)
 
-	if err := r.loadComputeInstances(ctx, result); err != nil {
-		return nil, err
+	if r.computeClient != nil {
+		if err := r.loadComputeInstances(ctx, result); err != nil {
+			return nil, err
+		}
 	}
 	if r.clusterClient != nil {
 		if err := r.loadClusters(ctx, result); err != nil {

--- a/osac-metering/metering-service/internal/watch/consumer.go
+++ b/osac-metering/metering-service/internal/watch/consumer.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -42,8 +43,18 @@ const (
 	defaultInitialDelay   = 1 * time.Second
 	defaultMaxDelay       = 30 * time.Second
 	defaultHandlerRetries = 3
-	meteringFilter        = "has(event.compute_instance) || has(event.cluster)"
 )
+
+func BuildFilter(vmaas, caas bool) string {
+	var parts []string
+	if vmaas {
+		parts = append(parts, "has(event.compute_instance)")
+	}
+	if caas {
+		parts = append(parts, "has(event.cluster)")
+	}
+	return strings.Join(parts, " || ")
+}
 
 // Consumer connects to the fulfillment-service gRPC Watch stream, maps
 // incoming events to CloudEvents, and publishes them to Kafka. It
@@ -57,6 +68,7 @@ type Consumer struct {
 	InitialDelay   time.Duration
 	MaxDelay       time.Duration
 	HandlerRetries int
+	Filter         string
 }
 
 func NewConsumer(
@@ -73,6 +85,7 @@ func NewConsumer(
 		InitialDelay:   defaultInitialDelay,
 		MaxDelay:       defaultMaxDelay,
 		HandlerRetries: defaultHandlerRetries,
+		Filter:         BuildFilter(true, true),
 	}
 }
 
@@ -101,7 +114,7 @@ func (c *Consumer) Run(ctx context.Context) error {
 }
 
 func (c *Consumer) consumeStream(ctx context.Context) (int, error) {
-	filter := meteringFilter
+	filter := c.Filter
 	stream, err := c.client.Watch(ctx, &privatev1.EventsWatchRequest{
 		Filter: &filter,
 	})

--- a/osac-operator/charts/operator/templates/_helpers.tpl
+++ b/osac-operator/charts/operator/templates/_helpers.tpl
@@ -68,3 +68,34 @@ Service account name
 {{- include "osac-operator.fullname" . }}
 {{- end }}
 {{- end }}
+
+{{/*
+Resolve a service-tier controller flag from global.services or a local override.
+Args: list of [context, controllerKey, serviceKey]
+  - controllerKey: key in .Values.controllers (e.g. "clusterOrder")
+  - serviceKey: key in .Values.global.services (e.g. "caas")
+If controllers.<controllerKey> is explicitly set, it wins.
+Otherwise, falls back to global.services.<serviceKey>.enabled (default true).
+*/}}
+{{- define "osac-operator.controllerEnabled" -}}
+{{- $ctx := index . 0 -}}
+{{- $ctrlKey := index . 1 -}}
+{{- $svcKey := index . 2 -}}
+{{- $ctrlVal := index $ctx.Values.controllers $ctrlKey -}}
+{{- if $ctrlVal | kindIs "invalid" | not -}}
+{{- $ctrlVal -}}
+{{- else -}}
+{{- $enabled := true -}}
+{{- if $ctx.Values.global -}}
+{{- if $ctx.Values.global.services -}}
+{{- $svc := index $ctx.Values.global.services $svcKey -}}
+{{- if $svc -}}
+{{- if hasKey $svc "enabled" -}}
+{{- $enabled = $svc.enabled -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- $enabled -}}
+{{- end -}}
+{{- end }}

--- a/osac-operator/charts/operator/templates/deployment.yaml
+++ b/osac-operator/charts/operator/templates/deployment.yaml
@@ -99,15 +99,15 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: OSAC_ENABLE_CLUSTER_CONTROLLER
-            value: {{ .Values.services.caas.enabled | quote }}
+            value: {{ include "osac-operator.controllerEnabled" (list . "clusterOrder" "caas") | quote }}
           - name: OSAC_ENABLE_COMPUTE_INSTANCE_CONTROLLER
-            value: {{ .Values.services.vmaas.enabled | quote }}
+            value: {{ include "osac-operator.controllerEnabled" (list . "computeInstance" "vmaas") | quote }}
           - name: OSAC_ENABLE_TENANT_CONTROLLER
             value: {{ .Values.controllers.tenant | quote }}
           - name: OSAC_ENABLE_NETWORKING_CONTROLLER
             value: {{ .Values.controllers.networking | quote }}
           - name: OSAC_ENABLE_BAREMETAL_INSTANCE_CONTROLLER
-            value: {{ .Values.services.bmaas.enabled | quote }}
+            value: {{ include "osac-operator.controllerEnabled" (list . "bareMetalInstance" "bmaas") | quote }}
           - name: OSAC_ENABLE_STORAGE_CONTROLLER
             value: {{ .Values.controllers.storage | quote }}
           - name: OSAC_ENABLE_VOLUME_CONTROLLER

--- a/osac-operator/charts/operator/templates/deployment.yaml
+++ b/osac-operator/charts/operator/templates/deployment.yaml
@@ -99,15 +99,15 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: OSAC_ENABLE_CLUSTER_CONTROLLER
-            value: {{ and .Values.controllers.clusterOrder .Values.services.caas.enabled | quote }}
+            value: {{ .Values.services.caas.enabled | quote }}
           - name: OSAC_ENABLE_COMPUTE_INSTANCE_CONTROLLER
-            value: {{ and .Values.controllers.computeInstance .Values.services.vmaas.enabled | quote }}
+            value: {{ .Values.services.vmaas.enabled | quote }}
           - name: OSAC_ENABLE_TENANT_CONTROLLER
             value: {{ .Values.controllers.tenant | quote }}
           - name: OSAC_ENABLE_NETWORKING_CONTROLLER
             value: {{ .Values.controllers.networking | quote }}
           - name: OSAC_ENABLE_BAREMETAL_INSTANCE_CONTROLLER
-            value: {{ and .Values.controllers.bareMetalInstance .Values.services.bmaas.enabled | quote }}
+            value: {{ .Values.services.bmaas.enabled | quote }}
           - name: OSAC_ENABLE_STORAGE_CONTROLLER
             value: {{ .Values.controllers.storage | quote }}
           - name: OSAC_ENABLE_VOLUME_CONTROLLER

--- a/osac-operator/charts/operator/templates/deployment.yaml
+++ b/osac-operator/charts/operator/templates/deployment.yaml
@@ -99,15 +99,15 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: OSAC_ENABLE_CLUSTER_CONTROLLER
-            value: {{ .Values.controllers.clusterOrder | quote }}
+            value: {{ and .Values.controllers.clusterOrder .Values.services.caas.enabled | quote }}
           - name: OSAC_ENABLE_COMPUTE_INSTANCE_CONTROLLER
-            value: {{ .Values.controllers.computeInstance | quote }}
+            value: {{ and .Values.controllers.computeInstance .Values.services.vmaas.enabled | quote }}
           - name: OSAC_ENABLE_TENANT_CONTROLLER
             value: {{ .Values.controllers.tenant | quote }}
           - name: OSAC_ENABLE_NETWORKING_CONTROLLER
             value: {{ .Values.controllers.networking | quote }}
           - name: OSAC_ENABLE_BAREMETAL_INSTANCE_CONTROLLER
-            value: {{ .Values.controllers.bareMetalInstance | quote }}
+            value: {{ and .Values.controllers.bareMetalInstance .Values.services.bmaas.enabled | quote }}
           - name: OSAC_ENABLE_STORAGE_CONTROLLER
             value: {{ .Values.controllers.storage | quote }}
           - name: OSAC_ENABLE_VOLUME_CONTROLLER

--- a/osac-operator/charts/operator/values.yaml
+++ b/osac-operator/charts/operator/values.yaml
@@ -44,14 +44,6 @@ controllers:
 #     vast: vast-csi-controller.osac-csi-backends.svc:50051
 vendorControllers: {}
 
-services:
-  caas:
-    enabled: true
-  vmaas:
-    enabled: true
-  bmaas:
-    enabled: true
-
 configSecret:
   name: "osac-config"
   optional: true

--- a/osac-operator/charts/operator/values.yaml
+++ b/osac-operator/charts/operator/values.yaml
@@ -47,6 +47,14 @@ controllers:
 #     vast: vast-csi-controller.osac-csi-backends.svc:50051
 vendorControllers: {}
 
+services:
+  caas:
+    enabled: true
+  vmaas:
+    enabled: true
+  bmaas:
+    enabled: true
+
 configSecret:
   name: "osac-config"
   optional: true

--- a/osac-operator/charts/operator/values.yaml
+++ b/osac-operator/charts/operator/values.yaml
@@ -25,11 +25,8 @@ fulfillment:
   tokenFile: ""
 
 controllers:
-  clusterOrder: true
-  computeInstance: true
   tenant: true
   networking: true
-  bareMetalInstance: true
   storage: true
   # The Volume controller provisions volumes via the vendor CSI controllers.
   # Safe to leave enabled even without a vendor backend: when vendorControllers

--- a/osac-operator/cmd/main.go
+++ b/osac-operator/cmd/main.go
@@ -206,6 +206,14 @@ func (f *controllerFlags) enableAllIfNoneSet() {
 	}
 }
 
+func (f *controllerFlags) validate() error {
+	if f.Cluster && !f.ComputeInstance && !f.BareMetalInstance {
+		return fmt.Errorf(
+			"CaaS (Cluster) requires at least one of VMaaS (ComputeInstance) or BMaaS (BareMetalInstance)")
+	}
+	return nil
+}
+
 // addSchemesForLocalControllers registers only the API schemes required by the enabled controllers.
 // Must be called before creating the manager.
 func addSchemesForLocalControllers(
@@ -1044,6 +1052,11 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	ctrlFlags.enableAllIfNoneSet()
+
+	if err := ctrlFlags.validate(); err != nil {
+		setupLog.Error(err, "invalid controller flag combination")
+		os.Exit(1)
+	}
 
 	if remoteClusterKubeconfig != "" && ctrlFlags.Cluster {
 		setupLog.Error(nil, "remote cluster kubeconfig option is not supported along with cluster controller")

--- a/osac-operator/cmd/main.go
+++ b/osac-operator/cmd/main.go
@@ -231,7 +231,7 @@ func addSchemesForLocalControllers(
 	if enableTenant {
 		utilruntime.Must(ovnv1.AddToScheme(localScheme))
 	}
-	if enableBareMetalInstance {
+	if enableBareMetalInstance || enableNetworking {
 		utilruntime.Must(bmfov1alpha1.AddToScheme(localScheme))
 	}
 	// +kubebuilder:scaffold:scheme

--- a/osac-operator/cmd/main.go
+++ b/osac-operator/cmd/main.go
@@ -541,7 +541,7 @@ func setupControllers(
 		}
 	}
 	if flags.Networking {
-		if err := setupNetworkingControllers(mgr, grpcConn, maxJobHistory); err != nil {
+		if err := setupNetworkingControllers(mgr, grpcConn, maxJobHistory, flags.BareMetalInstance); err != nil {
 			return fmt.Errorf("networking controllers: %w", err)
 		}
 	}
@@ -648,6 +648,7 @@ func setupNetworkingControllers(
 	mgr mcmanager.Manager,
 	grpcConn *grpc.ClientConn,
 	maxJobHistory int,
+	enableBareMetalInstance bool,
 ) error {
 	localMgr := mgr.GetLocalManager()
 	targetCluster := targetClusterFromManager(mgr)
@@ -747,7 +748,7 @@ func setupNetworkingControllers(
 		mgr, localMgr, grpcConn,
 		networkingNamespace, computeInstanceNamespace, clusterOrderNamespace, bareMetalInstanceNamespace,
 		externalIPAttachmentProvider, statusPollInterval, maxJobHistory, targetCluster, resolver,
-		networkClassesClient, networkProvisioningEnabled,
+		networkClassesClient, networkProvisioningEnabled, enableBareMetalInstance,
 	); err != nil {
 		return err
 	}
@@ -917,7 +918,7 @@ func setupExternalIPAttachmentControllers(
 	provider provisioning.ProvisioningProvider,
 	statusPollInterval time.Duration, maxJobHistory int, targetCluster multicluster.ClusterName,
 	resolver *dispatcher.Resolver, networkClassesClient privatev1.NetworkClassesClient,
-	networkProvisioningEnabled bool,
+	networkProvisioningEnabled bool, enableBareMetalInstance bool,
 ) error {
 	reconciler := controller.NewExternalIPAttachmentReconciler(
 		mgr, networkingNamespace, computeInstanceNamespace,
@@ -926,6 +927,7 @@ func setupExternalIPAttachmentControllers(
 		resolver, networkClassesClient,
 	)
 	reconciler.NetworkProvisioningEnabled = networkProvisioningEnabled
+	reconciler.BareMetalInstanceEnabled = enableBareMetalInstance
 	if err := reconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("externalipattachment controller: %w", err)
 	}

--- a/osac-operator/cmd/main_test.go
+++ b/osac-operator/cmd/main_test.go
@@ -288,3 +288,50 @@ var _ = Describe("parseVendorControllers", func() {
 		Expect(err.Error()).To(ContainSubstring("backend and endpoint must not be empty"))
 	})
 })
+
+var _ = Describe("controllerFlags.validate", func() {
+	It("accepts all controllers enabled", func() {
+		f := &controllerFlags{
+			Tenant: true, Storage: true, Volume: true,
+			ComputeInstance: true, Cluster: true,
+			Networking: true, BareMetalInstance: true,
+		}
+		Expect(f.validate()).To(Succeed())
+	})
+
+	It("accepts CaaS with VMaaS", func() {
+		f := &controllerFlags{Cluster: true, ComputeInstance: true}
+		Expect(f.validate()).To(Succeed())
+	})
+
+	It("accepts CaaS with BMaaS", func() {
+		f := &controllerFlags{Cluster: true, BareMetalInstance: true}
+		Expect(f.validate()).To(Succeed())
+	})
+
+	It("accepts CaaS with both VMaaS and BMaaS", func() {
+		f := &controllerFlags{Cluster: true, ComputeInstance: true, BareMetalInstance: true}
+		Expect(f.validate()).To(Succeed())
+	})
+
+	It("rejects CaaS without VMaaS or BMaaS", func() {
+		f := &controllerFlags{Cluster: true, Tenant: true, Networking: true}
+		Expect(f.validate()).To(MatchError(ContainSubstring("ComputeInstance")))
+		Expect(f.validate()).To(MatchError(ContainSubstring("BareMetalInstance")))
+	})
+
+	It("accepts VMaaS without CaaS", func() {
+		f := &controllerFlags{ComputeInstance: true, Tenant: true}
+		Expect(f.validate()).To(Succeed())
+	})
+
+	It("accepts BMaaS without CaaS", func() {
+		f := &controllerFlags{BareMetalInstance: true, Tenant: true}
+		Expect(f.validate()).To(Succeed())
+	})
+
+	It("accepts no controllers enabled", func() {
+		f := &controllerFlags{}
+		Expect(f.validate()).To(Succeed())
+	})
+})

--- a/osac-operator/internal/controller/externalipattachment_controller.go
+++ b/osac-operator/internal/controller/externalipattachment_controller.go
@@ -79,6 +79,10 @@ type ExternalIPAttachmentReconciler struct {
 	// NetworkProvisioningEnabled controls whether the controller dispatches AAP
 	// provisioning jobs. When false, resources are set to Ready immediately.
 	NetworkProvisioningEnabled bool
+	// BareMetalInstanceEnabled controls whether the controller watches
+	// BareMetalInstance resources. When false (BMaaS disabled), the BMF
+	// scheme is not registered and the watch must be skipped.
+	BareMetalInstanceEnabled bool
 }
 
 // NewExternalIPAttachmentReconciler creates a new reconciler for ExternalIPAttachment resources.
@@ -1094,7 +1098,7 @@ func (r *ExternalIPAttachmentReconciler) mapComputeInstanceToExternalIPAttachmen
 
 // SetupWithManager registers this controller with the multicluster manager.
 func (r *ExternalIPAttachmentReconciler) SetupWithManager(mgr mcmanager.Manager) error {
-	return mcbuilder.ControllerManagedBy(mgr).
+	b := mcbuilder.ControllerManagedBy(mgr).
 		For(&v1alpha1.ExternalIPAttachment{},
 			mcbuilder.WithPredicates(NetworkingNamespacePredicate(r.NetworkingNamespace)),
 			mcbuilder.WithEngageWithLocalCluster(true),
@@ -1112,13 +1116,15 @@ func (r *ExternalIPAttachmentReconciler) SetupWithManager(mgr mcmanager.Manager)
 			mcbuilder.WithPredicates(NamespacePredicate(r.ClusterOrderNamespace)),
 			mcbuilder.WithEngageWithLocalCluster(true),
 			mcbuilder.WithEngageWithProviderClusters(false),
-		).
-		Watches(
+		)
+	if r.BareMetalInstanceEnabled {
+		b = b.Watches(
 			&bmfov1alpha1.BareMetalInstance{},
 			mchandler.EnqueueRequestsFromMapFunc(r.mapBaremetalInstanceToExternalIPAttachments),
 			mcbuilder.WithPredicates(BareMetalInstanceNamespacePredicate(r.BaremetalInstanceNamespace)),
 			mcbuilder.WithEngageWithLocalCluster(true),
 			mcbuilder.WithEngageWithProviderClusters(false),
-		).
-		Complete(r)
+		)
+	}
+	return b.Complete(r)
 }

--- a/tests/e2e/vmaas/sanity/test_jwt_auth_smoke.py
+++ b/tests/e2e/vmaas/sanity/test_jwt_auth_smoke.py
@@ -10,8 +10,6 @@ from tests.e2e.core.osac_cli import OsacCLI
 from tests.e2e.core.runner import run_unchecked
 
 CLIENT_LISTABLE_RESOURCES = [
-    "clustertemplates",
-    "clusters",
     "computeinstancetemplates",
     "computeinstances",
     "hosttypes",


### PR DESCRIPTION
## Summary

- Implements per-service enablement (CaaS/VMaaS/BMaaS/MaaS) across all OSAC Helm subcharts using Helm's built-in `global.*` value propagation
- Adds `serviceFlags` struct and `--enable-{caas,vmaas,bmaas,maas}` CLI flags to the fulfillment-service gRPC server and REST gateway, with conditional service/handler registration
- Adds `controllerFlags.validate()` to the operator enforcing inter-service dependencies (CaaS requires VMaaS or BMaaS)
- Adds parameterized Helm helpers in both operator and fulfillment-service subcharts for nil-safe `global.services.*` resolution with local override support
- Adds JSON Schema `allOf` constraints enforcing CaaS↔VMaaS/BMaaS and MaaS→CaaS dependencies, plus BMaaS↔BMF operator gating
- Adds `UnknownServiceHandler` returning descriptive `Unimplemented` errors for disabled service RPCs
- Migrates all CI values files from per-subchart `operator.services.*` to umbrella-level `global.services.*`

## Commits

| Commit | Description |
|--------|-------------|
| [OSAC-4673](https://redhat.atlassian.net/browse/OSAC-4673) | Add `serviceFlags` struct and `--enable-*` CLI flags to fulfillment-service |
| [OSAC-4674](https://redhat.atlassian.net/browse/OSAC-4674) | Conditional gRPC service registration based on `serviceFlags` |
| [OSAC-4675](https://redhat.atlassian.net/browse/OSAC-4675) | Conditional REST gateway handler registration based on `serviceFlags` |
| [OSAC-4676](https://redhat.atlassian.net/browse/OSAC-4676) | Add `UnknownServiceHandler` for descriptive disabled-service errors |
| [OSAC-4677](https://redhat.atlassian.net/browse/OSAC-4677) | Add `services.*.enabled` Helm values and propagation to fulfillment-service |
| [OSAC-4699](https://redhat.atlassian.net/browse/OSAC-4699) | Add inter-service dependency validation to operator `controllerFlags` |
| [OSAC-4677](https://redhat.atlassian.net/browse/OSAC-4677) | Wire `services.*.enabled` to operator controllers and `bmf.enabled` |
| [OSAC-4677](https://redhat.atlassian.net/browse/OSAC-4677) | Replace redundant operator controller flags with `services.*` |
| [OSAC-4677](https://redhat.atlassian.net/browse/OSAC-4677) | Use `global.services.*` for cross-subchart service enablement |

## Test plan

- [x] Operator unit tests pass (`make test`)
- [x] Fulfillment-service unit tests pass (`ginkgo run -r internal`)
- [x] `helm template` renders correct flags for all-enabled (default), VMaaS-only, BMaaS-only profiles
- [x] All 6 CI values files pass `helm template` validation
- [x] JSON schema validates inter-service dependency constraints (MaaS→CaaS, BMaaS→BMF)
- [ ] E2E test on a Kind cluster with VMaaS-only profile
- [ ] E2E test on a Kind cluster with full profile

## Depends on

- https://github.com/osac-project/osac/pull/380 (aligned with its `global.services.*` approach)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

* **API surface**
  * Added `services.Flags` for CaaS, VMaaS, BMaaS, and MaaS enablement.
  * Added CLI flags, default handling, dependency validation, and enabled-service reporting.
  * Disabled gRPC requests return `Unavailable` and increment service-level metrics.
  * REST and gRPC registration now follows service enablement.
  * Shared infrastructure endpoints remain available.

* **Controllers**
  * Controller enablement now follows `global.services.*` values.
  * Added validation for required controller and service combinations.
  * Added nil-safe Helm helpers with local controller overrides.

* **Deployment and configuration**
  * Added global service settings to Helm values and schema.
  * CaaS requires VMaaS or BMaaS.
  * MaaS requires CaaS.
  * BMaaS is now the single enablement toggle for BMaaS and BMF.
  * BMF can use zero replicas when disabled.
  * Updated CI, Kind, VMaaS, BMaaS, and full-install profiles.

* **CI and integration**
  * Integration tests build and load the PR fulfillment-service image.
  * Template publishing skips disabled endpoints that return HTTP 404.
  * Updated workflow comments and installation overrides.

* **Tests**
  * Added unit and Ginkgo coverage for flags, validation, endpoint registration, disabled-service handling, and metrics.
  * Helm rendering and schema validation pass.
  * E2E workflows remain incomplete because three runs failed before collecting artifacts.

## Backward compatibility

* Services remain enabled by default when no service configuration is present.
* Existing local controller overrides remain supported.
* Deployments that use removed `bmf.enabled` or removed operator controller settings must migrate to `global.services.*` and the remaining controller configuration.
* Invalid service combinations now fail validation.

## Risk classification

**risk:show** — The change affects service exposure, controller startup, Helm dependency selection, and CI installation profiles. Validation, unit tests, Helm rendering, and schema checks pass, but E2E runs failed early without artifacts. It does not qualify as **risk:ask** because the change includes explicit dependency validation and broad automated coverage. It does not qualify as **risk:ship** because E2E behavior is not fully verified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->