### PR TITLE
OSAC-4488: Address CaaS test review feedback from PR #490

### DIFF
--- a/tests/e2e/caas/conftest.py
+++ b/tests/e2e/caas/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 from collections.abc import Iterator
 
 import pytest
@@ -17,10 +18,11 @@ from tests.e2e.core.runner import env
 # in the shared tenant, which the storage controller skips.
 @pytest.fixture(scope="session")
 def cli(namespace: str, fulfillment_address: str, service_account: str) -> Iterator[OsacCLI]:
+    """Session-scoped osac CLI authenticated with a service-account token."""
     instance = OsacCLI(
         binary=env("OSAC_CLI_PATH", "osac"),
         address=f"https://{fulfillment_address.rsplit(':', 1)[0]}",
-        token_script=f"oc create token -n {namespace} {service_account} --as system:admin",
+        token_script=f"oc create token -n {shlex.quote(namespace)} {shlex.quote(service_account)} --as system:admin",
         namespace=namespace,
     )
     yield instance
@@ -29,14 +31,17 @@ def cli(namespace: str, fulfillment_address: str, service_account: str) -> Itera
 
 @pytest.fixture(scope="session")
 def cluster_template() -> str:
+    """CaaS cluster template name, overridable via OSAC_CLUSTER_TEMPLATE."""
     return env("OSAC_CLUSTER_TEMPLATE", "ocp-ci-small")
 
 
 @pytest.fixture(scope="session")
 def pull_secret_path() -> str:
+    """Filesystem path to the OCP pull secret (OSAC_PULL_SECRET_PATH)."""
     return env("OSAC_PULL_SECRET_PATH")
 
 
 @pytest.fixture(scope="session")
 def ssh_public_key_path() -> str:
+    """Filesystem path to the SSH public key, default ~/.ssh/id_rsa.pub (OSAC_SSH_PUBLIC_KEY_PATH)."""
     return env("OSAC_SSH_PUBLIC_KEY_PATH", os.path.expanduser("~/.ssh/id_rsa.pub"))

