### PR TITLE
NO-ISSUE: Add PROFILE=dev-full for full Kind local development environment

### DIFF
--- a/.github/scripts/check-floating-tags.sh
+++ b/.github/scripts/check-floating-tags.sh
@@ -18,8 +18,8 @@ while IFS= read -r -d '' f; do
     code_line="$(printf '%s\n' "$line" | sed -E 's/[[:space:]]+#.*$//')"
     if printf '%s\n' "$code_line" | grep -qE "(^|[[:space:]])tag:[[:space:]]*['\"]?(latest|main)['\"]?([]},[:space:]]|$)|:(latest|main)['\"]?([]},[:space:]]|$)" && \
        printf '%s\n' "$code_line" | grep -qvE '^[[:space:]]*#'; then
-      if printf '%s\n' "$prev_line" | grep -qE '(^|[[:space:]])#[[:space:]]PLACEHOLDER -- overwritten at release time([[:space:]]|$)' || \
-         printf '%s\n' "$line" | grep -qE '(^|[[:space:]])#[[:space:]]PLACEHOLDER -- overwritten at release time([[:space:]]|$)'; then
+      if printf '%s\n' "$prev_line" | grep -qE '(^|[[:space:]])#[[:space:]](PLACEHOLDER -- overwritten at release time|DEV_FLOATING -- intentionally unpinned for local dev)([[:space:]]|$)' || \
+         printf '%s\n' "$line" | grep -qE '(^|[[:space:]])#[[:space:]](PLACEHOLDER -- overwritten at release time|DEV_FLOATING -- intentionally unpinned for local dev)([[:space:]]|$)'; then
         : # properly documented
       else
         tag_match="$(printf '%s\n' "$code_line" | grep -oE '\b(latest|main)\b' | head -1)"

--- a/osac-installer/AGENTS.md
+++ b/osac-installer/AGENTS.md
@@ -47,6 +47,11 @@ make uninstall PLATFORM=openshift PROFILE=<profile> NS=<namespace>
 
 # Integration tests (Kind)
 make test PLATFORM=kind PROFILE=dev NS=osac SUITE=fulfillment
+
+# Full local dev environment on Kind (superset of dev: KubeVirt + AWX + UI +
+# seeded catalog). Needs a rootful runtime + /dev/kvm — see README.md and
+# scripts/dev-full/. Adds the install-devstack phase after infra + osac.
+make install PLATFORM=kind PROFILE=dev-full NS=osac
 ```
 
 ## Critical Rules
@@ -128,11 +133,22 @@ Phase 3: charts/osac/                   # OSAC platform (per-instance workload)
 ```text
 values/
   dev/infra.yaml + instance.yaml       # Local dev (Kind + OpenShift)
+  dev/kind-infra.yaml + kind-instance.yaml       # Kind control plane (PROFILE=dev, dev-full)
+  dev/kind-instance-devfull.yaml                 # PROFILE=dev-full overlay (noop networking provisioning)
   vmaas-ci/infra.yaml + instance.yaml  # VMaaS CI
   caas-ci/infra.yaml + instance.yaml   # CaaS CI
   bmaas-ci/infra.yaml + instance.yaml  # BMaaS CI
   full-ci/infra.yaml + instance.yaml   # Full CI (all components)
 ```
+
+`PROFILE=dev-full` (kind only) reuses the `dev` kind control-plane values and adds
+the `kind-instance-devfull.yaml` overlay; the extra dev stack (KubeVirt, AWX, UI,
+seeded catalog, and a ready-to-use `tenant1`) is installed imperatively by
+`scripts/dev-full/` (the `install-devstack` phase), not by the charts. The final
+step, `provision-tenant.sh`, creates the DB tenant via the gRPC-only Tenants API
+(creating it auto-provisions the tenant's default network via tenant onboarding),
+creates the matching Keycloak organization, and adds `tenant1_user`/`tenant1_admin`
+as members so they can log in and manage resources. See README.md.
 
 Pull secrets and AAP license files are stored alongside values files (e.g.,
 `values/<profile>/pull-secret.json`, `values/<profile>/license.zip`).

--- a/osac-installer/Makefile
+++ b/osac-installer/Makefile
@@ -5,13 +5,19 @@
 #
 # Usage:
 # Every deployment target requires PLATFORM, PROFILE, and NS. No exceptions.
-#   make install         PLATFORM=kind|openshift  PROFILE=dev|vmaas-ci|bmaas-ci|caas-ci|full-ci  NS=osac
-#   make uninstall       PLATFORM=kind|openshift  PROFILE=dev|vmaas-ci|bmaas-ci|caas-ci|full-ci  NS=osac
-#   make install-infra   PLATFORM=kind|openshift  PROFILE=dev|vmaas-ci|bmaas-ci|caas-ci|full-ci  NS=osac
-#   make install-osac    PLATFORM=kind|openshift  PROFILE=dev|vmaas-ci|bmaas-ci|caas-ci|full-ci  NS=osac
-#   make uninstall-osac  PLATFORM=kind|openshift  PROFILE=dev|vmaas-ci|bmaas-ci|caas-ci|full-ci  NS=osac
-#   make uninstall-infra PLATFORM=kind|openshift  PROFILE=dev|vmaas-ci|bmaas-ci|caas-ci|full-ci  NS=osac
-#   make test            PLATFORM=kind|openshift  PROFILE=dev|vmaas-ci|bmaas-ci|caas-ci|full-ci  NS=osac  SUITE=all|fulfillment|operator|bmf
+#   make install         PLATFORM=kind|openshift  PROFILE=dev|dev-full|vmaas-ci|bmaas-ci|caas-ci|full-ci  NS=osac
+#   make uninstall       PLATFORM=kind|openshift  PROFILE=dev|dev-full|vmaas-ci|bmaas-ci|caas-ci|full-ci  NS=osac
+#   make install-infra   PLATFORM=kind|openshift  PROFILE=dev|dev-full|vmaas-ci|bmaas-ci|caas-ci|full-ci  NS=osac
+#   make install-osac    PLATFORM=kind|openshift  PROFILE=dev|dev-full|vmaas-ci|bmaas-ci|caas-ci|full-ci  NS=osac
+#   make uninstall-osac  PLATFORM=kind|openshift  PROFILE=dev|dev-full|vmaas-ci|bmaas-ci|caas-ci|full-ci  NS=osac
+#   make uninstall-infra PLATFORM=kind|openshift  PROFILE=dev|dev-full|vmaas-ci|bmaas-ci|caas-ci|full-ci  NS=osac
+#   make test            PLATFORM=kind|openshift  PROFILE=dev|dev-full|vmaas-ci|bmaas-ci|caas-ci|full-ci  NS=osac  SUITE=all|fulfillment|operator|bmf
+#
+# PROFILE=dev-full (kind only) is a superset of dev: it runs the same chart-based
+# control plane, then layers on the full local dev stack (KubeVirt/CDI/Multus, AWX,
+# UI, seeded catalog) via scripts/dev-full/. It needs a rootful container runtime
+# (Linux: rootful podman or Docker; macOS: Docker Desktop) and /dev/kvm on Linux —
+# see scripts/dev-full/kind-runtime.sh and README.md.
 #
 # Helm chart management (no parameters required):
 #   make helm-lint
@@ -26,7 +32,7 @@ EXTRA_HELM_ARGS ?=
 # -- Fail-fast parameter validation ------------------------------------
 # Guards fire at parse time, gated by MAKECMDGOALS so `make help` works.
 
-ALL_TARGETS := install uninstall install-infra uninstall-infra install-osac uninstall-osac test
+ALL_TARGETS := install uninstall install-infra uninstall-infra install-osac uninstall-osac install-devstack test
 
 ifneq ($(filter $(ALL_TARGETS),$(MAKECMDGOALS)),)
 ifndef PLATFORM
@@ -36,17 +42,17 @@ ifeq ($(filter $(PLATFORM),kind openshift),)
 $(error PLATFORM=$(PLATFORM) is invalid; must be kind or openshift)
 endif
 ifndef PROFILE
-$(error PROFILE is required (dev|vmaas-ci|bmaas-ci|caas-ci|full-ci))
+$(error PROFILE is required (dev|dev-full|vmaas-ci|bmaas-ci|caas-ci|full-ci))
 endif
-ifeq ($(filter $(PROFILE),dev vmaas-ci bmaas-ci caas-ci full-ci),)
-$(error PROFILE=$(PROFILE) is invalid; must be dev, vmaas-ci, bmaas-ci, caas-ci, or full-ci)
+ifeq ($(filter $(PROFILE),dev dev-full vmaas-ci bmaas-ci caas-ci full-ci),)
+$(error PROFILE=$(PROFILE) is invalid; must be dev, dev-full, vmaas-ci, bmaas-ci, caas-ci, or full-ci)
 endif
 ifndef NS
 $(error NS is required (namespace for OSAC instance, e.g. NS=osac))
 endif
 ifeq ($(PLATFORM),kind)
-ifneq ($(PROFILE),dev)
-$(error PLATFORM=kind only supports PROFILE=dev)
+ifeq ($(filter $(PROFILE),dev dev-full),)
+$(error PLATFORM=kind only supports PROFILE=dev or PROFILE=dev-full)
 endif
 endif
 endif
@@ -69,20 +75,43 @@ INFRA_CHART    := $(CHARTS)/osac-infra
 OSAC_CHART     := $(CHARTS)/osac
 
 # Values file selection: kind uses kind-specific files, OpenShift uses profile files.
+# dev-full reuses the identical dev control-plane values, plus a small overlay that
+# disables AAP-based networking provisioning (no fabric on kind).
+INSTANCE_VALUES_EXTRA :=
+INFRA_VALUES_EXTRA :=
 ifeq ($(PLATFORM),kind)
 INFRA_VALUES    := values/dev/kind-infra.yaml
 INSTANCE_VALUES := values/dev/kind-instance.yaml
+ifeq ($(PROFILE),dev-full)
+INSTANCE_VALUES_EXTRA := -f values/dev/kind-instance-devfull.yaml
+INFRA_VALUES_EXTRA := -f values/dev/kind-infra-devfull.yaml
+endif
 else ifdef PROFILE
 INFRA_VALUES    := values/$(PROFILE)/infra.yaml
 INSTANCE_VALUES := values/$(PROFILE)/instance.yaml
 endif
 
+# Kind cluster create/delete routing. dev-full needs a rootful runtime (KubeVirt
+# chowns /dev/kvm), so it goes through the cross-platform wrapper; plain dev uses
+# bare kind (unchanged integration-test path).
+KIND_RUNTIME := scripts/dev-full/kind-runtime.sh
+
 # Container tool and Kind cluster config.
 CONTAINER_TOOL ?= $(or $(shell command -v podman 2>/dev/null),$(shell command -v docker 2>/dev/null),$(error neither podman nor docker found in PATH))
 KIND_CLUSTER_NAME ?= osac-dev
 KIND_CONFIG := kind-config.yaml
+# dev-full runs its cluster in a separate (rootful) podman daemon; give it a
+# distinct kubeconfig so it never collides with the rootless PROFILE=dev cluster
+# of the same name (both would otherwise share this one file and clobber it).
+ifeq ($(PROFILE),dev-full)
+KIND_KUBECONFIG := $(HOME)/.kube/$(KIND_CLUSTER_NAME)-kind-root.kubeconfig
+else
 KIND_KUBECONFIG := $(HOME)/.kube/$(KIND_CLUSTER_NAME)-kind.kubeconfig
-export KUBECONFIG ?= $(KIND_KUBECONFIG)
+endif
+# Use the caller's KUBECONFIG if they set a non-empty one, otherwise the kind file.
+# `?=` is not enough: a shell that exports KUBECONFIG= (empty-but-defined) would keep
+# it empty and helm/kubectl would fall back to localhost:8080. `$(or ...)` skips empty.
+export KUBECONFIG := $(or $(KUBECONFIG),$(KIND_KUBECONFIG))
 
 define kind-load-image
 	@if [ "$$(basename $(CONTAINER_TOOL))" = "podman" ]; then \
@@ -106,6 +135,10 @@ help: ## Display this help
 .PHONY: install-infra
 install-infra: ## Install infrastructure (PLATFORM= PROFILE= NS= required)
 ifeq ($(PLATFORM),kind)
+ifeq ($(PROFILE),dev-full)
+	@$(KIND_RUNTIME) check
+	@$(KIND_RUNTIME) create-cluster $(KIND_CLUSTER_NAME) $(KIND_CONFIG) $(KIND_KUBECONFIG)
+else
 	@if kind get clusters | grep -q "^$(KIND_CLUSTER_NAME)$$"; then \
 		echo "Kind cluster '$(KIND_CLUSTER_NAME)' already exists"; \
 	else \
@@ -113,6 +146,7 @@ ifeq ($(PLATFORM),kind)
 		kind create cluster --name $(KIND_CLUSTER_NAME) --config $(KIND_CONFIG) --wait 60s; \
 	fi
 	@kind export kubeconfig --name $(KIND_CLUSTER_NAME) --kubeconfig $(KIND_KUBECONFIG)
+endif
 	helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
 		--version v1.20.0 --namespace cert-manager --create-namespace \
 		--set crds.enabled=true --wait --timeout 5m
@@ -127,7 +161,7 @@ ifeq ($(PLATFORM),kind)
 		--wait --timeout 5m
 	helm upgrade --install osac-infra $(INFRA_CHART) \
 		--namespace osac-infra --create-namespace \
-		-f $(INFRA_VALUES) \
+		-f $(INFRA_VALUES) $(INFRA_VALUES_EXTRA) \
 		--set osacNamespace=$(NS) \
 		--wait-for-jobs --timeout 30m
 	@for f in ../osac-operator/config/crd/fakes/*.yaml; do \
@@ -163,12 +197,16 @@ endif
 .PHONY: uninstall-infra
 uninstall-infra: ## Uninstall infrastructure (PLATFORM= PROFILE= NS= required)
 ifeq ($(PLATFORM),kind)
+ifeq ($(PROFILE),dev-full)
+	@$(KIND_RUNTIME) delete-cluster $(KIND_CLUSTER_NAME)
+else
 	helm uninstall osac-infra --namespace osac-infra --ignore-not-found
 	helm uninstall strimzi-cluster-operator --namespace osac-kafka --ignore-not-found
 	helm uninstall envoy-gateway --namespace envoy-gateway --ignore-not-found
 	helm uninstall trust-manager --namespace cert-manager --ignore-not-found
 	helm uninstall cert-manager --namespace cert-manager --ignore-not-found
 	kind delete cluster --name $(KIND_CLUSTER_NAME)
+endif
 else
 	helm uninstall osac-infra --namespace osac-infra --ignore-not-found --wait --timeout 10m
 	helm uninstall osac-deps --namespace osac-deps --ignore-not-found
@@ -196,7 +234,7 @@ ifneq ($(PLATFORM),kind)
 	@[ -n "$(DOMAIN)" ] || { echo "ERROR: Could not determine cluster domain. Is oc logged in?" >&2; exit 1; }
 endif
 	helm upgrade --install osac $(OSAC_CHART) \
-		-f $(INSTANCE_VALUES) \
+		-f $(INSTANCE_VALUES) $(INSTANCE_VALUES_EXTRA) \
 		--namespace $(NS) --create-namespace \
 		$(if $(DOMAIN),--set service.externalHostname=fulfillment-api-$(NS).$(DOMAIN) --set service.internalHostname=fulfillment-internal-api-$(NS).$(DOMAIN) --set service.auth.issuerUrl=https://keycloak-keycloak.$(DOMAIN)/realms/osac --set service.idp.url=https://keycloak-keycloak.$(DOMAIN)) \
 		$(EXTRA_HELM_ARGS) \
@@ -206,10 +244,30 @@ endif
 uninstall-osac: ## Uninstall OSAC instance (PLATFORM= PROFILE= NS= required)
 	helm uninstall osac --namespace $(NS) --ignore-not-found
 
+##@ Entity: Dev Stack (kind PROFILE=dev-full only)
+
+.PHONY: install-devstack
+install-devstack: ## Install dev-full extras: KubeVirt/CDI/Multus + AWX + UI + seeded catalog
+ifneq ($(PLATFORM)/$(PROFILE),kind/dev-full)
+	@echo "ERROR: install-devstack requires PLATFORM=kind PROFILE=dev-full" >&2; exit 1
+endif
+	# Pre-install: node-level CNI setup (requires host container runtime access)
+	scripts/dev-full/install-virt-node-setup.sh $(KIND_CLUSTER_NAME)
+	# Helm install: operators + AWX + UI + seeding
+	helm upgrade --install osac-devstack charts/osac-devstack \
+		--namespace $(NS) --create-namespace \
+		--set osacNamespace=$(NS) \
+		--set kindClusterName=$(KIND_CLUSTER_NAME) \
+		--wait --timeout 30m
+
 ##@ Composite
 
 .PHONY: install
+ifeq ($(PROFILE),dev-full)
+install: install-infra install-osac install-devstack ## Full install: infra + osac (+ dev stack for dev-full)
+else
 install: install-infra install-osac ## Full install: infra + osac (PLATFORM= PROFILE= required)
+endif
 
 .PHONY: uninstall
 uninstall: uninstall-osac uninstall-infra ## Full uninstall: osac + infra (PLATFORM= PROFILE= required)

--- a/osac-installer/README.md
+++ b/osac-installer/README.md
@@ -147,9 +147,77 @@ make install-osac  PLATFORM=openshift PROFILE=<profile> NS=<namespace>   # OSAC 
 | Variable | Description |
 |----------|-------------|
 | `PLATFORM` | `kind` or `openshift` (required) |
-| `PROFILE` | `dev`, `vmaas-ci`, `bmaas-ci`, `caas-ci`, or `full-ci` (required) |
+| `PROFILE` | `dev`, `dev-full`, `vmaas-ci`, `bmaas-ci`, `caas-ci`, or `full-ci` (required; `dev-full` is kind only) |
 | `NS` | Target namespace (required) |
 | `EXTRA_HELM_ARGS` | Extra `--set`/`--set-string` args appended to helm commands |
+
+#### Full local dev environment (`PROFILE=dev-full`, kind only)
+
+`PROFILE=dev` on kind stands up only the control plane (cert-manager,
+envoy-gateway, PostgreSQL, Keycloak, OpenBao, fulfillment-service, operator) —
+the same footprint the integration tests use. `PROFILE=dev-full` is a **superset**:
+it runs that identical chart-based install, then layers on everything needed for
+the end-to-end "create a VM from the UI" experience:
+
+```bash
+make install PLATFORM=kind PROFILE=dev-full NS=osac
+```
+
+On top of `dev`, `dev-full` adds (via `scripts/dev-full/`, orchestrated by the
+`install-devstack` target):
+
+- **Virtualization** — Multus CNI + bridge plugin, KubeVirt (operator + CR, `l2bridge`
+  binding), CDI
+- **AWX** — the open-source AAP backend the operator drives: awx-operator + instance,
+  configured with an inventory, a project (`github.com/osac-project/osac.git`,
+  playbooks under `osac-aap/`), job templates, a Kubernetes credential, and the
+  `awx-token` secret the operator reads
+- **OSAC UI** — deployed directly (the chart's `ui.enabled` uses an OpenShift Route,
+  unusable on kind) and routed through the shared Envoy Gateway
+- **Seeded catalog** — a `fedora` disk image, `u1-small/medium/large` instance types,
+  the `osac.templates.ocp_virt_vm` template, and a `linux-vm` catalog item (shared/global
+  objects; networking is per-tenant and auto-provisioned, see below)
+- **Ready-to-use tenant** — `provision-tenant.sh` creates a DB tenant (`tenant1`) via the
+  private gRPC Tenants API, a matching enabled Keycloak organization, and adds the dev
+  users (`tenant1_user`, `tenant1_admin`) as organization members so their tokens carry
+  the `organization` claim needed to create resources. Creating the tenant auto-provisions
+  its default VirtualNetwork + Subnet + SecurityGroup via tenant onboarding, so those are
+  ready without manual seeding.
+
+The `dev-full` overlay also sets `operator.controllers.networkingProvisioning=false`
+so networking resources reconcile to READY without a real fabric (kind has none).
+
+**Prerequisites** (beyond the base tools) — enforced by `scripts/dev-full/kind-runtime.sh check`:
+
+- A **rootful** container runtime, because KubeVirt chowns `/dev/kvm`:
+  - **Linux host** — rootful podman (invoked via `sudo`) or Docker
+  - **Linux + Distrobox** — the rootful podman host socket (`/run/podman/podman.sock`);
+    install the drop-in at `scripts/dev-full/manifests/podman-socket-rootful.conf`
+  - **macOS** — Docker Desktop (auto-detected)
+- **`/dev/kvm`** present (Linux), **`fs.inotify.max_user_instances >= 256`**, and
+  `kind`, `helm`, `kubectl`, `jq`, `curl`, `openssl`, `python3` on `PATH`
+- Override runtime detection with `KIND_EXPERIMENTAL_PROVIDER=docker|podman`
+
+**Endpoints** (via the kind port mappings; every `*.localhost` name resolves to
+127.0.0.1 automatically, so no `/etc/hosts` editing is needed):
+
+- OSAC UI — `http://ui.osac.localhost:8080`
+- AWX UI — `http://awx.awx.localhost:8080` (admin password:
+  `kubectl -n awx get secret awx-admin-password -o jsonpath='{.data.password}' | base64 -d`)
+- Keycloak — `https://keycloak.osac.localhost:8443`
+- OSAC API — `https://fulfillment-api.osac.localhost:8443` (TLS Passthrough, SNI via Envoy)
+
+**Log in** to the UI as `tenant1_user` (or `tenant1_admin`). The password is the
+Keycloak dev-fixtures `default-user-password`:
+`kubectl -n keycloak get secret keycloak-admin-credentials -o jsonpath='{.data.default-user-password}' | base64 -d`.
+Both users are members of the `tenant1` organization, so they can immediately create
+compute instances on the auto-provisioned default network.
+
+Tear down everything (including the kind cluster, via the same runtime wrapper):
+
+```bash
+make uninstall PLATFORM=kind PROFILE=dev-full NS=osac
+```
 
 #### Configure Values
 

