### PR TITLE
OSAC-4466: Support shared pull secrets in cluster templates

### DIFF
--- a/fulfillment-service/docs/AUTH.md
+++ b/fulfillment-service/docs/AUTH.md
@@ -443,6 +443,10 @@ fulfillment service. Valid values are `default` and `guest`.
    and must be scoped to a specific tenant. Platform-scoped resources (such as roles, users, host
    types, instance types, templates, and catalog items) can be placed in the `shared` tenant.
 
+   Secrets used by shared templates are a special case: their metadata is visible so references can
+   be resolved, but decrypted data and mutations are restricted to platform administrators and
+   controllers.
+
 2. **System Tenant**: The `system` tenant is a special tenant used for objects that are only visible
    to the system itself. Resources assigned to the `system` tenant are not visible to regular users.
    This is used internally for system-level resources. As with the `shared` tenant, tenant-scoped

--- a/fulfillment-service/docs/CATALOG_ITEMS.md
+++ b/fulfillment-service/docs/CATALOG_ITEMS.md
@@ -333,6 +333,27 @@ osac create cluster --catalog-item dev-sandbox \
   --pod-cidr "10.128.0.0/14"
 ```
 
+### Shared pull secrets in cluster templates
+
+Platform administrators can create a Vault-backed pull Secret in the `shared` tenant and reference
+it from a shared cluster template:
+
+```bash
+osac --tenant shared create secret --name shared-pull-secret \
+  --from-file=.dockerconfigjson=pull-secret.json
+```
+
+```yaml
+spec_defaults:
+  pull_secret_secret:
+    name: shared-pull-secret
+```
+
+The reference is resolved to a canonical Secret identifier when the template is published. Clusters
+that don't provide their own pull Secret inherit that reference, and the fulfillment controller
+retrieves its data while provisioning. Tenant users can use the shared credential through the
+template but cannot retrieve or mutate the shared Secret through the Secrets API.
+
 Use `--set` to pass template parameters or override editable spec fields. Each `--set` takes a
 single `KEY=VALUE` pair (split on the first `=`):
 

--- a/fulfillment-service/internal/cmd/service/start/grpcserver/reference_lookups.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/reference_lookups.go
@@ -280,8 +280,14 @@ func registerReferenceLookups(
 	if err != nil {
 		return fmt.Errorf("failed to create Secret DAO for reference lookups: %w", err)
 	}
-	references.RegisterDAOLookup(validator, "osac.private.v1.SecretLocalReference", secretsDAO)
-	references.RegisterDAOLookup(validator, "osac.public.v1.SecretLocalReference", secretsDAO)
+	validator.Register(
+		"osac.private.v1.SecretLocalReference",
+		references.NewScopedDAOLookupFunc(secretsDAO),
+	)
+	validator.Register(
+		"osac.public.v1.SecretLocalReference",
+		references.NewScopedDAOLookupFunc(secretsDAO),
+	)
 
 	return nil
 }

--- a/fulfillment-service/internal/controllers/tenant/tenant_reconciler_function.go
+++ b/fulfillment-service/internal/controllers/tenant/tenant_reconciler_function.go
@@ -680,7 +680,9 @@ func (t *task) ensureVaultNamespace(ctx context.Context) error {
 	if t.r.vaultLifecycle == nil {
 		return nil
 	}
-	if t.isBuiltin() {
+	// The shared tenant stores platform-managed Secrets used by shared templates, so it needs a
+	// Vault namespace. The system tenant remains internal-only and must not get one.
+	if t.tenant.GetMetadata().GetName() == auth.SystemTenant {
 		return nil
 	}
 	if t.isConditionTrue(condType) {

--- a/fulfillment-service/internal/controllers/tenant/tenant_reconciler_function_test.go
+++ b/fulfillment-service/internal/controllers/tenant/tenant_reconciler_function_test.go
@@ -2395,7 +2395,7 @@ var _ = Describe("Vault namespace provisioning", func() {
 		Expect(cond.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_FALSE))
 	})
 
-	It("skips vault provisioning for builtin tenants", func() {
+	It("provisions a vault namespace for the shared tenant", func() {
 		reconciler := &function{
 			logger:         logger,
 			idpManager:     idpManager,
@@ -2418,6 +2418,41 @@ var _ = Describe("Vault namespace provisioning", func() {
 		mockIDPClient.EXPECT().
 			GetTenant(gomock.Any(), auth.SharedTenant).
 			Return(&idp.Tenant{Name: auth.SharedTenant}, nil)
+		mockVaultClient.EXPECT().
+			EnsureTenantNamespace(gomock.Any(), auth.SharedTenant).
+			Return(nil)
+
+		t := &task{r: reconciler, tenant: tenant}
+		err := t.update(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		cond := findCondition(tenant)
+		Expect(cond).ToNot(BeNil())
+		Expect(cond.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
+	})
+
+	It("skips vault provisioning for the system tenant", func() {
+		reconciler := &function{
+			logger:         logger,
+			idpManager:     idpManager,
+			vaultLifecycle: mockVaultClient,
+		}
+
+		tenant := privatev1.Tenant_builder{
+			Id: "org-system",
+			Metadata: privatev1.Metadata_builder{
+				Name:       auth.SystemTenant,
+				Finalizers: []string{finalizers.Controller},
+				Tenant:     auth.SystemTenant,
+			}.Build(),
+			Status: privatev1.TenantStatus_builder{
+				State:         privatev1.TenantState_TENANT_STATE_SYNCED,
+				IdpTenantName: auth.SystemTenant,
+			}.Build(),
+		}.Build()
+
+		mockIDPClient.EXPECT().
+			GetTenant(gomock.Any(), auth.SystemTenant).
+			Return(&idp.Tenant{Name: auth.SystemTenant}, nil)
 
 		t := &task{r: reconciler, tenant: tenant}
 		err := t.update(ctx)

--- a/fulfillment-service/internal/references/lookups.go
+++ b/fulfillment-service/internal/references/lookups.go
@@ -40,6 +40,17 @@ func (e *errRefNotFound) IsNotFound() bool {
 // NewDAOLookupFunc creates a ReferenceLookupFunc backed by a GenericDAO. It queries the DAO
 // using a CEL filter that matches by id or metadata.name and returns the resolved reference metadata.
 func NewDAOLookupFunc[O dao.Object](d *dao.GenericDAO[O]) ReferenceLookupFunc {
+	return newDAOLookupFunc(d, false)
+}
+
+// NewScopedDAOLookupFunc creates a DAO lookup that additionally constrains references to an
+// explicitly supplied tenant/project. If the caller has no explicit tenant, it retains the
+// visibility-based behavior of NewDAOLookupFunc.
+func NewScopedDAOLookupFunc[O dao.Object](d *dao.GenericDAO[O]) ReferenceLookupFunc {
+	return newDAOLookupFunc(d, true)
+}
+
+func newDAOLookupFunc[O dao.Object](d *dao.GenericDAO[O], scopeExplicitTenant bool) ReferenceLookupFunc {
 	return func(ctx context.Context, tenant, project, id, name string) (*ResolvedRef, error) {
 		var filter string
 		switch {
@@ -54,6 +65,15 @@ func NewDAOLookupFunc[O dao.Object](d *dao.GenericDAO[O]) ReferenceLookupFunc {
 			filter = fmt.Sprintf("this.metadata.name == %s", strconv.Quote(name))
 		default:
 			return nil, &errRefNotFound{identifier: "(empty)"}
+		}
+		// When the caller supplies an explicit scope, keep local references inside it. Requests
+		// without metadata retain the existing visibility-based behavior so generic default-tenant
+		// assignment remains compatible.
+		if scopeExplicitTenant && tenant != "" {
+			filter += fmt.Sprintf(
+				" && this.metadata.tenant == %s && this.metadata.project == %s",
+				strconv.Quote(tenant), strconv.Quote(project),
+			)
 		}
 
 		response, err := d.List().

--- a/fulfillment-service/internal/servers/private_clusters_server.go
+++ b/fulfillment-service/internal/servers/private_clusters_server.go
@@ -431,7 +431,20 @@ func (s *PrivateClustersServer) Update(ctx context.Context,
 	if err = s.validatePullSecretMutualExclusionForUpdate(ctx, request); err != nil {
 		return
 	}
-	if err = s.validatePullSecretSecret(ctx, request.GetObject().GetSpec()); err != nil {
+	allowExistingSharedRef := false
+	requestedRef := request.GetObject().GetSpec().GetPullSecretSecret()
+	if requestedRef != nil && requestedRef.GetId() != "" {
+		existing, found, lookupErr := s.getExistingCluster(ctx, request)
+		if lookupErr != nil {
+			err = lookupErr
+			return
+		}
+		allowExistingSharedRef = found &&
+			existing.GetSpec().GetPullSecretSecret().GetId() == requestedRef.GetId()
+	}
+	if err = s.validatePullSecretSecret(
+		ctx, request.GetObject().GetSpec(), allowExistingSharedRef,
+	); err != nil {
 		return
 	}
 	if err = utils.ValidateClusterSpecFields(request.GetObject().GetSpec()); err != nil {
@@ -641,7 +654,9 @@ func (s *PrivateClustersServer) validatePullSecretMutualExclusionForUpdate(
 	return nil
 }
 
-func (s *PrivateClustersServer) validatePullSecretSecret(ctx context.Context, spec *privatev1.ClusterSpec) error {
+func (s *PrivateClustersServer) validatePullSecretSecret(
+	ctx context.Context, spec *privatev1.ClusterSpec, allowShared bool,
+) error {
 	ref := spec.GetPullSecretSecret()
 	if ref == nil {
 		return nil
@@ -662,6 +677,10 @@ func (s *PrivateClustersServer) validatePullSecretSecret(ctx context.Context, sp
 		}
 		s.logger.ErrorContext(ctx, "Failed to resolve pull_secret_secret reference", "error", err)
 		return grpcstatus.Errorf(grpccodes.Internal, "failed to resolve pull_secret_secret reference")
+	}
+	if resolved.Tenant == auth.SharedTenant && !allowShared {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"shared pull_secret_secret references must be inherited from a shared cluster template")
 	}
 	resolvedRef := &privatev1.SecretLocalReference{}
 	resolvedRef.SetId(resolved.ID)
@@ -1359,6 +1378,12 @@ func (s *PrivateClustersServer) validateAndTransformCluster(ctx context.Context,
 		return grpcstatus.Errorf(grpccodes.InvalidArgument, "template '%s' has been deleted", templateRefStr)
 	}
 
+	// Only a pull secret inherited from a shared template may cross the tenant boundary. Direct
+	// shared SecretLocalReference values on tenant clusters stay local.
+	inheritsPullSecretSecret := cluster.GetSpec().GetPullSecretSecret() == nil &&
+		template.GetMetadata().GetTenant() == auth.SharedTenant &&
+		template.GetSpecDefaults().GetPullSecretSecret() != nil
+
 	// Apply spec defaults from the template (user values take precedence):
 	utils.ApplyClusterSpecDefaults(cluster.GetSpec(), template.GetSpecDefaults())
 
@@ -1368,7 +1393,7 @@ func (s *PrivateClustersServer) validateAndTransformCluster(ctx context.Context,
 	}
 
 	// Validate pull_secret_secret reference exists:
-	if err = s.validatePullSecretSecret(ctx, cluster.GetSpec()); err != nil {
+	if err = s.validatePullSecretSecret(ctx, cluster.GetSpec(), inheritsPullSecretSecret); err != nil {
 		return err
 	}
 
@@ -1612,13 +1637,17 @@ func (s *PrivateClustersServer) validateAndTransformCatalogItem(ctx context.Cont
 	resolvedTemplateRef.SetName(template.GetMetadata().GetName())
 	cluster.GetSpec().SetTemplate(resolvedTemplateRef)
 
+	inheritsPullSecretSecret := cluster.GetSpec().GetPullSecretSecret() == nil &&
+		template.GetMetadata().GetTenant() == auth.SharedTenant &&
+		template.GetSpecDefaults().GetPullSecretSecret() != nil
+
 	// Apply spec defaults from the template (user and field_definition values take precedence):
 	utils.ApplyClusterSpecDefaults(cluster.GetSpec(), template.GetSpecDefaults())
 
 	if err := s.validatePullSecretMutualExclusion(cluster.GetSpec()); err != nil {
 		return err
 	}
-	if err := s.validatePullSecretSecret(ctx, cluster.GetSpec()); err != nil {
+	if err := s.validatePullSecretSecret(ctx, cluster.GetSpec(), inheritsPullSecretSecret); err != nil {
 		return err
 	}
 

--- a/fulfillment-service/internal/servers/private_clusters_server_test.go
+++ b/fulfillment-service/internal/servers/private_clusters_server_test.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/osac/fulfillment-service/internal/auth"
 	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/osac/fulfillment-service/internal/uuid"
 )
@@ -3151,6 +3152,36 @@ var _ = Describe("Private clusters server", func() {
 				Expect(grpcstatus.Convert(err).Message()).To(ContainSubstring("no secret"))
 			})
 
+			It("Rejects a directly supplied shared pull_secret_secret reference", func() {
+				_, err := secretsDao.Create().SetObject(privatev1.Secret_builder{
+					Id: "shared-secret-direct-id",
+					Metadata: privatev1.Metadata_builder{
+						Name:   "shared-secret-direct",
+						Tenant: auth.SharedTenant,
+					}.Build(),
+				}.Build()).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = server.Create(ctx, privatev1.ClustersCreateRequest_builder{
+					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
+						Spec: privatev1.ClusterSpec_builder{
+							Template: privatev1.ClusterTemplateReference_builder{Id: "my-template-id"}.Build(),
+							NodeSets: map[string]*privatev1.ClusterNodeSet{
+								"compute": privatev1.ClusterNodeSet_builder{Size: proto.Int32(3)}.Build(),
+								"gpu":     privatev1.ClusterNodeSet_builder{Size: proto.Int32(1)}.Build(),
+							},
+							PullSecretSecret: privatev1.SecretLocalReference_builder{Id: "shared-secret-direct-id"}.Build(),
+						}.Build(),
+						Status: privatev1.ClusterStatus_builder{Hub: "my-hub-id"}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(grpcstatus.Code(err)).To(Equal(grpccodes.InvalidArgument))
+				Expect(grpcstatus.Convert(err).Message()).To(ContainSubstring("inherited from a shared cluster template"))
+			})
+
 			It("Creates a cluster with inline pull_secret when pull_secret_secret is not set", func() {
 				response, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
 					Object: privatev1.Cluster_builder{
@@ -3341,6 +3372,81 @@ var _ = Describe("Private clusters server", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.GetObject().GetSpec().GetPullSecretSecret()).ToNot(BeNil())
 				Expect(response.GetObject().GetSpec().GetPullSecretSecret().GetId()).To(Equal("my-secret-id"))
+			})
+
+			It("inherits a canonical shared pull Secret when a tenant Secret has the same name", func() {
+				_, err := secretsDao.Create().SetObject(privatev1.Secret_builder{
+					Id: "shared-pull-secret-id",
+					Metadata: privatev1.Metadata_builder{
+						Name:   "my-secret-name",
+						Tenant: auth.SharedTenant,
+					}.Build(),
+				}.Build()).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				templatesDao, err := dao.NewGenericDAO[*privatev1.ClusterTemplate]().
+					SetLogger(logger).
+					SetTenancyLogic(tenancy).
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+				_, err = templatesDao.Create().SetObject(privatev1.ClusterTemplate_builder{
+					Id: "shared-template-with-secret-ref",
+					Metadata: privatev1.Metadata_builder{
+						Name:   "shared-template-with-secret-ref",
+						Tenant: auth.SharedTenant,
+					}.Build(),
+					Title:       "Shared template with pull Secret",
+					Description: "Shared template with a canonical pull Secret reference",
+					NodeSets: map[string]*privatev1.ClusterTemplateNodeSet{
+						"compute": privatev1.ClusterTemplateNodeSet_builder{
+							HostType: privatev1.HostTypeReference_builder{Id: "acme-1ti-id"}.Build(),
+							Size:     3,
+						}.Build(),
+					},
+					SpecDefaults: privatev1.ClusterTemplateSpecDefaults_builder{
+						PullSecretSecret: privatev1.SecretLocalReference_builder{
+							Id:   "shared-pull-secret-id",
+							Name: "my-secret-name",
+						}.Build(),
+					}.Build(),
+				}.Build()).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				response, err := server.Create(ctx, privatev1.ClustersCreateRequest_builder{
+					Object: privatev1.Cluster_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.New()[24:32]),
+						}.Build(),
+						Spec: privatev1.ClusterSpec_builder{
+							Template: privatev1.ClusterTemplateReference_builder{
+								Id: "shared-template-with-secret-ref",
+							}.Build(),
+							NodeSets: map[string]*privatev1.ClusterNodeSet{
+								"compute": privatev1.ClusterNodeSet_builder{Size: proto.Int32(3)}.Build(),
+							},
+						}.Build(),
+						Status: privatev1.ClusterStatus_builder{Hub: "my-hub-id"}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.GetObject().GetSpec().GetPullSecretSecret().GetId()).
+					To(Equal("shared-pull-secret-id"))
+
+				updateResponse, err := server.Update(ctx, privatev1.ClustersUpdateRequest_builder{
+					Object: privatev1.Cluster_builder{
+						Id: response.GetObject().GetId(),
+						Spec: privatev1.ClusterSpec_builder{
+							PullSecretSecret: privatev1.SecretLocalReference_builder{
+								Id:   "shared-pull-secret-id",
+								Name: "my-secret-name",
+							}.Build(),
+						}.Build(),
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"spec.pull_secret_secret"}},
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updateResponse.GetObject().GetSpec().GetPullSecretSecret().GetId()).
+					To(Equal("shared-pull-secret-id"))
 			})
 
 			It("User-provided pull_secret overrides template pull_secret_secret default", func() {

--- a/fulfillment-service/internal/servers/private_identity_providers_server.go
+++ b/fulfillment-service/internal/servers/private_identity_providers_server.go
@@ -314,6 +314,10 @@ func (s *PrivateIdentityProvidersServer) validateClientSecretSecret(
 		s.logger.ErrorContext(ctx, "Failed to resolve client_secret_secret reference", "error", err)
 		return grpcstatus.Errorf(grpccodes.Internal, "failed to resolve client_secret_secret reference")
 	}
+	if resolved.Tenant == auth.SharedTenant {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"shared secrets cannot be used as identity provider client_secret_secret references")
+	}
 	// Load the resolved Secret and ensure it carries a non-empty data["value"] entry, as required
 	// by the reconciler that consumes it. Rejecting here surfaces the problem as an INVALID_ARGUMENT
 	// at write time instead of a silent reconcile failure later.

--- a/fulfillment-service/internal/servers/private_identity_providers_server_test.go
+++ b/fulfillment-service/internal/servers/private_identity_providers_server_test.go
@@ -627,7 +627,10 @@ var _ = Describe("Private identity providers server", func() {
 	})
 
 	Describe("Client secret secret reference", func() {
-		var server *PrivateIdentityProvidersServer
+		var (
+			server     *PrivateIdentityProvidersServer
+			secretsDao *dao.GenericDAO[*privatev1.Secret]
+		)
 
 		BeforeEach(func() {
 			var err error
@@ -638,7 +641,7 @@ var _ = Describe("Private identity providers server", func() {
 				Build()
 			Expect(err).ToNot(HaveOccurred())
 
-			secretsDao, err := dao.NewGenericDAO[*privatev1.Secret]().
+			secretsDao, err = dao.NewGenericDAO[*privatev1.Secret]().
 				SetLogger(logger).
 				SetTenancyLogic(tenancy).
 				Build()
@@ -712,6 +715,30 @@ var _ = Describe("Private identity providers server", func() {
 			ref := response.GetObject().GetSpec().GetOidc().GetClientSecretSecret()
 			Expect(ref.GetId()).To(Equal("my-secret-id"))
 			Expect(ref.GetName()).To(Equal("my-secret-name"))
+		})
+
+		It("Rejects a shared client_secret_secret reference", func() {
+			_, err := secretsDao.Create().SetObject(privatev1.Secret_builder{
+				Id: "shared-client-secret-id",
+				Metadata: privatev1.Metadata_builder{
+					Name:   "shared-client-secret",
+					Tenant: auth.SharedTenant,
+				}.Build(),
+				Data: map[string][]byte{"value": []byte("shared-value")},
+			}.Build()).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = createIdp(privatev1.OidcConfig_builder{
+				AuthorizationUrl: "https://example.com/auth",
+				TokenUrl:         "https://example.com/token",
+				ClientId:         "client-id",
+				Issuer:           "https://example.com",
+				ClientSecretSecret: privatev1.SecretLocalReference_builder{
+					Id: "shared-client-secret-id",
+				}.Build(),
+			}.Build())
+			Expect(grpcstatus.Code(err)).To(Equal(grpccodes.InvalidArgument))
+			Expect(grpcstatus.Convert(err).Message()).To(ContainSubstring("shared secrets cannot be used"))
 		})
 
 		It("Rejects create when client_secret and client_secret_secret are both set", func() {

--- a/fulfillment-service/internal/servers/private_secrets_server.go
+++ b/fulfillment-service/internal/servers/private_secrets_server.go
@@ -127,6 +127,7 @@ func (b *PrivateSecretsServerBuilder) Build() (result *PrivateSecretsServer, err
 		SetTenancyLogic(b.tenancyLogic).
 		SetMetricsRegisterer(b.metricsRegisterer).
 		SetFilterDesc(b.filterDesc).
+		AddAllowedTenants(auth.SharedTenant).
 		Build()
 	if err != nil {
 		return
@@ -158,6 +159,9 @@ func (s *PrivateSecretsServer) Get(ctx context.Context,
 	}
 
 	obj := response.GetObject()
+	if err = s.authorizeSharedSecretManagement(ctx, obj); err != nil {
+		return
+	}
 	if s.secretStore != nil && obj.GetBackend() == privatev1.SecretBackend_SECRET_BACKEND_VAULT {
 		tenant := obj.GetMetadata().GetTenant()
 		project := obj.GetMetadata().GetProject()
@@ -206,25 +210,47 @@ func (s *PrivateSecretsServer) Create(ctx context.Context,
 		secret.SetBackend(privatev1.SecretBackend_SECRET_BACKEND_VAULT)
 	}
 
-	if s.secretStore != nil && secret.GetBackend() == privatev1.SecretBackend_SECRET_BACKEND_VAULT {
-		tenant, tenantErr := s.determineTenant(ctx, secret)
-		if tenantErr != nil {
-			err = tenantErr
-			return
-		}
-		project := secret.GetMetadata().GetProject()
-		name := secret.GetMetadata().GetName()
-
-		err = s.secretStore.Store(ctx, tenant, project, name, secret.GetData())
-		if err != nil {
-			err = vault.ToGrpcError(err)
-			return
-		}
-
+	persistInVault := s.secretStore != nil && secret.GetBackend() == privatev1.SecretBackend_SECRET_BACKEND_VAULT
+	var data map[string][]byte
+	if persistInVault {
+		data = secret.GetData()
 		secret.SetData(nil)
 	}
 
-	err = s.generic.Create(ctx, request, &response)
+	create := func(opCtx context.Context) error {
+		if createErr := s.generic.Create(opCtx, request, &response); createErr != nil {
+			return createErr
+		}
+		created := response.GetObject()
+		if authErr := s.authorizeSharedSecretManagement(opCtx, created); authErr != nil {
+			return authErr
+		}
+		if created.GetMetadata().GetTenant() == auth.SharedTenant {
+			if created.GetBackend() != privatev1.SecretBackend_SECRET_BACKEND_VAULT {
+				return grpcstatus.Errorf(grpccodes.InvalidArgument, "shared Secrets must use the Vault backend")
+			}
+			if s.secretStore == nil {
+				return grpcstatus.Errorf(grpccodes.FailedPrecondition,
+					"shared Secrets require a configured Vault backend")
+			}
+		}
+		if !persistInVault || isDryRun(opCtx) {
+			return nil
+		}
+		storeErr := s.secretStore.Store(
+			opCtx,
+			created.GetMetadata().GetTenant(),
+			created.GetMetadata().GetProject(),
+			created.GetMetadata().GetName(),
+			data,
+		)
+		return vault.ToGrpcError(storeErr)
+	}
+
+	err = s.withSavepoint(ctx, create)
+	if err != nil {
+		response = nil
+	}
 	return
 }
 
@@ -245,30 +271,45 @@ func (s *PrivateSecretsServer) Update(ctx context.Context,
 	}
 
 	existingSecret := getResponse.GetObject()
+	if err = s.authorizeSharedSecretManagement(ctx, existingSecret); err != nil {
+		return
+	}
 
 	err = s.validateSecretUpdate(ctx, request.GetObject(), existingSecret)
 	if err != nil {
 		return
 	}
 
-	if s.secretStore != nil &&
+	persistInVault := s.secretStore != nil &&
 		existingSecret.GetBackend() == privatev1.SecretBackend_SECRET_BACKEND_VAULT &&
-		len(request.GetObject().GetData()) > 0 {
-
-		tenant := existingSecret.GetMetadata().GetTenant()
-		project := existingSecret.GetMetadata().GetProject()
-		name := existingSecret.GetMetadata().GetName()
-
-		err = s.secretStore.Store(ctx, tenant, project, name, request.GetObject().GetData())
-		if err != nil {
-			err = vault.ToGrpcError(err)
-			return
-		}
-
+		len(request.GetObject().GetData()) > 0
+	var data map[string][]byte
+	if persistInVault {
+		data = request.GetObject().GetData()
 		request.GetObject().SetData(nil)
 	}
 
-	err = s.generic.Update(ctx, request, &response)
+	update := func(opCtx context.Context) error {
+		if updateErr := s.generic.Update(opCtx, request, &response); updateErr != nil {
+			return updateErr
+		}
+		if !persistInVault || isDryRun(opCtx) {
+			return nil
+		}
+		storeErr := s.secretStore.Store(
+			opCtx,
+			existingSecret.GetMetadata().GetTenant(),
+			existingSecret.GetMetadata().GetProject(),
+			existingSecret.GetMetadata().GetName(),
+			data,
+		)
+		return vault.ToGrpcError(storeErr)
+	}
+
+	err = s.withSavepoint(ctx, update)
+	if err != nil {
+		response = nil
+	}
 	return
 }
 
@@ -280,16 +321,16 @@ func (s *PrivateSecretsServer) Delete(ctx context.Context,
 		defer tx.ReportError(&err)
 	}
 
-	var obj *privatev1.Secret
-	if s.secretStore != nil {
-		getRequest := &privatev1.SecretsGetRequest{}
-		getRequest.SetId(request.GetId())
-		var getResponse *privatev1.SecretsGetResponse
-		err = s.generic.Get(ctx, getRequest, &getResponse)
-		if err != nil {
-			return
-		}
-		obj = getResponse.GetObject()
+	getRequest := &privatev1.SecretsGetRequest{}
+	getRequest.SetId(request.GetId())
+	var getResponse *privatev1.SecretsGetResponse
+	err = s.generic.Get(ctx, getRequest, &getResponse)
+	if err != nil {
+		return
+	}
+	obj := getResponse.GetObject()
+	if err = s.authorizeSharedSecretManagement(ctx, obj); err != nil {
+		return
 	}
 
 	err = s.generic.Delete(ctx, request, &response)
@@ -297,7 +338,7 @@ func (s *PrivateSecretsServer) Delete(ctx context.Context,
 		return
 	}
 
-	if obj != nil && obj.GetBackend() == privatev1.SecretBackend_SECRET_BACKEND_VAULT {
+	if s.secretStore != nil && obj != nil && obj.GetBackend() == privatev1.SecretBackend_SECRET_BACKEND_VAULT {
 		tenant := obj.GetMetadata().GetTenant()
 		project := obj.GetMetadata().GetProject()
 		name := obj.GetMetadata().GetName()
@@ -312,8 +353,53 @@ func (s *PrivateSecretsServer) Delete(ctx context.Context,
 	return
 }
 
+// authorizeSharedSecretManagement restricts decrypted reads and mutations of shared Secrets to
+// platform administrators and controllers. Both identities have universal tenant scope. Metadata
+// remains listable so shared template references can be resolved without exposing credential data.
+func (s *PrivateSecretsServer) authorizeSharedSecretManagement(ctx context.Context, secret *privatev1.Secret) error {
+	if secret == nil || secret.GetMetadata().GetTenant() != auth.SharedTenant {
+		return nil
+	}
+	allowed, err := s.canManageSharedSecrets(ctx)
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return grpcstatus.Errorf(
+			grpccodes.PermissionDenied,
+			"shared Secrets can only be read or managed by platform administrators and controllers",
+		)
+	}
+	return nil
+}
+
+func (s *PrivateSecretsServer) canManageSharedSecrets(ctx context.Context) (bool, error) {
+	assignable, err := s.tenancyLogic.DetermineAssignableTenants(ctx)
+	if err != nil {
+		return false, grpcstatus.Errorf(grpccodes.Internal, "failed to determine shared Secret access")
+	}
+	return assignable.Universal(), nil
+}
+
+func (s *PrivateSecretsServer) withSavepoint(ctx context.Context, operation func(context.Context) error) error {
+	tx, err := database.TxFromContext(ctx)
+	if err != nil {
+		return operation(ctx)
+	}
+	return tx.Savepoint(ctx, operation)
+}
+
 func (s *PrivateSecretsServer) Signal(ctx context.Context,
 	request *privatev1.SecretsSignalRequest) (response *privatev1.SecretsSignalResponse, err error) {
+	getRequest := &privatev1.SecretsGetRequest{}
+	getRequest.SetId(request.GetId())
+	var getResponse *privatev1.SecretsGetResponse
+	if err = s.generic.Get(ctx, getRequest, &getResponse); err != nil {
+		return
+	}
+	if err = s.authorizeSharedSecretManagement(ctx, getResponse.GetObject()); err != nil {
+		return
+	}
 	err = s.generic.Signal(ctx, request, &response)
 	return
 }
@@ -357,17 +443,6 @@ func (s *PrivateSecretsServer) validateHubSecretCreate(secret *privatev1.Secret)
 			"field 'data' must be empty when backend is HUB")
 	}
 	return nil
-}
-
-func (s *PrivateSecretsServer) determineTenant(ctx context.Context, secret *privatev1.Secret) (string, error) {
-	if t := secret.GetMetadata().GetTenant(); t != "" {
-		return t, nil
-	}
-	t, err := s.tenancyLogic.DetermineDefaultTenant(ctx)
-	if err != nil {
-		return "", grpcstatus.Errorf(grpccodes.Internal, "failed to determine tenant: %v", err)
-	}
-	return t, nil
 }
 
 func (s *PrivateSecretsServer) validateSecretUpdate(_ context.Context,

--- a/fulfillment-service/internal/servers/private_secrets_server_test.go
+++ b/fulfillment-service/internal/servers/private_secrets_server_test.go
@@ -27,6 +27,8 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/osac/fulfillment-service/internal/auth"
+	"github.com/osac-project/osac/fulfillment-service/internal/collections"
 	"github.com/osac-project/osac/fulfillment-service/internal/database"
 	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/osac/fulfillment-service/internal/events"
@@ -641,6 +643,110 @@ var _ = Describe("Private secrets server", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(response.GetObject().GetBackend()).To(Equal(
 					privatev1.SecretBackend_SECRET_BACKEND_HUB))
+			})
+		})
+
+		Describe("Shared Secret authorization", func() {
+			newTenantUserServer := func() *PrivateSecretsServer {
+				visibility, err := auth.NewVisibility().
+					AddVisibleTenants(auth.SharedTenant, testTenant).
+					Build()
+				Expect(err).ToNot(HaveOccurred())
+				restrictedTenancy := auth.NewMockTenancyLogic(ctrl)
+				restrictedTenancy.EXPECT().DetermineAssignableTenants(gomock.Any()).
+					Return(collections.NewSet(testTenant), nil).
+					AnyTimes()
+				restrictedTenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).
+					Return(testTenant, nil).
+					AnyTimes()
+				restrictedTenancy.EXPECT().DetermineVisibility(gomock.Any()).
+					Return(visibility, nil).
+					AnyTimes()
+
+				restrictedServer, buildErr := NewPrivateSecretsServer().
+					SetLogger(logger).
+					SetAttributionLogic(attribution).
+					SetTenancyLogic(restrictedTenancy).
+					SetSecretStore(mockStore).
+					SetHubSecretFetcher(mockHubSecretFetcher).
+					Build()
+				Expect(buildErr).ToNot(HaveOccurred())
+				return restrictedServer
+			}
+
+			createSharedSecret := func(name string) *privatev1.Secret {
+				mockStore.EXPECT().
+					Store(gomock.Any(), auth.SharedTenant, "", name, gomock.Any()).
+					Return(nil)
+				response, err := server.Create(ctx, privatev1.SecretsCreateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name:   name,
+							Tenant: auth.SharedTenant,
+						}.Build(),
+						Data: map[string][]byte{"key": []byte("value")},
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				return response.GetObject()
+			}
+
+			It("allows a platform administrator to create and retrieve a shared Vault Secret", func() {
+				created := createSharedSecret("shared-admin-secret")
+				mockStore.EXPECT().
+					Fetch(gomock.Any(), auth.SharedTenant, "", "shared-admin-secret").
+					Return(map[string][]byte{"key": []byte("value")}, nil)
+
+				response, err := server.Get(ctx, privatev1.SecretsGetRequest_builder{
+					Id: created.GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(response.GetObject().GetData()).To(HaveKey("key"))
+			})
+
+			It("rejects a tenant user's shared Secret create before writing to Vault", func() {
+				restrictedServer := newTenantUserServer()
+				_, err := restrictedServer.Create(ctx, privatev1.SecretsCreateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name:   "rejected-shared-secret",
+							Tenant: auth.SharedTenant,
+						}.Build(),
+						Data: map[string][]byte{"key": []byte("value")},
+					}.Build(),
+				}.Build())
+				Expect(status.Code(err)).To(Equal(codes.PermissionDenied))
+			})
+
+			It("lets tenant users see shared metadata but not retrieve or mutate its data", func() {
+				created := createSharedSecret("shared-protected-secret")
+				restrictedServer := newTenantUserServer()
+
+				list, err := restrictedServer.List(ctx, privatev1.SecretsListRequest_builder{
+					Filter: new("this.id == '" + created.GetId() + "'"),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(list.GetItems()).To(HaveLen(1))
+				Expect(list.GetItems()[0].GetData()).To(BeEmpty())
+
+				_, err = restrictedServer.Get(ctx, privatev1.SecretsGetRequest_builder{
+					Id: created.GetId(),
+				}.Build())
+				Expect(status.Code(err)).To(Equal(codes.PermissionDenied))
+
+				_, err = restrictedServer.Update(ctx, privatev1.SecretsUpdateRequest_builder{
+					Object: privatev1.Secret_builder{
+						Id:   created.GetId(),
+						Data: map[string][]byte{"key": []byte("changed")},
+					}.Build(),
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"data"}},
+				}.Build())
+				Expect(status.Code(err)).To(Equal(codes.PermissionDenied))
+
+				_, err = restrictedServer.Delete(ctx, privatev1.SecretsDeleteRequest_builder{
+					Id: created.GetId(),
+				}.Build())
+				Expect(status.Code(err)).To(Equal(codes.PermissionDenied))
 			})
 		})
 

--- a/fulfillment-service/internal/servers/private_tenants_server.go
+++ b/fulfillment-service/internal/servers/private_tenants_server.go
@@ -452,6 +452,10 @@ func (s *PrivateTenantsServer) validateBreakGlassCredentialsSecret(ctx context.C
 		s.logger.ErrorContext(ctx, "Failed to resolve break_glass_credentials_secret reference", "error", err)
 		return grpcstatus.Errorf(grpccodes.Internal, "failed to resolve break_glass_credentials_secret reference")
 	}
+	if resolved.Tenant == auth.SharedTenant {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"shared secrets cannot be used as break_glass_credentials_secret references")
+	}
 	resolvedRef := &privatev1.SecretLocalReference{}
 	resolvedRef.SetId(resolved.ID)
 	resolvedRef.SetName(resolved.Name)

--- a/osac-aap/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
+++ b/osac-aap/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
@@ -265,6 +265,13 @@ class ClusterNetwork(Base):
     service_cidr: str | None = None
 
 
+class SecretLocalReference(Base):
+    """Reference to a Secret resource by canonical ID or metadata name."""
+
+    id: str | None = None
+    name: str | None = None
+
+
 class ClusterTemplateSpecDefaults(Base):
     """Default values for cluster spec fields.
 
@@ -272,6 +279,7 @@ class ClusterTemplateSpecDefaults(Base):
     """
 
     pull_secret: str | None = None
+    pull_secret_secret: SecretLocalReference | None = None
     ssh_public_key: str | None = None
     release_image: str | None = None
     network: ClusterNetwork | None = None
@@ -345,7 +353,10 @@ class BaseTemplate(Base):
     @pydantic.computed_field
     def metadata(self) -> dict[str, str]:
         name = self.metadata_name if self.metadata_name else self.name.replace("_", "-")
-        return {"name": name}
+        # Template publishing runs as a platform administrator and all template resources are
+        # shared catalog objects. Make the scope explicit so local references (including shared
+        # pull Secrets) are canonicalized within the shared tenant.
+        return {"name": name, "tenant": "shared"}
 
 
 class ClusterTemplate(BaseTemplate):

--- a/osac-aap/collections/ansible_collections/osac/templates/README.md
+++ b/osac-aap/collections/ansible_collections/osac/templates/README.md
@@ -49,8 +49,8 @@ Minimal OpenShift cluster configuration.
 - 2 nodes
 - Resource class: fc430
 
-**Required Parameters:**
-- `pull_secret`: Red Hat pull secret for OpenShift installation
+**Cluster credentials:**
+- `spec_defaults.pull_secret_secret`: Reference to a platform-managed pull Secret
 - `ssh_public_key`: SSH public key for node access
 
 ### VM Templates
@@ -108,6 +108,8 @@ validation, and lifecycle management.
    allowed_resource_classes: []
 
    spec_defaults:
+     pull_secret_secret:
+       name: shared-pull-secret
      release_image: "quay.io/openshift-release-dev/ocp-release:4.17.0-multi"
 
    parameters:
@@ -120,6 +122,11 @@ validation, and lifecycle management.
 
 3. Implement provisioning tasks in `roles/my_cluster_template/tasks/install.yaml`
 4. Implement cleanup tasks in `roles/my_cluster_template/tasks/delete.yaml`
+
+The referenced Secret must be created by a platform administrator in the `shared` tenant before
+the template is published. Pull Secrets must store the registry credentials in the
+`.dockerconfigjson` data key. Tenant users can consume a shared pull Secret through a published
+cluster template, but only platform administrators and controllers can retrieve or mutate its data.
 
 ### Creating a New ComputeInstance Template
 

--- a/osac-aap/tests/unit/plugins/filter/test_find_template_roles.py
+++ b/osac-aap/tests/unit/plugins/filter/test_find_template_roles.py
@@ -6,6 +6,8 @@ import yaml
 from ansible.errors import AnsibleFilterError
 
 from find_template_roles import (
+    ClusterTemplate,
+    ClusterTemplateSpecDefaults,
     Metadata,
     ProtobufAnyValue,
     ProtobufType,
@@ -265,6 +267,25 @@ class TestMetadataTemplateTypes:
         metadata = _load_metadata(roles_dir, "ocp_virt_vm")
         assert metadata.spec_defaults is not None
         assert metadata.spec_defaults["boot_disk"] is not None
+
+    def test_cluster_pull_secret_reference_serialization(self):
+        defaults = ClusterTemplateSpecDefaults.model_validate(
+            {"pull_secret_secret": {"name": "shared-pull-secret"}}
+        )
+
+        template = ClusterTemplate(
+            collection="osac.service",
+            path=Path("roles/ocp_small"),
+            name="ocp_small",
+            parameters=[],
+            spec_defaults=defaults,
+        )
+        dumped = template.model_dump(mode="json", exclude_none=True)
+
+        assert dumped["metadata"] == {"name": "ocp-small", "tenant": "shared"}
+        assert dumped["spec_defaults"] == {
+            "pull_secret_secret": {"name": "shared-pull-secret"}
+        }
 
     def test_cluster_with_parameters(self, roles_dir):
         metadata = _load_metadata(roles_dir, "ocp_4_20_ai_maas")


### PR DESCRIPTION
## Summary

  - Provision a Vault namespace for the shared tenant.
  - Allow Vault-backed secrets in the shared tenant with protected credential access.
  - Authorize requests before writing secret data to Vault.
  - Allow shared pull-secret references only when inherited from a shared cluster template.
  - Preserve tenant-scoped behavior for IdP and other secret references.
  - Add `pull_secret_secret` support to osac-aap template definitions.
  - Document shared template pull-secret configuration.

  ## Testing

  - Go lint: passed
  - Targeted fulfillment-service unit tests: passed
  - osac-aap unit tests: passed
  - Fulfillment integration suite: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

### API surface
- Added `pull_secret_secret` support to `ClusterTemplateSpecDefaults`.
- Added `SecretLocalReference` with optional `id` and `name` fields.
- Added scoped DAO reference lookups with tenant and project filtering.

### Controllers and deployment
- Vault namespace provisioning now includes the `shared` tenant.
- The `system` tenant remains excluded from Vault provisioning.

### Authentication and secrets
- Shared secrets require universally scoped users.
- Authorization now covers shared-secret get, create, update, delete, and signal operations.
- Tenant users can view shared-secret metadata but cannot access secret data or mutate shared secrets.
- Vault-backed writes use transaction savepoints.
- Shared pull-secret references are valid only when inherited from shared cluster templates.
- IdP and tenant credential references continue to reject shared-tenant secrets.

### Tests
- Added coverage for shared-tenant Vault provisioning.
- Added authorization tests for shared secrets.
- Added cluster-template inheritance and update tests.
- Added rejection tests for direct shared-secret references.
- Added osac-aap serialization tests.

### Documentation
- Documented shared pull-secret configuration, Vault requirements, publication behavior, and access restrictions.
- Updated osac-aap template guidance to use `spec_defaults.pull_secret_secret`.

## Backward compatibility

- Cluster templates no longer require users to provide `pull_secret`.
- Existing tenant-scoped IdP and credential references retain their behavior.
- Direct references to shared pull secrets are rejected. Shared pull secrets must come from shared template inheritance.
- Consumers that depend on direct shared-secret access or user-provided template pull secrets require updates.

## Risk classification

**risk:show** — The change modifies secret authorization, Vault provisioning, reference validation, and cluster-template behavior. It includes targeted unit tests and integration test coverage, but the reported E2E workflows failed during early setup without diagnostic artifacts. This is not **risk:ship** because the change affects security-sensitive secret paths and E2E validation is incomplete. It does not qualify as **risk:ask** because the intended behavior is covered by focused tests and the failures were attributed to workflow or provisioning setup rather than confirmed product defects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->