### PR TITLE
NO-ISSUE: Fix trailing blank line in keycloak_admin.py

### DIFF
--- a/tests/core/keycloak_admin.py
+++ b/tests/core/keycloak_admin.py
@@ -305,4 +305,3 @@ def wait_for_project_not_in_keycloak(
         f"Project group '/{project_name}' (or variant) still exists in Keycloak after {timeout_seconds}s. "
         f"Organization ID: {org_id}."
     )
-


### PR DESCRIPTION
## Summary
- Remove extra blank line at end of `tests/core/keycloak_admin.py` that causes the `end-of-file-fixer` pre-commit hook to fail on every PR

## Test plan
- Pre-commit `end-of-file-fixer` hook should pass

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * No observable changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->