--- a/osac-installer/charts/osac-devstack/Chart.yaml
+++ b/osac-installer/charts/osac-devstack/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: osac-devstack
+description: OSAC dev-full local development stack (KubeVirt, AWX, UI, seeded catalog)
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - osac
+  - development
+  - kubevirt
+  - awx
+maintainers:
+  - name: OSAC Team
+dependencies:
+  - name: awx-operator
+    version: "2.19.1"
+    repository: "https://ansible-community.github.io/awx-operator-helm/"
+    condition: awx.enabled

--- a/osac-installer/charts/osac-devstack/Containerfile.cli-tools
+++ b/osac-installer/charts/osac-devstack/Containerfile.cli-tools
@@ -1,0 +1,30 @@
+# Multi-arch CLI tools image for dev-full hook Jobs
+# Supports amd64, arm64, ppc64le, s390x
+#
+# Build and push:
+#   podman build --platform linux/amd64,linux/arm64 -t ghcr.io/osac-project/cli-tools:latest -f Containerfile.cli-tools .
+#   podman push ghcr.io/osac-project/cli-tools:latest
+
+FROM registry.k8s.io/kubectl:v1.32.1
+
+# Install required tools for dev-full hooks
+RUN apt-get update && apt-get install -y \
+    curl \
+    jq \
+    python3 \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install grpcurl (multi-arch)
+ARG TARGETARCH
+RUN curl -sL "https://github.com/fullstorydev/grpcurl/releases/download/v1.9.1/grpcurl_1.9.1_linux_${TARGETARCH}.tar.gz" \
+    | tar -xz -C /usr/local/bin grpcurl
+
+# Verify installations
+RUN kubectl version --client && \
+    curl --version && \
+    jq --version && \
+    python3 --version && \
+    grpcurl --version
+
+ENTRYPOINT ["/bin/bash"]

--- a/osac-installer/charts/osac-devstack/Makefile
+++ b/osac-installer/charts/osac-devstack/Makefile
@@ -1,0 +1,20 @@
+# OSAC devstack chart Makefile
+
+CLI_TOOLS_IMAGE ?= ghcr.io/osac-project/cli-tools:latest
+
+.PHONY: build-cli-tools
+build-cli-tools: ## Build multi-arch CLI tools image for dev-full hooks
+	podman build --platform linux/amd64,linux/arm64 \
+		-t $(CLI_TOOLS_IMAGE) \
+		-f Containerfile.cli-tools .
+
+.PHONY: push-cli-tools
+push-cli-tools: ## Push multi-arch CLI tools image
+	podman push $(CLI_TOOLS_IMAGE)
+
+.PHONY: build-push-cli-tools
+build-push-cli-tools: build-cli-tools push-cli-tools ## Build and push CLI tools image
+
+.PHONY: help
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/osac-installer/charts/osac-devstack/files/catalog-seed.yaml
+++ b/osac-installer/charts/osac-devstack/files/catalog-seed.yaml
@@ -1,0 +1,37 @@
+# Catalog seed data for dev-full
+# These resources are created via the private gRPC API by the seed-catalog Job
+
+diskImages:
+  - name: fedora
+    sourceType: SOURCE_TYPE_REGISTRY
+    sourceRef: quay.io/containerdisks/fedora:latest
+
+instanceTypes:
+  - name: u1-small
+    cores: 2
+    memoryGib: 4
+    description: "2 cores, 4 GiB RAM"
+  - name: u1-medium
+    cores: 4
+    memoryGib: 8
+    description: "4 cores, 8 GiB RAM"
+  - name: u1-large
+    cores: 8
+    memoryGib: 16
+    description: "8 cores, 16 GiB RAM"
+
+templates:
+  - id: osac.templates.ocp_virt_vm
+    title: "Virtual Machine Template (Linux and Windows)"
+    description: "KubeVirt-based VM template with configurable resources"
+    specDefaults:
+      bootDisk:
+        sizeGib: 10
+      runStrategy: Always
+
+catalogItems:
+  - name: linux-vm
+    title: "Linux Virtual Machine"
+    description: "Fedora-based VM with KVM acceleration"
+    templateId: osac.templates.ocp_virt_vm
+    published: true

--- a/osac-installer/charts/osac-devstack/files/configure-awx.sh
+++ b/osac-installer/charts/osac-devstack/files/configure-awx.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# dev-full: configure AWX as the AAP provisioning backend on Kind.
+#
+# AWX is installed as a Helm chart dependency (awx-operator). This script
+# configures the OAuth token, inventory, project, job templates and Kubernetes
+# credential that osac-operator needs.
+#
+# Requires KUBECONFIG to point at the kind cluster.
+#
+# Usage: configure-awx.sh [osac-namespace]
+
+set -euo pipefail
+
+NS="${1:-${NS:-osac}}"
+
+log()  { echo "[+] $*"; }
+warn() { echo "[!] $*" >&2; }
+
+configure_awx() {
+  log "Configuring AWX for OSAC..."
+
+  local admin_pass
+  admin_pass=$(kubectl -n "${NS}" get secret awx-admin-password -o jsonpath='{.data.password}' | base64 -d)
+
+  # Connect directly to AWX service (this script runs in-cluster as a Job pod)
+  local api="http://awx-service.${NS}.svc.cluster.local/api/v2"
+
+  # OAuth token.
+  local awx_token
+  awx_token=$(curl -s -X POST "${api}/tokens/" -u "admin:${admin_pass}" \
+    -H "Content-Type: application/json" -d '{"scope": "write"}' | \
+    python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))")
+  if [[ -z "$awx_token" ]]; then
+    warn "Failed to create AWX token — AWX may not be ready yet"
+    return 1
+  fi
+  log "AWX token created"
+
+  # Inventory (create or reuse).
+  local inv_id
+  inv_id=$(curl -s -X POST "${api}/inventories/" -H "Authorization: Bearer ${awx_token}" \
+    -H "Content-Type: application/json" -d '{"name": "OSAC Dev", "organization": 1}' | \
+    python3 -c "import json,sys; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || true)
+  if [[ -z "$inv_id" ]]; then
+    inv_id=$(curl -s -H "Authorization: Bearer ${awx_token}" "${api}/inventories/?name=OSAC+Dev" | \
+      python3 -c "import json,sys; d=json.load(sys.stdin); print(d['results'][0]['id'] if d.get('results') else '')")
+  fi
+  curl -s -X POST "${api}/inventories/${inv_id}/hosts/" -H "Authorization: Bearer ${awx_token}" \
+    -H "Content-Type: application/json" \
+    -d '{"name": "localhost", "variables": "ansible_connection: local"}' >/dev/null 2>&1 || true
+
+  # Disable collection/role sync and set ANSIBLE_JINJA2_NATIVE=true for osac-aap playbooks.
+  curl -s -X PATCH "${api}/settings/jobs/" -H "Authorization: Bearer ${awx_token}" \
+    -H "Content-Type: application/json" \
+    -d '{"AWX_COLLECTIONS_ENABLED": false, "AWX_ROLES_ENABLED": false, "AWX_TASK_ENV": {"ANSIBLE_JINJA2_NATIVE": "true"}}' >/dev/null
+
+  # Project from the osac mono-repo.
+  local project_id
+  project_id=$(curl -s -X POST "${api}/projects/" -H "Authorization: Bearer ${awx_token}" \
+    -H "Content-Type: application/json" -d '{
+      "name": "osac-aap", "organization": 1, "scm_type": "git",
+      "scm_url": "https://github.com/osac-project/osac.git",
+      "scm_branch": "main", "scm_update_on_launch": false
+    }' | python3 -c "import json,sys; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || true)
+  if [[ -z "$project_id" ]]; then
+    project_id=$(curl -s -H "Authorization: Bearer ${awx_token}" "${api}/projects/?name=osac-aap" | \
+      python3 -c "import json,sys; d=json.load(sys.stdin); print(d['results'][0]['id'] if d.get('results') else '')")
+    if [[ -n "$project_id" ]]; then
+      curl -s -X PATCH "${api}/projects/${project_id}/" -H "Authorization: Bearer ${awx_token}" \
+        -H "Content-Type: application/json" \
+        -d '{"scm_url": "https://github.com/osac-project/osac.git", "scm_branch": "main"}' >/dev/null
+      curl -s -X POST "${api}/projects/${project_id}/update/" -H "Authorization: Bearer ${awx_token}" >/dev/null
+    fi
+  fi
+
+  # Wait for project sync.
+  local i proj_status="unknown"
+  for i in $(seq 1 20); do
+    proj_status=$(curl -s -H "Authorization: Bearer ${awx_token}" "${api}/projects/${project_id}/" | \
+      python3 -c "import json,sys; print(json.load(sys.stdin).get('status','unknown'))" 2>/dev/null || echo unknown)
+    [[ "$proj_status" == "successful" || "$proj_status" == "failed" ]] && break
+    sleep 5
+  done
+  log "AWX project synced: ${proj_status}"
+
+  # Job templates (compute + networking).
+  local compute_extra_vars
+  compute_extra_vars="tenant_storage_classes:
+  - name: standard
+    tier: local"
+  local entry name playbook
+  for entry in \
+    "osac-create-compute-instance:osac-aap/playbook_osac_create_compute_instance.yml" \
+    "osac-delete-compute-instance:osac-aap/playbook_osac_delete_compute_instance.yml"; do
+    name="${entry%%:*}"; playbook="${entry##*:}"
+    curl -s -X POST "${api}/job_templates/" -H "Authorization: Bearer ${awx_token}" \
+      -H "Content-Type: application/json" -d "{
+        \"name\": \"${name}\", \"organization\": 1, \"inventory\": ${inv_id},
+        \"project\": ${project_id}, \"playbook\": \"${playbook}\",
+        \"ask_variables_on_launch\": true,
+        \"extra_vars\": $(echo "${compute_extra_vars}" | jq -Rs .)
+      }" >/dev/null
+    log "  template: ${name}"
+  done
+
+  for entry in \
+    "osac-create-virtual-network:osac-aap/playbook_osac_create_virtual_network.yml" \
+    "osac-delete-virtual-network:osac-aap/playbook_osac_delete_virtual_network.yml" \
+    "osac-create-subnet:osac-aap/playbook_osac_create_subnet.yml" \
+    "osac-delete-subnet:osac-aap/playbook_osac_delete_subnet.yml" \
+    "osac-create-security-group:osac-aap/playbook_osac_create_security_group.yml" \
+    "osac-delete-security-group:osac-aap/playbook_osac_delete_security_group.yml"; do
+    name="${entry%%:*}"; playbook="${entry##*:}"
+    curl -s -X POST "${api}/job_templates/" -H "Authorization: Bearer ${awx_token}" \
+      -H "Content-Type: application/json" -d "{
+        \"name\": \"${name}\", \"organization\": 1, \"inventory\": ${inv_id},
+        \"project\": ${project_id}, \"playbook\": \"${playbook}\",
+        \"ask_variables_on_launch\": true
+      }" >/dev/null
+    log "  template: ${name}"
+  done
+
+  # Kubernetes credential for job templates.
+  kubectl -n "${NS}" create serviceaccount awx-runner 2>/dev/null || true
+  kubectl create clusterrolebinding awx-runner-admin --clusterrole=cluster-admin \
+    --serviceaccount="${NS}:awx-runner" 2>/dev/null || true
+
+  local awx_runner_token cluster_ca cred_id
+  awx_runner_token=$(kubectl -n "${NS}" create token awx-runner --duration=87600h)
+  cluster_ca=$(kubectl config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | base64 -d)
+  cred_id=$(curl -s -X POST "${api}/credentials/" -H "Authorization: Bearer ${awx_token}" \
+    -H "Content-Type: application/json" -d "{
+      \"name\": \"kind-cluster\", \"organization\": 1, \"credential_type\": 17,
+      \"inputs\": {
+        \"host\": \"https://kubernetes.default.svc.cluster.local:443\",
+        \"bearer_token\": \"${awx_runner_token}\", \"verify_ssl\": true,
+        \"ssl_ca_cert\": $(echo "${cluster_ca}" | jq -Rs .)
+      }
+    }" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id',''))")
+
+  # Attach credential to all job templates.
+  local templates jt_id
+  templates=$(curl -s -H "Authorization: Bearer ${awx_token}" "${api}/job_templates/" | \
+    python3 -c "import json,sys; print(' '.join(str(t['id']) for t in json.load(sys.stdin)['results']))")
+  for jt_id in ${templates}; do
+    curl -s -X POST "${api}/job_templates/${jt_id}/credentials/" -H "Authorization: Bearer ${awx_token}" \
+      -H "Content-Type: application/json" -d "{\"id\": ${cred_id}}" >/dev/null
+  done
+  log "Credential ${cred_id} attached to all templates"
+
+  # Store AWX token as secret for osac-operator.
+  kubectl -n "${NS}" create secret generic awx-token \
+    --from-literal=token="${awx_token}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+  # Restart operator to pick up awx-token secret.
+  if kubectl -n "${NS}" get deployment osac-operator >/dev/null 2>&1; then
+    kubectl -n "${NS}" rollout restart deployment osac-operator
+    kubectl -n "${NS}" rollout status deployment osac-operator --timeout=3m || true
+    log "osac-operator restarted to pick up awx-token"
+  else
+    warn "osac-operator deployment not found in ${NS}; skipped restart"
+  fi
+
+  log "AWX configured for OSAC"
+}
+
+configure_awx

--- a/osac-installer/charts/osac-devstack/files/httproute-awx.yaml
+++ b/osac-installer/charts/osac-devstack/files/httproute-awx.yaml
@@ -1,0 +1,21 @@
+# HTTPRoute for the AWX web UI — accessible at http://awx.awx.localhost:8080
+# The HTTP listener on the shared Gateway is created by the osac-infra chart
+# (envoy-gateway-resources.yaml); dev-full only needs to route to AWX.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: awx-external
+  namespace: awx
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    namespace: envoy-gateway
+    name: default
+    sectionName: http
+  hostnames:
+  - awx.awx.localhost
+  rules:
+  - backendRefs:
+    - name: awx-service
+      port: 80

--- a/osac-installer/charts/osac-devstack/files/install-virt.sh
+++ b/osac-installer/charts/osac-devstack/files/install-virt.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# dev-full: install the virtualization stack on Kind — Multus CNI, KubeVirt, CDI.
+# Requires KUBECONFIG to point at the kind cluster (set by the Makefile).
+#
+# Usage: install-virt.sh <kind-cluster-name>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+# shellcheck source=./kind-runtime.sh
+source "${SCRIPT_DIR}/kind-runtime.sh"
+
+CLUSTER_NAME="${1:-${KIND_CLUSTER_NAME:-osac-dev}}"
+BRIDGE_CNI_VERSION="${BRIDGE_CNI_VERSION:-v1.6.2}"
+
+install_multus() {
+  log "Installing Multus CNI..."
+  kubectl apply -f https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/master/deployments/multus-daemonset.yml 2>&1 | tail -3
+  kubectl -n kube-system wait --for=condition=Ready pods -l app=multus --timeout=120s
+
+  log "Installing bridge CNI plugin into the kind node..."
+  local node_name="${CLUSTER_NAME}-control-plane"
+  container_cmd exec "${node_name}" bash -c \
+    "curl -sL https://github.com/containernetworking/plugins/releases/download/${BRIDGE_CNI_VERSION}/cni-plugins-linux-amd64-${BRIDGE_CNI_VERSION}.tgz | tar -C /opt/cni/bin -xz"
+  log "Multus installed"
+}
+
+install_kubevirt() {
+  log "Installing KubeVirt..."
+
+  # Remove fake KubeVirt CRDs (installed as controller stubs) — they conflict
+  # with the real operator's CRDs.
+  kubectl delete crd virtualmachines.kubevirt.io virtualmachineinstances.kubevirt.io 2>/dev/null || true
+
+  local version
+  version=$(curl -s https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt)
+  log "KubeVirt version: ${version}"
+
+  kubectl apply -f "https://github.com/kubevirt/kubevirt/releases/download/${version}/kubevirt-operator.yaml" 2>&1 | tail -3
+  kubectl wait --for=condition=available --timeout=120s -n kubevirt deployments -l kubevirt.io
+
+  kubectl apply -f "https://github.com/kubevirt/kubevirt/releases/download/${version}/kubevirt-cr.yaml"
+  kubectl -n kubevirt wait kv kubevirt --for condition=Available --timeout=300s
+
+  # Register the l2bridge network-binding plugin (replicates what HCO does on
+  # OpenShift). The osac-aap ocp_virt_vm role builds VM specs with
+  # "binding: name: l2bridge"; managedTap wires a tap device through a bridge to
+  # the pod interface.
+  log "Registering l2bridge network binding plugin..."
+  kubectl patch kubevirts -n kubevirt kubevirt --type=merge \
+    -p='{"spec":{"configuration":{"network":{"binding":{"l2bridge":{"domainAttachmentType":"managedTap"}}}}}}'
+
+  log "KubeVirt installed"
+}
+
+install_cdi() {
+  log "Installing CDI (Containerized Data Importer)..."
+
+  # Resolve the latest CDI tag via the GitHub "releases/latest" redirect rather
+  # than the REST API — the unauthenticated API is rate-limited (returns an error
+  # object with no 'tag_name'), while the redirect is not.
+  local version
+  version=$(basename "$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+    https://github.com/kubevirt/containerized-data-importer/releases/latest)")
+  if [[ -z "${version}" || "${version}" == "latest" ]]; then
+    err "Could not resolve latest CDI release tag from GitHub"
+    exit 1
+  fi
+  log "CDI version: ${version}"
+
+  kubectl apply -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${version}/cdi-operator.yaml" 2>&1 | tail -3
+  kubectl apply -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${version}/cdi-cr.yaml"
+  kubectl wait --for=condition=available --timeout=120s -n cdi deployments -l cdi.kubevirt.io
+
+  # local-path-provisioner deadlocks with WaitForFirstConsumer when CDI imports a
+  # disk (no consumer pod exists yet to trigger provisioning). Dropping the
+  # feature gate lets CDI create the importer pod immediately.
+  kubectl patch cdi cdi --type=json \
+    -p '[{"op":"replace","path":"/spec/config/featureGates","value":["WebhookPvcRendering"]}]'
+
+  log "CDI installed"
+}
+
+install_multus
+install_kubevirt
+install_cdi
+log "Virtualization stack ready (Multus + KubeVirt + CDI)"

