### PR TITLE
OSAC-4741: Gate enable-ai-diagnostic on ref, not event type

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -157,13 +157,19 @@ jobs:
       test-source: "osac"
       test-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       test-ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      # AI failure diagnosis only for scheduled runs: those always run
-      # against main in this repo's own context (no fork involved), unlike
-      # pull_request/merge_group runs from PRs, which come from genuine
-      # forks and cannot get OIDC/WIF access at all regardless of this
-      # input (a GitHub Actions security policy, not something this input
-      # can override).
-      enable-ai-diagnostic: ${{ github.event_name == 'schedule' }}
+      # Gated on ref, not event type: the real constraint is WIF trust
+      # (main branch only), not which event triggered the run. This
+      # correctly covers schedule (always main) AND a manual
+      # workflow_dispatch run against main (same safe WIF context) --
+      # checking event_name == 'schedule' alone would wrongly exclude the
+      # latter, making it impossible to manually validate this feature
+      # through the real caller. pull_request is naturally excluded since
+      # its github.ref is the synthetic PR-merge ref, never
+      # refs/heads/main -- and moot regardless, since every real PR here
+      # is fork-originated and gets no OIDC/WIF access at all by GitHub
+      # Actions policy. merge_group is excluded the same way (its
+      # github.ref is the readonly-queue ref).
+      enable-ai-diagnostic: ${{ github.ref == 'refs/heads/main' }}
 
   e2e-bmaas-gate:
     if: always()

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -169,13 +169,19 @@ jobs:
       # flavor-name, namespace, etc.) are left at the reusable workflow's own
       # defaults -- none are required and this caller has no need to override
       # them today.
-      # AI failure diagnosis only for scheduled runs: those always run
-      # against main in this repo's own context (no fork involved), unlike
-      # pull_request/merge_group runs from PRs, which come from genuine
-      # forks and cannot get OIDC/WIF access at all regardless of this
-      # input (a GitHub Actions security policy, not something this input
-      # can override).
-      enable-ai-diagnostic: ${{ github.event_name == 'schedule' }}
+      # Gated on ref, not event type: the real constraint is WIF trust
+      # (main branch only), not which event triggered the run. This
+      # correctly covers schedule (always main) AND a manual
+      # workflow_dispatch run against main (same safe WIF context) --
+      # checking event_name == 'schedule' alone would wrongly exclude the
+      # latter, making it impossible to manually validate this feature
+      # through the real caller. pull_request is naturally excluded since
+      # its github.ref is the synthetic PR-merge ref, never
+      # refs/heads/main -- and moot regardless, since every real PR here
+      # is fork-originated and gets no OIDC/WIF access at all by GitHub
+      # Actions policy. merge_group is excluded the same way (its
+      # github.ref is the readonly-queue ref).
+      enable-ai-diagnostic: ${{ github.ref == 'refs/heads/main' }}
 
   e2e-caas-gate:
     if: always()

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -165,13 +165,19 @@ jobs:
       test-source: "osac"
       test-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       test-ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      # AI failure diagnosis only for scheduled runs: those always run
-      # against main in this repo's own context (no fork involved), unlike
-      # pull_request/merge_group runs from PRs, which come from genuine
-      # forks and cannot get OIDC/WIF access at all regardless of this
-      # input (a GitHub Actions security policy, not something this input
-      # can override).
-      enable-ai-diagnostic: ${{ github.event_name == 'schedule' }}
+      # Gated on ref, not event type: the real constraint is WIF trust
+      # (main branch only), not which event triggered the run. This
+      # correctly covers schedule (always main) AND a manual
+      # workflow_dispatch run against main (same safe WIF context) --
+      # checking event_name == 'schedule' alone would wrongly exclude the
+      # latter, making it impossible to manually validate this feature
+      # through the real caller. pull_request is naturally excluded since
+      # its github.ref is the synthetic PR-merge ref, never
+      # refs/heads/main -- and moot regardless, since every real PR here
+      # is fork-originated and gets no OIDC/WIF access at all by GitHub
+      # Actions policy. merge_group is excluded the same way (its
+      # github.ref is the readonly-queue ref).
+      enable-ai-diagnostic: ${{ github.ref == 'refs/heads/main' }}
 
   e2e-vmaas-gate:
     if: always()


### PR DESCRIPTION
## Summary
- `enable-ai-diagnostic: ${{ github.event_name == 'schedule' }}` in the three E2E callers wrongly excluded a manual `workflow_dispatch` run against `main`, which gets the identical safe WIF context as a scheduled run.
- The actual constraint is WIF trust (main branch only, `google-github-actions/auth`'s attribute condition), not which event triggered the run. Gating on `github.ref == 'refs/heads/main'` covers `schedule` and `workflow_dispatch`-on-`main` alike.
- `pull_request` stays naturally excluded (`github.ref` is the synthetic PR-merge ref, never `refs/heads/main`) and is moot anyway since every real PR here is fork-originated and gets no OIDC/WIF access by GitHub Actions policy. `merge_group` stays excluded the same way (readonly-queue ref).
- Pairs with [osac-test-infra#442](https://github.com/osac-project/osac-test-infra/pull/442), which made the identical fix on the reusable-workflow side (docs + no logic change there, since the reusable workflows just consume the boolean input as-is).

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` on all three modified files
- [ ] Manually `workflow_dispatch` one of the three E2E workflows against `main` and confirm the AI diagnostic step now runs (previously would have been skipped despite running on main)