### PR TITLE
OSAC-1165: Enable Kafka on Kind for integration tests

### DIFF
--- a/osac-installer/Makefile
+++ b/osac-installer/Makefile
@@ -122,6 +122,9 @@ ifeq ($(PLATFORM),kind)
 	helm upgrade --install envoy-gateway oci://docker.io/envoyproxy/gateway-helm \
 		--version v1.6.5 --namespace envoy-gateway --create-namespace \
 		--wait --timeout 5m
+	helm upgrade --install strimzi-cluster-operator oci://quay.io/strimzi-helm/strimzi-kafka-operator \
+		--version 1.1.0 --namespace osac-kafka --create-namespace \
+		--wait --timeout 5m
 	helm upgrade --install osac-infra $(INFRA_CHART) \
 		--namespace osac-infra --create-namespace \
 		-f $(INFRA_VALUES) \
@@ -161,6 +164,7 @@ endif
 uninstall-infra: ## Uninstall infrastructure (PLATFORM= PROFILE= NS= required)
 ifeq ($(PLATFORM),kind)
 	helm uninstall osac-infra --namespace osac-infra --ignore-not-found
+	helm uninstall strimzi-cluster-operator --namespace osac-kafka --ignore-not-found
 	helm uninstall envoy-gateway --namespace envoy-gateway --ignore-not-found
 	helm uninstall trust-manager --namespace cert-manager --ignore-not-found
 	helm uninstall cert-manager --namespace cert-manager --ignore-not-found
@@ -273,5 +277,7 @@ helm-validate: helm-lint ## Validate all charts (lint + template)
 			helm template osac-deps $(DEPS_CHART) --values "$$infra" && \
 			helm template osac-infra $(INFRA_CHART) --values "$$infra"; \
 	done
+	@echo "Validating values/dev/kind-infra.yaml..."
+	helm template osac-infra $(INFRA_CHART) --values values/dev/kind-infra.yaml
 	./scripts/validate-keycloak-credentials.sh
 	@echo "Validation passed."

--- a/osac-installer/charts/osac-infra/files/hooks/configure-kafka.sh
+++ b/osac-installer/charts/osac-infra/files/hooks/configure-kafka.sh
@@ -9,26 +9,39 @@ if oc wait kafka/osac-kafka -n "${KAFKA_NS}" --for=condition=Ready --timeout=5s 
   exit 0
 fi
 
-echo "Waiting for AMQ Streams install plan..."
-until INSTALL_PLAN=$(oc get subscription amq-streams -n "${KAFKA_NS}" -o jsonpath='{.status.installPlanRef.name}' 2>/dev/null) && [[ -n "${INSTALL_PLAN}" ]]; do
-  sleep 10
-done
+if oc get subscription amq-streams -n "${KAFKA_NS}" &>/dev/null; then
+  echo "Waiting for AMQ Streams install plan..."
+  until INSTALL_PLAN=$(oc get subscription amq-streams -n "${KAFKA_NS}" -o jsonpath='{.status.installPlanRef.name}' 2>/dev/null) && [[ -n "${INSTALL_PLAN}" ]]; do
+    sleep 10
+  done
 
-echo "Approving install plan ${INSTALL_PLAN}..."
-oc patch installplan "${INSTALL_PLAN}" -n "${KAFKA_NS}" --type merge -p '{"spec":{"approved":true}}'
+  echo "Approving install plan ${INSTALL_PLAN}..."
+  oc patch installplan "${INSTALL_PLAN}" -n "${KAFKA_NS}" --type merge -p '{"spec":{"approved":true}}'
 
-echo "Waiting for AMQ Streams Subscription to report installedCSV..."
-until AMQ_CSV=$(oc get subscription amq-streams -n "${KAFKA_NS}" -o jsonpath='{.status.installedCSV}' 2>/dev/null) && [[ -n "${AMQ_CSV}" ]]; do
-  sleep 10
-done
+  echo "Waiting for AMQ Streams Subscription to report installedCSV..."
+  until AMQ_CSV=$(oc get subscription amq-streams -n "${KAFKA_NS}" -o jsonpath='{.status.installedCSV}' 2>/dev/null) && [[ -n "${AMQ_CSV}" ]]; do
+    sleep 10
+  done
 
-echo "Waiting for CSV ${AMQ_CSV} to succeed..."
-until [[ "$(oc get csv "${AMQ_CSV}" -n "${KAFKA_NS}" -o jsonpath='{.status.phase}')" == "Succeeded" ]]; do
-  sleep 10
-done
+  echo "Waiting for CSV ${AMQ_CSV} to succeed..."
+  until [[ "$(oc get csv "${AMQ_CSV}" -n "${KAFKA_NS}" -o jsonpath='{.status.phase}')" == "Succeeded" ]]; do
+    sleep 10
+  done
 