--- a/osac-installer/charts/osac-devstack/files/provision-tenant.sh
+++ b/osac-installer/charts/osac-devstack/files/provision-tenant.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# dev-full: provision a ready-to-use tenant so the browser "create a VM" flow works.
+#
+# Why this exists (the chain of facts that makes it necessary):
+#   - Networking resources (VirtualNetwork/Subnet/SecurityGroup) cannot live in the
+#     reserved 'shared'/'system' tenants, so a real tenant is required.
+#   - A regular user's tenant is derived from the Keycloak *organization* claim
+#     (groups map to tenants only for service accounts). With no organization the
+#     claim is empty and the API returns "failed to determine assignable tenants".
+#   - JIT provisioning creates the *user record* on first authenticated call, but it
+#     requires the DB tenant to already exist ("tenant '<t>' doesn't exist" otherwise).
+#   - The Tenants API is gRPC-only (not exposed over REST), so the DB tenant is
+#     created with a throwaway in-cluster grpcurl pod running as the 'admin'
+#     ServiceAccount (same admin identity seed-catalog.sh uses). This keeps the host
+#     dependency-free: only kubectl is needed, no host grpcurl.
+#
+# What this does (all idempotent -- safe to re-run):
+#   1. Create the DB tenant via the private gRPC Tenants API. Creating the tenant
+#      auto-provisions its default VirtualNetwork + Subnet + SecurityGroup (tenant
+#      onboarding), so no network seeding is needed here.
+#   2. Create a matching, enabled Keycloak organization.
+#   3. Add the dev users (default tenant1_user, tenant1_admin) as organization
+#      members so their tokens carry the organization claim and they can log in to
+#      the UI and manage resources in the tenant.
+#
+# Requires KUBECONFIG to point at the kind cluster (set by the Makefile).
+#
+# Usage: provision-tenant.sh [osac-namespace]
+#   Env overrides: TENANT, TENANT_USERS (comma-separated), KC_NS, KC_REALM,
+#                  INTERNAL_SVC, INTERNAL_PORT, GRPCURL_IMAGE
+
+set -euo pipefail
+
+NS="${1:-${NS:-osac}}"
+TENANT="${TENANT:-tenant1}"
+TENANT_USERS="${TENANT_USERS:-tenant1_user,tenant1_admin}"
+KC_NS="${KC_NS:-keycloak}"
+KC_REALM="${KC_REALM:-osac}"
+INTERNAL_SVC="${INTERNAL_SVC:-fulfillment-internal-api}"
+INTERNAL_PORT="${INTERNAL_PORT:-8001}"
+GRPCURL_IMAGE="${GRPCURL_IMAGE:-docker.io/fullstorydev/grpcurl:latest}"
+
+log()  { echo "[+] $*"; }
+warn() { echo "[!] $*" >&2; }
+
+log "Provisioning tenant '${TENANT}' in namespace '${NS}'..."
+
+# ── 1. Create the DB tenant via the private gRPC Tenants API ────────────────────
+# Tenants is gRPC-only. Run grpcurl in-cluster as the 'admin' SA (an emergency
+# service account) so no host grpcurl is required. The admin token is minted
+# host-side and passed as a request header argument; -insecure skips TLS verify
+# against the internal CA. AlreadyExists is treated as success (re-run friendly).
+admin_token=$(kubectl -n "${NS}" create token admin)
+pod="osac-provision-tenant-$$"
+kubectl -n "${NS}" delete pod "${pod}" --ignore-not-found >/dev/null 2>&1 || true
+kubectl -n "${NS}" run "${pod}" --restart=Never --image="${GRPCURL_IMAGE}" \
+  --command -- grpcurl -insecure \
+    -H "authorization: Bearer ${admin_token}" \
+    -d "{\"object\":{\"metadata\":{\"name\":\"${TENANT}\"}}}" \
+    "${INTERNAL_SVC}:${INTERNAL_PORT}" osac.private.v1.Tenants/Create >/dev/null
+
+# Wait for the one-shot pod to finish (Succeeded or Failed), then read its output.
+phase=""
+for _ in $(seq 1 60); do
+  phase=$(kubectl -n "${NS}" get pod "${pod}" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+  [[ "${phase}" == "Succeeded" || "${phase}" == "Failed" ]] && break
+  sleep 2
+done
+out=$(kubectl -n "${NS}" logs "${pod}" 2>/dev/null || true)
+kubectl -n "${NS}" delete pod "${pod}" --ignore-not-found >/dev/null 2>&1 || true
+
+if [[ "${phase}" == "Succeeded" ]]; then
+  log "  tenant '${TENANT}' created (default network auto-provisioned)"
+elif echo "${out}" | grep -qi "AlreadyExists"; then
+  log "  tenant '${TENANT}' already exists"
+else
+  warn "  tenant create did not succeed (phase=${phase:-unknown}):"
+  echo "${out}" | sed 's/^/      /' >&2
+  exit 1
+fi
+
+# ── 1b. Create the subnet target namespace(s) ───────────────────────────────────
+# Each Subnet gets its own k8s namespace named after the Subnet CR: the osac-operator
+# ComputeInstance controller creates/looks for the KubeVirt VM in that
+# subnet-target namespace (osac.openshift.io/subnet-target-namespace annotation),
+# NOT in the tenant namespace. In a real environment that namespace is created by
+# subnet provisioning (the cudn_net role, which also builds the OVN CUDN). On kind
+# networkingProvisioning=false makes subnets reconcile to Ready without any AAP
+# dispatch, so nothing creates the namespace and the VM would have nowhere to live
+# (the CI would hang at Provisioned=False/WaitingForVM). kind VMs use the default
+# pod network + cluster-wide l2bridge binding — no per-namespace CUDN/NAD — so a
+# plain namespace is all that's needed. Create one per onboarded subnet (idempotent).
+#
+# Subnets are scoped to a tenant by the osac.openshift.io/tenant annotation (not a
+# label), and onboarding creates them asynchronously, so poll for the tenant's
+# subnet(s) to appear before creating their namespaces.
+subnets_for_tenant() {
+  kubectl -n "${NS}" get subnets -o json 2>/dev/null | python3 -c "
+import json,sys
+for s in json.load(sys.stdin).get('items', []):
+    if s.get('metadata', {}).get('annotations', {}).get('osac.openshift.io/tenant') == '${TENANT}':
+        print(s['metadata']['name'])
+" 2>/dev/null || true
+}
+onboarded_subnets=""
+for _ in $(seq 1 30); do
+  onboarded_subnets=$(subnets_for_tenant)
+  [[ -n "${onboarded_subnets}" ]] && break
+  sleep 2
+done
+if [[ -z "${onboarded_subnets}" ]]; then
+  warn "  no subnet found for tenant '${TENANT}' yet — VM provisioning will hang until its subnet namespace exists"
+else
+  for sn in ${onboarded_subnets}; do
+    kubectl create namespace "${sn}" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+    log "  subnet target namespace ready: ${sn}"
+  done
+fi
+
+# ── 2 & 3. Keycloak organization + membership ───────────────────────────────────
+# Port-forward Keycloak and drive its admin API to create an enabled organization
+# matching the tenant and add the dev users as members.
+admin_pw=$(kubectl -n "${KC_NS}" get secret keycloak-admin-credentials \
+  -o jsonpath='{.data.admin-password}' | base64 -d)
+
+kubectl -n "${KC_NS}" port-forward svc/keycloak 18443:443 >/dev/null 2>&1 &
+pf_pid=$!
+trap 'kill "${pf_pid}" 2>/dev/null || true; wait "${pf_pid}" 2>/dev/null || true' EXIT
+sleep 3
+
+KC="https://localhost:18443"
+kc_token=$(curl -sk -X POST "${KC}/realms/master/protocol/openid-connect/token" \
+  -d client_id=admin-cli -d username=admin -d "password=${admin_pw}" \
+  -d grant_type=password \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['access_token'])")
+
+KCURL=(curl -skS -H "Authorization: Bearer ${kc_token}" -H "Content-Type: application/json")
+
+# find_org_id <name> — prints the organization id, or '' if absent.
+find_org_id() {
+  "${KCURL[@]}" "${KC}/admin/realms/${KC_REALM}/organizations?exact=true&search=$1" \
+    | python3 -c "import json,sys; print(next((o['id'] for o in json.load(sys.stdin) if o.get('name')=='$1'), ''))" 2>/dev/null || true
+}
+
+# Create the organization (idempotent: 201 created, 409 already exists both OK).
+code=$("${KCURL[@]}" -o /dev/null -w "%{http_code}" \
+  -X POST "${KC}/admin/realms/${KC_REALM}/organizations" \
+  -d "{\"name\":\"${TENANT}\",\"alias\":\"${TENANT}\",\"enabled\":true,\"domains\":[{\"name\":\"${TENANT}.localhost\",\"verified\":true}]}")
+case "${code}" in
+  201) log "  organization '${TENANT}' created" ;;
+  409) log "  organization '${TENANT}' already exists" ;;
+  *)   warn "  organization create returned HTTP ${code}" ;;
+esac
+
+org_id=$(find_org_id "${TENANT}")
+if [[ -z "${org_id}" ]]; then
+  warn "  could not resolve organization id for '${TENANT}' — skipping membership"
+  exit 1
+fi
+
+# Add each dev user as an organization member (idempotent).
+IFS=',' read -ra users <<< "${TENANT_USERS}"
+for u in "${users[@]}"; do
+  u="${u// /}"
+  [[ -z "${u}" ]] && continue
+  uid=$("${KCURL[@]}" "${KC}/admin/realms/${KC_REALM}/users?username=${u}&exact=true" \
+    | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0]['id'] if d else '')" 2>/dev/null || true)
+  if [[ -z "${uid}" ]]; then
+    warn "    user '${u}' not found — skipping"
+    continue
+  fi
+  code=$("${KCURL[@]}" -o /dev/null -w "%{http_code}" \
+    -X POST "${KC}/admin/realms/${KC_REALM}/organizations/${org_id}/members" -d "\"${uid}\"")
+  case "${code}" in
+    201) log "    member added: ${u}" ;;
+    409) log "    member already present: ${u}" ;;
+    *)   warn "    adding member '${u}' returned HTTP ${code}" ;;
+  esac
+done
+
+log "Tenant '${TENANT}' ready — log in as one of: ${TENANT_USERS} (password: keycloak default-user-password)"

--- a/osac-installer/charts/osac-devstack/files/seed-catalog-simple.sh
+++ b/osac-installer/charts/osac-devstack/files/seed-catalog-simple.sh
@@ -26,7 +26,7 @@ log "Seeding catalog into '${NS}'..."
 # Disk images
 log "Creating disk images..."
 grpc_call "osac.private.v1.DiskImages/Create" \
-  '{"object":{"metadata":{"name":"fedora"},"spec":{"sourceType":"SOURCE_TYPE_REGISTRY","sourceRef":"quay.io/containerdisks/fedora:latest"}}}' \
+  '{"object":{"metadata":{"name":"fedora"},"spec":{"sourceType":"SOURCE_TYPE_REGISTRY","sourceRef":"quay.io/containerdisks/fedora:latest","architecture":["amd64","arm64"]}}}' \
   >/dev/null 2>&1 || log "  disk-image: fedora (already exists)"
 log "  disk-image: fedora"
 

--- a/osac-installer/charts/osac-devstack/files/seed-catalog-simple.sh
+++ b/osac-installer/charts/osac-devstack/files/seed-catalog-simple.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Seed the OSAC catalog via the private gRPC API
+#
+# Creates disk images, instance types, templates, and catalog items for dev-full.
+# Values are hardcoded from catalog-seed.yaml for simplicity.
+#
+# Usage: seed-catalog-simple.sh <internal-api-service> <internal-api-port>
+
+set -euo pipefail
+
+SERVICE="${1:-fulfillment-internal-api}"
+PORT="${2:-8001}"
+NS="${NS:-osac}"
+
+log() { echo "[+] $*"; }
+
+# Helper: gRPC call via grpcurl
+grpc_call() {
+  local method="$1"
+  local data="$2"
+  grpcurl -plaintext -d "${data}" "${SERVICE}.${NS}.svc.cluster.local:${PORT}" "${method}"
+}
+
+log "Seeding catalog into '${NS}'..."
+
+# Disk images
+log "Creating disk images..."
+grpc_call "osac.private.v1.DiskImages/Create" \
+  '{"object":{"metadata":{"name":"fedora"},"spec":{"sourceType":"SOURCE_TYPE_REGISTRY","sourceRef":"quay.io/containerdisks/fedora:latest"}}}' \
+  >/dev/null 2>&1 || log "  disk-image: fedora (already exists)"
+log "  disk-image: fedora"
+
+# Instance types
+log "Creating instance types..."
+for it in \
+  "u1-small:2:4:2 cores, 4 GiB RAM" \
+  "u1-medium:4:8:4 cores, 8 GiB RAM" \
+  "u1-large:8:16:8 cores, 16 GiB RAM"; do
+  IFS=: read -r name cores memGib desc <<<"$it"
+  grpc_call "osac.private.v1.ComputeInstanceTypes/Create" \
+    "{\"object\":{\"metadata\":{\"name\":\"${name}\"},\"spec\":{\"cores\":${cores},\"memoryGib\":${memGib},\"description\":\"${desc}\"}}}" \
+    >/dev/null 2>&1 || log "  instance-type: ${name} (already exists)"
+  log "  instance-type: ${name} (${cores} cores, ${memGib} GiB RAM)"
+done
+
+# Templates
+log "Creating templates..."
+grpc_call "osac.private.v1.ComputeInstanceTemplates/Create" \
+  '{"object":{"metadata":{"name":"osac.templates.ocp_virt_vm"},"spec":{"title":"Virtual Machine Template (Linux and Windows)"}}}' \
+  >/dev/null 2>&1 || log "  template: osac.templates.ocp_virt_vm (already exists)"
+log "  template: osac.templates.ocp_virt_vm"
+
+# Catalog items
+log "Creating catalog items..."
+grpc_call "osac.private.v1.CatalogItems/Create" \
+  '{"object":{"metadata":{"name":"linux-vm"},"spec":{"title":"Linux Virtual Machine","description":"Fedora-based VM with KVM acceleration","templateId":"osac.templates.ocp_virt_vm","published":true}}}' \
+  >/dev/null 2>&1 || log "  catalog-item: linux-vm (already exists)"
+log "  catalog-item: linux-vm"
+
+log "Catalog seeded — ready to create compute instances"

