### PR TITLE
OSAC-4741: Enable AI failure diagnosis for nightly-build's E2E validation

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -516,9 +516,9 @@ jobs:
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.skip_e2e != 'true'
     permissions:
       contents: read
-      # Required by e2e-vmaas-full-install.yml@main's "e2e" job -- only
-      # exercised there when enable-ai-diagnostic is true (we never pass
-      # it), but GitHub statically validates a called reusable workflow's
+      # Required by e2e-vmaas-full-install.yml@main's "e2e" job when
+      # enable-ai-diagnostic is true (now always the case here, see below)
+      # -- GitHub statically validates a called reusable workflow's
       # declared job permissions against what the caller grants regardless
       # of runtime reachability, so it must still be granted here.
       id-token: write
@@ -531,6 +531,16 @@ jobs:
       test-infra-ref: main
       test-source: osac
       test-ref: ${{ needs.prepare.outputs.temp-branch }}
+      # This pipeline only runs via schedule/workflow_dispatch against
+      # main, same safe WIF context as the regular e2e-*-full-install.yml
+      # callers' own enable-ai-diagnostic gating -- see that input's
+      # description in osac-test-infra for the full reasoning. Without
+      # this, a nightly e2e failure only gets a generic "Nightly Build
+      # Failed" Slack ping (see notify-failure below) with no diagnosis;
+      # workflow_run-based Phase 2 doesn't cover this pipeline either,
+      # since it tracks this file's own top-level name ("Nightly Build"),
+      # not the reusable workflow it happens to call into.
+      enable-ai-diagnostic: ${{ github.ref == 'refs/heads/main' }}
 
   e2e-caas-test:
     name: E2E validation (caas)
@@ -549,6 +559,8 @@ jobs:
       test-infra-ref: main
       test-source: osac
       test-ref: ${{ needs.prepare.outputs.temp-branch }}
+      # See e2e-vmaas-test's identical input above for why this is set.
+      enable-ai-diagnostic: ${{ github.ref == 'refs/heads/main' }}
 
   e2e-bmaas-test:
     name: E2E validation (bmaas)
@@ -567,6 +579,8 @@ jobs:
       test-infra-ref: main
       test-source: osac
       test-ref: ${{ needs.prepare.outputs.temp-branch }}
+      # See e2e-vmaas-test's identical input above for why this is set.
+      enable-ai-diagnostic: ${{ github.ref == 'refs/heads/main' }}
 
   # -------------------------------------------------------------------
   # Job 5: Publish — promote every image from its provisional sha-<short>


### PR DESCRIPTION
## Summary
`nightly-build.yaml`'s `e2e-vmaas-test`/`e2e-caas-test`/`e2e-bmaas-test` jobs call the exact same `osac-test-infra` `e2e-*-full-install.yml` reusable workflows the regular scheduled E2E callers do -- but a nightly failure here currently gets **no AI diagnosis at all**, from either phase:

- **Phase 1** (same-job diagnosis into the Job Summary) needs `enable-ai-diagnostic` explicitly passed by the caller. This file never did -- the existing comment on the `id-token: write` grant even said so directly: *"only exercised there when enable-ai-diagnostic is true (we never pass it)"*.
- **Phase 2** (the `workflow_run` listener in `ai-diagnostic-e2e.yml`) doesn't cover it either, since it tracks the completed run's own **top-level** workflow name ("Nightly Build"), not the reusable workflow it happens to call into.

Right now a nightly E2E failure only produces a generic "Nightly Build Failed" Slack ping (see the existing `notify-failure` job) with a link to the run and nothing else -- arguably a higher-priority gap to close than the PR case, since nobody's watching a nightly cron run the way a PR author watches their own PR, and a failure here blocks the actual release.

## Fix
Wires in `enable-ai-diagnostic: ${{ github.ref == 'refs/heads/main' }}` on all three `e2e-*-test` jobs -- the exact same gating already proven on `osac`'s regular scheduled E2E callers. This pipeline only ever runs via `schedule`/`workflow_dispatch` against `main`, the same safe WIF context those callers rely on. Whoever gets the Slack alert and clicks through to the failing `e2e-*-test` job will now see the AI diagnosis right there in that job's own Step Summary -- no new mechanism needed, reusing what's already built and merged.

## Test plan
- [x] YAML syntax check
- [ ] Live validation: confirm the diagnosis actually appears in the Job Summary the next time (or a manual `workflow_dispatch`) this pipeline has a real E2E failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced nightly validation for core services with AI-assisted diagnostics.
  * Automated checks now provide richer troubleshooting information when issues are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->