### PR TITLE
OSAC-4812: gate jobs post pending commit status instead of failing

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -184,22 +184,29 @@ jobs:
     if: always()
     needs: [changes, e2e-readiness, e2e-bmaas-full-install]
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
-      - if: needs.e2e-readiness.result == 'failure'
-        run: |
-          echo "e2e-readiness failed: expensive e2e is gated until unlock."
-          echo "Need coderabbitai[bot] APPROVED on this HEAD, lgtm, or /e2e-ready."
-          echo "See .github/e2e-readiness.md"
-          echo "Upstream: changes=${{ needs.changes.result }} e2e-readiness=failure full-install=${{ needs.e2e-bmaas-full-install.result }}"
-          exit 1
-      - if: >-
-          needs.e2e-readiness.result != 'failure'
-          && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
-        run: |
-          echo "Upstream job results:"
-          echo "  changes: ${{ needs.changes.result }}"
-          echo "  e2e-readiness: ${{ needs.e2e-readiness.result }}"
-          echo "  e2e-bmaas-full-install: ${{ needs.e2e-bmaas-full-install.result }}"
-          echo ""
-          echo "One or more upstream jobs failed or were cancelled."
-          exit 1
+      - name: Post gate status
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+        with:
+          script: |
+            const r = {
+              changes: '${{ needs.changes.result }}',
+              readiness: '${{ needs.e2e-readiness.result }}',
+              install: '${{ needs.e2e-bmaas-full-install.result }}',
+            };
+            let state = 'success', description = 'All checks passed';
+            if (r.readiness === 'failure') {
+              state = 'pending';
+              description = 'Waiting for e2e readiness (lgtm, coderabbit approve, or /e2e-ready)';
+            } else if (Object.values(r).some(v => v === 'failure' || v === 'cancelled')) {
+              state = 'failure';
+              description = `changes=${r.changes} readiness=${r.readiness} install=${r.install}`;
+            }
+            const sha = context.payload.pull_request?.head?.sha ?? context.sha;
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner, repo: context.repo.repo,
+              sha, state, context: 'e2e-bmaas-gate',
+              description: description.slice(0, 140),
+            });

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -187,22 +187,29 @@ jobs:
     if: always()
     needs: [changes, e2e-readiness, e2e-caas-full-install]
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
-      - if: needs.e2e-readiness.result == 'failure'
-        run: |
-          echo "e2e-readiness failed: expensive e2e is gated until unlock."
-          echo "Need coderabbitai[bot] APPROVED on this HEAD, lgtm, or /e2e-ready."
-          echo "See .github/e2e-readiness.md"
-          echo "Upstream: changes=${{ needs.changes.result }} e2e-readiness=failure full-install=${{ needs.e2e-caas-full-install.result }}"
-          exit 1
-      - if: >-
-          needs.e2e-readiness.result != 'failure'
-          && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
-        run: |
-          echo "Upstream job results:"
-          echo "  changes: ${{ needs.changes.result }}"
-          echo "  e2e-readiness: ${{ needs.e2e-readiness.result }}"
-          echo "  e2e-caas-full-install: ${{ needs.e2e-caas-full-install.result }}"
-          echo ""
-          echo "One or more upstream jobs failed or were cancelled."
-          exit 1
+      - name: Post gate status
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+        with:
+          script: |
+            const r = {
+              changes: '${{ needs.changes.result }}',
+              readiness: '${{ needs.e2e-readiness.result }}',
+              install: '${{ needs.e2e-caas-full-install.result }}',
+            };
+            let state = 'success', description = 'All checks passed';
+            if (r.readiness === 'failure') {
+              state = 'pending';
+              description = 'Waiting for e2e readiness (lgtm, coderabbit approve, or /e2e-ready)';
+            } else if (Object.values(r).some(v => v === 'failure' || v === 'cancelled')) {
+              state = 'failure';
+              description = `changes=${r.changes} readiness=${r.readiness} install=${r.install}`;
+            }
+            const sha = context.payload.pull_request?.head?.sha ?? context.sha;
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner, repo: context.repo.repo,
+              sha, state, context: 'e2e-caas-gate',
+              description: description.slice(0, 140),
+            });

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -183,22 +183,29 @@ jobs:
     if: always()
     needs: [changes, e2e-readiness, e2e-vmaas-full-install]
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
-      - if: needs.e2e-readiness.result == 'failure'
-        run: |
-          echo "e2e-readiness failed: expensive e2e is gated until unlock."
-          echo "Need coderabbitai[bot] APPROVED on this HEAD, lgtm, or /e2e-ready."
-          echo "See .github/e2e-readiness.md"
-          echo "Upstream: changes=${{ needs.changes.result }} e2e-readiness=failure full-install=${{ needs.e2e-vmaas-full-install.result }}"
-          exit 1
-      - if: >-
-          needs.e2e-readiness.result != 'failure'
-          && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
-        run: |
-          echo "Upstream job results:"
-          echo "  changes: ${{ needs.changes.result }}"
-          echo "  e2e-readiness: ${{ needs.e2e-readiness.result }}"
-          echo "  e2e-vmaas-full-install: ${{ needs.e2e-vmaas-full-install.result }}"
-          echo ""
-          echo "One or more upstream jobs failed or were cancelled."
-          exit 1
+      - name: Post gate status
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+        with:
+          script: |
+            const r = {
+              changes: '${{ needs.changes.result }}',
+              readiness: '${{ needs.e2e-readiness.result }}',
+              install: '${{ needs.e2e-vmaas-full-install.result }}',
+            };
+            let state = 'success', description = 'All checks passed';
+            if (r.readiness === 'failure') {
+              state = 'pending';
+              description = 'Waiting for e2e readiness (lgtm, coderabbit approve, or /e2e-ready)';
+            } else if (Object.values(r).some(v => v === 'failure' || v === 'cancelled')) {
+              state = 'failure';
+              description = `changes=${r.changes} readiness=${r.readiness} install=${r.install}`;
+            }
+            const sha = context.payload.pull_request?.head?.sha ?? context.sha;
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner, repo: context.repo.repo,
+              sha, state, context: 'e2e-vmaas-gate',
+              description: description.slice(0, 140),
+            });