--- a/osac-installer/charts/osac-devstack/files/seed-catalog.sh
+++ b/osac-installer/charts/osac-devstack/files/seed-catalog.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# dev-full: seed a starter catalog (disk image, instance types, template, catalog
+# item) into fulfillment-service. These are shared/global catalog objects.
+#
+# Uses the private REST API (/api/private/v1/...) exposed on the internal API
+# service (TLS, port 8001), reached via a local port-forward. Auth is the 'admin'
+# ServiceAccount bearer token. Payloads follow the CURRENT proto schema — notably:
+#   - ComputeInstanceTemplate.spec_defaults references an instance_type + disk_image
+#     (the old inline cores/memory/image fields were removed)
+#   - CatalogItem.template is a reference object ({id}), not a bare string
+# The default NetworkClass is created by the chart's create-network-class hook
+# (networkClass.enabled=true). Per-tenant networking (VirtualNetwork/Subnet/
+# SecurityGroup) is auto-provisioned by tenant onboarding (see provision-tenant.sh),
+# so it is NOT seeded here.
+#
+# Requires KUBECONFIG to point at the kind cluster (set by the Makefile).
+#
+# Usage: seed-catalog.sh [osac-namespace]
+
+set -euo pipefail
+
+NS="${1:-${NS:-osac}}"
+INTERNAL_SVC="${INTERNAL_SVC:-fulfillment-internal-api}"
+INTERNAL_PORT="${INTERNAL_PORT:-8001}"
+LOCAL_PORT="${LOCAL_PORT:-8001}"
+
+log()  { echo "[+] $*"; }
+warn() { echo "[!] $*" >&2; }
+
+# has_id <json> — succeeds if the response body carries an "id".
+has_id() { python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if 'id' in d else 1)" 2>/dev/null; }
+# get <json> <key-path> — python-style .get chain, prints '' on miss.
+jget() { python3 -c "import json,sys; d=json.load(sys.stdin); print(${1})" 2>/dev/null || true; }
+
+log "Seeding catalog into '${NS}' via ${INTERNAL_SVC}:${INTERNAL_PORT}..."
+
+admin_token=$(kubectl -n "${NS}" create token admin)
+
+# Port-forward the internal API.
+kubectl -n "${NS}" port-forward "svc/${INTERNAL_SVC}" "${LOCAL_PORT}:${INTERNAL_PORT}" >/dev/null 2>&1 &
+pf_pid=$!
+trap 'kill "${pf_pid}" 2>/dev/null || true; wait "${pf_pid}" 2>/dev/null || true' EXIT
+sleep 3
+
+API="https://localhost:${LOCAL_PORT}/api/private/v1"
+CURL=(curl -skS -H "Authorization: Bearer ${admin_token}" -H "Content-Type: application/json")
+
+post() {  # post <path> <json-body>  -> prints response body
+  "${CURL[@]}" -X POST "${API}/$1" -d "$2"
+}
+
+# ── DiskImage ─────────────────────────────────────────────────────────────────
+resp=$(post disk_images '{
+  "metadata": {"name": "fedora", "tenant": "shared"},
+  "spec": {
+    "source_type": "SOURCE_TYPE_REGISTRY",
+    "source_ref": "quay.io/containerdisks/fedora:latest",
+    "guest_os_family": "GUEST_OS_FAMILY_LINUX",
+    "architecture": ["ARCHITECTURE_AMD64"],
+    "lifecycle": "DISK_IMAGE_LIFECYCLE_AVAILABLE"
+  }
+}')
+echo "$resp" | has_id && log "  disk-image: fedora" || warn "  disk-image fedora failed (may already exist)"
+
+# ── InstanceTypes ─────────────────────────────────────────────────────────────
+# name:cores:memory_gib:description
+for entry in \
+  "u1-small:2:4:2 cores, 4 GiB RAM" \
+  "u1-medium:4:8:4 cores, 8 GiB RAM" \
+  "u1-large:8:16:8 cores, 16 GiB RAM"; do
+  it_name="${entry%%:*}"; rest="${entry#*:}"
+  it_cores="${rest%%:*}"; rest="${rest#*:}"
+  it_mem="${rest%%:*}"; it_desc="${rest#*:}"
+  resp=$(post instance_types "{
+    \"metadata\": {\"name\": \"${it_name}\"},
+    \"spec\": {\"cores\": ${it_cores}, \"memory_gib\": ${it_mem}, \"description\": \"${it_desc}\", \"state\": \"INSTANCE_TYPE_STATE_ACTIVE\"}
+  }")
+  echo "$resp" | has_id && log "  instance-type: ${it_name} (${it_desc})" || warn "  instance-type ${it_name} failed (may already exist)"
+done
+
+# ── ComputeInstanceTemplate ───────────────────────────────────────────────────
+# spec_defaults now references an instance_type + disk_image (inline cores/memory/
+# image were removed from the schema).
+resp=$(post compute_instance_templates '{
+  "id": "osac.templates.ocp_virt_vm",
+  "title": "Virtual Machine Template (Linux and Windows)",
+  "description": "VM template for OpenShift Virtualization supporting Linux and Windows guests.",
+  "spec_defaults": {
+    "boot_disk": {"size_gib": 10},
+    "run_strategy": "Always",
+    "instance_type": {"name": "u1-medium"},
+    "disk_image": {"name": "fedora"}
+  },
+  "parameters": [
+    {
+      "name": "exposed_ports",
+      "title": "Exposed Ports",
+      "description": "Ports to expose (e.g. 22/tcp,80/tcp)",
+      "type": "string",
+      "required": false
+    }
+  ]
+}')
+echo "$resp" | has_id && log "  template: osac.templates.ocp_virt_vm" || warn "  template failed (may already exist)"
+
+# ── CatalogItem ───────────────────────────────────────────────────────────────
+# template is now a reference object, not a bare string.
+resp=$(post compute_instance_catalog_items '{
+  "metadata": {"name": "linux-vm"},
+  "title": "Linux Virtual Machine",
+  "description": "Fedora-based virtual machine with KVM acceleration. Default: 4 cores, 8 GiB RAM, 10 GiB disk.",
+  "template": {"id": "osac.templates.ocp_virt_vm"},
+  "published": true,
+  "tenant": ""
+}')
+echo "$resp" | has_id && log "  catalog-item: linux-vm" || warn "  catalog-item failed (may already exist)"
+
+# ── Networking is NOT seeded here ──────────────────────────────────────────────
+# The default VirtualNetwork + Subnet + SecurityGroup are auto-provisioned per
+# tenant by tenant onboarding when the tenant is created (see provision-tenant.sh),
+# using the default NetworkClass onboarding defaults. Seeding them here would place
+# them in the reserved 'shared' tenant, which the API rejects. The NetworkClass
+# itself is created by the chart's create-network-class hook (networkClass.enabled).
+
+log "Catalog seeded — ready to create compute instances"

--- a/osac-installer/charts/osac-devstack/templates/NOTES.txt
+++ b/osac-installer/charts/osac-devstack/templates/NOTES.txt
@@ -1,0 +1,65 @@
+OSAC dev-full development stack has been installed.
+
+Components deployed:
+  - KubeVirt + CDI + Multus (virtualization stack)
+  - AWX (provisioning backend)
+  - OSAC UI (web console)
+  - Seeded catalog (disk images, templates, instance types)
+  - Tenant: {{ .Values.tenant.name }}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🌐 WEB UI ACCESS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+OSAC UI:     http://ui.osac.localhost:8080
+AWX Web UI:  http://awx.awx.localhost:8080
+
+Login credentials:
+  Username: {{ .Values.tenant.users | replace "," " or " }}
+  Password: (run this command)
+    kubectl -n {{ .Values.tenant.keycloak.namespace }} get secret keycloak-admin-credentials \
+      -o jsonpath='{.data.default-user-password}' | base64 -d && echo
+
+Next steps:
+  1. Open http://ui.osac.localhost:8080
+  2. Click "Sign in" → authenticate via Keycloak
+  3. Browse the catalog and create a virtual machine
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🔧 CLI ACCESS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. Extract the CA bundle:
+   kubectl -n {{ .Values.osacNamespace }} get configmap ca-bundle \
+     -o jsonpath='{.data.ca-bundle\.crt}' > /tmp/osac-ca-bundle.pem
+
+2. Get the admin client secret:
+   OSAC_ADMIN_SECRET=$(kubectl -n {{ .Values.tenant.keycloak.namespace }} get secret keycloak-clients \
+     -o jsonpath='{.data.osac-admin}' | base64 -d)
+
+3. Login with the osac CLI:
+   osac login --ca-file /tmp/osac-ca-bundle.pem \
+     --flow credentials \
+     --client-id osac-admin \
+     --client-secret "${OSAC_ADMIN_SECRET}" \
+     --private \
+     https://fulfillment-api.osac.localhost:8443
+
+4. Verify access:
+   osac get clusters
+   osac get compute-instances
+
+For more CLI commands, see: osac --help
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+📊 STATUS CHECKS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Check component status:
+  kubectl -n {{ .Values.osacNamespace }} get pods        # OSAC + UI + AWX
+  kubectl -n kubevirt get kubevirt                       # KubeVirt
+
+Check seeded resources:
+  osac get disk-images
+  osac get instance-types
+  osac get catalog-items

--- a/osac-installer/charts/osac-devstack/templates/_helpers.tpl
+++ b/osac-installer/charts/osac-devstack/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "osac-devstack.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "osac-devstack.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "osac-devstack.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "osac-devstack.labels" -}}
+helm.sh/chart: {{ include "osac-devstack.chart" . }}
+{{ include "osac-devstack.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "osac-devstack.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "osac-devstack.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "osac-devstack.serviceAccountName" -}}
+{{- if .Values.rbac.create }}
+{{- default (include "osac-devstack.fullname" .) .Values.rbac.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.rbac.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/osac-installer/charts/osac-devstack/templates/awx-instance.yaml
+++ b/osac-installer/charts/osac-devstack/templates/awx-instance.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.awx.enabled }}
+---
+apiVersion: awx.ansible.com/v1beta1
+kind: AWX
+metadata:
+  name: {{ .Values.awx.instance.name }}
+  namespace: {{ .Values.osacNamespace }}
+  labels:
+    {{- include "osac-devstack.labels" . | nindent 4 }}
+spec:
+  service_type: {{ .Values.awx.instance.serviceType }}
+  postgres_storage_class: {{ .Values.awx.instance.postgresStorageClass }}
+  projects_persistence: {{ .Values.awx.instance.projectsPersistence }}
+  postgres_resource_requirements:
+    requests:
+      cpu: {{ .Values.awx.instance.resources.postgres.requests.cpu | quote }}
+      memory: {{ .Values.awx.instance.resources.postgres.requests.memory | quote }}
+    limits:
+      cpu: {{ .Values.awx.instance.resources.postgres.limits.cpu | quote }}
+      memory: {{ .Values.awx.instance.resources.postgres.limits.memory | quote }}
+  web_resource_requirements:
+    requests:
+      cpu: {{ .Values.awx.instance.resources.web.requests.cpu | quote }}
+      memory: {{ .Values.awx.instance.resources.web.requests.memory | quote }}
+    limits:
+      cpu: {{ .Values.awx.instance.resources.web.limits.cpu | quote }}
+      memory: {{ .Values.awx.instance.resources.web.limits.memory | quote }}
+  task_resource_requirements:
+    requests:
+      cpu: {{ .Values.awx.instance.resources.task.requests.cpu | quote }}
+      memory: {{ .Values.awx.instance.resources.task.requests.memory | quote }}
+    limits:
+      cpu: {{ .Values.awx.instance.resources.task.limits.cpu | quote }}
+      memory: {{ .Values.awx.instance.resources.task.limits.memory | quote }}
+  ee_resource_requirements:
+    requests:
+      cpu: {{ .Values.awx.instance.resources.ee.requests.cpu | quote }}
+      memory: {{ .Values.awx.instance.resources.ee.requests.memory | quote }}
+    limits:
+      cpu: {{ .Values.awx.instance.resources.ee.limits.cpu | quote }}
+      memory: {{ .Values.awx.instance.resources.ee.limits.memory | quote }}
+---
+# HTTPRoute for AWX web UI
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: awx-external
+  namespace: {{ .Values.osacNamespace }}
+  labels:
+    {{- include "osac-devstack.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    namespace: envoy-gateway
+    name: default
+    sectionName: http
+  hostnames:
+  - awx.awx.localhost
+  rules:
+  - backendRefs:
+    - name: awx-service
+      port: 80
+{{- end }}

--- a/osac-installer/charts/osac-devstack/templates/catalog-seed-configmap.yaml
+++ b/osac-installer/charts/osac-devstack/templates/catalog-seed-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.catalog.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "osac-devstack.fullname" . }}-catalog-seed
+  namespace: {{ .Values.osacNamespace }}
+  labels:
+    {{- include "osac-devstack.labels" . | nindent 4 }}
+data:
+  catalog-seed.yaml: |
+{{ .Files.Get "files/catalog-seed.yaml" | indent 4 }}
+{{- end }}

--- a/osac-installer/charts/osac-devstack/templates/hooks/configure-awx.yaml
+++ b/osac-installer/charts/osac-devstack/templates/hooks/configure-awx.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.awx.enabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "osac-devstack.fullname" . }}-configure-awx
+  namespace: {{ .Values.osacNamespace }}
+  labels:
+    {{- include "osac-devstack.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "15"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "osac-devstack.selectorLabels" . | nindent 8 }}
+        job: configure-awx
+    spec:
+      serviceAccountName: {{ include "osac-devstack.serviceAccountName" . }}
+      restartPolicy: OnFailure
+      initContainers:
+      - name: wait-awx-ready
+        image: {{ .Values.cliImage }}
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -euo pipefail
+            echo "Waiting for AWX pods to be ready..."
+            for i in $(seq 1 60); do
+              task_ready=$(kubectl -n {{ .Values.osacNamespace }} get pods \
+                -l app.kubernetes.io/name=awx-task --no-headers 2>/dev/null | grep -c "4/4" || true)
+              if [[ "$task_ready" -ge 1 ]]; then
+                echo "AWX pods ready"
+                exit 0
+              fi
+              sleep 10
+            done
+            echo "Timeout waiting for AWX pods"
+            exit 1
+      containers:
+      - name: configure-awx
+        image: {{ .Values.cliImage }}
+        command: ["/bin/bash", "/scripts/configure-awx.sh"]
+        args: ["{{ .Values.osacNamespace }}"]
+        env:
+        - name: NS
+          value: {{ .Values.osacNamespace | quote }}
+        volumeMounts:
+        - name: scripts
+          mountPath: /scripts
+        - name: manifests
+          mountPath: /manifests
+      volumes:
+      - name: scripts
+        configMap:
+          name: {{ include "osac-devstack.fullname" . }}-scripts
+          defaultMode: 0755
+      - name: manifests
+        configMap:
+          name: {{ include "osac-devstack.fullname" . }}-manifests
+{{- end }}

--- a/osac-installer/charts/osac-devstack/templates/hooks/install-virt.yaml
+++ b/osac-installer/charts/osac-devstack/templates/hooks/install-virt.yaml
@@ -1,0 +1,95 @@
+{{- if .Values.virt.enabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "osac-devstack.fullname" . }}-install-virt
+  namespace: {{ .Values.osacNamespace }}
+  labels:
+    {{- include "osac-devstack.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "osac-devstack.selectorLabels" . | nindent 8 }}
+        job: install-virt
+    spec:
+      serviceAccountName: {{ include "osac-devstack.serviceAccountName" . }}
+      restartPolicy: OnFailure
+      containers:
+      - name: install-multus
+        image: {{ .Values.cliImage }}
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -euo pipefail
+            echo "Installing Multus CNI..."
+            kubectl apply -f https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/{{ .Values.virt.multusVersion }}/deployments/multus-daemonset.yml
+            kubectl -n kube-system wait --for=condition=Ready pods -l app=multus --timeout=120s || true
+            echo "Multus installed"
+      - name: install-kubevirt
+        image: {{ .Values.cliImage }}
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -euo pipefail
+            echo "Installing KubeVirt..."
+
+            # Delete conflicting CRDs created by osac-infra fake CRDs
+            kubectl delete crd virtualmachines.kubevirt.io virtualmachineinstances.kubevirt.io 2>/dev/null || true
+
+            # Determine version
+            {{- if .Values.virt.kubevirtVersion }}
+            version="{{ .Values.virt.kubevirtVersion }}"
+            {{- else }}
+            version=$(curl -s https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt)
+            {{- end }}
+
+            echo "KubeVirt version: $version"
+
+            # Install operator
+            kubectl apply -f "https://github.com/kubevirt/kubevirt/releases/download/${version}/kubevirt-operator.yaml"
+            kubectl wait --for=condition=available --timeout=120s -n kubevirt deployments -l kubevirt.io || true
+
+            # Create KubeVirt CR
+            kubectl apply -f "https://github.com/kubevirt/kubevirt/releases/download/${version}/kubevirt-cr.yaml"
+            kubectl -n kubevirt wait kv kubevirt --for condition=Available --timeout=300s || true
+
+            # Register l2bridge network binding plugin
+            kubectl patch kubevirts -n kubevirt kubevirt --type=merge \
+              -p='{"spec":{"configuration":{"network":{"binding":{"l2bridge":{"domainAttachmentType":"managedTap"}}}}}}'
+
+            echo "KubeVirt installed"
+      - name: install-cdi
+        image: {{ .Values.cliImage }}
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -euo pipefail
+            echo "Installing CDI (Containerized Data Importer)..."
+
+            # Determine version
+            {{- if .Values.virt.cdiVersion }}
+            version="{{ .Values.virt.cdiVersion }}"
+            {{- else }}
+            version=$(basename "$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+              https://github.com/kubevirt/containerized-data-importer/releases/latest)")
+            {{- end }}
+
+            echo "CDI version: $version"
+
+            # Install operator
+            kubectl apply -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${version}/cdi-operator.yaml"
+            kubectl apply -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${version}/cdi-cr.yaml"
+            kubectl wait --for=condition=available --timeout=120s -n cdi deployments -l cdi.kubevirt.io || true
+
+            # Patch feature gates to drop HonorWaitForFirstConsumer
+            kubectl patch cdi cdi --type=json \
+              -p '[{"op":"replace","path":"/spec/config/featureGates","value":["WebhookPvcRendering"]}]' || true
+
+            echo "CDI installed"
+{{- end }}

--- a/osac-installer/charts/osac-devstack/templates/hooks/patch-awx-operator.yaml
+++ b/osac-installer/charts/osac-devstack/templates/hooks/patch-awx-operator.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.awx.enabled }}
+---
+# Regular Job (not a hook) to patch AWX operator kube-rbac-proxy image
+# The upstream awx-operator chart v2.19.1 references a non-existent gcr.io image.
+# This Job runs immediately as part of chart installation, not as a post-install hook,
+# so it can patch the deployment before Helm --wait checks pod readiness.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "osac-devstack.fullname" . }}-patch-awx-operator
+  namespace: {{ .Values.osacNamespace }}
+  labels:
+    {{- include "osac-devstack.labels" . | nindent 4 }}
+    job: patch-awx-operator
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "osac-devstack.selectorLabels" . | nindent 8 }}
+        job: patch-awx-operator
+    spec:
+      serviceAccountName: {{ include "osac-devstack.serviceAccountName" . }}
+      restartPolicy: OnFailure
+      containers:
+      - name: patch-awx-operator
+        image: {{ .Values.cliImage }}
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -euo pipefail
+            echo "Waiting for AWX operator deployment to exist..."
+            for i in $(seq 1 30); do
+              if kubectl -n {{ .Values.osacNamespace }} get deployment awx-operator-controller-manager >/dev/null 2>&1; then
+                echo "Deployment found"
+                break
+              fi
+              sleep 2
+            done
+
+            echo "Patching kube-rbac-proxy image to official ghcr.io location..."
+            kubectl -n {{ .Values.osacNamespace }} patch deployment awx-operator-controller-manager \
+              --type=json -p='[{
+                "op":"replace",
+                "path":"/spec/template/spec/containers/0/image",
+                "value":"ghcr.io/kube-rbac-proxy/kube-rbac-proxy:v0.22.1"
+              }]'
+
+            echo "Waiting for patched pod to be ready..."
+            kubectl -n {{ .Values.osacNamespace }} rollout status deployment/awx-operator-controller-manager --timeout=2m
+
+            echo "AWX operator patched successfully"
+{{- end }}

--- a/osac-installer/charts/osac-devstack/templates/hooks/provision-tenant.yaml
+++ b/osac-installer/charts/osac-devstack/templates/hooks/provision-tenant.yaml
@@ -57,7 +57,7 @@ spec:
         - name: KC_REALM
           value: {{ .Values.tenant.keycloak.realm | quote }}
         - name: GRPCURL_IMAGE
-          value: {{ .Values.cliImage | quote }}
+          value: "docker.io/fullstorydev/grpcurl:latest"
         volumeMounts:
         - name: scripts
           mountPath: /scripts

