### PR TITLE
DO NOT MERGE: validate OSAC-4741 shared cross-repo diagnostic workflow

### DIFF
--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -160,7 +160,11 @@ jobs:
       pr-number: ${{ github.event.pull_request.number }}
       # Checkout osac-test-infra for tests/Containerfile (not the caller repo)
       test-infra-repository: osac-project/osac-test-infra
-      test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+      # TEMPORARY -- OSAC-4741 validation only, DO NOT MERGE. Deliberately
+      # invalid ref so the reusable workflow's own first checkout step
+      # fails immediately (before any real cluster/infra is touched), to
+      # validate the new cross-repo workflow_call diagnostic pipeline.
+      test-infra-ref: "definitely-not-a-real-branch-osac-4741-validation"
       # OSAC-3593: Use tests from osac mono-repo instead of osac-test-infra
       test-source: "osac"
       test-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}


### PR DESCRIPTION
Temporary, throwaway PR to validate the new cross-repo workflow_call design (osac#697 + osac-test-infra#450) end-to-end: does osac's ~15-line wrapper correctly invoke osac-test-infra's shared ai-diagnostic-e2e.yml, with github.event/github.repository correctly reflecting *this* repo's own triggering event across the repo boundary?

Forces an immediate failure via a deliberately invalid `test-infra-ref` input, so the reusable e2e-caas-full-install.yml's own first checkout step fails fast (before any real cluster/infra is touched) -- cheaper than a real cluster-boot failure.

Expect: `E2E CaaS Full Install` fails quickly -> osac's `AI diagnostic (E2E fork PR failures)` wrapper fires -> calls into osac-test-infra's shared workflow -> resolves this PR (in `osac`, not `osac-test-infra`) from the failed run's head SHA -> posts a commit status + sticky comment here, same as the native osac-test-infra validation already confirmed working.

Leaving open for inspection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test validation to verify that an invalid branch reference is rejected during the initial checkout.
  * Prevents subsequent cluster or infrastructure operations from running when checkout fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->