--- a/.github/workflows/label-gate.yml
+++ b/.github/workflows/label-gate.yml
@@ -13,28 +13,29 @@ on:
 jobs:
   check-labels:
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Auto-pass for merge queue
         if: github.event_name == 'merge_group'
         run: echo "Labels already validated on PR"
-      - name: Check required Prow labels
+      - name: Post label gate status
         if: github.event_name == 'pull_request'
-        env:
-          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
-        run: |
-          missing=()
-          for label in lgtm approved jira/valid-reference; do
-            if ! echo "$LABELS" | jq -e "index(\"$label\")" > /dev/null 2>&1; then
-              missing+=("$label")
-            fi
-          done
-          if [[ ${#missing[@]} -gt 0 ]]; then
-            echo "::error::Missing required labels: ${missing[*]}"
-            echo ""
-            echo "Required labels are set by Prow plugins via OWNERS files:"
-            echo "  lgtm           - reviewer types /lgtm"
-            echo "  approved       - approver types /approve"
-            echo "  jira/valid-reference - PR title has valid Jira key"
-            exit 1
-          fi
-          echo "All required labels present"
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+        with:
+          script: |
+            const labels = ${{ toJSON(github.event.pull_request.labels.*.name) }};
+            const required = ['lgtm', 'approved', 'jira/valid-reference'];
+            const missing = required.filter(l => !labels.includes(l));
+            const state = missing.length ? 'pending' : 'success';
+            const description = missing.length
+              ? `Missing: ${missing.join(', ')}`
+              : 'All required labels present';
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state,
+              context: 'label-gate',
+              description,
+            });


### PR DESCRIPTION
Replace exit-1 gate logic with actions/github-script commit-status posts: preconditions not met → pending, met → success, genuine failure → failure.  Gate jobs always exit 0; the commit-status context carries the real state.

Affected jobs:
- check-labels in label-gate.yml
- e2e-{caas,bmaas,vmaas}-gate in e2e-*-full-install.yml

Assisted-by: Claude Code claude-code-action@anthropic.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## CI

- Updated `check-labels` and the `e2e-{caas,bmaas,vmaas}-gate` jobs.
- Gate jobs now post commit statuses through `actions/github-script`.
- Gates post `pending` when prerequisites are not met, `success` when all conditions pass, and `failure` for genuine upstream failures.
- Gate jobs now exit successfully. The commit-status context reports the actual gate state.
- Added `statuses: write` permissions.
- Label checks use the `label-gate` context. E2E checks use their job-specific contexts.
- No API, controller, database, authentication, deployment, test, or documentation changes are included.

## Backward compatibility

- Workflow consumers must use the commit-status contexts instead of gate-job exit codes to determine gate state.
- The change preserves gate enforcement through commit statuses but changes the observable job result from failure to success.

## Risk classification

- **risk:show** — The change affects CI workflow behavior and commit-status reporting, but it does not modify runtime application behavior or production data.
- It does not qualify for **risk:ship** because it changes repository-level CI behavior.
- It does not qualify for **risk:ask** because the workflows report explicit `pending`, `success`, and `failure` states and retain failure detection for genuine upstream errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->