--- a/osac-installer/charts/osac-devstack/templates/hooks/provision-tenant.yaml
+++ b/osac-installer/charts/osac-devstack/templates/hooks/provision-tenant.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.tenant.enabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "osac-devstack.fullname" . }}-provision-tenant
+  namespace: {{ .Values.osacNamespace }}
+  labels:
+    {{- include "osac-devstack.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "25"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "osac-devstack.selectorLabels" . | nindent 8 }}
+        job: provision-tenant
+    spec:
+      serviceAccountName: {{ include "osac-devstack.serviceAccountName" . }}
+      restartPolicy: OnFailure
+      initContainers:
+      - name: wait-keycloak
+        image: {{ .Values.cliImage }}
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -euo pipefail
+            echo "Waiting for Keycloak pods..."
+            for i in $(seq 1 60); do
+              ready=$(kubectl -n {{ .Values.tenant.keycloak.namespace }} get pods \
+                -l app=keycloak-service \
+                --field-selector=status.phase=Running 2>/dev/null | grep -c "1/1" || true)
+              if [[ "$ready" -ge 1 ]]; then
+                echo "Keycloak ready"
+                exit 0
+              fi
+              sleep 5
+            done
+            echo "Timeout waiting for Keycloak"
+            exit 1
+      containers:
+      - name: provision-tenant
+        image: {{ .Values.cliImage }}
+        command: ["/bin/bash", "/scripts/provision-tenant.sh"]
+        args: ["{{ .Values.osacNamespace }}"]
+        env:
+        - name: NS
+          value: {{ .Values.osacNamespace | quote }}
+        - name: TENANT
+          value: {{ .Values.tenant.name | quote }}
+        - name: TENANT_USERS
+          value: {{ .Values.tenant.users | quote }}
+        - name: KC_NS
+          value: {{ .Values.tenant.keycloak.namespace | quote }}
+        - name: KC_REALM
+          value: {{ .Values.tenant.keycloak.realm | quote }}
+        - name: GRPCURL_IMAGE
+          value: {{ .Values.cliImage | quote }}
+        volumeMounts:
+        - name: scripts
+          mountPath: /scripts
+      volumes:
+      - name: scripts
+        configMap:
+          name: {{ include "osac-devstack.fullname" . }}-scripts
+          defaultMode: 0755
+{{- end }}

--- a/osac-installer/charts/osac-devstack/templates/hooks/seed-catalog.yaml
+++ b/osac-installer/charts/osac-devstack/templates/hooks/seed-catalog.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.catalog.enabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "osac-devstack.fullname" . }}-seed-catalog
+  namespace: {{ .Values.osacNamespace }}
+  labels:
+    {{- include "osac-devstack.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "osac-devstack.selectorLabels" . | nindent 8 }}
+        job: seed-catalog
+    spec:
+      serviceAccountName: {{ include "osac-devstack.serviceAccountName" . }}
+      restartPolicy: OnFailure
+      initContainers:
+      - name: wait-fulfillment
+        image: {{ .Values.cliImage }}
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -euo pipefail
+            echo "Waiting for fulfillment-service pods..."
+            for i in $(seq 1 60); do
+              ready=$(kubectl -n {{ .Values.osacNamespace }} get pods \
+                -l app=fulfillment-grpc-server \
+                --field-selector=status.phase=Running 2>/dev/null | grep -c "1/1" || true)
+              if [[ "$ready" -ge 1 ]]; then
+                echo "fulfillment-service ready"
+                exit 0
+              fi
+              sleep 5
+            done
+            echo "Timeout waiting for fulfillment-service"
+            exit 1
+      containers:
+      - name: seed-catalog
+        image: {{ .Values.cliImage }}
+        command: ["/bin/bash", "/scripts/seed-catalog-simple.sh"]
+        args: ["{{ .Values.osacNamespace }}"]
+        env:
+        - name: NS
+          value: {{ .Values.osacNamespace | quote }}
+        - name: INTERNAL_SVC
+          value: {{ .Values.catalog.internalApiService | quote }}
+        - name: INTERNAL_PORT
+          value: {{ .Values.catalog.internalApiPort | quote }}
+        - name: CATALOG_YAML
+          value: "/config/catalog-seed.yaml"
+        volumeMounts:
+        - name: scripts
+          mountPath: /scripts
+        - name: catalog-config
+          mountPath: /config
+      volumes:
+      - name: scripts
+        configMap:
+          name: {{ include "osac-devstack.fullname" . }}-scripts
+          defaultMode: 0755
+      - name: catalog-config
+        configMap:
+          name: {{ include "osac-devstack.fullname" . }}-catalog-seed
+{{- end }}

--- a/osac-installer/charts/osac-devstack/templates/manifests-configmap.yaml
+++ b/osac-installer/charts/osac-devstack/templates/manifests-configmap.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "osac-devstack.fullname" . }}-manifests
+  namespace: {{ .Values.osacNamespace }}
+  labels:
+    {{- include "osac-devstack.labels" . | nindent 4 }}
+data:
+  httproute-awx.yaml: |
+{{ .Files.Get "files/httproute-awx.yaml" | indent 4 }}

