### PR TITLE
NO-ISSUE: always report required CI checks

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,6 +1,10 @@
 ---
 name: "Ansible Lint"
 
+# Required check name: ansible-lint
+# No paths on pull_request: a trigger path filter leaves that name pending
+# in the merge queue on PRs that do not touch osac-aap. Skip is on steps.
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -8,36 +12,74 @@ concurrency:
 on:  # yamllint disable-line rule:truthy
   pull_request:
     branches: [main]
-    paths:
-      - 'osac-aap/**'
-      - '!osac-aap/OWNERS'
-      - '!osac-aap/LICENSE'
-      - '!osac-aap/**/*.md'
-      - '!osac-aap/docs/**'
+  merge_group:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
-  ansible-lint:
+  changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should-run: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || steps.filter.outputs.aap == 'true' }}
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        if: github.event_name == 'merge_group'
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        id: filter
+        with:
+          filters: |
+            aap:
+              - 'osac-aap/**'
+              - '!osac-aap/OWNERS'
+              - '!osac-aap/LICENSE'
+              - '!osac-aap/**/*.md'
+              - '!osac-aap/docs/**'
+              - '.github/workflows/ansible-lint.yml'
+
+  ansible-lint:
+    name: ansible-lint
+    needs: changes
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Fail if path filter failed
+        if: needs.changes.result != 'success'
+        run: exit 1
+      - id: should-run
+        if: needs.changes.result == 'success' && needs.changes.outputs.should-run == 'true'
+        run: echo "run=true" >> "$GITHUB_OUTPUT"
       - name: Checkout
-        uses: actions/checkout@v7
-
+        if: steps.should-run.outputs.run
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: "Set up Python"
-        uses: actions/setup-python@v6
+        if: steps.should-run.outputs.run
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
+      - name: Set up Python
+        if: steps.should-run.outputs.run
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version-file: "osac-aap/pyproject.toml"
-
       - name: Install the project
+        if: steps.should-run.outputs.run
         working-directory: osac-aap
         run: uv sync --locked --all-extras --group development
-
       - name: Run ansible-lint
+        if: steps.should-run.outputs.run
         working-directory: osac-aap
         # Explicit "." is required: without a target path, ansible-lint
         # discovers files via `git ls-files` against the whole repo (not

--- a/.github/workflows/build-bmf-image.yaml
+++ b/.github/workflows/build-bmf-image.yaml
@@ -105,13 +105,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -144,7 +146,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # No `type=ref,event=tag` here: the `tags:` trigger above only ever
@@ -166,18 +168,18 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-operator
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: bare-metal-fulfillment-operator/Containerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
       # Extract the commit SHA tag for manifest generation
       - name: Extract commit SHA tag
         id: sha-tag
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
         run: |
           # Extract the sha tag from the metadata output
           FULL_SHA_TAG=$(echo "${{ steps.meta.outputs.tags }}" | grep -E "sha-[0-9a-f]{7}" | head -n1)
@@ -191,7 +193,7 @@ jobs:
 
       # Generate manifests with helm template pointing to the SHA-tagged image
       - name: Generate manifests with helm template
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
         working-directory: bare-metal-fulfillment-operator
         env:
           SHA_IMG: ${{ steps.sha-tag.outputs.full-sha-tag }}
@@ -211,7 +213,7 @@ jobs:
 
       # Create Dockerfile for manifest container
       - name: Create manifest container Dockerfile
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
         working-directory: bare-metal-fulfillment-operator
         run: |
           cat > Dockerfile.manifests << 'EOF'
@@ -225,8 +227,8 @@ jobs:
       # Extract metadata for manifest container
       - name: Extract manifest container metadata
         id: meta-manifests
-        if: github.event_name != 'pull_request'
-        uses: docker/metadata-action@v6
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -234,8 +236,8 @@ jobs:
 
       # Build and push manifest container
       - name: Build and push manifest container
-        if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v7
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: bare-metal-fulfillment-operator
           file: bare-metal-fulfillment-operator/Dockerfile.manifests

