### PR TITLE
NO-ISSUE: Grant id-token: write for osac-test-infra's e2e reusable workflows

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -117,6 +117,10 @@ jobs:
       && needs.changes.outputs.should-run == 'true'
       && (needs.e2e-readiness.result == 'success'
           || needs.e2e-readiness.result == 'skipped')
+    permissions:
+      contents: read
+      # See e2e-vmaas-full-install.yml's identical grant for why this is needed.
+      id-token: write
     uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-full-install.yml@main
     with:
       test-suite: ${{ inputs.test-suite || 'bmaas' }}

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -128,6 +128,10 @@ jobs:
       && needs.changes.outputs.should-run == 'true'
       && (needs.e2e-readiness.result == 'success'
           || needs.e2e-readiness.result == 'skipped')
+    permissions:
+      contents: read
+      # See e2e-vmaas-full-install.yml's identical grant for why this is needed.
+      id-token: write
     uses: osac-project/osac-test-infra/.github/workflows/e2e-caas-full-install.yml@main
     with:
       test-suite: ${{ inputs.test-suite || 'caas' }}

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -124,6 +124,14 @@ jobs:
       && needs.changes.outputs.should-run == 'true'
       && (needs.e2e-readiness.result == 'success'
           || needs.e2e-readiness.result == 'skipped')
+    permissions:
+      contents: read
+      # Required by e2e-vmaas-full-install.yml@main's "e2e" job -- only
+      # exercised there when enable-ai-diagnostic is true (we never pass
+      # it), but GitHub statically validates a called reusable workflow's
+      # declared job permissions against what the caller grants regardless
+      # of runtime reachability, so it must still be granted here.
+      id-token: write
     uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main
     with:
       test-suite: ${{ inputs.test-suite || 'vmaas' }}

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -516,6 +516,12 @@ jobs:
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.skip_e2e != 'true'
     permissions:
       contents: read
+      # Required by e2e-vmaas-full-install.yml@main's "e2e" job -- only
+      # exercised there when enable-ai-diagnostic is true (we never pass
+      # it), but GitHub statically validates a called reusable workflow's
+      # declared job permissions against what the caller grants regardless
+      # of runtime reachability, so it must still be granted here.
+      id-token: write
     uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main
     with:
       test-suite: vmaas
@@ -532,6 +538,8 @@ jobs:
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.skip_e2e != 'true'
     permissions:
       contents: read
+      # See e2e-vmaas-test's identical grant above for why this is needed.
+      id-token: write
     uses: osac-project/osac-test-infra/.github/workflows/e2e-caas-full-install.yml@main
     with:
       test-suite: caas
@@ -548,6 +556,8 @@ jobs:
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.skip_e2e != 'true'
     permissions:
       contents: read
+      # See e2e-vmaas-test's identical grant above for why this is needed.
+      id-token: write
     uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-full-install.yml@main
     with:
       test-suite: bmaas


### PR DESCRIPTION
## Summary

**Urgent — this currently breaks e2e on every PR, not just nightly.**

`osac-test-infra` added `id-token: write` to the `e2e` job's permissions in all three full-install reusable workflows today (only exercised when `enable-ai-diagnostic` is true, which we never pass — see the comment in their file: "only exercised when enable-ai-diagnostic is true (always false for fork PR runs)"). Every caller in this repo only granted `contents: read`. GitHub statically validates a called reusable workflow's declared job permissions against what the caller grants, regardless of runtime reachability, so every job calling these workflows started failing immediately:

```
Error calling workflow 'osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main'.
The nested job 'e2e' is requesting 'id-token: write', but is only allowed 'id-token: none'.
```

See https://github.com/osac-project/osac/actions/runs/33518949968.

## What changed

Added `id-token: write` alongside the existing `contents: read` in all 4 affected callers:
- `nightly-build.yaml`'s `e2e-vmaas-test`/`e2e-caas-test`/`e2e-bmaas-test` jobs (already had an explicit `permissions:` block, just missing this one line)
- `e2e-vmaas-full-install.yml` / `e2e-bmaas-full-install.yml` / `e2e-caas-full-install.yml`'s own top-level `e2e-*-full-install` jobs (had no job-level `permissions:` block at all, inheriting only the workflow-level `contents: read`)

## Test plan

- [x] YAML syntax validated for all 4 changed files
- [x] Confirmed via `osac-test-infra`'s current `upstream/main` that this is exactly the new requirement (`e2e-*-full-install.yml` job permissions, line ~153)
- [x] Confirmed no other `osac-test-infra` e2e reusable workflow call (`e2e-ready-label-cleanup.yml`) is affected — different job, no `id-token` requirement
- [ ] Confirm a PR/nightly e2e run actually passes the permission check after this merges

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated end-to-end installation and nightly build workflows with the required permissions.
  * Improved workflow reliability for BMAAS, CAAS, and VMAAS validation runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->