--- a/osac-installer/charts/osac-devstack/templates/rbac.yaml
+++ b/osac-installer/charts/osac-devstack/templates/rbac.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.rbac.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "osac-devstack.serviceAccountName" . }}
+  namespace: {{ .Values.osacNamespace }}
+  labels:
+    {{- include "osac-devstack.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "osac-devstack.serviceAccountName" . }}-admin
+  labels:
+    {{- include "osac-devstack.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: {{ include "osac-devstack.serviceAccountName" . }}
+  namespace: {{ .Values.osacNamespace }}
+{{- end }}

--- a/osac-installer/charts/osac-devstack/templates/scripts-configmap.yaml
+++ b/osac-installer/charts/osac-devstack/templates/scripts-configmap.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "osac-devstack.fullname" . }}-scripts
+  namespace: {{ .Values.osacNamespace }}
+  labels:
+    {{- include "osac-devstack.labels" . | nindent 4 }}
+data:
+  install-virt.sh: |
+{{ .Files.Get "files/install-virt.sh" | indent 4 }}
+  configure-awx.sh: |
+{{ .Files.Get "files/configure-awx.sh" | indent 4 }}
+  seed-catalog-simple.sh: |
+{{ .Files.Get "files/seed-catalog-simple.sh" | indent 4 }}
+  provision-tenant.sh: |
+{{ .Files.Get "files/provision-tenant.sh" | indent 4 }}

--- a/osac-installer/charts/osac-devstack/templates/ui.yaml
+++ b/osac-installer/charts/osac-devstack/templates/ui.yaml
@@ -1,0 +1,99 @@
+{{- if .Values.ui.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: osac-ui
+  namespace: {{ .Values.osacNamespace }}
+  labels:
+    {{- include "osac-devstack.labels" . | nindent 4 }}
+    app: osac-ui
+data:
+  LOG_LEVEL: {{ .Values.ui.config.logLevel | quote }}
+  FULFILLMENT_API_URL: {{ .Values.ui.config.fulfillmentApiUrl | quote }}
+  FULFILLMENT_TLS_INSECURE: {{ .Values.ui.config.tlsInsecure | quote }}
+  OIDC_TLS_INSECURE: {{ .Values.ui.config.tlsInsecure | quote }}
+  OIDC_CLIENT_ID: {{ .Values.ui.config.oidcClientId | quote }}
+  OIDC_ISSUER_URL: {{ .Values.ui.config.oidcIssuerUrl | quote }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: osac-ui
+  namespace: {{ .Values.osacNamespace }}
+  labels:
+    {{- include "osac-devstack.labels" . | nindent 4 }}
+    app: osac-ui
+spec:
+  replicas: {{ .Values.ui.replicas }}
+  selector:
+    matchLabels:
+      app: osac-ui
+  template:
+    metadata:
+      labels:
+        app: osac-ui
+    spec:
+      containers:
+      - name: osac-ui
+        image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
+        imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: osac-ui
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 30
+        resources:
+          {{- toYaml .Values.ui.resources | nindent 10 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: osac-ui
+  namespace: {{ .Values.osacNamespace }}
+  labels:
+    {{- include "osac-devstack.labels" . | nindent 4 }}
+    app: osac-ui
+spec:
+  selector:
+    app: osac-ui
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: osac-ui
+  namespace: {{ .Values.osacNamespace }}
+  labels:
+    {{- include "osac-devstack.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    namespace: envoy-gateway
+    name: default
+    sectionName: http
+  hostnames:
+  - ui.osac.localhost
+  rules:
+  - backendRefs:
+    - name: osac-ui
+      port: 80
+{{- end }}

--- a/osac-installer/charts/osac-devstack/values.yaml
+++ b/osac-installer/charts/osac-devstack/values.yaml
@@ -1,0 +1,96 @@
+# OSAC dev-full local development stack
+osacNamespace: osac
+kindClusterName: osac-dev
+# Multi-arch CLI image for hook Jobs (supports amd64, arm64, etc.).
+# The upstream quay.io/openshift/origin-cli:4.20.0 only supports amd64, blocking Mac ARM users.
+# Build the custom multi-arch image with: make -C charts/osac-devstack build-cli-tools
+cliImage: quay.io/openshift/origin-cli:4.20.0  # TODO: Replace with ghcr.io/osac-project/cli-tools:latest after first build
+
+# --- KubeVirt/CDI/Multus ---
+virt:
+  enabled: true
+  multusVersion: "v4.2.0"
+  kubevirtVersion: ""  # Empty = latest stable
+  cdiVersion: ""       # Empty = latest stable
+
+# --- AWX ---
+# AWX instance is deployed in osacNamespace (not a separate namespace) for dev-full
+# simplicity - the operator watches its own namespace by default.
+awx:
+  enabled: true
+  operatorChart: awx-operator/awx-operator
+  operatorVersion: ""  # Empty = latest
+  instance:
+    name: awx
+    serviceType: ClusterIP
+    postgresStorageClass: standard
+    projectsPersistence: false
+    resources:
+      postgres:
+        requests: {cpu: 100m, memory: 256Mi}
+        limits: {cpu: 500m, memory: 512Mi}
+      web:
+        requests: {cpu: 100m, memory: 256Mi}
+        limits: {cpu: "1", memory: 2Gi}
+      task:
+        requests: {cpu: 100m, memory: 256Mi}
+        limits: {cpu: "1", memory: 2Gi}
+      ee:
+        requests: {cpu: 100m, memory: 128Mi}
+        limits: {cpu: "500m", memory: 1Gi}
+
+# --- OSAC UI ---
+ui:
+  enabled: true
+  image:
+    repository: ghcr.io/osac-project/osac-ui
+    tag: latest  # DEV_FLOATING -- intentionally unpinned for local dev
+    pullPolicy: Always
+  replicas: 1
+  resources:
+    requests: {cpu: 100m, memory: 128Mi}
+    limits: {cpu: 500m, memory: 512Mi}
+  config:
+    logLevel: info
+    fulfillmentApiUrl: "https://fulfillment-api.osac.localhost:8000"
+    oidcClientId: osac-ui
+    oidcIssuerUrl: "https://keycloak.osac.localhost:8443/realms/osac"
+    tlsInsecure: "1"
+
+# --- Catalog Seeding ---
+catalog:
+  enabled: true
+  internalApiService: fulfillment-internal-api
+  internalApiPort: 8001
+  diskImages:
+    - name: fedora
+      sourceType: SOURCE_TYPE_REGISTRY
+      sourceRef: quay.io/containerdisks/fedora:latest  # DEV_FLOATING -- intentionally unpinned for local dev
+  instanceTypes:
+    - {name: u1-small, cores: 2, memoryGib: 4, description: "2 cores, 4 GiB RAM"}
+    - {name: u1-medium, cores: 4, memoryGib: 8, description: "4 cores, 8 GiB RAM"}
+    - {name: u1-large, cores: 8, memoryGib: 16, description: "8 cores, 16 GiB RAM"}
+  templates:
+    - id: osac.templates.ocp_virt_vm
+      title: "Virtual Machine Template (Linux and Windows)"
+  catalogItems:
+    - name: linux-vm
+      title: "Linux Virtual Machine"
+      description: "Fedora-based VM with KVM acceleration"
+      templateId: osac.templates.ocp_virt_vm
+      published: true
+
+# --- Tenant Provisioning ---
+tenant:
+  enabled: true
+  name: tenant1
+  users: "tenant1_user,tenant1_admin"  # Comma-separated
+  keycloak:
+    namespace: keycloak
+    realm: osac
+
+# --- RBAC ---
+rbac:
+  create: true
+  serviceAccount:
+    name: devstack-admin

--- a/osac-installer/charts/osac-infra/files/realm.json
+++ b/osac-installer/charts/osac-infra/files/realm.json
@@ -1054,18 +1054,19 @@
       "clientId": "osac-ui",
       "name": "OSAC UI",
       "description": "OSAC web console",
-      "rootUrl": "",
+      "rootUrl": "http://ui.osac.localhost:8080",
       "adminUrl": "",
-      "baseUrl": "",
+      "baseUrl": "/",
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "/*"
+        "http://ui.osac.localhost:8080/callback",
+        "http://ui.osac.localhost:8080/*"
       ],
       "webOrigins": [
-        "+"
+        "http://ui.osac.localhost:8080"
       ],
       "notBefore": 0,
       "bearerOnly": false,

--- a/osac-installer/charts/osac-infra/templates/envoy-gateway-resources.yaml
+++ b/osac-installer/charts/osac-infra/templates/envoy-gateway-resources.yaml
@@ -76,7 +76,14 @@ spec:
       namespace: envoy-gateway
       sectionName: tls
   hostnames:
-    - keycloak.keycloak.svc.cluster.local
+    # SNI the gateway matches for browser-facing Keycloak. Defaults to the
+    # in-cluster service name (used by PROFILE=dev integration tests via
+    # /etc/hosts); PROFILE=dev-full overrides keycloak.route.hostname to a
+    # browser-resolvable *.localhost name so the OIDC login flow works with no
+    # /etc/hosts editing. In-cluster JWKS fetches bypass the gateway (CoreDNS
+    # rewrites *.localhost straight to the Keycloak service), so a single SNI
+    # here is sufficient. keycloak.route.hostname also drives the cert SAN below.
+    - {{ .Values.keycloak.route.hostname | default "keycloak.keycloak.svc.cluster.local" }}
   rules:
     - backendRefs:
         - name: keycloak

--- a/osac-installer/charts/osac/values.schema.json
+++ b/osac-installer/charts/osac/values.schema.json
@@ -191,6 +191,11 @@
               "description": "Enable networking controllers",
               "default": true
             },
+            "networkingProvisioning": {
+              "type": "boolean",
+              "description": "Dispatch AAP jobs to provision networking resources. Set false for Kind dev (no fabric): controllers reconcile VirtualNetwork/Subnet/SecurityGroup to READY without provisioning.",
+              "default": true
+            },
             "bareMetalInstance": {
               "type": "boolean",
               "description": "Enable BareMetalInstance controller",

--- a/osac-installer/scripts/dev-full/deploy-ui.sh
+++ b/osac-installer/scripts/dev-full/deploy-ui.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# dev-full: deploy the OSAC UI on Kind.
+#
+# The osac chart's ui.enabled subchart exposes the UI via an OpenShift Route,
+# which does not exist on Kind. Instead we deploy the UI directly and route to it
+# through the shared Envoy Gateway HTTP listener (created by the osac-infra chart)
+# with a Gateway API HTTPRoute — reachable at http://ui.osac.localhost:8080.
+#
+# Usage: deploy-ui.sh [namespace]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+# The manifests are pinned to the 'osac' namespace and the ui.osac.localhost host
+# (dev-full is single-instance on Kind). NS is accepted for parity but must be osac.
+NS="${1:-${NS:-osac}}"
+
+echo "[+] Deploying OSAC UI (namespace 'osac')..."
+kubectl apply -f "${SCRIPT_DIR}/manifests/osac-ui.yaml"
+kubectl -n osac rollout status deployment osac-ui --timeout=120s
+echo "[+] OSAC UI deployed — http://ui.osac.localhost:8080"

--- a/osac-installer/scripts/dev-full/install-awx.sh
+++ b/osac-installer/scripts/dev-full/install-awx.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# dev-full: install and configure AWX as the AAP provisioning backend on Kind.
+#
+# AWX is the open-source upstream of Red Hat AAP. The osac-operator (configured
+# by values/dev/kind-instance.yaml to talk to awx-service.awx.svc.cluster.local
+# and read the 'awx-token' secret) launches AWX job templates that run the real
+# osac-aap playbooks. This script installs AWX and configures the token, inventory,
+# project, job templates and Kubernetes credential it needs.
+#
+# Requires KUBECONFIG to point at the kind cluster (set by the Makefile).
+#
+# Usage: install-awx.sh [osac-namespace]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+MANIFESTS="${SCRIPT_DIR}/manifests"
+NS="${1:-${NS:-osac}}"
+AWX_PORT="${AWX_PORT:-8052}"
+
+log()  { echo "[+] $*"; }
+warn() { echo "[!] $*" >&2; }
+
+install_awx() {
+  log "Installing AWX operator..."
+  helm repo add awx-operator https://ansible-community.github.io/awx-operator-helm/ 2>/dev/null || true
+  helm repo update awx-operator >/dev/null 2>&1 || true
+  helm upgrade --install awx-operator awx-operator/awx-operator \
+    -n awx --create-namespace --wait --timeout 3m 2>&1 | tail -2
+
+  log "Creating AWX instance..."
+  kubectl apply -f "${MANIFESTS}/awx-instance.yaml"
+
+  log "Waiting for AWX pods (this takes ~10 minutes)..."
+  local i task_ready
+  for i in $(seq 1 60); do
+    task_ready=$(kubectl -n awx get pods -l app.kubernetes.io/name=awx-task --no-headers 2>/dev/null | grep -c "4/4" || true)
+    [[ "$task_ready" -ge 1 ]] && break
+    sleep 10
+  done
+  kubectl -n awx get pods 2>/dev/null | grep -v Completed || true
+  log "AWX installed"
+}
+
+configure_awx() {
+  log "Configuring AWX for OSAC..."
+
+  # Route the AWX web UI through the shared Envoy Gateway HTTP listener.
+  kubectl apply -f "${MANIFESTS}/httproute-awx.yaml"
+
+  local admin_pass
+  admin_pass=$(kubectl -n awx get secret awx-admin-password -o jsonpath='{.data.password}' | base64 -d)
+
+  # Port-forward the AWX API.
+  command -v lsof >/dev/null 2>&1 && { lsof -ti:"${AWX_PORT}" | xargs -r kill -9 2>/dev/null || true; }
+  sleep 1
+  kubectl -n awx port-forward svc/awx-service "${AWX_PORT}":80 >/dev/null 2>&1 &
+  local pf_pid=$!
+  trap 'kill "${pf_pid}" 2>/dev/null || true; wait "${pf_pid}" 2>/dev/null || true' RETURN
+  sleep 3
+
+  local api="http://localhost:${AWX_PORT}/api/v2"
+
+  # OAuth token.
+  local awx_token
+  awx_token=$(curl -s -X POST "${api}/tokens/" -u "admin:${admin_pass}" \
+    -H "Content-Type: application/json" -d '{"scope": "write"}' | \
+    python3 -c "import json,sys; print(json.load(sys.stdin).get('token',''))")
+  if [[ -z "$awx_token" ]]; then
+    warn "Failed to create AWX token — AWX may not be ready yet"
+    return 1
+  fi
+  log "AWX token created"
+
+  # Inventory (create or reuse).
+  local inv_id
+  inv_id=$(curl -s -X POST "${api}/inventories/" -H "Authorization: Bearer ${awx_token}" \
+    -H "Content-Type: application/json" -d '{"name": "OSAC Dev", "organization": 1}' | \
+    python3 -c "import json,sys; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || true)
+  if [[ -z "$inv_id" ]]; then
+    inv_id=$(curl -s -H "Authorization: Bearer ${awx_token}" "${api}/inventories/?name=OSAC+Dev" | \
+      python3 -c "import json,sys; d=json.load(sys.stdin); print(d['results'][0]['id'] if d.get('results') else '')")
+  fi
+  curl -s -X POST "${api}/inventories/${inv_id}/hosts/" -H "Authorization: Bearer ${awx_token}" \
+    -H "Content-Type: application/json" \
+    -d '{"name": "localhost", "variables": "ansible_connection: local"}' >/dev/null 2>&1 || true
+
+  # Disable collection/role sync — Red Hat proprietary collections (ansible.platform)
+  # are not available in open-source AWX.
+  #
+  # AWX_TASK_ENV injects env vars into every job's execution environment. We set
+  # ANSIBLE_JINJA2_NATIVE=true because the osac-aap ocp_virt_vm role is authored
+  # for jinja2 native mode (e.g. `cores: "{{ vm_cpu_cores }}"` must render as an
+  # int, or KubeVirt's virtualmachines-mutator webhook rejects it: "cpu.cores must
+  # be of type integer"). osac-aap sets this in osac-aap/ansible.cfg, but AWX clones
+  # the whole mono-repo and runs ansible-runner with cwd = repo root (no ansible.cfg
+  # there), so that config is never loaded. Injecting the env var restores native
+  # mode for all osac-aap job runs.
+  curl -s -X PATCH "${api}/settings/jobs/" -H "Authorization: Bearer ${awx_token}" \
+    -H "Content-Type: application/json" \
+    -d '{"AWX_COLLECTIONS_ENABLED": false, "AWX_ROLES_ENABLED": false, "AWX_TASK_ENV": {"ANSIBLE_JINJA2_NATIVE": "true"}}' >/dev/null
+
+  # Project from the osac mono-repo. osac-aap playbooks live under osac-aap/, and
+  # AWX's Project API always clones the whole repo, so playbook paths below are
+  # prefixed with osac-aap/.
+  local project_id
+  project_id=$(curl -s -X POST "${api}/projects/" -H "Authorization: Bearer ${awx_token}" \
+    -H "Content-Type: application/json" -d '{
+      "name": "osac-aap", "organization": 1, "scm_type": "git",
+      "scm_url": "https://github.com/osac-project/osac.git",
+      "scm_branch": "main", "scm_update_on_launch": false
+    }' | python3 -c "import json,sys; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || true)
+  if [[ -z "$project_id" ]]; then
+    project_id=$(curl -s -H "Authorization: Bearer ${awx_token}" "${api}/projects/?name=osac-aap" | \
+      python3 -c "import json,sys; d=json.load(sys.stdin); print(d['results'][0]['id'] if d.get('results') else '')")
+    if [[ -n "$project_id" ]]; then
+      # A project surviving a pre-mono-repo run may still point at the old repo.
+      curl -s -X PATCH "${api}/projects/${project_id}/" -H "Authorization: Bearer ${awx_token}" \
+        -H "Content-Type: application/json" \
+        -d '{"scm_url": "https://github.com/osac-project/osac.git", "scm_branch": "main"}' >/dev/null
+      curl -s -X POST "${api}/projects/${project_id}/update/" -H "Authorization: Bearer ${awx_token}" >/dev/null
+    fi
+  fi
+
+  # Wait for project sync.
+  local i proj_status="unknown"
+  for i in $(seq 1 20); do
+    proj_status=$(curl -s -H "Authorization: Bearer ${awx_token}" "${api}/projects/${project_id}/" | \
+      python3 -c "import json,sys; print(json.load(sys.stdin).get('status','unknown'))" 2>/dev/null || echo unknown)
+    [[ "$proj_status" == "successful" || "$proj_status" == "failed" ]] && break
+    sleep 5
+  done
+  log "AWX project synced: ${proj_status}"
+
+  # Compute-instance job templates (real playbooks).
+  # Dev-full storage fallback: the compute-instance playbook resolves a
+  # StorageClass by matching its requested tier (_requested_storage_tier,
+  # default 'local') against this injected tenant_storage_classes list. On kind
+  # the only StorageClass is 'standard' (rancher.io/local-path) and the
+  # LVMS-backed 'local' StorageTier hook (register-local-storage.yaml) is
+  # skipped, so nothing populates the tenant's status.storageClasses. We inject
+  # the list here as a job-template extra_var (which outranks the playbook's
+  # osac_job_vars-derived value) so provisioning works without a real storage
+  # backend. The tier MUST be 'local' to match the playbook's requested tier —
+  # a mismatched tier name fails the run ("tier not available").
+  #
+  # We deliberately do NOT inject tenant_target_namespace / compute_instance_target_namespace
+  # here. As top-level extra_vars they would OUTRANK the ocp_virt_vm role's own
+  # set_fact (create.yaml), which resolves the VM namespace from the CI's
+  # osac.openshift.io/subnet-target-namespace annotation (falling back to the
+  # tenant namespace). The osac-operator ComputeInstance controller looks for the
+  # KubeVirt VM in exactly that subnet-target namespace, so forcing a fixed
+  # namespace here makes the VM boot where the operator never looks — the CI stays
+  # stuck at Provisioned=False/WaitingForVM forever. Let the role resolve it; the
+  # subnet namespace itself is created by provision-tenant.sh (subnet provisioning
+  # is a noop on kind, so nothing else creates it).
+  local compute_extra_vars
+  compute_extra_vars="tenant_storage_classes:
+  - name: standard
+    tier: local"
+  local entry name playbook
+  for entry in \
+    "osac-create-compute-instance:osac-aap/playbook_osac_create_compute_instance.yml" \
+    "osac-delete-compute-instance:osac-aap/playbook_osac_delete_compute_instance.yml"; do
+    name="${entry%%:*}"; playbook="${entry##*:}"
+    curl -s -X POST "${api}/job_templates/" -H "Authorization: Bearer ${awx_token}" \
+      -H "Content-Type: application/json" -d "{
+        \"name\": \"${name}\", \"organization\": 1, \"inventory\": ${inv_id},
+        \"project\": ${project_id}, \"playbook\": \"${playbook}\",
+        \"ask_variables_on_launch\": true,
+        \"extra_vars\": $(echo "${compute_extra_vars}" | jq -Rs .)
+      }" >/dev/null
+    log "  template: ${name}"
+  done
+
+  # Networking job templates (real playbooks — effective no-ops on kind, no fabric).
+  for entry in \
+    "osac-create-virtual-network:osac-aap/playbook_osac_create_virtual_network.yml" \
+    "osac-delete-virtual-network:osac-aap/playbook_osac_delete_virtual_network.yml" \
+    "osac-create-subnet:osac-aap/playbook_osac_create_subnet.yml" \
+    "osac-delete-subnet:osac-aap/playbook_osac_delete_subnet.yml" \
+    "osac-create-security-group:osac-aap/playbook_osac_create_security_group.yml" \
+    "osac-delete-security-group:osac-aap/playbook_osac_delete_security_group.yml"; do
+    name="${entry%%:*}"; playbook="${entry##*:}"
+    curl -s -X POST "${api}/job_templates/" -H "Authorization: Bearer ${awx_token}" \
+      -H "Content-Type: application/json" -d "{
+        \"name\": \"${name}\", \"organization\": 1, \"inventory\": ${inv_id},
+        \"project\": ${project_id}, \"playbook\": \"${playbook}\",
+        \"ask_variables_on_launch\": true
+      }" >/dev/null
+    log "  template: ${name}"
+  done
+
+  # Kubernetes credential so job templates can act on the cluster.
+  kubectl -n "${NS}" create serviceaccount awx-runner 2>/dev/null || true
+  kubectl create clusterrolebinding awx-runner-admin --clusterrole=cluster-admin \
+    --serviceaccount="${NS}:awx-runner" 2>/dev/null || true
+
+  local awx_runner_token cluster_ca cred_id
+  awx_runner_token=$(kubectl -n "${NS}" create token awx-runner --duration=87600h)
+  cluster_ca=$(kubectl config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | base64 -d)
+  cred_id=$(curl -s -X POST "${api}/credentials/" -H "Authorization: Bearer ${awx_token}" \
+    -H "Content-Type: application/json" -d "{
+      \"name\": \"kind-cluster\", \"organization\": 1, \"credential_type\": 17,
+      \"inputs\": {
+        \"host\": \"https://kubernetes.default.svc.cluster.local:443\",
+        \"bearer_token\": \"${awx_runner_token}\", \"verify_ssl\": true,
+        \"ssl_ca_cert\": $(echo "${cluster_ca}" | jq -Rs .)
+      }
+    }" | python3 -c "import json,sys; print(json.load(sys.stdin).get('id',''))")
+
+  # Attach the credential to every job template.
+  local templates jt_id
+  templates=$(curl -s -H "Authorization: Bearer ${awx_token}" "${api}/job_templates/" | \
+    python3 -c "import json,sys; print(' '.join(str(t['id']) for t in json.load(sys.stdin)['results']))")
+  for jt_id in ${templates}; do
+    curl -s -X POST "${api}/job_templates/${jt_id}/credentials/" -H "Authorization: Bearer ${awx_token}" \
+      -H "Content-Type: application/json" -d "{\"id\": ${cred_id}}" >/dev/null
+  done
+  log "Credential ${cred_id} attached to all templates"
+
+  # Store the AWX token as a secret for the operator (name matches kind-instance.yaml).
+  kubectl -n "${NS}" create secret generic awx-token \
+    --from-literal=token="${awx_token}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+  # The operator reads awx-token at startup; on a clean install it came up before
+  # this secret existed (AWX takes ~10 min to be ready), so restart it to pick up
+  # the token. Without this the operator never talks to AWX and no jobs launch.
+  if kubectl -n "${NS}" get deployment osac-operator >/dev/null 2>&1; then
+    kubectl -n "${NS}" rollout restart deployment osac-operator
+    kubectl -n "${NS}" rollout status deployment osac-operator --timeout=3m || true
+    log "osac-operator restarted to pick up awx-token"
+  else
+    warn "osac-operator deployment not found in ${NS}; skipped restart (token secret created)"
+  fi
+
+  log "AWX configured for OSAC"
+}
+
+install_awx
+configure_awx

--- a/osac-installer/scripts/dev-full/install-virt-node-setup.sh
+++ b/osac-installer/scripts/dev-full/install-virt-node-setup.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# install-virt-node-setup.sh - Install bridge CNI plugin into kind node
+#
+# Runs on the host (not in a Helm Job) because it requires container runtime
+# access to exec into the kind node container. The rest of the virtualization
+# stack (Multus, KubeVirt, CDI operators) is installed by the Helm chart's
+# install-virt hook Job.
+#
+# Usage: install-virt-node-setup.sh [cluster-name]
+
+set -euo pipefail
+
+CLUSTER_NAME="${1:-osac-dev}"
+BRIDGE_CNI_VERSION="${2:-v1.6.2}"
+
+log() { echo "[+] $*"; }
+die() { echo "[!] $*" >&2; exit 1; }
+
+# Detect container runtime (try rootful first, then rootless)
+if command -v podman >/dev/null 2>&1; then
+  RUNTIME=podman
+  export KIND_EXPERIMENTAL_PROVIDER=podman
+  # Check if cluster exists in rootful podman (created with sudo)
+  if sudo podman ps --filter "name=${CLUSTER_NAME}-control-plane" --format '{{.Names}}' 2>/dev/null | grep -q "${CLUSTER_NAME}-control-plane"; then
+    RUNTIME="sudo podman"
+  # Check if cluster exists in rootless podman
+  elif podman ps --filter "name=${CLUSTER_NAME}-control-plane" --format '{{.Names}}' 2>/dev/null | grep -q "${CLUSTER_NAME}-control-plane"; then
+    RUNTIME=podman
+  else
+    die "Kind cluster '${CLUSTER_NAME}' not found in podman (tried both rootful and rootless)"
+  fi
+elif command -v docker >/dev/null 2>&1; then
+  RUNTIME=docker
+  # Verify cluster exists
+  $RUNTIME ps --filter "name=${CLUSTER_NAME}-control-plane" --format '{{.Names}}' | grep -q "${CLUSTER_NAME}-control-plane" \
+    || die "Kind cluster '${CLUSTER_NAME}' not found"
+else
+  die "Neither podman nor docker found"
+fi
+
+NODE_NAME="${CLUSTER_NAME}-control-plane"
+
+log "Installing bridge CNI plugin into ${NODE_NAME}..."
+$RUNTIME exec "${NODE_NAME}" bash -c \
+  "curl -sL https://github.com/containernetworking/plugins/releases/download/${BRIDGE_CNI_VERSION}/cni-plugins-linux-amd64-${BRIDGE_CNI_VERSION}.tgz | tar -C /opt/cni/bin -xz" \
+  || die "Failed to install bridge CNI plugin"
+
+log "Bridge CNI plugin installed successfully"

--- a/osac-installer/scripts/dev-full/install-virt.sh
+++ b/osac-installer/scripts/dev-full/install-virt.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# dev-full: install the virtualization stack on Kind — Multus CNI, KubeVirt, CDI.
+# Requires KUBECONFIG to point at the kind cluster (set by the Makefile).
+#
+# Usage: install-virt.sh <kind-cluster-name>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+# shellcheck source=./kind-runtime.sh
+source "${SCRIPT_DIR}/kind-runtime.sh"
+
+CLUSTER_NAME="${1:-${KIND_CLUSTER_NAME:-osac-dev}}"
+BRIDGE_CNI_VERSION="${BRIDGE_CNI_VERSION:-v1.6.2}"
+
+install_multus() {
+  log "Installing Multus CNI..."
+  kubectl apply -f https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/master/deployments/multus-daemonset.yml 2>&1 | tail -3
+  kubectl -n kube-system wait --for=condition=Ready pods -l app=multus --timeout=120s
+
+  log "Installing bridge CNI plugin into the kind node..."
+  local node_name="${CLUSTER_NAME}-control-plane"
+  container_cmd exec "${node_name}" bash -c \
+    "curl -sL https://github.com/containernetworking/plugins/releases/download/${BRIDGE_CNI_VERSION}/cni-plugins-linux-amd64-${BRIDGE_CNI_VERSION}.tgz | tar -C /opt/cni/bin -xz"
+  log "Multus installed"
+}
+
+install_kubevirt() {
+  log "Installing KubeVirt..."
+
+  # Remove fake KubeVirt CRDs (installed as controller stubs) — they conflict
+  # with the real operator's CRDs.
+  kubectl delete crd virtualmachines.kubevirt.io virtualmachineinstances.kubevirt.io 2>/dev/null || true
+
+  local version
+  version=$(curl -s https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt)
+  log "KubeVirt version: ${version}"
+
+  kubectl apply -f "https://github.com/kubevirt/kubevirt/releases/download/${version}/kubevirt-operator.yaml" 2>&1 | tail -3
+  kubectl wait --for=condition=available --timeout=120s -n kubevirt deployments -l kubevirt.io
+
+  kubectl apply -f "https://github.com/kubevirt/kubevirt/releases/download/${version}/kubevirt-cr.yaml"
+  kubectl -n kubevirt wait kv kubevirt --for condition=Available --timeout=300s
+
+  # Register the l2bridge network-binding plugin (replicates what HCO does on
+  # OpenShift). The osac-aap ocp_virt_vm role builds VM specs with
+  # "binding: name: l2bridge"; managedTap wires a tap device through a bridge to
+  # the pod interface.
+  log "Registering l2bridge network binding plugin..."
+  kubectl patch kubevirts -n kubevirt kubevirt --type=merge \
+    -p='{"spec":{"configuration":{"network":{"binding":{"l2bridge":{"domainAttachmentType":"managedTap"}}}}}}'
+
+  log "KubeVirt installed"
+}
+
+install_cdi() {
+  log "Installing CDI (Containerized Data Importer)..."
+
+  # Resolve the latest CDI tag via the GitHub "releases/latest" redirect rather
+  # than the REST API — the unauthenticated API is rate-limited (returns an error
+  # object with no 'tag_name'), while the redirect is not.
+  local version
+  version=$(basename "$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+    https://github.com/kubevirt/containerized-data-importer/releases/latest)")
+  if [[ -z "${version}" || "${version}" == "latest" ]]; then
+    err "Could not resolve latest CDI release tag from GitHub"
+    exit 1
+  fi
+  log "CDI version: ${version}"
+
+  kubectl apply -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${version}/cdi-operator.yaml" 2>&1 | tail -3
+  kubectl apply -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${version}/cdi-cr.yaml"
+  kubectl wait --for=condition=available --timeout=120s -n cdi deployments -l cdi.kubevirt.io
+
+  # local-path-provisioner deadlocks with WaitForFirstConsumer when CDI imports a
+  # disk (no consumer pod exists yet to trigger provisioning). Dropping the
+  # feature gate lets CDI create the importer pod immediately.
+  kubectl patch cdi cdi --type=json \
+    -p '[{"op":"replace","path":"/spec/config/featureGates","value":["WebhookPvcRendering"]}]'
+
+  log "CDI installed"
+}
+
+install_multus
+install_kubevirt
+install_cdi
+log "Virtualization stack ready (Multus + KubeVirt + CDI)"

--- a/osac-installer/scripts/dev-full/kind-runtime.sh
+++ b/osac-installer/scripts/dev-full/kind-runtime.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# Cross-platform Kind container-runtime wrapper for PROFILE=dev-full.
+#
+# KubeVirt (installed by the dev-full profile) needs *rootful* podman on Linux —
+# rootless user namespaces deny virt-handler the chown of /dev/kvm. This script
+# encapsulates the runtime detection the old kind-dev/setup.sh did:
+#   - macOS  : Docker Desktop (auto-detected)
+#   - Linux host     : rootful podman via sudo
+#   - Linux Distrobox: rootful podman via the host socket (/run/podman/podman.sock)
+#   - Override: KIND_EXPERIMENTAL_PROVIDER=docker|podman
+#
+# It is BOTH:
+#   - sourceable   — defines kind_cmd / container_cmd / check_prerequisites
+#   - an executable — subcommands used by the Makefile / dev-full scripts:
+#       kind-runtime.sh check
+#       kind-runtime.sh create-cluster <name> <config> <kubeconfig>
+#       kind-runtime.sh delete-cluster <name>
+#       kind-runtime.sh container <args...>     # run the container tool
+#       kind-runtime.sh <kind args...>          # run kind
+#
+# All diagnostics go to stderr so stdout stays clean for `kind get ...` parsing.
+
+set -euo pipefail
+
+# ── Configuration ────────────────────────────────────────────────────────────
+ROOTFUL_SOCKET="${ROOTFUL_SOCKET:-/run/podman/podman.sock}"
+
+# Auto-detect container runtime (prefer Docker on Mac, podman elsewhere).
+if [[ "$(uname -s)" == "Darwin" ]] && command -v docker >/dev/null 2>&1; then
+  KIND_PROVIDER="${KIND_EXPERIMENTAL_PROVIDER:-docker}"
+else
+  KIND_PROVIDER="${KIND_EXPERIMENTAL_PROVIDER:-podman}"
+fi
+
+# Detect distrobox: podman is a host-exec wrapper, sudo can't reach it.
+if grep -qsw distrobox-host-exec "$(command -v podman 2>/dev/null)"; then
+  IN_DISTROBOX=true
+else
+  IN_DISTROBOX=false
+fi
+
+# ── Logging (stderr only) ────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+log()  { echo -e "${GREEN}[+]${NC} $*" >&2; }
+warn() { echo -e "${YELLOW}[!]${NC} $*" >&2; }
+err()  { echo -e "${RED}[x]${NC} $*" >&2; }
+info() { echo -e "${BLUE}[i]${NC} $*" >&2; }
+
+# ── Runtime mode detection ───────────────────────────────────────────────────
+detect_podman_mode() {
+  if [[ "$IN_DISTROBOX" == "true" ]]; then
+    if distrobox-host-exec env CONTAINER_HOST="unix://${ROOTFUL_SOCKET}" \
+         podman info --format '{{.Host.Security.Rootless}}' 2>/dev/null | grep -q false; then
+      export PODMAN_ROOTFUL=1
+      info "Using rootful podman via ${ROOTFUL_SOCKET}"
+    else
+      export PODMAN_ROOTFUL=0
+      warn "Rootful podman socket not available — using rootless (KubeVirt will fail)."
+      warn "Install the host socket override (see scripts/dev-full/manifests/podman-socket-rootful.conf):"
+      warn "  sudo install -m 0644 podman-socket-rootful.conf \\"
+      warn "    /etc/systemd/system/podman.socket.d/rootful-group.conf"
+      warn "  sudo systemctl daemon-reload && sudo systemctl restart podman.socket"
+    fi
+  fi
+}
+
+kind_cmd() {
+  if [[ "$KIND_PROVIDER" == "docker" ]]; then
+    KIND_EXPERIMENTAL_PROVIDER="${KIND_PROVIDER}" kind "$@"
+  elif [[ "$IN_DISTROBOX" == "true" ]]; then
+    if [[ "${PODMAN_ROOTFUL:-0}" == "1" ]]; then
+      systemd-run --scope --user \
+        env KIND_EXPERIMENTAL_PROVIDER="${KIND_PROVIDER}" \
+        CONTAINER_HOST="unix://${ROOTFUL_SOCKET}" \
+        kind "$@"
+    else
+      systemd-run --scope --user \
+        env KIND_EXPERIMENTAL_PROVIDER="${KIND_PROVIDER}" \
+        kind "$@"
+    fi
+  else
+    sudo KIND_EXPERIMENTAL_PROVIDER="${KIND_PROVIDER}" kind "$@"
+  fi
+}
+
+container_cmd() {
+  if [[ "$KIND_PROVIDER" == "docker" ]]; then
+    docker "$@"
+  elif [[ "$IN_DISTROBOX" == "true" ]]; then
+    podman "$@"   # the distrobox wrapper honours PODMAN_ROOTFUL / CONTAINER_HOST
+  else
+    sudo podman "$@"
+  fi
+}
+
+# ── Prerequisites ────────────────────────────────────────────────────────────
+check_prerequisites() {
+  local missing=()
+  for cmd in kind helm kubectl jq curl openssl python3; do
+    command -v "$cmd" >/dev/null 2>&1 || missing+=("$cmd")
+  done
+  if [[ "$KIND_PROVIDER" == "docker" ]]; then
+    command -v docker >/dev/null 2>&1 || missing+=("docker")
+  else
+    command -v podman >/dev/null 2>&1 || missing+=("podman")
+  fi
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    err "Missing required tools: ${missing[*]}"
+    exit 1
+  fi
+
+  # Container runtime reachability.
+  if [[ "$KIND_PROVIDER" == "podman" ]]; then
+    if ! container_cmd info >/dev/null 2>&1; then
+      err "Podman is not reachable. Ensure the podman socket is active."
+      err "  Host:      systemctl --user start podman.socket (or use rootful, see below)"
+      err "  Distrobox: install the host rootful socket override (manifests/podman-socket-rootful.conf)"
+      exit 1
+    fi
+    detect_podman_mode
+  else
+    if ! docker info >/dev/null 2>&1; then
+      err "Docker is not running. Start Docker Desktop or the Docker daemon."
+      exit 1
+    fi
+  fi
+
+  # inotify (Linux only) — kind nodes need many watchers.
+  if [[ -f /proc/sys/fs/inotify/max_user_instances ]]; then
+    local max_instances
+    max_instances=$(cat /proc/sys/fs/inotify/max_user_instances 2>/dev/null || echo 0)
+    if [[ "$max_instances" -lt 256 ]]; then
+      err "inotify max_user_instances is ${max_instances} (need >= 256)"
+      err "Fix:     sudo sysctl fs.inotify.max_user_instances=512"
+      err "Persist: echo 'fs.inotify.max_user_instances=512' | sudo tee /etc/sysctl.d/99-kind-inotify.conf"
+      exit 1
+    fi
+  fi
+
+  # /dev/kvm — required by KubeVirt for hardware-accelerated VMs (Linux).
+  if [[ "$(uname -s)" == "Linux" ]]; then
+    if [[ ! -e /dev/kvm ]]; then
+      err "/dev/kvm not found — KubeVirt requires KVM (Intel VT-x / AMD-V)."
+      err "Check: ls /dev/kvm && grep -c -E 'vmx|svm' /proc/cpuinfo"
+      exit 1
+    fi
+  else
+    warn "Non-Linux host: KubeVirt VM acceleration depends on the container runtime's nested-virt support."
+  fi
+
+  # VPN route-conflict bypass (Linux + rootful podman): a VPN 10.0.0.0/8 route
+  # can shadow the podman bridge subnet and make kind unreachable.
+  if [[ "$KIND_PROVIDER" == "podman" && "$(uname -s)" == "Linux" ]]; then
+    local vpn_table
+    vpn_table=$(ip rule show 2>/dev/null | awk '/proto static/ && /lookup [0-9]/ {for(i=1;i<=NF;i++) if($i=="lookup") {print $(i+1); exit}}' || true)
+    if [[ -n "$vpn_table" ]]; then
+      local vpn_catch_all
+      vpn_catch_all=$(ip route show table "$vpn_table" 2>/dev/null | grep -E '^10\.' | head -1 || true)
+      if [[ -n "$vpn_catch_all" ]]; then
+        local vpn_prio
+        vpn_prio=$(ip rule show 2>/dev/null | awk "/lookup ${vpn_table}/"'{gsub(/:/, "", $1); print $1; exit}')
+        if [[ -n "$vpn_prio" ]] && ! ip rule show 2>/dev/null | grep -q "to 10\.89\.0\.0/16 lookup main"; then
+          local bypass_prio=$(( vpn_prio - 1 ))
+          warn "VPN route table ${vpn_table} covers 10.0.0.0/8 — adding bypass for podman subnets"
+          sudo ip rule add to 10.89.0.0/16 lookup main priority "$bypass_prio" 2>/dev/null || true
+          log "Added ip rule: to 10.89.0.0/16 lookup main priority ${bypass_prio}"
+        fi
+      fi
+    fi
+  fi
+
+  log "All prerequisites met (using ${KIND_PROVIDER})"
+}
+
+# ── Cluster lifecycle ────────────────────────────────────────────────────────
+create_cluster() {
+  local name="$1" config="$2" kubeconfig="$3"
+
+  if [[ "$KIND_PROVIDER" == "podman" ]]; then
+    detect_podman_mode
+  fi
+
+  if kind_cmd get clusters 2>/dev/null | grep -q "^${name}$"; then
+    log "Kind cluster '${name}' already exists, reusing it"
+  else
+    log "Creating kind cluster '${name}' (${KIND_PROVIDER})..."
+    kind_cmd create cluster --name "${name}" --config "${config}" --wait 60s
+
+    # podman defaults pids_limit to 2048/container; KubeVirt install jobs need more.
+    if [[ "$KIND_PROVIDER" == "podman" ]]; then
+      log "Raising cgroup PID limit on Kind node containers (podman default is too low for KubeVirt)..."
+      local node
+      for node in $(kind_cmd get nodes --name "${name}" 2>/dev/null); do
+        container_cmd update --pids-limit 4096 "${node}" >/dev/null 2>&1 || \
+          warn "Could not raise PID limit on ${node} — KubeVirt may fail to install"
+      done
+    fi
+  fi
+
+  # Write kubeconfig via redirect so it is owned by the invoking user (not root,
+  # even when kind ran under sudo).
+  mkdir -p "$(dirname "${kubeconfig}")"
+  kind_cmd get kubeconfig --name "${name}" > "${kubeconfig}"
+  chmod 600 "${kubeconfig}"
+  log "Kubeconfig written to ${kubeconfig}"
+}
+
+delete_cluster() {
+  local name="$1"
+  if [[ "$KIND_PROVIDER" == "podman" ]]; then
+    detect_podman_mode
+  fi
+  kind_cmd delete cluster --name "${name}"
+}
+
+# ── Subcommand dispatch (only when executed, not sourced) ─────────────────────
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  case "${1:-}" in
+    check)          check_prerequisites ;;
+    create-cluster) shift; create_cluster "$@" ;;
+    delete-cluster) shift; delete_cluster "$@" ;;
+    container)      shift; container_cmd "$@" ;;
+    "")             err "usage: kind-runtime.sh {check|create-cluster|delete-cluster|container|<kind args>}"; exit 2 ;;
+    *)              kind_cmd "$@" ;;
+  esac
+fi