--- a/.github/workflows/build-bmf-image.yaml
+++ b/.github/workflows/build-bmf-image.yaml
@@ -1,14 +1,14 @@
 name: Build bare-metal-fulfillment-operator image
 
+# Required check name: Run unit tests (bare-metal-fulfillment-operator)
+# No paths on pull_request: a trigger path filter leaves that name pending
+# in the merge queue. Skip is on steps. Image build stays gated on should-run.
+
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'bare-metal-fulfillment-operator/**'
-      - '!bare-metal-fulfillment-operator/OWNERS'
-      - '!bare-metal-fulfillment-operator/LICENSE'
-      - '!bare-metal-fulfillment-operator/**/*.md'
-      - '!bare-metal-fulfillment-operator/docs/**'
+    branches: [main]
+  merge_group:
   push:
     branches:
     - main
@@ -31,31 +31,73 @@ env:
 
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should-run: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || steps.filter.outputs.code == 'true' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        if: github.event_name == 'merge_group'
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'bare-metal-fulfillment-operator/**'
+              - '!bare-metal-fulfillment-operator/OWNERS'
+              - '!bare-metal-fulfillment-operator/LICENSE'
+              - '!bare-metal-fulfillment-operator/**/*.md'
+              - '!bare-metal-fulfillment-operator/docs/**'
+              - '.github/workflows/build-bmf-image.yaml'
+
   test:
-    name: Run Tests
+    name: Run unit tests (bare-metal-fulfillment-operator)
+    needs: changes
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
+      - name: Fail if path filter failed
+        if: needs.changes.result != 'success'
+        run: exit 1
+      - id: should-run
+        if: needs.changes.result == 'success' && needs.changes.outputs.should-run == 'true'
+        run: echo "run=true" >> "$GITHUB_OUTPUT"
       - name: Checkout repository
-        uses: actions/checkout@v7
-
+        if: steps.should-run.outputs.run
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v6
+        if: steps.should-run.outputs.run
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6
         with:
           go-version-file: 'bare-metal-fulfillment-operator/go.mod'
-
       - name: Install kind
-        uses: helm/kind-action@v1
+        if: steps.should-run.outputs.run
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc  # v1
         with:
           install_only: true
-
       - name: Run unit tests
+        if: steps.should-run.outputs.run
         working-directory: bare-metal-fulfillment-operator
         run: make test
 
   build:
-    needs: test
+    needs: [changes, test]
+    if: >-
+      always()
+      && needs.changes.result == 'success'
+      && needs.changes.outputs.should-run == 'true'
+      && needs.test.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,14 +1,14 @@
 name: Build container image
 
+# Required check name: Run unit tests (osac-operator)
+# No paths on pull_request: a trigger path filter leaves that name pending
+# in the merge queue. Skip is on steps. Image build stays gated on should-run.
+
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - 'osac-operator/**'
-      - '!osac-operator/OWNERS'
-      - '!osac-operator/LICENSE'
-      - '!osac-operator/**/*.md'
-      - '!osac-operator/docs/**'
+    branches: [main]
+  merge_group:
   push:
     branches:
     - main
