### PR TITLE
OSAC-1165: Issue Kafka listener certificates from the shared CA

### DIFF
--- a/osac-installer/charts/osac-infra/files/hooks/configure-kafka.sh
+++ b/osac-installer/charts/osac-infra/files/hooks/configure-kafka.sh
@@ -2,14 +2,27 @@
 set -euo pipefail
 
 KAFKA_NS=osac-kafka
+LISTENER_TLS_SECRET=osac-kafka-listener-tls
 
-# Idempotency guard: skip all work if Kafka is already healthy.
-if oc wait kafka/osac-kafka -n "${KAFKA_NS}" --for=condition=Ready --timeout=5s 2>/dev/null; then
-  echo "Kafka cluster already ready, nothing to do."
-  exit 0
-fi
+wait_for_listener_tls() {
+  echo "Waiting for Kafka listener TLS secret ${LISTENER_TLS_SECRET}..."
+  local deadline=$((SECONDS + 600))
+  until oc get secret "${LISTENER_TLS_SECRET}" -n "${KAFKA_NS}" \
+    -o jsonpath='{.data.tls\.crt}' 2>/dev/null | grep -q .; do
+    if [ "${SECONDS}" -ge "${deadline}" ]; then
+      echo "Timed out waiting for secret ${LISTENER_TLS_SECRET} in ${KAFKA_NS}"
+      exit 1
+    fi
+    sleep 5
+  done
+  echo "Kafka listener TLS secret is ready."
+}
 
-if oc get subscription amq-streams -n "${KAFKA_NS}" &>/dev/null; then
+# Always apply the Kafka CR so listener (and other) spec changes take effect on
+# upgrade. Skip the operator wait when the cluster already exists.
+if oc get kafka/osac-kafka -n "${KAFKA_NS}" &>/dev/null; then
+  echo "Kafka cluster already present, skipping operator wait."
+elif oc get subscription amq-streams -n "${KAFKA_NS}" &>/dev/null; then
   echo "Waiting for AMQ Streams install plan..."
   until INSTALL_PLAN=$(oc get subscription amq-streams -n "${KAFKA_NS}" -o jsonpath='{.status.installPlanRef.name}' 2>/dev/null) && [[ -n "${INSTALL_PLAN}" ]]; do
     sleep 10
@@ -42,6 +55,8 @@ else
   done
   oc wait --for=condition=Available deploy/strimzi-cluster-operator -n "${KAFKA_NS}" --timeout=300s
 fi
+
+wait_for_listener_tls
 
 echo "Applying Kafka cluster..."
 oc apply -f /config/kafka-cluster.yaml