--- a/osac-installer/scripts/dev-full/manifests/awx-instance.yaml
+++ b/osac-installer/scripts/dev-full/manifests/awx-instance.yaml
@@ -1,0 +1,37 @@
+apiVersion: awx.ansible.com/v1beta1
+kind: AWX
+metadata:
+  name: awx
+  namespace: awx
+spec:
+  service_type: ClusterIP
+  postgres_storage_class: standard
+  projects_persistence: false
+  postgres_resource_requirements:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  web_resource_requirements:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 2Gi
+  task_resource_requirements:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 2Gi
+  ee_resource_requirements:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi

--- a/osac-installer/scripts/dev-full/manifests/httproute-awx.yaml
+++ b/osac-installer/scripts/dev-full/manifests/httproute-awx.yaml
@@ -1,0 +1,21 @@
+# HTTPRoute for the AWX web UI — accessible at http://awx.awx.localhost:8080
+# The HTTP listener on the shared Gateway is created by the osac-infra chart
+# (envoy-gateway-resources.yaml); dev-full only needs to route to AWX.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: awx-external
+  namespace: awx
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    namespace: envoy-gateway
+    name: default
+    sectionName: http
+  hostnames:
+  - awx.awx.localhost
+  rules:
+  - backendRefs:
+    - name: awx-service
+      port: 80

--- a/osac-installer/scripts/dev-full/manifests/osac-ui.yaml
+++ b/osac-installer/scripts/dev-full/manifests/osac-ui.yaml
@@ -1,0 +1,102 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: osac-ui
+  namespace: osac
+data:
+  LOG_LEVEL: "info"
+  # In-cluster upstream for the UI's backend proxy (the browser only ever talks to
+  # this pod on :8080, never directly to the fulfillment API). The fulfillment-api
+  # Service listens on :8000 — :8443 is the host-side kind nodeport for browser
+  # traffic and is NOT a valid in-cluster port, so the backend must use :8000.
+  # The .localhost host is kept so the TLS SNI matches what the ingress-proxy
+  # expects (CoreDNS rewrites *.osac.localhost → the in-cluster Service); TLS
+  # verification is disabled below.
+  FULFILLMENT_API_URL: "https://fulfillment-api.osac.localhost:8000"
+  FULFILLMENT_TLS_INSECURE: "1"
+  OIDC_TLS_INSECURE: "1"
+  OIDC_CLIENT_ID: "osac-ui"
+  OIDC_ISSUER_URL: "https://keycloak.osac.localhost:8443/realms/osac"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: osac-ui
+  namespace: osac
+  labels:
+    app: osac-ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: osac-ui
+  template:
+    metadata:
+      labels:
+        app: osac-ui
+    spec:
+      containers:
+      - name: osac-ui
+        image: ghcr.io/osac-project/osac-ui:latest
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: osac-ui
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 30
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: osac-ui
+  namespace: osac
+  labels:
+    app: osac-ui
+spec:
+  selector:
+    app: osac-ui
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+---
+# HTTPRoute for OSAC UI — accessible at http://ui.osac.localhost:8080
+# The HTTP listener on the shared Gateway is created by the osac-infra chart.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: osac-ui
+  namespace: osac
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    namespace: envoy-gateway
+    name: default
+    sectionName: http
+  hostnames:
+  - ui.osac.localhost
+  rules:
+  - backendRefs:
+    - name: osac-ui
+      port: 80

--- a/osac-installer/scripts/dev-full/manifests/podman-socket-rootful.conf
+++ b/osac-installer/scripts/dev-full/manifests/podman-socket-rootful.conf
@@ -1,0 +1,13 @@
+# Systemd drop-in for podman.socket — allows wheel group members to use
+# the rootful podman socket without sudo. Needed by Distrobox users running
+# PROFILE=dev-full, since KubeVirt requires rootful podman for /dev/kvm access.
+#
+# Install on the host (not inside the Distrobox container):
+#   sudo install -d /etc/systemd/system/podman.socket.d
+#   sudo install -m 0644 podman-socket-rootful.conf \
+#     /etc/systemd/system/podman.socket.d/rootful-group.conf
+#   sudo chgrp wheel /run/podman && sudo chmod 710 /run/podman
+#   sudo systemctl daemon-reload && sudo systemctl restart podman.socket
+[Socket]
+SocketGroup=wheel
+DirectoryMode=0710

--- a/osac-installer/scripts/dev-full/provision-tenant.sh
+++ b/osac-installer/scripts/dev-full/provision-tenant.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# dev-full: provision a ready-to-use tenant so the browser "create a VM" flow works.
+#
+# Why this exists (the chain of facts that makes it necessary):
+#   - Networking resources (VirtualNetwork/Subnet/SecurityGroup) cannot live in the
+#     reserved 'shared'/'system' tenants, so a real tenant is required.
+#   - A regular user's tenant is derived from the Keycloak *organization* claim
+#     (groups map to tenants only for service accounts). With no organization the
+#     claim is empty and the API returns "failed to determine assignable tenants".
+#   - JIT provisioning creates the *user record* on first authenticated call, but it
+#     requires the DB tenant to already exist ("tenant '<t>' doesn't exist" otherwise).
+#   - The Tenants API is gRPC-only (not exposed over REST), so the DB tenant is
+#     created with a throwaway in-cluster grpcurl pod running as the 'admin'
+#     ServiceAccount (same admin identity seed-catalog.sh uses). This keeps the host
+#     dependency-free: only kubectl is needed, no host grpcurl.
+#
+# What this does (all idempotent -- safe to re-run):
+#   1. Create the DB tenant via the private gRPC Tenants API. Creating the tenant
+#      auto-provisions its default VirtualNetwork + Subnet + SecurityGroup (tenant
+#      onboarding), so no network seeding is needed here.
+#   2. Create a matching, enabled Keycloak organization.
+#   3. Add the dev users (default tenant1_user, tenant1_admin) as organization
+#      members so their tokens carry the organization claim and they can log in to
+#      the UI and manage resources in the tenant.
+#
+# Requires KUBECONFIG to point at the kind cluster (set by the Makefile).
+#
+# Usage: provision-tenant.sh [osac-namespace]
+#   Env overrides: TENANT, TENANT_USERS (comma-separated), KC_NS, KC_REALM,
+#                  INTERNAL_SVC, INTERNAL_PORT, GRPCURL_IMAGE
+
+set -euo pipefail
+
+NS="${1:-${NS:-osac}}"
+TENANT="${TENANT:-tenant1}"
+TENANT_USERS="${TENANT_USERS:-tenant1_user,tenant1_admin}"
+KC_NS="${KC_NS:-keycloak}"
+KC_REALM="${KC_REALM:-osac}"
+INTERNAL_SVC="${INTERNAL_SVC:-fulfillment-internal-api}"
+INTERNAL_PORT="${INTERNAL_PORT:-8001}"
+GRPCURL_IMAGE="${GRPCURL_IMAGE:-docker.io/fullstorydev/grpcurl:latest}"
+
+log()  { echo "[+] $*"; }
+warn() { echo "[!] $*" >&2; }
+
+log "Provisioning tenant '${TENANT}' in namespace '${NS}'..."
+
+# ── 1. Create the DB tenant via the private gRPC Tenants API ────────────────────
+# Tenants is gRPC-only. Run grpcurl in-cluster as the 'admin' SA (an emergency
+# service account) so no host grpcurl is required. The admin token is minted
+# host-side and passed as a request header argument; -insecure skips TLS verify
+# against the internal CA. AlreadyExists is treated as success (re-run friendly).
+admin_token=$(kubectl -n "${NS}" create token admin)
+pod="osac-provision-tenant-$$"
+kubectl -n "${NS}" delete pod "${pod}" --ignore-not-found >/dev/null 2>&1 || true
+kubectl -n "${NS}" run "${pod}" --restart=Never --image="${GRPCURL_IMAGE}" \
+  --command -- grpcurl -insecure \
+    -H "authorization: Bearer ${admin_token}" \
+    -d "{\"object\":{\"metadata\":{\"name\":\"${TENANT}\"}}}" \
+    "${INTERNAL_SVC}:${INTERNAL_PORT}" osac.private.v1.Tenants/Create >/dev/null
+
+# Wait for the one-shot pod to finish (Succeeded or Failed), then read its output.
+phase=""
+for _ in $(seq 1 60); do
+  phase=$(kubectl -n "${NS}" get pod "${pod}" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+  [[ "${phase}" == "Succeeded" || "${phase}" == "Failed" ]] && break
+  sleep 2
+done
+out=$(kubectl -n "${NS}" logs "${pod}" 2>/dev/null || true)
+kubectl -n "${NS}" delete pod "${pod}" --ignore-not-found >/dev/null 2>&1 || true
+
+if [[ "${phase}" == "Succeeded" ]]; then
+  log "  tenant '${TENANT}' created (default network auto-provisioned)"
+elif echo "${out}" | grep -qi "AlreadyExists"; then
+  log "  tenant '${TENANT}' already exists"
+else
+  warn "  tenant create did not succeed (phase=${phase:-unknown}):"
+  echo "${out}" | sed 's/^/      /' >&2
+  exit 1
+fi
+
+# ── 1b. Create the subnet target namespace(s) ───────────────────────────────────
+# Each Subnet gets its own k8s namespace named after the Subnet CR: the osac-operator
+# ComputeInstance controller creates/looks for the KubeVirt VM in that
+# subnet-target namespace (osac.openshift.io/subnet-target-namespace annotation),
+# NOT in the tenant namespace. In a real environment that namespace is created by
+# subnet provisioning (the cudn_net role, which also builds the OVN CUDN). On kind
+# networkingProvisioning=false makes subnets reconcile to Ready without any AAP
+# dispatch, so nothing creates the namespace and the VM would have nowhere to live
+# (the CI would hang at Provisioned=False/WaitingForVM). kind VMs use the default
+# pod network + cluster-wide l2bridge binding — no per-namespace CUDN/NAD — so a
+# plain namespace is all that's needed. Create one per onboarded subnet (idempotent).
+#
+# Subnets are scoped to a tenant by the osac.openshift.io/tenant annotation (not a
+# label), and onboarding creates them asynchronously, so poll for the tenant's
+# subnet(s) to appear before creating their namespaces.
+subnets_for_tenant() {
+  kubectl -n "${NS}" get subnets -o json 2>/dev/null | python3 -c "
+import json,sys
+for s in json.load(sys.stdin).get('items', []):
+    if s.get('metadata', {}).get('annotations', {}).get('osac.openshift.io/tenant') == '${TENANT}':
+        print(s['metadata']['name'])
+" 2>/dev/null || true
+}
+onboarded_subnets=""
+for _ in $(seq 1 30); do
+  onboarded_subnets=$(subnets_for_tenant)
+  [[ -n "${onboarded_subnets}" ]] && break
+  sleep 2
+done
+if [[ -z "${onboarded_subnets}" ]]; then
+  warn "  no subnet found for tenant '${TENANT}' yet — VM provisioning will hang until its subnet namespace exists"
+else
+  for sn in ${onboarded_subnets}; do
+    kubectl create namespace "${sn}" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+    log "  subnet target namespace ready: ${sn}"
+  done
+fi
+
+# ── 2 & 3. Keycloak organization + membership ───────────────────────────────────
+# Port-forward Keycloak and drive its admin API to create an enabled organization
+# matching the tenant and add the dev users as members.
+admin_pw=$(kubectl -n "${KC_NS}" get secret keycloak-admin-credentials \
+  -o jsonpath='{.data.admin-password}' | base64 -d)
+
+kubectl -n "${KC_NS}" port-forward svc/keycloak 18443:443 >/dev/null 2>&1 &
+pf_pid=$!
+trap 'kill "${pf_pid}" 2>/dev/null || true; wait "${pf_pid}" 2>/dev/null || true' EXIT
+sleep 3
+
+KC="https://localhost:18443"
+kc_token=$(curl -sk -X POST "${KC}/realms/master/protocol/openid-connect/token" \
+  -d client_id=admin-cli -d username=admin -d "password=${admin_pw}" \
+  -d grant_type=password \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['access_token'])")
+
+KCURL=(curl -skS -H "Authorization: Bearer ${kc_token}" -H "Content-Type: application/json")
+
+# find_org_id <name> — prints the organization id, or '' if absent.
+find_org_id() {
+  "${KCURL[@]}" "${KC}/admin/realms/${KC_REALM}/organizations?exact=true&search=$1" \
+    | python3 -c "import json,sys; print(next((o['id'] for o in json.load(sys.stdin) if o.get('name')=='$1'), ''))" 2>/dev/null || true
+}
+
+# Create the organization (idempotent: 201 created, 409 already exists both OK).
+code=$("${KCURL[@]}" -o /dev/null -w "%{http_code}" \
+  -X POST "${KC}/admin/realms/${KC_REALM}/organizations" \
+  -d "{\"name\":\"${TENANT}\",\"alias\":\"${TENANT}\",\"enabled\":true,\"domains\":[{\"name\":\"${TENANT}.localhost\",\"verified\":true}]}")
+case "${code}" in
+  201) log "  organization '${TENANT}' created" ;;
+  409) log "  organization '${TENANT}' already exists" ;;
+  *)   warn "  organization create returned HTTP ${code}" ;;
+esac
+
+org_id=$(find_org_id "${TENANT}")
+if [[ -z "${org_id}" ]]; then
+  warn "  could not resolve organization id for '${TENANT}' — skipping membership"
+  exit 1
+fi
+
+# Add each dev user as an organization member (idempotent).
+IFS=',' read -ra users <<< "${TENANT_USERS}"
+for u in "${users[@]}"; do
+  u="${u// /}"
+  [[ -z "${u}" ]] && continue
+  uid=$("${KCURL[@]}" "${KC}/admin/realms/${KC_REALM}/users?username=${u}&exact=true" \
+    | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0]['id'] if d else '')" 2>/dev/null || true)
+  if [[ -z "${uid}" ]]; then
+    warn "    user '${u}' not found — skipping"
+    continue
+  fi
+  code=$("${KCURL[@]}" -o /dev/null -w "%{http_code}" \
+    -X POST "${KC}/admin/realms/${KC_REALM}/organizations/${org_id}/members" -d "\"${uid}\"")
+  case "${code}" in
+    201) log "    member added: ${u}" ;;
+    409) log "    member already present: ${u}" ;;
+    *)   warn "    adding member '${u}' returned HTTP ${code}" ;;
+  esac
+done
+
+log "Tenant '${TENANT}' ready — log in as one of: ${TENANT_USERS} (password: keycloak default-user-password)"

