### PR TITLE
NO-ISSUE: always report generated-code checks

### DIFF
--- a/.github/workflows/check-generated-code.yaml
+++ b/.github/workflows/check-generated-code.yaml
@@ -1,26 +1,13 @@
 name: Check generated code
 
 on:
+  # No paths: required names "Check generated code (fulfillment-service)"
+  # and "(osac-operator)" must report on every PR. Skip is on job steps
+  # (dorny + should-run). A trigger path filter leaves those names pending
+  # forever on PRs that only touch other components (e.g. BMFO-only).
   pull_request:
-    paths:
-      - 'fulfillment-service/**'
-      - '!fulfillment-service/OWNERS'
-      - '!fulfillment-service/LICENSE'
-      - '!fulfillment-service/**/*.md'
-      - '!fulfillment-service/docs/**'
-      - '!fulfillment-service/.claude/**'
-      - 'osac-operator/**'
-      - '!osac-operator/OWNERS'
-      - '!osac-operator/LICENSE'
-      - '!osac-operator/**/*.md'
-      - '!osac-operator/docs/**'
-      - '!osac-operator/.claude/**'
-      - 'osac-metering/metering-service/**'
-      - '!osac-metering/metering-service/OWNERS'
-      - '!osac-metering/metering-service/LICENSE'
-      - '!osac-metering/metering-service/**/*.md'
-      - '!osac-metering/metering-service/docs/**'
-      - '!osac-metering/metering-service/.claude/**'
+    branches:
+      - main
   merge_group:
 
 permissions:


### PR DESCRIPTION
## Summary
- Drop `on.pull_request.paths` so required checks `Check generated code (fulfillment-service)` and `Check generated code (osac-operator)` always report.
- Trigger path filters skipped the whole workflow on BMFO-only PRs (e.g. #559), leaving those names pending forever and blocking merge.
- Skip stays on job steps (dorny + `should-run`); `buf generate` still runs only when those components actually change.

## Jira
N/A

## Test plan
- [x] `actionlint` on `.github/workflows/check-generated-code.yaml`
- [ ] BMFO-only PR (or this PR itself) reports both generated-code checks as success with skipped generate steps
- [ ] PR that touches `fulfillment-service/` or `osac-operator/` still runs `buf generate`

---

_This PR description was drafted with AI assistance ([create-pr](https://github.com/osac-project/osac-workspace/tree/main/skills/create-pr) v0.1.3). Review for accuracy_