### PR TITLE
NO-ISSUE: fix: cancel stale merge-queue E2E runs on reshuffle

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -34,8 +34,8 @@ on:
         default: "main"
 
 concurrency:
-  group: e2e-bmaas-full-install-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: e2e-bmaas-full-install-${{ github.event.pull_request.number || (github.event_name == 'merge_group' && 'merge-queue') || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
 
 jobs:
   changes:

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -34,8 +34,8 @@ on:
         default: "main"
 
 concurrency:
-  group: e2e-caas-full-install-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: e2e-caas-full-install-${{ github.event.pull_request.number || (github.event_name == 'merge_group' && 'merge-queue') || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
 
 jobs:
   changes:

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -34,8 +34,8 @@ on:
         default: "main"
 
 concurrency:
-  group: e2e-vmaas-full-install-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: e2e-vmaas-full-install-${{ github.event.pull_request.number || (github.event_name == 'merge_group' && 'merge-queue') || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
 
 jobs:
   changes:


### PR DESCRIPTION
## Summary
- E2E merge-group runs used a unique concurrency group (`github.run_id`) and never cancelled on reshuffle, causing stale runs to hit the 40-minute helm timeout against deleted refs
- ~50% of merge-group runs in the last 3 days failed on "Install OSAC" due to this — the AAP project sync tries `git checkout <stale-SHA>` and gets `unable to read tree`
- Fix: share a single concurrency group per workflow for `merge_group` events and enable `cancel-in-progress`

## Test plan
- [ ] Verify merge-queue runs are cancelled when the queue reshuffles (check for `aborted` state instead of 40-min `failure`)
- [ ] Verify PR and scheduled runs are unaffected

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **CI:** Updated the BMAAS, CAAS, and VMAAS E2E workflows.
- `merge_group` runs now use the shared `merge-queue` concurrency group.
- `cancel-in-progress` now cancels older `merge_group` runs.
- Pull request and scheduled run behavior remains unchanged.
- This prevents stale merge-queue runs from using deleted refs and reaching the Helm timeout.
- The change has no API, controller, database, authentication, deployment, test, or documentation impact.
- No backward-compatibility impact is expected.

## Risk classification

**risk:show** — The change affects CI workflow execution and can cancel in-progress merge-queue runs. It does not change application runtime behavior or production deployment logic.

It does not qualify for **risk:ask** because the change does not modify production code, APIs, data, authentication, or deployment behavior. It exceeds **risk:ship** because it changes concurrency and cancellation behavior in shared CI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->