### PR TITLE
OSAC-3593: pass test-source and test-ref to nightly e2e jobs

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -523,6 +523,8 @@ jobs:
       installer-ref: ${{ needs.prepare.outputs.temp-branch }}
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: main
+      test-source: osac
+      test-ref: ${{ needs.prepare.outputs.temp-branch }}
 
   e2e-caas-test:
     name: E2E validation (caas)
@@ -537,6 +539,8 @@ jobs:
       installer-ref: ${{ needs.prepare.outputs.temp-branch }}
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: main
+      test-source: osac
+      test-ref: ${{ needs.prepare.outputs.temp-branch }}
 
   e2e-bmaas-test:
     name: E2E validation (bmaas)
@@ -551,6 +555,8 @@ jobs:
       installer-ref: ${{ needs.prepare.outputs.temp-branch }}
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: main
+      test-source: osac
+      test-ref: ${{ needs.prepare.outputs.temp-branch }}
 
   # -------------------------------------------------------------------
   # Job 5: Publish — promote every image from its provisional sha-<short>


### PR DESCRIPTION
The nightly build calls all three reusable e2e workflows but was relying on their defaults for test-source. Explicitly pass test-source: osac and test-ref pointing to the temp-branch so nightly runs always exercise tests from the mono-repo at the correct commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated nightly end-to-end test runs to use the prepared temporary branch and explicitly identify the test source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->