### PR TITLE
NO-ISSUE: Revert " Update dependency go to v1.27.0

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -24,7 +24,7 @@ runs:
   steps:
   - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6
     with:
-      go-version: '1.27.0'
+      go-version: '1.26.3'
       # Without this, setup-go looks for go.sum at the repo root by
       # default -- this is a mono-repo, every component's go.sum lives in
       # its own subdirectory, so the built-in module cache silently never


### PR DESCRIPTION
Reverts osac-project/osac#644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go development environment to version 1.26.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->