@@ -31,35 +31,77 @@ env:
 
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should-run: ${{ (github.event_name != 'pull_request' && github.event_name != 'merge_group') || steps.filter.outputs.code == 'true' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        if: github.event_name == 'merge_group'
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'osac-operator/**'
+              - '!osac-operator/OWNERS'
+              - '!osac-operator/LICENSE'
+              - '!osac-operator/**/*.md'
+              - '!osac-operator/docs/**'
+              - '.github/workflows/build-image.yaml'
+
   test:
-    name: Run Tests
+    name: Run unit tests (osac-operator)
+    needs: changes
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
+      - name: Fail if path filter failed
+        if: needs.changes.result != 'success'
+        run: exit 1
+      - id: should-run
+        if: needs.changes.result == 'success' && needs.changes.outputs.should-run == 'true'
+        run: echo "run=true" >> "$GITHUB_OUTPUT"
       - name: Checkout repository
-        uses: actions/checkout@v7
-
+        if: steps.should-run.outputs.run
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v6
+        if: steps.should-run.outputs.run
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6
         with:
           go-version-file: 'osac-operator/go.mod'
-
       - name: Install kind
-        uses: helm/kind-action@v1
+        if: steps.should-run.outputs.run
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc  # v1
         with:
           install_only: true
-
       - name: Run unit tests
+        if: steps.should-run.outputs.run
         working-directory: osac-operator
         run: make test
-
       - name: Lint Helm charts
+        if: steps.should-run.outputs.run
         working-directory: osac-operator
         run: make helm-lint
 
   build:
-    needs: test
+    needs: [changes, test]
+    if: >-
+      always()
+      && needs.changes.result == 'success'
+      && needs.changes.outputs.should-run == 'true'
+      && needs.test.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -109,13 +109,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -148,7 +150,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # No `type=ref,event=tag` here: the `tags:` trigger above only ever
@@ -170,18 +172,18 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-operator
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
           file: osac-operator/Containerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
       # Extract the commit SHA tag for manifest generation
       - name: Extract commit SHA tag
         id: sha-tag
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
         run: |
           # Extract the sha tag from the metadata output
           FULL_SHA_TAG=$(echo "${{ steps.meta.outputs.tags }}" | grep -E "sha-[0-9a-f]{7}" | head -n1)
@@ -195,7 +197,7 @@ jobs:
 
       # Generate manifests with helm template pointing to the SHA-tagged image
       - name: Generate manifests with helm template
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
         working-directory: osac-operator
         env:
           SHA_IMG: ${{ steps.sha-tag.outputs.full-sha-tag }}
@@ -215,7 +217,7 @@ jobs:
 
       # Create Dockerfile for manifest container
       - name: Create manifest container Dockerfile
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
         working-directory: osac-operator
         run: |
           cat > Dockerfile.manifests << 'EOF'
@@ -229,8 +231,8 @@ jobs:
       # Extract metadata for manifest container
       - name: Extract manifest container metadata
         id: meta-manifests
-        if: github.event_name != 'pull_request'
-        uses: docker/metadata-action@v6
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -238,8 +240,8 @@ jobs:
 
       # Build and push manifest container
       - name: Build and push manifest container
-        if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v7
+        if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: osac-operator
           file: osac-operator/Dockerfile.manifests

--- a/.github/workflows/check-generated-code.yaml
+++ b/.github/workflows/check-generated-code.yaml
@@ -1,10 +1,10 @@
 name: Check generated code
 
 on:
-  # No paths: required names "Check generated code (fulfillment-service)"
-  # and "(osac-operator)" must report on every PR. Skip is on job steps
-  # (dorny + should-run). A trigger path filter leaves those names pending
-  # forever on PRs that only touch other components (e.g. BMFO-only).
+# No paths: required names "Check generated code (fulfillment-service)",
+# "(osac-operator)", and "(osac-metering/metering-service)" must report on
+# every PR. Skip is on job steps (dorny + should-run). A trigger path filter
+# leaves those names pending forever on PRs that only touch other components.
   pull_request:
     branches:
       - main
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Fixed list so both required names always exist. Skip is on steps
+        # Fixed list so all required names always exist. Skip is on steps
         # (`matrix` is not valid in a job-level `if:`).
         component:
           - fulfillment-service

--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -14,16 +14,15 @@
 
 name: Check pull request
 
+# Required check names: Check Python code, Check Go and proto code, Build binaries
+# No paths on pull_request: a trigger path filter leaves those names pending
+# in the merge queue on PRs that do not touch fulfillment-service. Skip is on steps.
+
 on:
   pull_request:
     branches:
     - main
-    paths:
-      - 'fulfillment-service/**'
-      - '!fulfillment-service/OWNERS'
-      - '!fulfillment-service/LICENSE'
-      - '!fulfillment-service/**/*.md'
-      - '!fulfillment-service/docs/**'
+  merge_group:
 
 permissions:
   contents: read
@@ -35,33 +34,82 @@ jobs:
   # same hook set (trailing-whitespace, yamllint, etc.) repo-wide with
   # correctly component-scoped excludes, making this duplicate redundant.
 
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should-run: ${{ steps.filter.outputs.service == 'true' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        if: github.event_name == 'merge_group'
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
+        id: filter
+        with:
+          filters: |
+            service:
+              - 'fulfillment-service/**'
+              - '!fulfillment-service/OWNERS'
+              - '!fulfillment-service/LICENSE'
+              - '!fulfillment-service/**/*.md'
+              - '!fulfillment-service/docs/**'
+              - '.github/workflows/check-pull-request.yaml'
+
   check-python-code:
     name: Check Python code
+    needs: changes
+    if: always()
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+    - name: Fail if path filter failed
+      if: needs.changes.result != 'success'
+      run: exit 1
+    - id: should-run
+      if: needs.changes.result == 'success' && needs.changes.outputs.should-run == 'true'
+      run: echo "run=true" >> "$GITHUB_OUTPUT"
+    - if: steps.should-run.outputs.run
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
         persist-credentials: false
-    - uses: ./.github/actions/setup-python
-    - working-directory: fulfillment-service
+    - if: steps.should-run.outputs.run
+      uses: ./.github/actions/setup-python
+    - if: steps.should-run.outputs.run
+      working-directory: fulfillment-service
       run: uv run ruff check
 
   check-go-code:
     name: Check Go and proto code
+    needs: changes
+    if: always()
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+    - name: Fail if path filter failed
+      if: needs.changes.result != 'success'
+      run: exit 1
+    - id: should-run
+      if: needs.changes.result == 'success' && needs.changes.outputs.should-run == 'true'
+      run: echo "run=true" >> "$GITHUB_OUTPUT"
+    - if: steps.should-run.outputs.run
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
         persist-credentials: false
-    - uses: ./.github/actions/setup-go
+    - if: steps.should-run.outputs.run
+      uses: ./.github/actions/setup-go
       with:
         working-directory: fulfillment-service
-    - uses: ./.github/actions/setup-python
-    - uses: bufbuild/buf-action@8c6a16e16f12ba20b6470afa9c2ba9b5ba8c97c3  # v1
+    - if: steps.should-run.outputs.run
+      uses: ./.github/actions/setup-python
+    - if: steps.should-run.outputs.run
+      uses: bufbuild/buf-action@8c6a16e16f12ba20b6470afa9c2ba9b5ba8c97c3  # v1
       with:
         version: '1.50.0'
         setup_only: true
-    - working-directory: fulfillment-service
+    - if: steps.should-run.outputs.run
+      working-directory: fulfillment-service
       run: |
         uv run dev.py lint
 
@@ -71,15 +119,26 @@ jobs:
 
   build-binaries:
     name: Build binaries
+    needs: changes
+    if: always()
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+    - name: Fail if path filter failed
+      if: needs.changes.result != 'success'
+      run: exit 1
+    - id: should-run
+      if: needs.changes.result == 'success' && needs.changes.outputs.should-run == 'true'
+      run: echo "run=true" >> "$GITHUB_OUTPUT"
+    - if: steps.should-run.outputs.run
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
         persist-credentials: false
-    - uses: ./.github/actions/setup-go
+    - if: steps.should-run.outputs.run
+      uses: ./.github/actions/setup-go
       with:
         working-directory: fulfillment-service
-    - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7
+    - if: steps.should-run.outputs.run
+      uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7
       with:
         workdir: fulfillment-service
         args: build --snapshot --clean

--- a/.github/workflows/darwin-keychain-tests.yml
+++ b/.github/workflows/darwin-keychain-tests.yml
@@ -19,34 +19,69 @@
 # macos-latest runner, instead of moving the whole unit-tests.yml suite to macOS.
 name: Darwin Keychain Tests
 
+# Required check name: Run darwin keychain tests
+# No paths on pull_request: a trigger path filter leaves that name pending
+# in the merge queue. Skip is on steps; macos-latest only when those files change.
+
 on:
   pull_request:
     branches:
     - main
-    paths:
-    - '.github/workflows/darwin-keychain-tests.yml'
-    - 'fulfillment-service/internal/config/config_secret_store.go'
-    - 'fulfillment-service/internal/config/config_secret_store_darwin.go'
-    - 'fulfillment-service/internal/config/config_secret_store_darwin_test.go'
-    - 'fulfillment-service/internal/config/config_secret_store_other.go'
-    - 'fulfillment-service/internal/config/config_settings.go'
-    - 'fulfillment-service/internal/config/config_settings_test.go'
+  merge_group:
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should-run: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.darwin == 'true' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        if: github.event_name == 'merge_group'
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        id: filter
+        with:
+          filters: |
+            darwin:
+              - '.github/workflows/darwin-keychain-tests.yml'
+              - 'fulfillment-service/internal/config/config_secret_store.go'
+              - 'fulfillment-service/internal/config/config_secret_store_darwin.go'
+              - 'fulfillment-service/internal/config/config_secret_store_darwin_test.go'
+              - 'fulfillment-service/internal/config/config_secret_store_other.go'
+              - 'fulfillment-service/internal/config/config_settings.go'
+              - 'fulfillment-service/internal/config/config_settings_test.go'
+
   run-darwin-keychain-tests:
     name: Run darwin keychain tests
-    runs-on: macos-latest
+    needs: changes
+    if: always()
+    runs-on: ${{ needs.changes.outputs.should-run == 'true' && 'macos-latest' || 'ubuntu-latest' }}
     steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+    - name: Fail if path filter failed
+      if: needs.changes.result != 'success'
+      run: exit 1
+    - id: should-run
+      if: needs.changes.result == 'success' && needs.changes.outputs.should-run == 'true'
+      run: echo "run=true" >> "$GITHUB_OUTPUT"
+    - if: steps.should-run.outputs.run
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
         persist-credentials: false
-    - uses: ./.github/actions/setup-go
+    - if: steps.should-run.outputs.run
+      uses: ./.github/actions/setup-go
       with:
         working-directory: fulfillment-service
-    - working-directory: fulfillment-service
+    - if: steps.should-run.outputs.run
+      working-directory: fulfillment-service
       run: |
         go test -run 'TestKeychainAvailable|TestSettingsSave_FallsBackToFileWithNoKeychain' -v ./internal/config/...

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,11 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
       # Fails the check when a newly-introduced dependency carries a known
       # vulnerability (SCA gate). Pin this SHA when actions/dependency-review-action
       # needs to be bumped.
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0
         with:
+          # Required for merge_group; pull_request has defaults but these
+          # expressions also cover that event.
+          base-ref: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha }}
+          head-ref: ${{ github.event.merge_group.head_sha || github.event.pull_request.head.sha }}
           # Pre-existing stale indirect dependencies in
           # bare-metal-fulfillment-operator/go.mod, never caught because that
           # repo's own CI never ran this check -- not introduced by merging it

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,6 +7,7 @@ permissions:
 on:
   pull_request:
     branches: [main]
+  merge_group:
 
 jobs:
   dependency-review:

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -1,26 +1,15 @@
 name: Helm Lint
 
+# Required check names: Check Helm CRD sync (osac-operator),
+# Check Helm CRD sync (bare-metal-fulfillment-operator),
+# Lint Helm charts (osac-installer)
+# No paths on pull_request: a trigger path filter leaves those names pending
+# in the merge queue. Skip is on steps (dorny + should-run).
+
 on:
   pull_request:
-    paths:
-      - 'osac-operator/api/**'
-      - 'osac-operator/charts/**'
-      - 'osac-operator/config/crd/bases/**'
-      - 'osac-operator/hack/sync-helm-crds.py'
-      - 'osac-operator/Makefile'
-      - 'bare-metal-fulfillment-operator/api/**'
-      - 'bare-metal-fulfillment-operator/charts/**'
-      - 'bare-metal-fulfillment-operator/config/crd/bases/**'
-      - 'bare-metal-fulfillment-operator/hack/sync-helm-crds.py'
-      - 'bare-metal-fulfillment-operator/Makefile'
-      - 'fulfillment-service/charts/**'
-      - 'osac-aap/charts/**'
-      - 'osac-csi-driver/charts/**'
-      - 'osac-metering/charts/**'
-      - 'osac-installer/charts/**'
-      - 'osac-installer/values/**'
-      - 'osac-installer/ct.yaml'
-      - '.github/workflows/helm-lint.yaml'
+    branches: [main]
+  merge_group:
 
 permissions:
   contents: read
@@ -29,12 +18,18 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       changes: ${{ steps.filter.outputs.changes || '[]' }}
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        if: github.event_name == 'merge_group'
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         id: filter
         with:
           filters: |
@@ -77,15 +72,19 @@ jobs:
   helm-crds-sync:
     name: Check Helm CRD sync (${{ matrix.component }})
     needs: changes
+    if: always()
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         component: [osac-operator, bare-metal-fulfillment-operator]
     steps:
+    - name: Fail if path filter failed
+      if: needs.changes.result != 'success'
+      run: exit 1
     - name: Check component changes
       id: should-run
-      if: github.event_name != 'pull_request' || contains(fromJSON(needs.changes.outputs.changes), matrix.component)
+      if: needs.changes.result == 'success' && contains(fromJSON(needs.changes.outputs.changes), matrix.component)
       run: echo "run=true" >> "$GITHUB_OUTPUT"
 
     - name: Checkout repository
@@ -112,6 +111,7 @@ jobs:
   helm-lint:
     name: Lint Helm chart (${{ matrix.component }}/${{ matrix.chart }})
     needs: changes
+    if: always()
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -137,9 +137,12 @@ jobs:
           - component: osac-metering
             chart: osac-metering
     steps:
+    - name: Fail if path filter failed
+      if: needs.changes.result != 'success'
+      run: exit 1
     - name: Check component changes
       id: should-run
-      if: github.event_name != 'pull_request' || contains(fromJSON(needs.changes.outputs.changes), matrix.component)
+      if: needs.changes.result == 'success' && contains(fromJSON(needs.changes.outputs.changes), matrix.component)
       run: echo "run=true" >> "$GITHUB_OUTPUT"
 
     - name: Checkout repository
@@ -187,39 +190,53 @@ jobs:
   helm-lint-installer:
     name: Lint Helm charts (osac-installer)
     needs: changes
+    if: always()
     runs-on: ubuntu-latest
-    if: >
-      github.event_name != 'pull_request' ||
-      contains(fromJSON(needs.changes.outputs.changes), 'osac-installer') ||
-      contains(fromJSON(needs.changes.outputs.changes), 'osac-operator') ||
-      contains(fromJSON(needs.changes.outputs.changes), 'bare-metal-fulfillment-operator') ||
-      contains(fromJSON(needs.changes.outputs.changes), 'fulfillment-service') ||
-      contains(fromJSON(needs.changes.outputs.changes), 'osac-aap') ||
-      contains(fromJSON(needs.changes.outputs.changes), 'osac-csi-driver') ||
-      contains(fromJSON(needs.changes.outputs.changes), 'osac-metering')
     steps:
+    - name: Fail if path filter failed
+      if: needs.changes.result != 'success'
+      run: exit 1
+    - name: Check whether to lint
+      id: should-run
+      if: >-
+        needs.changes.result == 'success' && (
+          contains(fromJSON(needs.changes.outputs.changes), 'osac-installer') ||
+          contains(fromJSON(needs.changes.outputs.changes), 'osac-operator') ||
+          contains(fromJSON(needs.changes.outputs.changes), 'bare-metal-fulfillment-operator') ||
+          contains(fromJSON(needs.changes.outputs.changes), 'fulfillment-service') ||
+          contains(fromJSON(needs.changes.outputs.changes), 'osac-aap') ||
+          contains(fromJSON(needs.changes.outputs.changes), 'osac-csi-driver') ||
+          contains(fromJSON(needs.changes.outputs.changes), 'osac-metering'))
+      run: echo "run=true" >> "$GITHUB_OUTPUT"
+
     - name: Checkout repository
+      if: steps.should-run.outputs.run
       uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
       with:
         persist-credentials: false
 
     - name: Set up Helm
+      if: steps.should-run.outputs.run
       uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
       with:
         version: v3.21.4
 
     - name: Set up chart-testing
+      if: steps.should-run.outputs.run
       uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f  # v2.8.0
 
     - name: Build chart dependencies
+      if: steps.should-run.outputs.run
       working-directory: osac-installer
       run: helm dependency build charts/osac/
 
     - name: Run chart-testing lint
+      if: steps.should-run.outputs.run
       working-directory: osac-installer
       run: ct lint --all --config ct.yaml
 
     - name: Template with CI values
+      if: steps.should-run.outputs.run
       working-directory: osac-installer
       run: |
         set -euo pipefail
@@ -229,6 +246,7 @@ jobs:
         done
 
     - name: Template with environment values
+      if: steps.should-run.outputs.run
       working-directory: osac-installer
       run: |
         set -euo pipefail

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -89,13 +89,13 @@ jobs:
 
     - name: Checkout repository
       if: steps.should-run.outputs.run
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
         persist-credentials: false
 
     - name: Set up Go
       if: steps.should-run.outputs.run
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6
       with:
         go-version: stable
 
@@ -147,7 +147,7 @@ jobs:
 
     - name: Checkout repository
       if: steps.should-run.outputs.run
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
         persist-credentials: false
 


### PR DESCRIPTION
## Summary
- Always report cheap CI names on every PR/`merge_group` (skip on steps) so they can be required without hanging the merge queue. Same pattern as generated-code (PR #699).
- Rename colliding `Run Tests` jobs to `Run unit tests (osac-operator)` and `Run unit tests (bare-metal-fulfillment-operator)`.
- Triggered by [#707](https://github.com/osac-project/osac/pull/707): `ansible-lint` went red on a lock bump and was not a merge gate.

Enforce the new names via [osac-project/github-config#205](https://github.com/osac-project/github-config/pull/205) (`repo_osac.required_status_checks`). Do not edit the live `ci-status-checks` ruleset in this repo; tofu apply overwrites it.

## Test plan
- [ ] This PR: named checks report (green no-op or real run). No extra image builds on unrelated paths.
- [ ] After github-config#205 applies: a docs-only / unrelated-component PR still merges (names report, work skipped).
- [ ] An `osac-aap` change still has to pass `ansible-lint` before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **CI:** Updated workflows to run on pull requests and `merge_group` events. Moved path filtering into jobs so required checks remain visible in the merge queue. Pinned GitHub Actions and disabled persisted checkout credentials.
- **Tests:** Added conditional execution for Ansible, image, Helm, Darwin, fulfillment-service, dependency-review, and generated-code checks. Filter failures now fail the relevant check. Renamed colliding `Run Tests` checks.
- **Deployment:** Prevented image and manifest publishing during `merge_group` events.
- **Documentation:** Updated the documented required generated-code checks.
- **API surface, controllers, database, and auth:** No changes.
- **Backward compatibility:** No runtime behavior changes. CI trigger, required status-check, and merge queue behavior changes. After merge, update `ci-status-checks` with the requested contexts and retain `strict_required_status_checks_policy: false`.

## Risk classification

**risk:show** — The changes affect CI workflow triggers, required status checks, merge queue behavior, action pinning, and image publishing conditions. They do not modify application runtime code, APIs, data, authentication, or production deployment logic.

This is not **risk:ship** because CI configuration changes can affect merge eligibility and artifact publication. It does not qualify as **risk:ask** because the workflows include explicit filtering, failure handling, conditional execution, and merge-queue safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->