-echo "Waiting for AMQ Streams cluster operator deployment..."
-oc wait --for=condition=Available deploy -l olm.owner="${AMQ_CSV}" -n "${KAFKA_NS}" --timeout=300s
+  echo "Waiting for AMQ Streams cluster operator deployment..."
+  oc wait --for=condition=Available deploy -l olm.owner="${AMQ_CSV}" -n "${KAFKA_NS}" --timeout=300s
+else
+  echo "No AMQ Streams subscription found; waiting for Strimzi operator..."
+  until oc get kafka -n "${KAFKA_NS}" &>/dev/null && oc get kafkanodepool -n "${KAFKA_NS}" &>/dev/null; do
+    sleep 5
+  done
+
+  echo "Waiting for Strimzi cluster operator deployment..."
+  until oc get deploy/strimzi-cluster-operator -n "${KAFKA_NS}" &>/dev/null; do
+    sleep 5
+  done
+  oc wait --for=condition=Available deploy/strimzi-cluster-operator -n "${KAFKA_NS}" --timeout=300s
+fi
 
 echo "Applying Kafka cluster..."
 oc apply -f /config/kafka-cluster.yaml

--- a/osac-installer/charts/osac-infra/templates/NOTES.txt
+++ b/osac-installer/charts/osac-infra/templates/NOTES.txt
@@ -28,3 +28,6 @@ Components:
 {{- if .Values.bundledPostgres.enabled }}
   - Bundled PostgreSQL (dev/CI)
 {{- end }}
+{{- if .Values.kafka.enabled }}
+  - Kafka cluster (osac-kafka)
+{{- end }}

--- a/osac-installer/charts/osac-infra/templates/hooks/configure-kafka.yaml
+++ b/osac-installer/charts/osac-infra/templates/hooks/configure-kafka.yaml
@@ -100,7 +100,6 @@ spec:
             - name: scripts
               mountPath: /scripts
           securityContext:
-            runAsNonRoot: true
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:

--- a/osac-installer/values/dev/kind-infra.yaml
+++ b/osac-installer/values/dev/kind-infra.yaml
@@ -1,5 +1,5 @@
 # Kind dev environment -- infrastructure values for osac-infra chart.
-# cert-manager, trust-manager, and envoy gateway are installed as
+# cert-manager, trust-manager, envoy gateway, and Strimzi are installed as
 # separate Helm releases by the root Makefile (install-infra).
 # This values file configures the infra chart templates only.
 
@@ -19,7 +19,10 @@ metallb:
 mce:
   enabled: false
 kafka:
-  enabled: false
+  enabled: true
+  replicas: 1
+  storage:
+    size: 10Gi
 
 # --- Envoy Gateway resources (Gateway, GatewayClass, EnvoyProxy) ---
 envoygateway:

--- a/osac-installer/values/dev/kind-instance.yaml
+++ b/osac-installer/values/dev/kind-instance.yaml
@@ -165,7 +165,8 @@ capiProvider:
   enabled: false
 
 kafka:
-  enabled: false
+  enabled: true
+  replicas: 1
 
 # --- Vault compatible secret store (OpenBao) ---
 bundledVault:


### PR DESCRIPTION
## Summary
- Install the Strimzi Kafka operator from Helm during Kind `install-infra`, because Kind has no OLM and cannot use the AMQ Streams subscription.
- Teach the configure-kafka hook to wait for Strimzi when that subscription is absent, and size the Kind cluster to a single 10Gi broker.
- Drop `runAsNonRoot` on the hook so the origin-cli image can start without an OpenShift SCC.

## Test plan
- [ ] `make -C osac-installer install-infra PLATFORM=kind PROFILE=dev NS=osac`
- [ ] Confirm `kafka/osac-kafka` in namespace `osac-kafka` becomes Ready
- [ ] OpenShift path unchanged: the hook still approves the AMQ Streams install plan when the subscription exists
- [ ] `make -C osac-installer helm-validate`

Related: https://redhat.atlassian.net/browse/OSAC-1165
Related: https://redhat.atlassian.net/browse/OSAC-4760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kafka is now enabled by default in development Kind environments, with one replica and 10 GiB of storage.
  * Kind infrastructure installation now deploys the Strimzi Kafka operator, and uninstallation removes it.
  * Installation waits for Kafka resources and the Strimzi operator to become available before continuing.
  * Helm deployment notes now display Kafka cluster information when Kafka is enabled.
* **Documentation**
  * Kind infrastructure documentation now identifies Strimzi as a separately installed component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->