### PR TITLE
OSAC-4635: add Metal3 BMO API surface sanity e2e

### DIFF
--- a/tests/e2e/bmaas/sanity/test_bmo_api_surface.py
+++ b/tests/e2e/bmaas/sanity/test_bmo_api_surface.py
@@ -10,15 +10,19 @@ https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html-
 
 from __future__ import annotations
 
+import re
 import subprocess
 import uuid
 from collections.abc import Generator
 from typing import Any
 
 import pytest
+import yaml
 
 from tests.e2e.core.k8s_api import K8sApiClient
 from tests.e2e.core.runner import run
+
+_K8S_DNS_LABEL = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
 
 METAL3_GROUP = "metal3.io"
 METAL3_VERSION = "v1alpha1"
@@ -107,6 +111,12 @@ def _bmh_unknown_field(*, namespace: str, name: str) -> dict[str, Any]:
     }
 
 
+def _k8s_dns_label(name: str, *, what: str) -> str:
+    if not _K8S_DNS_LABEL.fullmatch(name):
+        raise ValueError(f"invalid {what}: {name!r}")
+    return name
+
+
 def _oc(*args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["oc", "--as", "system:admin", *args], capture_output=True, text=True, check=False
@@ -121,40 +131,42 @@ def k8s_api() -> K8sApiClient:
 @pytest.fixture(scope="module")
 def restricted_bmh_token(bmh_namespace: str, test_run_id: str) -> Generator[str, None, None]:
     """SA that can get/list/patch BMHs but not patch the status subresource."""
-    sa = f"e2e-bmo-api-{test_run_id}"
-    role = f"{sa}-role"
-    binding = f"{sa}-binding"
-    manifest = f"""
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {sa}
-  namespace: {bmh_namespace}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: {role}
-  namespace: {bmh_namespace}
-rules:
-  - apiGroups: ["{METAL3_GROUP}"]
-    resources: ["baremetalhosts"]
-    verbs: ["get", "list", "watch", "patch", "update"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {binding}
-  namespace: {bmh_namespace}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {role}
-subjects:
-  - kind: ServiceAccount
-    name: {sa}
-    namespace: {bmh_namespace}
-"""
+    namespace = _k8s_dns_label(bmh_namespace, what="bmh_namespace")
+    sa = _k8s_dns_label(f"e2e-bmo-api-{test_run_id}", what="serviceaccount name")
+    role = _k8s_dns_label(f"{sa}-role", what="role name")
+    binding = _k8s_dns_label(f"{sa}-binding", what="rolebinding name")
+    manifest = yaml.safe_dump_all(
+        [
+            {
+                "apiVersion": "v1",
+                "kind": "ServiceAccount",
+                "metadata": {"name": sa, "namespace": namespace},
+            },
+            {
+                "apiVersion": "rbac.authorization.k8s.io/v1",
+                "kind": "Role",
+                "metadata": {"name": role, "namespace": namespace},
+                "rules": [
+                    {
+                        "apiGroups": [METAL3_GROUP],
+                        "resources": ["baremetalhosts"],
+                        "verbs": ["get", "list", "watch", "patch", "update"],
+                    }
+                ],
+            },
+            {
+                "apiVersion": "rbac.authorization.k8s.io/v1",
+                "kind": "RoleBinding",
+                "metadata": {"name": binding, "namespace": namespace},
+                "roleRef": {
+                    "apiGroup": "rbac.authorization.k8s.io",
+                    "kind": "Role",
+                    "name": role,
+                },
+                "subjects": [{"kind": "ServiceAccount", "name": sa, "namespace": namespace}],
+            },
+        ]
+    )
     subprocess.run(
         ["oc", "--as", "system:admin", "apply", "-f", "-"],
         input=manifest,
@@ -169,7 +181,7 @@ subjects:
             "token",
             sa,
             "-n",
-            bmh_namespace,
+            namespace,
             "--duration",
             "1h",
             "--as",
@@ -177,9 +189,9 @@ subjects:
         )
         yield token
     finally:
-        _oc("delete", "rolebinding", binding, "-n", bmh_namespace, "--ignore-not-found")
-        _oc("delete", "role", role, "-n", bmh_namespace, "--ignore-not-found")
-        _oc("delete", "sa", sa, "-n", bmh_namespace, "--ignore-not-found")
+        _oc("delete", "rolebinding", binding, "-n", namespace, "--ignore-not-found")
+        _oc("delete", "role", role, "-n", namespace, "--ignore-not-found")
+        _oc("delete", "sa", sa, "-n", namespace, "--ignore-not-found")
 
 
 def test_metal3_crd_http_matrix(
@@ -198,7 +210,7 @@ def test_metal3_crd_http_matrix(
     - LIST Provisioning (cluster-scoped) → 200 and ≥1 item (singleton present)
     - Unauthenticated LIST BMH → 401 or 403 (OCP often 403)
     - Named GET missing BMH → 404; GET existing BMH → 200
-    - dryRun=All invalid creates → 422 (BMH missing online, HFC missing updates,
+    - dryRun=All invalid creates → 400 or 422 (BMH missing online, HFC missing updates,
       HFS missing settings, DataImage missing url)
     - dryRun=All BMH with unknown spec field → 400/422, or 2xx with field pruned
       (Metal3 structural schemas commonly prune rather than reject)
@@ -214,12 +226,12 @@ def test_metal3_crd_http_matrix(
     # --- LIST surface for every namespaced CRD ---
     for resource in NAMESPACED_RESOURCES:
         resp = k8s_api.request("GET", _api_path(resource=resource, namespace=bmh_namespace))
-        assert resp.status == 200, f"LIST {resource}: expected 200, got {resp.status}: {resp.body}"
+        assert resp.status == 200, f"LIST {resource}: expected 200, got {resp.status}"
         assert isinstance(resp.body, dict) and "items" in resp.body
 
     # --- Provisioning cluster-scoped singleton ---
     prov = k8s_api.request("GET", _api_path(resource="provisionings"))
-    assert prov.status == 200, f"LIST provisionings: expected 200, got {prov.status}: {prov.body}"
+    assert prov.status == 200, f"LIST provisionings: expected 200, got {prov.status}"
     assert isinstance(prov.body, dict)
     items = prov.body.get("items", [])
     assert len(items) >= 1, "expected at least one cluster-scoped Provisioning object"
@@ -252,7 +264,9 @@ def test_metal3_crd_http_matrix(
     for resource, body in validation_cases:
         path = f"{_api_path(resource=resource, namespace=bmh_namespace)}?dryRun=All"
         resp = k8s_api.request("POST", path, body=body)
-        assert resp.status == 422, f"dryRun POST {resource} invalid: expected 422, got {resp.status}: {resp.body}"
+        assert resp.status in VALIDATION_STATUSES, (
+            f"dryRun POST {resource} invalid: expected {VALIDATION_STATUSES}, got {resp.status}"
+        )
 
     unknown = k8s_api.request(
         "POST",
@@ -265,12 +279,12 @@ def test_metal3_crd_http_matrix(
         assert isinstance(unknown.body, dict)
         spec = unknown.body.get("spec") or {}
         assert "e2eUnknownField" not in spec, (
-            f"unknown field accepted into stored/returned BMH spec (expected prune or reject): {spec}"
+            "unknown field accepted into stored/returned BMH spec (expected prune or reject)"
         )
     else:
         raise AssertionError(
             f"unknown field: expected reject {UNKNOWN_FIELD_REJECT} or prune "
-            f"{UNKNOWN_FIELD_PRUNE}, got {unknown.status}: {unknown.body}"
+            f"{UNKNOWN_FIELD_PRUNE}, got {unknown.status}"
         )
 
     # --- Existing BMH GET + restricted SA RBAC ---
@@ -298,7 +312,7 @@ def test_metal3_crd_http_matrix(
         content_type="application/merge-patch+json",
     )
     assert allow_resp.status == 200, (
-        f"restricted dryRun PATCH BMH (metadata): expected 200, got {allow_resp.status}: {allow_resp.body}"
+        f"restricted dryRun PATCH BMH (metadata): expected 200, got {allow_resp.status}"
     )
 
     # No-op spec patch (reuse current online) so dryRun cannot change power state.
@@ -310,7 +324,7 @@ def test_metal3_crd_http_matrix(
         content_type="application/merge-patch+json",
     )
     assert spec_resp.status == 200, (
-        f"restricted dryRun PATCH BMH (spec): expected 200, got {spec_resp.status}: {spec_resp.body}"
+        f"restricted dryRun PATCH BMH (spec): expected 200, got {spec_resp.status}"
     )
 
     status_patch = {
@@ -326,5 +340,5 @@ def test_metal3_crd_http_matrix(
         content_type="application/merge-patch+json",
     )
     assert deny_resp.status == 403, (
-        f"restricted dryRun PATCH /status: expected 403, got {deny_resp.status}: {deny_resp.body}"
+        f"restricted dryRun PATCH /status: expected 403, got {deny_resp.status}"
     )

--- a/tests/e2e/bmaas/sanity/test_bmo_api_surface.py
+++ b/tests/e2e/bmaas/sanity/test_bmo_api_surface.py
@@ -1,0 +1,330 @@
+"""Metal3 / BMO Kubernetes API surface checks (HTTP status codes only).
+
+Portable across CI, virtual-BMH labs, and physical labs: talks only to the
+kube-apiserver OpenAPI for metal3.io CRDs. Does not require free BMHs,
+fulfillment, or real firmware hardware.
+
+API reference (OCP 4.22 Provisioning APIs, Ch 2-9 and 12-13):
+https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html-single/provisioning_apis/index
+"""
+
+from __future__ import annotations
+
+import subprocess
+import uuid
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+
+from tests.e2e.core.k8s_api import K8sApiClient
+from tests.e2e.core.runner import run
+
+METAL3_GROUP = "metal3.io"
+METAL3_VERSION = "v1alpha1"
+
+# Namespaced CRDs BMaaS / Metal3 inventory commonly touches.
+NAMESPACED_RESOURCES: tuple[str, ...] = (
+    "baremetalhosts",
+    "hardwaredata",
+    "preprovisioningimages",
+    "dataimages",
+    "hostfirmwarecomponents",
+    "hostfirmwaresettings",
+    "firmwareschemas",
+    "hostupdatepolicies",
+    "bmceventsubscriptions",
+)
+
+# OpenShift anonymous often returns 403; some stacks return 401.
+UNAUTHENTICATED_STATUSES = {401, 403}
+# CRD OpenAPI rejection is usually 422; some stacks return 400.
+VALIDATION_STATUSES = {400, 422}
+# Unknown fields: strict apiservers reject; structural CRDs often prune → 2xx.
+UNKNOWN_FIELD_REJECT = VALIDATION_STATUSES
+UNKNOWN_FIELD_PRUNE = {200, 201}
+
+
+def _api_path(*, resource: str, namespace: str | None = None, name: str | None = None) -> str:
+    base = f"/apis/{METAL3_GROUP}/{METAL3_VERSION}"
+    base = f"{base}/namespaces/{namespace}/{resource}" if namespace else f"{base}/{resource}"
+    if name:
+        return f"{base}/{name}"
+    return base
+
+
+def _bmh_missing_online(*, namespace: str, name: str) -> dict[str, Any]:
+    return {
+        "apiVersion": f"{METAL3_GROUP}/{METAL3_VERSION}",
+        "kind": "BareMetalHost",
+        "metadata": {"name": name, "namespace": namespace},
+        "spec": {
+            "bmc": {"address": "redfish://192.0.2.1", "credentialsName": "e2e-missing"},
+            "bootMACAddress": "00:11:22:33:44:55",
+            # intentionally omit required spec.online
+        },
+    }
+
+
+def _hfc_missing_updates(*, namespace: str, name: str) -> dict[str, Any]:
+    return {
+        "apiVersion": f"{METAL3_GROUP}/{METAL3_VERSION}",
+        "kind": "HostFirmwareComponents",
+        "metadata": {"name": name, "namespace": namespace},
+        "spec": {},  # updates required
+    }
+
+
+def _hfs_missing_settings(*, namespace: str, name: str) -> dict[str, Any]:
+    return {
+        "apiVersion": f"{METAL3_GROUP}/{METAL3_VERSION}",
+        "kind": "HostFirmwareSettings",
+        "metadata": {"name": name, "namespace": namespace},
+        "spec": {},  # settings required
+    }
+
+
+def _dataimage_missing_url(*, namespace: str, name: str) -> dict[str, Any]:
+    return {
+        "apiVersion": f"{METAL3_GROUP}/{METAL3_VERSION}",
+        "kind": "DataImage",
+        "metadata": {"name": name, "namespace": namespace},
+        "spec": {},  # url required
+    }
+
+
+def _bmh_unknown_field(*, namespace: str, name: str) -> dict[str, Any]:
+    return {
+        "apiVersion": f"{METAL3_GROUP}/{METAL3_VERSION}",
+        "kind": "BareMetalHost",
+        "metadata": {"name": name, "namespace": namespace},
+        "spec": {
+            "online": False,
+            "bmc": {"address": "redfish://192.0.2.1", "credentialsName": "e2e-missing"},
+            "bootMACAddress": "00:11:22:33:44:55",
+            "e2eUnknownField": True,
+        },
+    }
+
+
+def _oc(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["oc", "--as", "system:admin", *args], capture_output=True, text=True, check=False
+    )
+
+
+@pytest.fixture(scope="module")
+def k8s_api() -> K8sApiClient:
+    return K8sApiClient.from_kubeconfig()
+
+
+@pytest.fixture(scope="module")
+def restricted_bmh_token(bmh_namespace: str, test_run_id: str) -> Generator[str, None, None]:
+    """SA that can get/list/patch BMHs but not patch the status subresource."""
+    sa = f"e2e-bmo-api-{test_run_id}"
+    role = f"{sa}-role"
+    binding = f"{sa}-binding"
+    manifest = f"""
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {sa}
+  namespace: {bmh_namespace}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {role}
+  namespace: {bmh_namespace}
+rules:
+  - apiGroups: ["{METAL3_GROUP}"]
+    resources: ["baremetalhosts"]
+    verbs: ["get", "list", "watch", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {binding}
+  namespace: {bmh_namespace}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {role}
+subjects:
+  - kind: ServiceAccount
+    name: {sa}
+    namespace: {bmh_namespace}
+"""
+    subprocess.run(
+        ["oc", "--as", "system:admin", "apply", "-f", "-"],
+        input=manifest,
+        text=True,
+        check=True,
+        capture_output=True,
+    )
+    try:
+        token = run(
+            "oc",
+            "create",
+            "token",
+            sa,
+            "-n",
+            bmh_namespace,
+            "--duration",
+            "1h",
+            "--as",
+            "system:admin",
+        )
+        yield token
+    finally:
+        _oc("delete", "rolebinding", binding, "-n", bmh_namespace, "--ignore-not-found")
+        _oc("delete", "role", role, "-n", bmh_namespace, "--ignore-not-found")
+        _oc("delete", "sa", sa, "-n", bmh_namespace, "--ignore-not-found")
+
+
+def test_metal3_crd_http_matrix(
+    k8s_api: K8sApiClient,
+    bmh_namespace: str,
+    restricted_bmh_token: str,
+    test_run_id: str,
+) -> None:
+    """HTTP status matrix for metal3 CRDs BMaaS depends on (adjusted portable AC).
+
+    Docs: OCP 4.22 Provisioning APIs (html-single), chapters 2-9 and 12-13
+    https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html-single/provisioning_apis/index
+
+    Covered (all environments with Metal3 installed):
+    - LIST each namespaced CRD → 200 (empty list OK)
+    - LIST Provisioning (cluster-scoped) → 200 and ≥1 item (singleton present)
+    - Unauthenticated LIST BMH → 401 or 403 (OCP often 403)
+    - Named GET missing BMH → 404; GET existing BMH → 200
+    - dryRun=All invalid creates → 422 (BMH missing online, HFC missing updates,
+      HFS missing settings, DataImage missing url)
+    - dryRun=All BMH with unknown spec field → 400/422, or 2xx with field pruned
+      (Metal3 structural schemas commonly prune rather than reject)
+    - Restricted SA: dryRun PATCH BMH metadata → 200; dryRun PATCH spec → 200;
+      dryRun PATCH /status → 403
+
+    Not covered here (other matrix IDs): BMI lifecycle, inventory exhaustion,
+    real firmware flash, inspect field content, DataImage attach on a live host.
+    """
+    suffix = test_run_id
+    probe = f"e2e-bmo-api-{suffix}"
+
+    # --- LIST surface for every namespaced CRD ---
+    for resource in NAMESPACED_RESOURCES:
+        resp = k8s_api.request("GET", _api_path(resource=resource, namespace=bmh_namespace))
+        assert resp.status == 200, f"LIST {resource}: expected 200, got {resp.status}: {resp.body}"
+        assert isinstance(resp.body, dict) and "items" in resp.body
+
+    # --- Provisioning cluster-scoped singleton ---
+    prov = k8s_api.request("GET", _api_path(resource="provisionings"))
+    assert prov.status == 200, f"LIST provisionings: expected 200, got {prov.status}: {prov.body}"
+    assert isinstance(prov.body, dict)
+    items = prov.body.get("items", [])
+    assert len(items) >= 1, "expected at least one cluster-scoped Provisioning object"
+    # Namespaced collection path must not pretend Provisioning is namespaced.
+    namespaced_prov = k8s_api.request("GET", _api_path(resource="provisionings", namespace=bmh_namespace))
+    assert namespaced_prov.status in {404, 405}, (
+        f"Provisioning must not be a normal namespaced collection; got {namespaced_prov.status}"
+    )
+
+    # --- Unauthenticated ---
+    anon = k8s_api.anonymous_client()
+    unauth = anon.request("GET", _api_path(resource="baremetalhosts", namespace=bmh_namespace))
+    assert unauth.status in UNAUTHENTICATED_STATUSES, (
+        f"unauthenticated LIST BMH: expected {UNAUTHENTICATED_STATUSES}, got {unauth.status}"
+    )
+
+    # --- Named GET 404 ---
+    missing = k8s_api.request(
+        "GET", _api_path(resource="baremetalhosts", namespace=bmh_namespace, name="does-not-exist-xyz")
+    )
+    assert missing.status == 404, f"GET missing BMH: expected 404, got {missing.status}"
+
+    # --- Validation via dryRun=All ---
+    validation_cases: list[tuple[str, dict[str, Any]]] = [
+        ("baremetalhosts", _bmh_missing_online(namespace=bmh_namespace, name=f"{probe}-bmh")),
+        ("hostfirmwarecomponents", _hfc_missing_updates(namespace=bmh_namespace, name=f"{probe}-hfc")),
+        ("hostfirmwaresettings", _hfs_missing_settings(namespace=bmh_namespace, name=f"{probe}-hfs")),
+        ("dataimages", _dataimage_missing_url(namespace=bmh_namespace, name=f"{probe}-di")),
+    ]
+    for resource, body in validation_cases:
+        path = f"{_api_path(resource=resource, namespace=bmh_namespace)}?dryRun=All"
+        resp = k8s_api.request("POST", path, body=body)
+        assert resp.status == 422, f"dryRun POST {resource} invalid: expected 422, got {resp.status}: {resp.body}"
+
+    unknown = k8s_api.request(
+        "POST",
+        f"{_api_path(resource='baremetalhosts', namespace=bmh_namespace)}?dryRun=All",
+        body=_bmh_unknown_field(namespace=bmh_namespace, name=f"{probe}-unk"),
+    )
+    if unknown.status in UNKNOWN_FIELD_REJECT:
+        pass  # strict OpenAPI / field validation
+    elif unknown.status in UNKNOWN_FIELD_PRUNE:
+        assert isinstance(unknown.body, dict)
+        spec = unknown.body.get("spec") or {}
+        assert "e2eUnknownField" not in spec, (
+            f"unknown field accepted into stored/returned BMH spec (expected prune or reject): {spec}"
+        )
+    else:
+        raise AssertionError(
+            f"unknown field: expected reject {UNKNOWN_FIELD_REJECT} or prune "
+            f"{UNKNOWN_FIELD_PRUNE}, got {unknown.status}: {unknown.body}"
+        )
+
+    # --- Existing BMH GET + restricted SA RBAC ---
+    listed = k8s_api.request("GET", _api_path(resource="baremetalhosts", namespace=bmh_namespace))
+    assert listed.status == 200 and isinstance(listed.body, dict)
+    bmh_items = listed.body.get("items", [])
+    assert bmh_items, (
+        f"need ≥1 BareMetalHost in {bmh_namespace} to exercise GET + RBAC "
+        "(lab/CI must pre-create inventory BMHs)"
+    )
+    bmh_name = bmh_items[0]["metadata"]["name"]
+    bmh_path = _api_path(resource="baremetalhosts", namespace=bmh_namespace, name=bmh_name)
+
+    existing = k8s_api.request("GET", bmh_path)
+    assert existing.status == 200, f"GET existing BMH: expected 200, got {existing.status}"
+    assert isinstance(existing.body, dict)
+    assert existing.body.get("metadata", {}).get("name") == bmh_name
+
+    restricted = k8s_api.with_bearer_token(restricted_bmh_token)
+    allowed_patch = {"metadata": {"annotations": {"osac.e2e.io/bmo-api-probe": uuid.uuid4().hex[:8]}}}
+    allow_resp = restricted.request(
+        "PATCH",
+        f"{bmh_path}?dryRun=All",
+        body=allowed_patch,
+        content_type="application/merge-patch+json",
+    )
+    assert allow_resp.status == 200, (
+        f"restricted dryRun PATCH BMH (metadata): expected 200, got {allow_resp.status}: {allow_resp.body}"
+    )
+
+    # No-op spec patch (reuse current online) so dryRun cannot change power state.
+    current_online = existing.body.get("spec", {}).get("online", False)
+    spec_resp = restricted.request(
+        "PATCH",
+        f"{bmh_path}?dryRun=All",
+        body={"spec": {"online": current_online}},
+        content_type="application/merge-patch+json",
+    )
+    assert spec_resp.status == 200, (
+        f"restricted dryRun PATCH BMH (spec): expected 200, got {spec_resp.status}: {spec_resp.body}"
+    )
+
+    status_patch = {
+        "apiVersion": f"{METAL3_GROUP}/{METAL3_VERSION}",
+        "kind": "BareMetalHost",
+        "metadata": {"name": bmh_name, "namespace": bmh_namespace},
+        "status": {"errorMessage": f"e2e-forbidden-{uuid.uuid4().hex[:8]}"},
+    }
+    deny_resp = restricted.request(
+        "PATCH",
+        bmh_path + "/status?dryRun=All",
+        body=status_patch,
+        content_type="application/merge-patch+json",
+    )
+    assert deny_resp.status == 403, (
+        f"restricted dryRun PATCH /status: expected 403, got {deny_resp.status}: {deny_resp.body}"
+    )

--- a/tests/e2e/core/k8s_api.py
+++ b/tests/e2e/core/k8s_api.py
@@ -1,0 +1,129 @@
+"""Raw Kubernetes API HTTP helpers for CRD surface checks (status codes only)."""
+
+from __future__ import annotations
+
+import base64
+import json
+import ssl
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import yaml
+
+from tests.e2e.core.runner import env
+
+
+@dataclass(frozen=True)
+class K8sApiResponse:
+    status: int
+    body: dict[str, Any] | list[Any] | str
+
+
+@dataclass
+class K8sApiClient:
+    """Minimal HTTPS client for kube-apiserver using the current kubeconfig."""
+
+    server: str
+    _ssl_context: ssl.SSLContext
+    _auth_header: str | None = None
+    _ca_path: str | None = None
+
+    @classmethod
+    def from_kubeconfig(cls, kubeconfig: str | None = None) -> K8sApiClient:
+        path = Path(kubeconfig or env("KUBECONFIG", str(Path.home() / ".kube/config")))
+        cfg = yaml.safe_load(path.read_text())
+        cluster = cfg["clusters"][0]["cluster"]
+        user = cfg["users"][0]["user"]
+        server = cluster["server"].rstrip("/")
+
+        ca_path: str | None = None
+        ctx = ssl.create_default_context()
+        if ca := cluster.get("certificate-authority-data"):
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".crt") as ca_file:
+                ca_file.write(base64.b64decode(ca))
+                ca_path = ca_file.name
+            ctx.load_verify_locations(cafile=ca_path)
+        elif ca_file_path := cluster.get("certificate-authority"):
+            ca_path = ca_file_path
+            ctx.load_verify_locations(cafile=ca_path)
+        else:
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+
+        auth_header: str | None = None
+        if token := user.get("token"):
+            auth_header = f"Bearer {token}"
+        elif "client-certificate-data" in user and "client-key-data" in user:
+            with (
+                tempfile.NamedTemporaryFile(delete=False, suffix=".crt") as cert_file,
+                tempfile.NamedTemporaryFile(delete=False, suffix=".key") as key_file,
+            ):
+                cert_file.write(base64.b64decode(user["client-certificate-data"]))
+                key_file.write(base64.b64decode(user["client-key-data"]))
+                cert_path, key_path = cert_file.name, key_file.name
+            ctx.load_cert_chain(certfile=cert_path, keyfile=key_path)
+        else:
+            raise RuntimeError("kubeconfig user has neither token nor client certificate")
+
+        return cls(server=server, _ssl_context=ctx, _auth_header=auth_header, _ca_path=ca_path)
+
+    def anonymous_client(self) -> K8sApiClient:
+        """Client with cluster CA only — no bearer token and no client certificate."""
+        ctx = ssl.create_default_context()
+        if self._ca_path:
+            ctx.load_verify_locations(cafile=self._ca_path)
+        else:
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+        return K8sApiClient(server=self.server, _ssl_context=ctx, _auth_header=None, _ca_path=self._ca_path)
+
+    def with_bearer_token(self, token: str) -> K8sApiClient:
+        """Client authenticated with a bearer token (no inherited client certificate)."""
+        ctx = ssl.create_default_context()
+        if self._ca_path:
+            ctx.load_verify_locations(cafile=self._ca_path)
+        else:
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+        return K8sApiClient(
+            server=self.server, _ssl_context=ctx, _auth_header=f"Bearer {token}", _ca_path=self._ca_path
+        )
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        body: dict[str, Any] | None = None,
+        content_type: str = "application/json",
+    ) -> K8sApiResponse:
+        url = f"{self.server}{path}"
+        data = None if body is None else json.dumps(body).encode()
+        headers: dict[str, str] = {}
+        if self._auth_header:
+            headers["Authorization"] = self._auth_header
+        if data is not None:
+            headers["Content-Type"] = content_type
+        req = Request(url, data=data, headers=headers, method=method.upper())
+        try:
+            with urlopen(req, context=self._ssl_context, timeout=60) as resp:
+                raw = resp.read().decode()
+                parsed: dict[str, Any] | list[Any] | str
+                try:
+                    parsed = json.loads(raw) if raw else {}
+                except json.JSONDecodeError:
+                    parsed = raw
+                return K8sApiResponse(status=resp.status, body=parsed)
+        except HTTPError as exc:
+            raw = exc.read().decode()
+            try:
+                parsed_err: dict[str, Any] | list[Any] | str = json.loads(raw) if raw else {}
+            except json.JSONDecodeError:
+                parsed_err = raw
+            return K8sApiResponse(status=exc.code, body=parsed_err)
+        except URLError as exc:
+            raise RuntimeError(f"kube-apiserver request failed: {method} {path}: {exc}") from exc

--- a/tests/e2e/core/k8s_api.py
+++ b/tests/e2e/core/k8s_api.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 import yaml
@@ -21,6 +22,36 @@ from tests.e2e.core.runner import env
 class K8sApiResponse:
     status: int
     body: dict[str, Any] | list[Any] | str
+
+
+def _cluster_and_user(cfg: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    current = cfg.get("current-context")
+    if not current:
+        raise RuntimeError("kubeconfig has no current-context")
+    contexts = {c["name"]: c["context"] for c in cfg.get("contexts") or []}
+    ctx = contexts.get(current)
+    if not ctx:
+        raise RuntimeError(f"kubeconfig current-context {current!r} not found")
+    cluster_name, user_name = ctx.get("cluster"), ctx.get("user")
+    clusters = {c["name"]: c["cluster"] for c in cfg.get("clusters") or []}
+    users = {u["name"]: u["user"] for u in cfg.get("users") or []}
+    cluster, user = clusters.get(cluster_name), users.get(user_name)
+    if cluster is None or user is None:
+        raise RuntimeError(f"kubeconfig context {current!r} is missing cluster or user")
+    return cluster, user
+
+
+def _require_https(server: str) -> str:
+    parsed = urlparse(server)
+    if parsed.scheme != "https":
+        raise RuntimeError(f"kube-apiserver URL must be https, got {parsed.scheme!r}")
+    return server
+
+
+def _ssl_context_with_ca(ca_path: str) -> ssl.SSLContext:
+    ctx = ssl.create_default_context()
+    ctx.load_verify_locations(cafile=ca_path)
+    return ctx
 
 
 @dataclass
@@ -36,9 +67,8 @@ class K8sApiClient:
     def from_kubeconfig(cls, kubeconfig: str | None = None) -> K8sApiClient:
         path = Path(kubeconfig or env("KUBECONFIG", str(Path.home() / ".kube/config")))
         cfg = yaml.safe_load(path.read_text())
-        cluster = cfg["clusters"][0]["cluster"]
-        user = cfg["users"][0]["user"]
-        server = cluster["server"].rstrip("/")
+        cluster, user = _cluster_and_user(cfg)
+        server = _require_https(cluster["server"].rstrip("/"))
 
         ca_path: str | None = None
         ctx = ssl.create_default_context()
@@ -51,21 +81,26 @@ class K8sApiClient:
             ca_path = ca_file_path
             ctx.load_verify_locations(cafile=ca_path)
         else:
-            ctx.check_hostname = False
-            ctx.verify_mode = ssl.CERT_NONE
+            raise RuntimeError("kubeconfig cluster has no certificate-authority")
 
         auth_header: str | None = None
         if token := user.get("token"):
             auth_header = f"Bearer {token}"
         elif "client-certificate-data" in user and "client-key-data" in user:
-            with (
-                tempfile.NamedTemporaryFile(delete=False, suffix=".crt") as cert_file,
-                tempfile.NamedTemporaryFile(delete=False, suffix=".key") as key_file,
-            ):
-                cert_file.write(base64.b64decode(user["client-certificate-data"]))
-                key_file.write(base64.b64decode(user["client-key-data"]))
-                cert_path, key_path = cert_file.name, key_file.name
-            ctx.load_cert_chain(certfile=cert_path, keyfile=key_path)
+            cert_path = key_path = None
+            try:
+                with (
+                    tempfile.NamedTemporaryFile(delete=False, suffix=".crt") as cert_file,
+                    tempfile.NamedTemporaryFile(delete=False, suffix=".key") as key_file,
+                ):
+                    cert_file.write(base64.b64decode(user["client-certificate-data"]))
+                    key_file.write(base64.b64decode(user["client-key-data"]))
+                    cert_path, key_path = cert_file.name, key_file.name
+                ctx.load_cert_chain(certfile=cert_path, keyfile=key_path)
+            finally:
+                for tmp in (cert_path, key_path):
+                    if tmp:
+                        Path(tmp).unlink(missing_ok=True)
         else:
             raise RuntimeError("kubeconfig user has neither token nor client certificate")
 
@@ -73,24 +108,24 @@ class K8sApiClient:
 
     def anonymous_client(self) -> K8sApiClient:
         """Client with cluster CA only — no bearer token and no client certificate."""
-        ctx = ssl.create_default_context()
-        if self._ca_path:
-            ctx.load_verify_locations(cafile=self._ca_path)
-        else:
-            ctx.check_hostname = False
-            ctx.verify_mode = ssl.CERT_NONE
-        return K8sApiClient(server=self.server, _ssl_context=ctx, _auth_header=None, _ca_path=self._ca_path)
+        if not self._ca_path:
+            raise RuntimeError("kube-apiserver client has no CA path")
+        return K8sApiClient(
+            server=self.server,
+            _ssl_context=_ssl_context_with_ca(self._ca_path),
+            _auth_header=None,
+            _ca_path=self._ca_path,
+        )
 
     def with_bearer_token(self, token: str) -> K8sApiClient:
         """Client authenticated with a bearer token (no inherited client certificate)."""
-        ctx = ssl.create_default_context()
-        if self._ca_path:
-            ctx.load_verify_locations(cafile=self._ca_path)
-        else:
-            ctx.check_hostname = False
-            ctx.verify_mode = ssl.CERT_NONE
+        if not self._ca_path:
+            raise RuntimeError("kube-apiserver client has no CA path")
         return K8sApiClient(
-            server=self.server, _ssl_context=ctx, _auth_header=f"Bearer {token}", _ca_path=self._ca_path
+            server=self.server,
+            _ssl_context=_ssl_context_with_ca(self._ca_path),
+            _auth_header=f"Bearer {token}",
+            _ca_path=self._ca_path,
         )
 
     def request(


### PR DESCRIPTION
## Summary
- Adds HTTP-only Metal3 / BMO kube-apiserver surface checks under `tests/e2e/bmaas/sanity/` so they run on PRs (`-n 4`), not serial.
- New `tests/e2e/core/k8s_api.py` helper talks to the apiserver OpenAPI (status codes only). No fulfillment, no host consume, no firmware.

**Jira:** https://redhat.atlassian.net/browse/OSAC-4635

## Test plan
- [x] Local: `pytest tests/e2e/bmaas/sanity/test_bmo_api_surface.py -n 0` on bmaas-sno-qe — `test_metal3_crd_http_matrix` passed (~44s)
- [ ] CI BMaaS e2e-full-install (sanity suite) green
- [ ] Confirm LIST/GET/unauth/dryRun validation + restricted SA status PATCH 403 on GHA virtual BMHs


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for the Metal3/Bare Metal Operator Kubernetes API, including resource access, authentication, object retrieval, validation, unknown-field handling, and permission boundaries.
  * Added support for authenticated and anonymous HTTPS Kubernetes requests with structured response and error handling.
  * Added restricted-access scenarios covering metadata, specification, and status permissions, with cleanup after testing.
  * Improved validation of Kubernetes names and namespaces and strengthened kubeconfig security checks, including HTTPS and certificate authority requirements.
  * Reduced sensitive Kubernetes response data in CI assertion output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->