--- a/tests/e2e/caas/regression/test_cluster_version.py
+++ b/tests/e2e/caas/regression/test_cluster_version.py
@@ -33,16 +33,17 @@ def test_cluster_create_with_version(
     """Verify explicit version resolution and reference protection."""
     version = private_grpc.ensure_cluster_version(version="4.20.0-e2e", image=TEST_RELEASE_IMAGE)
 
-    name = unique_name("e2e-cluster-version")
-    uuid = cli.create_cluster(
-        name=name,
-        template=cluster_template,
-        version=version["name"],
-        template_parameter_files={"pull_secret": pull_secret_path},
-        template_parameters={"ssh_public_key": Path(ssh_public_key_path).read_text().strip()},
-    )
-
+    uuid: str | None = None
     try:
+        name = unique_name("e2e-cluster-version")
+        uuid = cli.create_cluster(
+            name=name,
+            template=cluster_template,
+            version=version["name"],
+            template_parameter_files={"pull_secret": pull_secret_path},
+            template_parameters={"ssh_public_key": Path(ssh_public_key_path).read_text().strip()},
+        )
+
         co_name = wait_for_cluster_order_cr(k8s=k8s_hub_client, uuid=uuid)
 
         cluster = grpc.get_cluster(cluster_id=uuid)
@@ -72,20 +73,20 @@ def test_cluster_create_with_version(
         wait_for_cluster_grpc_deleting_or_archived(grpc=grpc, uuid=uuid)
         wait_for_cluster_deletion(k8s=k8s_hub_client, name=co_name)
         wait_for_cluster_grpc_removal(grpc=grpc, uuid=uuid)
+        uuid = None
     finally:
-        with contextlib.suppress(subprocess.CalledProcessError):
-            cli.delete_cluster(uuid=uuid)
+        if uuid is not None:
+            with contextlib.suppress(subprocess.SubprocessError):
+                cli.delete_cluster(uuid=uuid)
+            with contextlib.suppress(TimeoutError):
+                wait_for_cluster_grpc_removal(grpc=grpc, uuid=uuid)
+        private_grpc.call_unchecked(service="osac.private.v1.ClusterVersions/Delete", data={"id": version["id"]})
 
 
 def test_cluster_create_rejected_for_invalid_version(
     grpc: GRPCClient, private_grpc: GRPCClient, cluster_template: str
 ) -> None:
     """Verify creation is rejected for disabled, obsolete, and missing versions."""
-    disabled = private_grpc.ensure_cluster_version(version="4.20.0-e2e-disabled", image=TEST_RELEASE_IMAGE)
-    private_grpc.update_cluster_version(version_id=disabled["id"], enabled=False)
-
-    obsolete = private_grpc.ensure_cluster_version(version="4.20.0-e2e-obsolete", image=TEST_RELEASE_IMAGE)
-    private_grpc.update_cluster_version(version_id=obsolete["id"], state="CLUSTER_VERSION_STATE_OBSOLETE")
 
     def _create_with_version(version_name: str) -> tuple[str, int]:
         return grpc.call_unchecked(
@@ -93,14 +94,27 @@ def test_cluster_create_rejected_for_invalid_version(
             data={"object": {"spec": {"template": {"name": cluster_template}, "version": {"name": version_name}}}},
         )
 
-    output, rc = _create_with_version(disabled["name"])
-    assert rc != 0, f"Expected create to reject disabled version, got: {output}"
-    assert "disabled" in output.lower(), f"Expected 'disabled' in rejection, got: {output}"
+    created_version_ids: list[str] = []
+    try:
+        disabled = private_grpc.ensure_cluster_version(version="4.20.0-e2e-disabled", image=TEST_RELEASE_IMAGE)
+        created_version_ids.append(disabled["id"])
+        private_grpc.update_cluster_version(version_id=disabled["id"], enabled=False)
 
-    output, rc = _create_with_version(obsolete["name"])
-    assert rc != 0, f"Expected create to reject obsolete version, got: {output}"
-    assert "obsolete" in output.lower(), f"Expected 'obsolete' in rejection, got: {output}"
+        obsolete = private_grpc.ensure_cluster_version(version="4.20.0-e2e-obsolete", image=TEST_RELEASE_IMAGE)
+        created_version_ids.append(obsolete["id"])
+        private_grpc.update_cluster_version(version_id=obsolete["id"], state="CLUSTER_VERSION_STATE_OBSOLETE")
 
-    output, rc = _create_with_version("4-20-0-e2e-does-not-exist")
-    assert rc != 0, f"Expected create to reject non-existent version, got: {output}"
-    assert "not found" in output.lower(), f"Expected 'not found' in rejection, got: {output}"
+        output, rc = _create_with_version(disabled["name"])
+        assert rc != 0, f"Expected create to reject disabled version, got: {output}"
+        assert "disabled" in output.lower(), f"Expected 'disabled' in rejection, got: {output}"
+
+        output, rc = _create_with_version(obsolete["name"])
+        assert rc != 0, f"Expected create to reject obsolete version, got: {output}"
+        assert "obsolete" in output.lower(), f"Expected 'obsolete' in rejection, got: {output}"
+
+        output, rc = _create_with_version("4-20-0-e2e-does-not-exist")
+        assert rc != 0, f"Expected create to reject non-existent version, got: {output}"
+        assert "not found" in output.lower(), f"Expected 'not found' in rejection, got: {output}"
+    finally:
+        for version_id in created_version_ids:
+            private_grpc.call_unchecked(service="osac.private.v1.ClusterVersions/Delete", data={"id": version_id})

--- a/tests/e2e/caas/regression/test_cluster_version.py
+++ b/tests/e2e/caas/regression/test_cluster_version.py
@@ -34,6 +34,7 @@ def test_cluster_create_with_version(
     version = private_grpc.ensure_cluster_version(version="4.20.0-e2e", image=TEST_RELEASE_IMAGE)
 
     uuid: str | None = None
+    co_name: str | None = None
     try:
         name = unique_name("e2e-cluster-version")
         uuid = cli.create_cluster(
@@ -78,6 +79,10 @@ def test_cluster_create_with_version(
         if uuid is not None:
             with contextlib.suppress(subprocess.SubprocessError):
                 cli.delete_cluster(uuid=uuid)
+        if co_name is not None:
+            with contextlib.suppress(TimeoutError):
+                wait_for_cluster_deletion(k8s=k8s_hub_client, name=co_name)
+        if uuid is not None:
             with contextlib.suppress(TimeoutError):
                 wait_for_cluster_grpc_removal(grpc=grpc, uuid=uuid)
         private_grpc.call_unchecked(service="osac.private.v1.ClusterVersions/Delete", data={"id": version["id"]})

--- a/tests/e2e/caas/sanity/test_cluster_create.py
+++ b/tests/e2e/caas/sanity/test_cluster_create.py
@@ -33,6 +33,9 @@ def test_cluster_create(
     ssh_public_key_path: str,
     metering: MeteringCollector,
 ) -> None:
+    """Verify the full CaaS cluster lifecycle: create, provision to Ready, version and
+    releaseImage propagation to the HostedCluster, N+1 metering heartbeat decomposition,
+    worker scale-up reflected in updated.v1 metering, and deletion."""
     name = unique_name("e2e-cluster")
     uuid = cli.create_cluster(
         name=name,
@@ -79,6 +82,7 @@ def test_cluster_create(
 
         # Derive expected N+1 count from cluster spec
         node_sets = cluster.get("object", {}).get("spec", {}).get("nodeSets", {})
+        assert node_sets, "Cluster spec should have at least one node set for the scaling test"
         expected_components = 1 + len(node_sets)
 
         # Verify N+1 heartbeat decomposition

--- a/tests/e2e/caas/sanity/test_cluster_create.py
+++ b/tests/e2e/caas/sanity/test_cluster_create.py
@@ -140,5 +140,5 @@ def test_cluster_create(
         wait_for_cluster_grpc_removal(grpc=grpc, uuid=uuid)
         metering.verify()
     finally:
-        with contextlib.suppress(subprocess.CalledProcessError):
+        with contextlib.suppress(subprocess.SubprocessError):
             cli.delete_cluster(uuid=uuid)


### PR DESCRIPTION
## [OSAC-4488](https://redhat.atlassian.net/browse/OSAC-4488): Address caas test review feedback from PR #490

**Jira:** https://redhat.atlassian.net/browse/OSAC-4488
**Parent epic:** [OSAC-3593](https://redhat.atlassian.net/browse/OSAC-3593) (migrate e2e test suite into the osac mono-repo)
**Follows:** #490 (caas e2e migration)

### Summary

Addresses the automated-review findings raised on the merged caas e2e migration
(#490) so the migrated `tests/e2e/caas/` suite is correct, secure, and
consistent with repo conventions. Test-only change — no product code.

### Changes

**`tests/e2e/caas/conftest.py`**
- Quote `namespace` and `service_account` with `shlex.quote()` in the
  `oc create token` command passed to `osac login --token-script` (the CLI runs
  that string in a shell) — closes a shell-injection vector.
- Add docstrings to the `cli`, `cluster_template`, `pull_secret_path`, and
  `ssh_public_key_path` fixtures.

**`tests/e2e/caas/test_cluster_create.py`**
- Assert `node_sets` is non-empty before deriving the component count and
  scaling a worker set, so an empty spec surfaces a clear failure instead of an
  opaque `StopIteration`.
- Clean up the `ClusterVersion` resources created by
  `test_cluster_create_with_version` and
  `test_cluster_create_rejected_for_invalid_version` in `finally` blocks so
  repeated runs don't leave stale versions on the shared cluster. Cleanup is
  robust on failure paths: resources are created inside the `try`, versions are
  tracked as they are created, and a referenced version's delete waits for full
  cluster removal first (instant on the happy path).
- Add a docstring to `test_cluster_create`.

### Testing

- **Unit tests:** N/A (e2e suite).
- **Integration/e2e tests:** the suite requires a live cluster and runs in CI
  (`e2e-caas-full-install`). Behavioral changes here are an in-test assertion and
  teardown hardening; no new test scenario is introduced.
- **Local validation:** `ruff check` clean, `ruff format --check` clean,
  `pytest tests/e2e/caas/ --collect-only` collects all 4 tests, and secret scans
  (`gitleaks`, `detect-private-key`) pass.

### Review findings addressed (from #490)

- [x] StopIteration edge case + assert `node_sets` non-empty
- [x] Missing ClusterVersion cleanup on failure paths
- [x] Shell injection in `conftest.py` token-script
- [x] Sensitive data in logs (verified already mitigated — token never enters
      Python; cleanup suppresses without logging)
- [x] Docstring coverage
- [x] AI attribution — `Assisted-by:` trailers, no `Co-Authored-By`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **Tests:** Updated the migrated `tests/e2e/caas/` E2E suite.
- **Security:** Added shell quoting for namespace and service-account values in the `oc create token` command.
- **Test reliability:** Added fixture and test docstrings, validated non-empty `node_sets`, and improved cleanup for clusters and `ClusterVersion` resources.
- **Resource cleanup:** Failed cluster-version tests now wait for `ClusterOrder` deletion before waiting for gRPC removal.
- **Product code:** No API, controller, database, authentication, deployment, or production-code changes.
- **Backward compatibility:** No impact is expected.

## Risk classification

**risk:ship** — The change is limited to test fixtures and E2E tests. It does not change production behavior or public interfaces. Lint, formatting, test collection, and secret-scan checks passed.

The change is not **risk:show** because it has no production behavior impact. It is not **risk:ask** because it introduces no unresolved production risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->