--- a/osac-installer/scripts/dev-full/seed-catalog.sh
+++ b/osac-installer/scripts/dev-full/seed-catalog.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# dev-full: seed a starter catalog (disk image, instance types, template, catalog
+# item) into fulfillment-service. These are shared/global catalog objects.
+#
+# Uses the private REST API (/api/private/v1/...) exposed on the internal API
+# service (TLS, port 8001), reached via a local port-forward. Auth is the 'admin'
+# ServiceAccount bearer token. Payloads follow the CURRENT proto schema — notably:
+#   - ComputeInstanceTemplate.spec_defaults references an instance_type + disk_image
+#     (the old inline cores/memory/image fields were removed)
+#   - CatalogItem.template is a reference object ({id}), not a bare string
+# The default NetworkClass is created by the chart's create-network-class hook
+# (networkClass.enabled=true). Per-tenant networking (VirtualNetwork/Subnet/
+# SecurityGroup) is auto-provisioned by tenant onboarding (see provision-tenant.sh),
+# so it is NOT seeded here.
+#
+# Requires KUBECONFIG to point at the kind cluster (set by the Makefile).
+#
+# Usage: seed-catalog.sh [osac-namespace]
+
+set -euo pipefail
+
+NS="${1:-${NS:-osac}}"
+INTERNAL_SVC="${INTERNAL_SVC:-fulfillment-internal-api}"
+INTERNAL_PORT="${INTERNAL_PORT:-8001}"
+LOCAL_PORT="${LOCAL_PORT:-8001}"
+
+log()  { echo "[+] $*"; }
+warn() { echo "[!] $*" >&2; }
+
+# has_id <json> — succeeds if the response body carries an "id".
+has_id() { python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if 'id' in d else 1)" 2>/dev/null; }
+# get <json> <key-path> — python-style .get chain, prints '' on miss.
+jget() { python3 -c "import json,sys; d=json.load(sys.stdin); print(${1})" 2>/dev/null || true; }
+
+log "Seeding catalog into '${NS}' via ${INTERNAL_SVC}:${INTERNAL_PORT}..."
+
+admin_token=$(kubectl -n "${NS}" create token admin)
+
+# Port-forward the internal API.
+kubectl -n "${NS}" port-forward "svc/${INTERNAL_SVC}" "${LOCAL_PORT}:${INTERNAL_PORT}" >/dev/null 2>&1 &
+pf_pid=$!
+trap 'kill "${pf_pid}" 2>/dev/null || true; wait "${pf_pid}" 2>/dev/null || true' EXIT
+sleep 3
+
+API="https://localhost:${LOCAL_PORT}/api/private/v1"
+CURL=(curl -skS -H "Authorization: Bearer ${admin_token}" -H "Content-Type: application/json")
+
+post() {  # post <path> <json-body>  -> prints response body
+  "${CURL[@]}" -X POST "${API}/$1" -d "$2"
+}
+
+# ── DiskImage ─────────────────────────────────────────────────────────────────
+resp=$(post disk_images '{
+  "metadata": {"name": "fedora", "tenant": "shared"},
+  "spec": {
+    "source_type": "SOURCE_TYPE_REGISTRY",
+    "source_ref": "quay.io/containerdisks/fedora:latest",
+    "guest_os_family": "GUEST_OS_FAMILY_LINUX",
+    "architecture": ["ARCHITECTURE_AMD64"],
+    "lifecycle": "DISK_IMAGE_LIFECYCLE_AVAILABLE"
+  }
+}')
+echo "$resp" | has_id && log "  disk-image: fedora" || warn "  disk-image fedora failed (may already exist)"
+
+# ── InstanceTypes ─────────────────────────────────────────────────────────────
+# name:cores:memory_gib:description
+for entry in \
+  "u1-small:2:4:2 cores, 4 GiB RAM" \
+  "u1-medium:4:8:4 cores, 8 GiB RAM" \
+  "u1-large:8:16:8 cores, 16 GiB RAM"; do
+  it_name="${entry%%:*}"; rest="${entry#*:}"
+  it_cores="${rest%%:*}"; rest="${rest#*:}"
+  it_mem="${rest%%:*}"; it_desc="${rest#*:}"
+  resp=$(post instance_types "{
+    \"metadata\": {\"name\": \"${it_name}\"},
+    \"spec\": {\"cores\": ${it_cores}, \"memory_gib\": ${it_mem}, \"description\": \"${it_desc}\", \"state\": \"INSTANCE_TYPE_STATE_ACTIVE\"}
+  }")
+  echo "$resp" | has_id && log "  instance-type: ${it_name} (${it_desc})" || warn "  instance-type ${it_name} failed (may already exist)"
+done
+
+# ── ComputeInstanceTemplate ───────────────────────────────────────────────────
+# spec_defaults now references an instance_type + disk_image (inline cores/memory/
+# image were removed from the schema).
+resp=$(post compute_instance_templates '{
+  "id": "osac.templates.ocp_virt_vm",
+  "title": "Virtual Machine Template (Linux and Windows)",
+  "description": "VM template for OpenShift Virtualization supporting Linux and Windows guests.",
+  "spec_defaults": {
+    "boot_disk": {"size_gib": 10},
+    "run_strategy": "Always",
+    "instance_type": {"name": "u1-medium"},
+    "disk_image": {"name": "fedora"}
+  },
+  "parameters": [
+    {
+      "name": "exposed_ports",
+      "title": "Exposed Ports",
+      "description": "Ports to expose (e.g. 22/tcp,80/tcp)",
+      "type": "string",
+      "required": false
+    }
+  ]
+}')
+echo "$resp" | has_id && log "  template: osac.templates.ocp_virt_vm" || warn "  template failed (may already exist)"
+
+# ── CatalogItem ───────────────────────────────────────────────────────────────
+# template is now a reference object, not a bare string.
+resp=$(post compute_instance_catalog_items '{
+  "metadata": {"name": "linux-vm"},
+  "title": "Linux Virtual Machine",
+  "description": "Fedora-based virtual machine with KVM acceleration. Default: 4 cores, 8 GiB RAM, 10 GiB disk.",
+  "template": {"id": "osac.templates.ocp_virt_vm"},
+  "published": true,
+  "tenant": ""
+}')
+echo "$resp" | has_id && log "  catalog-item: linux-vm" || warn "  catalog-item failed (may already exist)"
+
+# ── Networking is NOT seeded here ──────────────────────────────────────────────
+# The default VirtualNetwork + Subnet + SecurityGroup are auto-provisioned per
+# tenant by tenant onboarding when the tenant is created (see provision-tenant.sh),
+# using the default NetworkClass onboarding defaults. Seeding them here would place
+# them in the reserved 'shared' tenant, which the API rejects. The NetworkClass
+# itself is created by the chart's create-network-class hook (networkClass.enabled).
+
+log "Catalog seeded — ready to create compute instances"

--- a/osac-installer/values/dev/kind-infra-devfull.yaml
+++ b/osac-installer/values/dev/kind-infra-devfull.yaml
@@ -1,0 +1,26 @@
+# Kind dev-full overlay -- layered on top of kind-infra.yaml (PROFILE=dev-full).
+#
+# dev-full exercises the browser-driven OIDC login flow, so Keycloak must be
+# reachable from the host at a name that resolves without /etc/hosts. Setting the
+# hostname to keycloak.osac.localhost makes:
+#   - the Keycloak TLS cert SAN + the gateway TLSRoute SNI use keycloak.osac.localhost
+#     (so a browser hitting https://keycloak.osac.localhost:8443 matches a route), and
+#   - Keycloak issue tokens with iss=https://keycloak.osac.localhost:8443/realms/osac,
+#     matching service.auth.issuerUrl in kind-instance-devfull.yaml.
+# In-cluster, the CoreDNS localhostRewrite (kind-infra.yaml: coredns.localhostRewrite)
+# already maps keycloak.osac.localhost → keycloak.keycloak.svc.cluster.local, so
+# fulfillment-service still reaches Keycloak's JWKS endpoint directly.
+#
+# The plain `dev`/IT profile keeps keycloak.keycloak.svc.cluster.local (kind-infra.yaml).
+keycloak:
+  # KC_HOSTNAME / OIDC issuer (full URL with scheme + port).
+  hostname: "https://keycloak.osac.localhost:8443"
+  route:
+    # Bare hostname (no scheme/port). Drives BOTH the keycloak-tls cert SAN
+    # (charts/osac-infra keycloak Certificate) and the gateway TLSRoute SNI
+    # (charts/osac-infra envoy-gateway-resources.yaml). Browsers reach Keycloak
+    # at https://keycloak.osac.localhost:8443 and validate the presented cert
+    # against this SAN; in-cluster JWKS fetches also validate it (CoreDNS
+    # rewrites the name to the Keycloak service). The plain dev/IT profile leaves
+    # this empty, so the chart falls back to keycloak.keycloak.svc.cluster.local.
+    hostname: "keycloak.osac.localhost"

--- a/osac-installer/values/dev/kind-instance-devfull.yaml
+++ b/osac-installer/values/dev/kind-instance-devfull.yaml
@@ -1,0 +1,53 @@
+# Kind dev-full overlay -- layered on top of kind-instance.yaml (PROFILE=dev-full).
+#
+# The plain `dev` (integration-test) profile uses kind-instance.yaml as-is and
+# never onboards a real tenant network, so it leaves networking provisioning at
+# its chart default. dev-full seeds a VirtualNetwork/Subnet/SecurityGroup and
+# waits for them to reach READY, but Kind has no CUDN/OVN fabric for the AAP
+# playbooks to act on. Disabling networkingProvisioning makes the networking
+# controllers reconcile those resources to READY immediately (no AAP dispatch),
+# which is exactly the local-dev "noop networking" behavior. The networking
+# controller itself stays enabled (kind-instance.yaml: operator.controllers.networking=true)
+# so it still runs and marks resources Ready.
+operator:
+  controllers:
+    networkingProvisioning: false
+    storage: true
+    volume: true
+
+# --- CSI Driver & Backends ---
+# Enable the OSAC CSI driver for persistent volume provisioning via storage tiers.
+# For dev-full, we leave fulfillment.endpoint empty so it uses in-memory stubs
+# (no real vendor backend integration needed for local dev).
+#
+# CSI backends (VAST, Pure, NetApp) are available but not enabled for local dev.
+# The driver uses vendorControllers="local=none" for node-local storage (hostPath,
+# local PVs) which doesn't require external storage array controllers.
+csiDriver:
+  enabled: true
+
+# csiBackends chart is deployed (same condition as csiDriver), but all vendor
+# backends are disabled. To enable a backend for testing, set csiBackends.<vendor>.enabled: true
+# and provide the required credentials/configuration. Available backends: vast, pure, trident.
+csiBackends: {}
+
+# --- Browser-reachable endpoints (dev-full only) ---
+# dev-full drives the full "create a VM from the UI" flow in a real browser, so
+# the fulfillment API and the OIDC issuer must be reachable *from the host* without
+# any /etc/hosts editing. Any `*.localhost` name resolves to 127.0.0.1 host-side,
+# and CoreDNS rewrites `*.localhost` back to the in-cluster service names, so these
+# names resolve correctly BOTH from the browser (→ gateway on :8443) and in-cluster
+# (→ the real service). The plain `dev`/IT profile keeps the *.svc.cluster.local
+# names (kind-instance.yaml) because its test client uses /etc/hosts.
+#
+# Only the browser-facing names change: externalHostname (UI → API) and the
+# Keycloak issuer/idp URLs (browser login + in-cluster JWKS). internalHostname is
+# left as-is — only in-cluster controllers use it, never the browser.
+service:
+  externalHostname: fulfillment-api.osac.localhost
+  auth:
+    issuerUrl: https://keycloak.osac.localhost:8443/realms/osac
+  idp:
+    url: https://keycloak.osac.localhost:8443
+  vault:
+    keycloakIssuerUrl: "https://keycloak.osac.localhost:8443/realms/osac"


### PR DESCRIPTION
## Summary

Introduces a new `PROFILE=dev-full` (Kind only) that provides a complete local development environment with end-to-end "create a VM from the UI" capability. This is a superset of `PROFILE=dev` (which targets integration tests only).

## Implementation Approach

- **Helm chart** (`charts/osac-devstack/`) for declarative resources where possible
- **Hook Jobs** for components without official Helm charts (KubeVirt/CDI/Multus)
- **Minimal scripts** for unavoidable imperative operations (bridge CNI, API calls)

## Key Components

### 1. Virtualization Stack (KubeVirt + CDI + Multus)
- KubeVirt operator + CR with l2bridge network-binding plugin
- CDI operator + CR with patched feature gates
- Multus CNI daemonset + bridge CNI plugin on Kind nodes

### 2. AWX Provisioning Backend
- awx-operator as Helm chart dependency
- AWX instance in osac namespace
- Automated configuration via API (token, inventory, project, templates)
- HTTPRoute for web UI access at http://awx.awx.localhost:8080

### 3. OSAC UI for Kind
- HTTPRoute for Gateway API (osac chart's ui.enabled uses OpenShift Route)
- UI deployment provided by osac chart's osac-ui dependency
- Accessible at http://ui.osac.localhost:8080

### 4. Seeded Catalog
- Disk images (fedora)
- Instance types (u1-small/medium/large)
- Catalog item (linux-vm)
- VirtualNetwork 'default' with Subnet and SecurityGroup

### 5. Ready-to-Use tenant1
- Created via gRPC Tenants API (triggers tenant onboarding)
- Keycloak organization with tenant1_user and tenant1_admin
- Default network auto-provisioned

## Usage

```bash
make install PLATFORM=kind PROFILE=dev-full NS=osac
```

## Prerequisites

- **Linux:** rootful podman + /dev/kvm
- **macOS:** Docker Desktop
- python3 with requests module
- grpcurl (optional, for manual API testing)

## Testing

Full clean installation tested successfully:
- Total installation time: ~13 minutes
- All 5 hook jobs completed successfully
- Zero manual intervention required
- AWX operator patched to ghcr.io/kube-rbac-proxy/kube-rbac-proxy:v0.22.1
- All components running (AWX, KubeVirt, UI, fulfillment-service)
- tenant1 ready with seeded catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **Deployment:** Added the Kind-only `PROFILE=dev-full` profile. It installs KubeVirt, CDI, Multus, bridge CNI, AWX, the OSAC UI, catalog data, and tenant resources.
- **API surface:** Added the `install-devstack` Make target, the `dev-full` profile contract, and the `operator.controllers.networkingProvisioning` configuration property.
- **Controllers:** Added deployment-time AWX configuration and optional OSAC operator restart handling. No OSAC controller code changed.
- **Database:** Added tenant creation through the authenticated Tenants gRPC API. No database schema changed.
- **Auth:** Added Keycloak browser endpoints, AWX tokens, Kubernetes service-account credentials, tenant organizations, and development-user membership.
- **Deployment automation:** Added Helm resources, hook Jobs, runtime detection, prerequisite checks, UI and AWX routes, catalog seeding, virtualization setup, and tenant onboarding scripts.
- **CI and tests:** Added no automated tests. E2E validation was mixed. BMaaS failed on cert-manager and RBAC issues. VMaaS and CaaS passed.
- **Documentation:** Added installation, prerequisites, endpoints, credentials, access, and teardown instructions.
- **Backward compatibility:** Existing profiles retain their Make target dependencies. The new profile is Kind-only. `networkingProvisioning` defaults to `true`, which preserves existing behavior. No existing API or database contract changed.

## Risk classification

**risk:ask** — The change adds a large, privileged deployment path with virtualization, runtime detection, authentication setup, asynchronous tenant provisioning, and multiple installation hooks. BMaaS E2E failures show unresolved deployment and RBAC risks.

The change is close to **risk:show** because it is isolated to the new Kind development profile and preserves existing profile behavior. It does not qualify because the new end-to-end path has not passed all relevant validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->