--- a/osac-installer/charts/osac-infra/templates/hooks/configure-kafka.yaml
+++ b/osac-installer/charts/osac-infra/templates/hooks/configure-kafka.yaml
@@ -37,6 +37,43 @@ rules:
     verbs: ["get", "create", "patch", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: osac-infra-configure-kafka
+  namespace: osac-kafka
+  labels:
+    {{- include "osac-infra.hookLabels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+    "helm.sh/hook-weight": "10"
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["osac-kafka-listener-tls"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: osac-infra-configure-kafka
+  namespace: osac-kafka
+  labels:
+    {{- include "osac-infra.hookLabels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded,hook-failed
+    "helm.sh/hook-weight": "10"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: osac-infra-configure-kafka
+subjects:
+  - kind: ServiceAccount
+    name: osac-infra-configure-kafka
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: osac-infra-configure-kafka

--- a/osac-installer/charts/osac-infra/templates/kafka-certificate.yaml
+++ b/osac-installer/charts/osac-infra/templates/kafka-certificate.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.kafka.enabled }}
+{{/*
+Listener certificate for the internal TLS listener, issued by the same CA as
+other OSAC components. Clients trust it via the ca-bundle ConfigMap rather than
+the Strimzi-generated cluster CA.
+*/}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: osac-kafka-listener
+  namespace: osac-kafka
+  labels:
+    {{- include "osac-infra.labels" . | nindent 4 }}
+spec:
+  issuerRef:
+    kind: {{ .Values.certs.issuerRef.kind }}
+    name: {{ required "certs.issuerRef.name is required" .Values.certs.issuerRef.name }}
+  secretName: osac-kafka-listener-tls
+  # Strimzi requires the listener private key in unencrypted PKCS#8 form.
+  privateKey:
+    encoding: PKCS8
+    rotationPolicy: Always
+  dnsNames:
+    # Bootstrap service (clients use the FQDN).
+    - osac-kafka-kafka-bootstrap
+    - osac-kafka-kafka-bootstrap.osac-kafka
+    - osac-kafka-kafka-bootstrap.osac-kafka.svc
+    - osac-kafka-kafka-bootstrap.osac-kafka.svc.cluster.local
+    # Per-broker pod DNS via the headless brokers service (covers node-pool names).
+    - "*.osac-kafka-kafka-brokers"
+    - "*.osac-kafka-kafka-brokers.osac-kafka"
+    - "*.osac-kafka-kafka-brokers.osac-kafka.svc"
+    - "*.osac-kafka-kafka-brokers.osac-kafka.svc.cluster.local"
+{{- end }}

--- a/osac-installer/charts/osac-infra/templates/kafka.yaml
+++ b/osac-installer/charts/osac-infra/templates/kafka.yaml
@@ -43,6 +43,11 @@ data:
             tls: true
             authentication:
               type: scram-sha-512
+            configuration:
+              brokerCertChainAndKey:
+                secretName: osac-kafka-listener-tls
+                certificate: tls.crt
+                key: tls.key
         config:
           offsets.topic.replication.factor: {{ .Values.kafka.replicas }}
           transaction.state.log.replication.factor: {{ .Values.kafka.replicas }}

--- a/osac-metering/charts/osac-metering/templates/_helpers.tpl
+++ b/osac-metering/charts/osac-metering/templates/_helpers.tpl
@@ -39,10 +39,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- .Values.kafka.brokers | default "osac-kafka-kafka-bootstrap.osac-kafka.svc.cluster.local:9093" }}
 {{- end -}}
 
-{{- define "osac-metering.kafkaCaSecret" -}}
-{{- .Values.kafka.caSecret | default "osac-kafka-cluster-ca-cert" }}
-{{- end -}}
-
 {{- define "osac-metering.kafkaTopic" -}}
 osac.metering.lifecycle
 {{- end -}}

--- a/osac-metering/charts/osac-metering/templates/deployment.yaml
+++ b/osac-metering/charts/osac-metering/templates/deployment.yaml
@@ -66,8 +66,6 @@ spec:
               value: {{ include "osac-metering.kafkaClusterNamespace" . }}
             - name: SASL_SECRET
               value: {{ include "osac-metering.kafkaSaslSecretName" . }}
-            - name: CA_SECRET
-              value: {{ include "osac-metering.kafkaCaSecret" . }}
           volumeMounts:
             - name: kafka-secrets
               mountPath: /etc/kafka-secrets
@@ -106,11 +104,9 @@ spec:
               }
 
               wait_for_secret "${SASL_SECRET}" "${SOURCE_NS}"
-              wait_for_secret "${CA_SECRET}" "${SOURCE_NS}"
 
               oc get secret "${SASL_SECRET}" -n "${SOURCE_NS}" -o jsonpath='{.data.password}' | base64 -d > /etc/kafka-secrets/password
-              oc get secret "${CA_SECRET}" -n "${SOURCE_NS}" -o jsonpath='{.data.ca\.crt}' | base64 -d > /etc/kafka-secrets/ca.crt
-              echo "Kafka secrets fetched."
+              echo "Kafka SASL secret fetched."
       containers:
         - name: {{ include "osac-metering.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -129,7 +125,7 @@ spec:
             - name: KAFKA_BROKERS
               value: {{ include "osac-metering.kafkaBrokers" . | quote }}
             - name: KAFKA_TLS_CA_CERT
-              value: /etc/kafka-secrets/ca.crt
+              value: /etc/ca-bundle/bundle.pem
             - name: KAFKA_SASL_USERNAME
               value: {{ include "osac-metering.kafkaSaslUsername" . | quote }}
             - name: KAFKA_SASL_PASSWORD_FILE

--- a/osac-metering/charts/osac-metering/templates/echo-adapter-deployment.yaml
+++ b/osac-metering/charts/osac-metering/templates/echo-adapter-deployment.yaml
@@ -30,6 +30,9 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 1Mi
+        - name: ca-bundle
+          configMap:
+            name: {{ .Values.certs.caBundle.configMap }}
         - name: tmp
           emptyDir:
             sizeLimit: 10Mi
@@ -43,8 +46,6 @@ spec:
               value: {{ include "osac-metering.kafkaClusterNamespace" . }}
             - name: SASL_SECRET
               value: osac-metering-echo-adapter
-            - name: CA_SECRET
-              value: {{ include "osac-metering.kafkaCaSecret" . }}
           volumeMounts:
             - name: kafka-secrets
               mountPath: /etc/kafka-secrets
@@ -83,11 +84,9 @@ spec:
               }
 
               wait_for_secret "${SASL_SECRET}" "${SOURCE_NS}"
-              wait_for_secret "${CA_SECRET}" "${SOURCE_NS}"
 
               oc get secret "${SASL_SECRET}" -n "${SOURCE_NS}" -o jsonpath='{.data.password}' | base64 -d > /etc/kafka-secrets/password
-              oc get secret "${CA_SECRET}" -n "${SOURCE_NS}" -o jsonpath='{.data.ca\.crt}' | base64 -d > /etc/kafka-secrets/ca.crt
-              echo "Kafka secrets fetched."
+              echo "Kafka SASL secret fetched."
       containers:
         - name: echo-adapter
           image: "{{ .Values.echoAdapter.image.repository }}:{{ .Values.echoAdapter.image.tag }}"
@@ -98,7 +97,7 @@ spec:
             - name: KAFKA_TLS_ENABLED
               value: "true"
             - name: KAFKA_TLS_CA_CERT
-              value: /etc/kafka-secrets/ca.crt
+              value: /etc/ca-bundle/bundle.pem
             - name: KAFKA_SASL_USERNAME
               value: osac-metering-echo-adapter
             - name: KAFKA_CONSUMER_GROUP
@@ -114,6 +113,9 @@ spec:
           volumeMounts:
             - name: kafka-secrets
               mountPath: /etc/kafka-secrets
+              readOnly: true
+            - name: ca-bundle
+              mountPath: /etc/ca-bundle
               readOnly: true
           ports:
             - name: http

--- a/osac-metering/charts/osac-metering/templates/kafka-secrets-rbac.yaml
+++ b/osac-metering/charts/osac-metering/templates/kafka-secrets-rbac.yaml
@@ -1,6 +1,7 @@
-{{- /* Grants the metering ServiceAccount read access to Kafka secrets
-     in the Kafka cluster namespace. The initContainer uses this to
-     fetch SASL credentials and CA cert at startup. */}}
+{{- /* Grants the metering ServiceAccount read access to KafkaUser
+     secrets in the Kafka cluster namespace. The initContainer uses this
+     to fetch SASL credentials at startup. TLS trust uses the shared
+     ca-bundle ConfigMap, not the Strimzi cluster CA. */}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -13,7 +14,6 @@ rules:
     resources: ["secrets"]
     resourceNames:
       - {{ include "osac-metering.kafkaSaslSecretName" . }}
-      - {{ include "osac-metering.kafkaCaSecret" . }}
       {{- if .Values.echoAdapter.enabled }}
       - osac-metering-echo-adapter
       {{- end }}

--- a/osac-metering/charts/osac-metering/templates/m360-adapter-deployment.yaml
+++ b/osac-metering/charts/osac-metering/templates/m360-adapter-deployment.yaml
@@ -30,6 +30,9 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 1Mi
+        - name: ca-bundle
+          configMap:
+            name: {{ .Values.certs.caBundle.configMap }}
         - name: m360-api-key
           secret:
             secretName: {{ required "m360Adapter.m360.apiKeySecret is required when m360Adapter is enabled" .Values.m360Adapter.m360.apiKeySecret }}
@@ -46,8 +49,6 @@ spec:
               value: {{ include "osac-metering.kafkaClusterNamespace" . }}
             - name: SASL_SECRET
               value: osac-metering-m360-adapter
-            - name: CA_SECRET
-              value: {{ include "osac-metering.kafkaCaSecret" . }}
           volumeMounts:
             - name: kafka-secrets
               mountPath: /etc/kafka-secrets
@@ -86,11 +87,9 @@ spec:
               }
 
               wait_for_secret "${SASL_SECRET}" "${SOURCE_NS}"
-              wait_for_secret "${CA_SECRET}" "${SOURCE_NS}"
 
               oc get secret "${SASL_SECRET}" -n "${SOURCE_NS}" -o jsonpath='{.data.password}' | base64 -d > /etc/kafka-secrets/password
-              oc get secret "${CA_SECRET}" -n "${SOURCE_NS}" -o jsonpath='{.data.ca\.crt}' | base64 -d > /etc/kafka-secrets/ca.crt
-              echo "Kafka secrets fetched."
+              echo "Kafka SASL secret fetched."
       containers:
         - name: m360-adapter
           image: "{{ required "m360Adapter.image.repository is required when m360Adapter is enabled" .Values.m360Adapter.image.repository }}:{{ required "m360Adapter.image.tag is required when m360Adapter is enabled" .Values.m360Adapter.image.tag }}"
@@ -101,7 +100,7 @@ spec:
             - name: KAFKA_TLS_ENABLED
               value: "true"
             - name: KAFKA_TLS_CA_CERT
-              value: /etc/kafka-secrets/ca.crt
+              value: /etc/ca-bundle/bundle.pem
             - name: KAFKA_SASL_USERNAME
               value: osac-metering-m360-adapter
             - name: KAFKA_CONSUMER_GROUP
@@ -123,6 +122,9 @@ spec:
           volumeMounts:
             - name: kafka-secrets
               mountPath: /etc/kafka-secrets
+              readOnly: true
+            - name: ca-bundle
+              mountPath: /etc/ca-bundle
               readOnly: true
             - name: m360-api-key
               mountPath: /etc/m360

--- a/osac-metering/charts/osac-metering/values.yaml
+++ b/osac-metering/charts/osac-metering/values.yaml
@@ -29,11 +29,11 @@ resources:
 
 # Kafka connection and topic naming. Override to point at a different
 # Kafka cluster or to prefix topics for per-instance isolation.
+# TLS trust uses certs.caBundle (the shared OSAC CA), not the Strimzi cluster CA.
 kafka:
   brokers: ""          # default: osac-kafka-kafka-bootstrap.osac-kafka.svc.cluster.local:9093
   clusterName: ""      # default: osac-kafka
   clusterNamespace: "" # default: osac-kafka
-  caSecret: ""         # default: osac-kafka-cluster-ca-cert
 
 # Prefix prepended to all topic names (e.g. "pr101" -> "pr101.osac.metering.lifecycle").
 # When set, this chart skips KafkaTopic/KafkaUser creation (the parent chart owns them).


### PR DESCRIPTION
## Summary

- Issue the Kafka internal TLS listener certificate from the same `default-ca` ClusterIssuer used by other OSAC components, instead of trusting Strimzi's self-generated cluster CA.
- Point Kafka clients at the shared `ca-bundle` ConfigMap. That unifies TLS trust across the platform and simplifies connecting the fulfillment service to the broker, which no longer needs a copy of `osac-kafka-cluster-ca-cert`.
- Limit the configure-kafka hook to `get` only the `osac-kafka-listener-tls` secret.

Related: https://redhat.atlassian.net/browse/OSAC-1165

## Test plan

- [ ] `make -C osac-installer helm-validate`
- [ ] `make -C osac-installer helm-lint`
- [ ] Confirm `Certificate/osac-kafka-listener` in `osac-kafka` is issued by `default-ca` and the Kafka listener uses `osac-kafka-listener-tls`
- [ ] Confirm metering (and adapters, if enabled) mount `ca-bundle` and set `KAFKA_TLS_CA_CERT=/etc/ca-bundle/bundle.pem`
- [ ] Confirm the configure-kafka hook Role names only `osac-kafka-listener-tls`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Deployment

- Kafka internal TLS now uses a cert-manager `Certificate` and the configured shared issuer.
- Kafka uses the `osac-kafka-listener-tls` Secret for broker certificates.
- The Kafka configuration hook waits up to 10 minutes for the listener TLS Secret.
- The hook now supports both AMQ Streams subscription readiness and legacy Strimzi deployment detection.
- A namespaced `Role` and `RoleBinding` grant the hook ServiceAccount read access only to the listener TLS Secret.
- Metering and adapter deployments now mount the shared `ca-bundle` ConfigMap.
- Kafka TLS trust uses `/etc/ca-bundle/bundle.pem`.
- Init containers no longer retrieve the Kafka cluster CA Secret.
- Kafka SASL credentials remain read from Secrets.

## API surface

- Removed the `kafka.caSecret` Helm value.
- Removed the `osac-metering.kafkaCaSecret` Helm helper.
- Consumers must use the shared `certs.caBundle` configuration.

## Security

- Reduced Kafka hook Secret access to the required listener TLS Secret.
- Removed obsolete Kafka CA Secret access from metering RBAC.
- The hook Job no longer sets `runAsNonRoot: true`, which requires security review.

## Backward compatibility

- Existing deployments that set `kafka.caSecret` require configuration updates.
- Fulfillment service clients no longer need to copy `osac-kafka-cluster-ca-cert`.
- Clients must trust the shared `ca-bundle` ConfigMap and use the configured bundle path.
- Kafka setup behavior changed for existing clusters because the hook no longer exits early when Kafka is already ready.

## CI and tests

- The planned validation covers Helm validation and linting.
- The test plan also covers certificate creation, listener configuration, and CA bundle mounts.
- VMaaS and BMaaS full-install E2E diagnostics identified failures during Kafka setup. These failures involve the new listener Secret wait and require review of Kafka deployment, certificate, and initialization logs.
- Kind Kafka enablement is included with the pending PR `#709` dependency.

## Risk classification

- **risk:show** — The change modifies deployment sequencing, certificate issuance, RBAC, Kafka listener configuration, and client trust configuration. It also removes a Helm value and changes the required CA source.
- It does not qualify as **risk:ask** because the change does not alter application data, database schemas, or external API contracts.
- It is not **risk:ship** because Kafka installation can fail during certificate creation or Secret readiness, as shown by the full-install E2E diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->