### PR TITLE
OSAC-3593: run e2e for tests/e2e path changes

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -13,4 +13,6 @@ Human GitHub `APPROVED` does **not** unlock. Fork PRs still need `ok-to-test` (o
 
 Cheap checks stay ungated. Schedules / `workflow_dispatch` / `merge_group` skip the readiness job.
 
+Path filter skips docs / unit-test-only PRs (`!**/tests/**` and friends). `tests/e2e/**` is the full-install suite and **must** still set `should-run` (`e2e-suite` filter). Do not fold `tests/e2e` back into the ignore list.
+
 Details + smoke checklist: [`.github/e2e-readiness.md`](e2e-readiness.md).

--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -47,7 +47,9 @@ jobs:
       # Same ignore list for pull_request and merge_group (OSAC-3879).
       # schedule / workflow_dispatch always run. e2e-*-gate still if: always()
       # so ruleset-required checks report when expensive E2E is skipped.
-      should-run: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || steps.filter.outputs.code == 'true' }}
+      # tests/e2e/** is the full-install suite (OSAC-3593); still run when that
+      # tree changes even though `code` ignores **/tests/**.
+      should-run: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || steps.filter.outputs.code == 'true' || steps.filter.outputs.e2e-suite == 'true' }}
     steps:
       # dorny/paths-filter uses git diff on merge_group (not the PR Files API),
       # so the repo must be checked out with enough history for base..head.
@@ -81,6 +83,8 @@ jobs:
               - '!**/it/**'
               - '!**/conftest.py'
               - '!**/fixtures/**'
+            e2e-suite:
+              - 'tests/e2e/**'
 
   # OSAC-3370: cheap readiness gate before expensive runners.
   # Allow: lgtm present, e2e-ready applied by github-actions[bot], or

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -47,7 +47,9 @@ jobs:
       # Same ignore list for pull_request and merge_group (OSAC-3879).
       # schedule / workflow_dispatch always run. e2e-*-gate still if: always()
       # so ruleset-required checks report when expensive E2E is skipped.
-      should-run: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || steps.filter.outputs.code == 'true' }}
+      # tests/e2e/** is the full-install suite (OSAC-3593); still run when that
+      # tree changes even though `code` ignores **/tests/**.
+      should-run: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || steps.filter.outputs.code == 'true' || steps.filter.outputs.e2e-suite == 'true' }}
     steps:
       # dorny/paths-filter uses git diff on merge_group (not the PR Files API),
       # so the repo must be checked out with enough history for base..head.
@@ -81,6 +83,8 @@ jobs:
               - '!**/it/**'
               - '!**/conftest.py'
               - '!**/fixtures/**'
+            e2e-suite:
+              - 'tests/e2e/**'
 
   # OSAC-3370: cheap readiness gate before expensive runners.
   # Allow: lgtm present, e2e-ready applied by github-actions[bot], or

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -47,7 +47,9 @@ jobs:
       # Same ignore list for pull_request and merge_group (OSAC-3879).
       # schedule / workflow_dispatch always run. e2e-*-gate still if: always()
       # so ruleset-required checks report when expensive E2E is skipped.
-      should-run: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || steps.filter.outputs.code == 'true' }}
+      # tests/e2e/** is the full-install suite (OSAC-3593); still run when that
+      # tree changes even though `code` ignores **/tests/**.
+      should-run: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || steps.filter.outputs.code == 'true' || steps.filter.outputs.e2e-suite == 'true' }}
     steps:
       # dorny/paths-filter uses git diff on merge_group (not the PR Files API),
       # so the repo must be checked out with enough history for base..head.
@@ -81,6 +83,8 @@ jobs:
               - '!**/it/**'
               - '!**/conftest.py'
               - '!**/fixtures/**'
+            e2e-suite:
+              - 'tests/e2e/**'
 
   # OSAC-3370: cheap readiness gate before expensive runners.
   # Allow: lgtm present, e2e-ready applied by github-actions[bot], or


### PR DESCRIPTION
## Summary
- Full-install e2e ignored `**/tests/**`, so PRs that only touch `tests/e2e/` (e.g. #681) skipped VMaaS/BMaaS/CaaS.
- Add an `e2e-suite` path filter and OR it into `should-run`. Docs/unit-test-only skips stay.

## Jira
https://redhat.atlassian.net/browse/OSAC-3593

## Test plan
- [x] actionlint on the three full-install workflows
- [ ] PR that only changes `tests/e2e/**` starts `e2e-readiness` (not skip)
- [ ] Docs-only PR still skips full-install
- [ ] Unit/integration/pre-commit unchanged (they already run on `tests/e2e`)

---

_This PR description was drafted with AI assistance ([create-pr](https://github.com/osac-project/osac-workspace/tree/main/skills/create-pr) v0.1.3). Review for accuracy_