### PR TITLE
OSAC-4818: port --fork-name and docs fork-overrides to bootstrap.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ osac-ui/
 osac-test-infra/
 osac-docs/
 
+# Local GitHub fork-name mappings (see tools/fork-overrides.sh.example).
+/tools/fork-overrides.sh
+
 # Harness output and osac-ai-skills fan-out. Keep repo-local Claude settings
 # and hook *scripts* tracked; fan-out only adds .claude/hooks/README.md.
 .claude/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,10 @@ conventional GitHub layout on **writeable siblings only** (`origin` = you,
 `upstream` = osac-project). Pick a name and stick with it; re-running with a
 different name mutates sibling remotes. This osac checkout, `osac-ux`, and
 vendor clones are never renamed — skills keep resolving remotes by URL.
-`--no-fork` skips forking even if `--fork-name` is also passed. Never forked:
+`--no-fork` skips forking even if `--fork-name` is also passed. A later
+`--no-fork` after `--fork-name origin` does not rewrite remotes back and
+skips updates on siblings whose `origin` is already the fork (no `gh`).
+Never forked:
 `osac-ux`, `.osac-ai-skills`, `.ai-workflows`. Pass `--no-fork` for
 read-only or CI clones (requires no `gh`). Default path requires
 authenticated `gh`. The GitHub fork of [osac-project/docs](https://github.com/osac-project/docs)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ After clone, run `tools/bootstrap.sh` to vendor AI skills and workflows (see [AI
 
 ### Parallel worktrees
 
-Source [`tools/osac-helpers.sh`](tools/osac-helpers.sh) and run `osac-new-worktree <branch>` from this repo. It adds a sibling worktree (`../osac-<branch-basename>`), runs `tools/bootstrap.sh` there (extra args after the branch are forwarded, e.g. `--no-fork`), and appends Jira context to `.claude/CLAUDE.md` when the branch name contains `OSAC-NNNN`. Override the parent directory with `OSAC_WORKTREE_PARENT`. Clean up with `git worktree remove` on that path (default `../osac-<suffix>`; with `OSAC_WORKTREE_PARENT`, `$OSAC_WORKTREE_PARENT/osac-<suffix>`).
+Source [`tools/osac-helpers.sh`](tools/osac-helpers.sh) and run `osac-new-worktree <branch>` from this repo. It adds a sibling worktree (`../osac-<branch-basename>`), runs `tools/bootstrap.sh` there (extra args after the branch are forwarded, e.g. `--no-fork` or `--fork-name origin`), and appends Jira context to `.claude/CLAUDE.md` when the branch name contains `OSAC-NNNN`. Override the parent directory with `OSAC_WORKTREE_PARENT`. Clean up with `git worktree remove` on that path (default `../osac-<suffix>`; with `OSAC_WORKTREE_PARENT`, `$OSAC_WORKTREE_PARENT/osac-<suffix>`).
 
 ## Components
 
@@ -63,10 +63,17 @@ covers broader project-level architecture guides and diagrams).
 root (skill-relative paths when this checkout is the project root). By
 default it also forks the writeable three to your GitHub account (`origin` =
 osac-project, `fork` = you — the `$PUSH_REMOTE` that `resolve-remotes.sh`
-reports) so `/create-pr` has a push remote. Never forked:
+reports) so `/create-pr` has a push remote. `--fork-name origin` uses the
+conventional GitHub layout on **writeable siblings only** (`origin` = you,
+`upstream` = osac-project). Pick a name and stick with it; re-running with a
+different name mutates sibling remotes. This osac checkout, `osac-ux`, and
+vendor clones are never renamed — skills keep resolving remotes by URL.
+`--no-fork` skips forking even if `--fork-name` is also passed. Never forked:
 `osac-ux`, `.osac-ai-skills`, `.ai-workflows`. Pass `--no-fork` for
 read-only or CI clones (requires no `gh`). Default path requires
-authenticated `gh`.
+authenticated `gh`. The GitHub fork of [osac-project/docs](https://github.com/osac-project/docs)
+is named `osac-docs` (not `docs`); extra mappings go in `tools/fork-overrides.sh`
+(see `tools/fork-overrides.sh.example`).
 
 | Repo | Local path | Fork remote | Description |
 |------|------------|-------------|-------------|
@@ -118,6 +125,8 @@ A directory nested as `osac-workspace/osac/` still aborts (override:
 `OSAC_ALLOW_NESTED_BOOTSTRAP=1`) so it cannot install a second skill overlay.
 Use a standalone clone or worktree of this repo, not that nested copy. For a
 clone-only sibling pass (no GitHub forks), use `tools/bootstrap.sh --no-fork`.
+`--fork-name origin` only rearranges remotes on writeable siblings (see
+[External Repos](#external-repos)).
 
 Edit OSAC-native skills only in `osac-project/osac-ai-skills`. Local `skills/`
 and `.osac-ai-skills/` are bootstrap-managed and gitignored, as are the

--- a/README.md
+++ b/README.md
@@ -46,7 +46,10 @@ After clone, run `tools/bootstrap.sh` from this repo root. It vendors
 [flightctl/ai-workflows](https://github.com/flightctl/ai-workflows), clones
 skill-relative sibling repos (see `AGENTS.md`), forks the writeable siblings
 to your GitHub account, and links Claude Code / Cursor / Gemini CLI skill
-discovery. Requires an authenticated `gh` session unless you pass `--no-fork`. This
+discovery. Requires an authenticated `gh` session unless you pass `--no-fork`.
+`--fork-name origin` sets writeable sibling remotes to `origin` = your fork and
+`upstream` = osac-project; it does not change this checkout or skill vendor
+remotes. The GitHub fork of `osac-project/docs` is `osac-docs`. This
 repo is the project root. A nested `osac-workspace/osac/` checkout aborts;
 use a standalone clone or worktree instead.
 
@@ -76,7 +79,7 @@ source tools/osac-helpers.sh
 osac-new-worktree feat/OSAC-1234
 ```
 
-Creates `../osac-OSAC-1234` by default (or `$OSAC_WORKTREE_PARENT/osac-OSAC-1234`), checks out the new branch, and runs `tools/bootstrap.sh` (extra args after the branch are forwarded, e.g. `--no-fork`). Remove with `git worktree remove` on that path from the original clone.
+Creates `../osac-OSAC-1234` by default (or `$OSAC_WORKTREE_PARENT/osac-OSAC-1234`), checks out the new branch, and runs `tools/bootstrap.sh` (extra args after the branch are forwarded, e.g. `--no-fork` or `--fork-name origin`). Remove with `git worktree remove` on that path from the original clone.
 
 > [!WARNING]
 > Be mindful of the content you commit to this repository. Do not commit any

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ to your GitHub account, and links Claude Code / Cursor / Gemini CLI skill
 discovery. Requires an authenticated `gh` session unless you pass `--no-fork`.
 `--fork-name origin` sets writeable sibling remotes to `origin` = your fork and
 `upstream` = osac-project; it does not change this checkout or skill vendor
-remotes. The GitHub fork of `osac-project/docs` is `osac-docs`. This
+remotes. `--no-fork` wins over `--fork-name`. After `--fork-name origin`, a
+later `--no-fork` run skips updates on those origin-as-fork siblings rather
+than calling `gh`. The GitHub fork of `osac-project/docs` is `osac-docs`. This
 repo is the project root. A nested `osac-workspace/osac/` checkout aborts;
 use a standalone clone or worktree instead.
 

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -374,7 +374,7 @@ is_github_fork_of_org_repo() {
 
 ensure_fork_remote() {
   local repo="$1" dir="$2"
-  local url occupant old_url target renamed_to="" fork_repo
+  local url occupant target renamed_to="" fork_repo
   local fork_name_args=()
   fork_repo=$(fork_repo_for "$repo")
   if [[ "$fork_repo" != "$repo" ]]; then
@@ -394,14 +394,13 @@ ensure_fork_remote() {
     fi
     occupant=$(git -C "$dir" remote get-url "$FORK_REMOTE_NAME")
     if remote_url_matches_suffix "$occupant" "${GITHUB_ORG}/${repo}"; then
-      old_url="$occupant"
       target="upstream"
       while git -C "$dir" remote get-url "$target" &>/dev/null; do
         target="osac-${target}"
       done
       git -C "$dir" remote rename "$FORK_REMOTE_NAME" "$target"
       renamed_to="$target"
-      echo "  Renamed existing '${FORK_REMOTE_NAME}' (${old_url}) → '${target}'"
+      echo "  Renamed existing '${FORK_REMOTE_NAME}' → '${target}'"
     else
       echo "  Remote '${FORK_REMOTE_NAME}' already exists with a different URL. Skipping."
       return 1

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -50,11 +50,14 @@ is named osac-docs (override extra mappings in tools/fork-overrides.sh).
 
 osac-ux is a reference clone (no fork). Vendor checkouts (.osac-ai-skills,
 .ai-workflows) are never forked. --no-fork skips forking even when
---fork-name is also passed.
+--fork-name is also passed. After --fork-name origin, a later --no-fork
+run does not rewrite remotes and skips updates on those origin-as-fork
+siblings (no gh).
 
 Options:
   --no-fork          Clone siblings from osac-project without forking.
                      Useful for read-only access or CI environments.
+                     Does not update siblings already using --fork-name origin.
   --fork-name NAME   Name for the writeable-sibling push remote (default: fork).
   --help             Show this help message.
 

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -371,6 +371,24 @@ fork_remote_is_user_fork() {
   fork_remote_push_matches "$dir" "$remote" "$expected_suffix"
 }
 
+# git remote rename retargets branch.*.remote to the new name. After we add
+# the fork back as $to_remote, point those branches at the fork again so
+# `git push` on main does not go to osac-project.
+restore_branch_remotes() {
+  local dir="$1" from_remote="$2" to_remote="$3"
+  local line key value branch configs
+  configs=$(git -C "$dir" config --get-regexp '^branch\..*\.remote$' 2>/dev/null || true)
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    key="${line%% *}"
+    value="${line#* }"
+    [[ "$value" == "$from_remote" ]] || continue
+    branch="${key#branch.}"
+    branch="${branch%.remote}"
+    git -C "$dir" config "branch.${branch}.remote" "$to_remote"
+  done <<< "$configs"
+}
+
 # True when $GH_USER/$(fork_repo_for "$repo") is a GitHub fork of
 # osac-project/$repo (not an unrelated same-name repo — common for docs,
 # whose fork is osac-docs).
@@ -425,6 +443,9 @@ ensure_fork_remote() {
     fi
     echo "  Failed to add '${FORK_REMOTE_NAME}' remote for ${repo}."
     return 1
+  fi
+  if [[ -n "$renamed_to" ]]; then
+    restore_branch_remotes "$dir" "$renamed_to" "$FORK_REMOTE_NAME"
   fi
   git -C "$dir" fetch "$FORK_REMOTE_NAME" || {
     echo "  Fetch of ${FORK_REMOTE_NAME} failed for ${repo}. Remote was added."

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Install AI workflow skills for this repo.
 #
-# Usage: tools/bootstrap.sh [--no-fork]
+# Usage: tools/bootstrap.sh [--no-fork] [--fork-name NAME]
 #
 # This script:
 #   1. Clones or updates osac-project/osac-ai-skills (prefers ~/.osac-ai-skills)
@@ -14,8 +14,9 @@
 #      (enhancement-proposals, osac-ux, osac-ui, osac-docs). osac-docs
 #      is osac-project/docs — not docs/. E2E suites live in-tree at
 #      tests/e2e/; osac-test-infra is not cloned.
-#      Writeable siblings get a `fork` remote (origin = osac-project).
-#      osac-ux and vendor clones are never forked.
+#      Writeable siblings get a push remote (default name `fork`;
+#      origin = osac-project). --fork-name only rearranges remotes on
+#      those siblings — not this checkout, osac-ux, or vendor clones.
 #
 # Re-run anytime to update to latest main.
 set -euo pipefail
@@ -31,22 +32,30 @@ GIT_PROTOCOL="https"
 
 usage() {
   cat <<'EOF'
-Usage: tools/bootstrap.sh [--no-fork]
+Usage: tools/bootstrap.sh [--no-fork] [--fork-name NAME]
 
 Vendors AI skills/workflows and clones skill-relative sibling repos under
 this checkout.
 
 By default, each writeable sibling is forked to your GitHub account:
   origin     = osac-project/<repo>     (upstream source, PR target)
-  fork       = <your-username>/<repo>  (push target for feature branches)
+  <fork-name> = <your-username>/<repo>  (push target; default name: fork)
+
+--fork-name origin uses the conventional GitHub layout on writeable
+siblings only (origin = your fork, upstream = osac-project). Pick a name
+and stick with it — re-running with a different name mutates remotes.
+This checkout, osac-ux, and vendor clones are never renamed. Skills
+resolve remotes by URL, not by name.
 
 osac-ux is a reference clone (no fork). Vendor checkouts (.osac-ai-skills,
-.ai-workflows) are never forked.
+.ai-workflows) are never forked. --no-fork skips forking even when
+--fork-name is also passed.
 
 Options:
-  --no-fork   Clone siblings from osac-project without forking.
-              Useful for read-only access or CI environments.
-  --help      Show this help message.
+  --no-fork          Clone siblings from osac-project without forking.
+                     Useful for read-only access or CI environments.
+  --fork-name NAME   Name for the writeable-sibling push remote (default: fork).
+  --help             Show this help message.
 
 Prerequisites:
   - gh CLI installed and authenticated (gh auth login), unless --no-fork
@@ -56,6 +65,11 @@ EOF
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --no-fork) NO_FORK=true; shift ;;
+    --fork-name)
+      [[ -n "${2:-}" ]] || { echo "Error: --fork-name requires a value" >&2; usage >&2; exit 1; }
+      FORK_REMOTE_NAME="$2"
+      shift 2
+      ;;
     --help|-h) usage; exit 0 ;;
     *)
       echo "Unknown option: $1" >&2
@@ -139,23 +153,24 @@ ai_workflows_checkout_ok() {
   is_git_work_tree_root "$dir" && [[ -x "${dir}/install.sh" ]]
 }
 
-# Fetch + rebase a git checkout onto origin/main. Warns and continues on
-# failure rather than exiting — a stale checkout is recoverable manually.
-# Skip when HEAD is not main so a later bootstrap does not rebase a feature
-# branch (siblings now have a fork remote; developers will check those out).
+# Fetch + rebase a git checkout onto $remote/main (default origin). Warns and
+# continues on failure rather than exiting — a stale checkout is recoverable
+# manually. Skip when HEAD is not main so a later bootstrap does not rebase a
+# feature branch (siblings now have a push remote; developers will check those
+# out). Vendors always pass origin (or omit the third arg).
 update_git_repo() {
-  local dir="$1" label="$2"
+  local dir="$1" label="$2" remote="${3:-origin}"
   local branch
   branch=$(git -C "$dir" symbolic-ref --short HEAD 2>/dev/null || echo "")
   if [[ "$branch" != "main" ]]; then
     echo "  ${label} is on '${branch:-unknown}'. Skipping update to avoid rebasing your work."
     return 0
   fi
-  if ! (cd "${dir}" && git fetch origin -q); then
+  if ! (cd "${dir}" && git fetch "$remote" -q); then
     echo "  Fetch failed for ${label}. Skipping update."
-  elif ! (cd "${dir}" && git rebase origin/main --autostash -q); then
+  elif ! (cd "${dir}" && git rebase "${remote}/main" --autostash -q); then
     (cd "${dir}" && git rebase --abort 2>/dev/null || true)
-    echo "  Rebase failed for ${label}. Resolve manually: cd ${dir} && git rebase origin/main"
+    echo "  Rebase failed for ${label}. Resolve manually: cd ${dir} && git rebase ${remote}/main"
   else
     echo "  ${label} up to date"
   fi
@@ -237,14 +252,53 @@ SIBLINGS=(
   "docs:osac-docs"
 )
 
+# True when $url is a path or SSH remote for $suffix (e.g. osac-project/docs).
+# Require / or : before the suffix so evil-osac-project/<repo> does not match.
+remote_url_matches_suffix() {
+  local url="$1" suffix="$2"
+  local stripped="${url%.git}"
+  [[ "$stripped" == *"/${suffix}" || "$stripped" == *":${suffix}" ]]
+}
+
+find_upstream_remote() {
+  local dir="$1" repo="$2"
+  local remote url
+  local expected_suffix="${GITHUB_ORG}/${repo}"
+  for remote in $(git -C "$dir" remote 2>/dev/null); do
+    url=$(git -C "$dir" remote get-url "$remote" 2>/dev/null) || continue
+    if remote_url_matches_suffix "$url" "$expected_suffix"; then
+      echo "$remote"
+      return 0
+    fi
+  done
+  return 1
+}
+
 is_expected_sibling() {
   local dir="$1" repo="$2"
-  local expected_suffix="${GITHUB_ORG}/${repo}"
   local url
   url=$(git -C "$dir" remote get-url origin 2>/dev/null) || return 1
-  # Require a path or SSH separator so evil-osac-project/<repo> does not match.
-  # origin only: update_git_repo rebases origin/main, so any other remote is irrelevant.
-  [[ "${url%.git}" == *"/${expected_suffix}" || "${url%.git}" == *":${expected_suffix}" ]]
+  if remote_url_matches_suffix "$url" "${GITHUB_ORG}/${repo}"; then
+    return 0
+  fi
+  # --fork-name origin layout: origin is the user's fork, another remote is org.
+  if [[ "$NO_FORK" == false && -n "$GH_USER" ]] \
+     && remote_url_matches_suffix "$url" "${GH_USER}/${repo}"; then
+    find_upstream_remote "$dir" "$repo" >/dev/null
+    return $?
+  fi
+  return 1
+}
+
+sibling_update_remote() {
+  local dir="$1" repo="$2"
+  local url
+  url=$(git -C "$dir" remote get-url origin 2>/dev/null) || { echo origin; return 0; }
+  if remote_url_matches_suffix "$url" "${GITHUB_ORG}/${repo}"; then
+    echo origin
+    return 0
+  fi
+  find_upstream_remote "$dir" "$repo"
 }
 
 get_fork_url() {
@@ -264,10 +318,9 @@ fork_remote_push_matches() {
   local push_urls
   push_urls=$(git -C "$dir" remote get-url --push --all "$remote" 2>/dev/null) || return 1
   [[ -n "$push_urls" ]] || return 1
-  local push_url stripped
+  local push_url
   while IFS= read -r push_url; do
-    stripped="${push_url%.git}"
-    [[ "$stripped" == *"/${expected_suffix}" || "$stripped" == *":${expected_suffix}" ]] || return 1
+    remote_url_matches_suffix "$push_url" "$expected_suffix" || return 1
   done <<< "$push_urls"
   return 0
 }
@@ -283,7 +336,7 @@ is_github_fork_of_org_repo() {
 
 ensure_fork_remote() {
   local repo="$1" dir="$2"
-  local url
+  local url occupant old_url target renamed_to=""
   if ! gh repo fork "${GITHUB_ORG}/${repo}" --clone=false --default-branch-only; then
     if ! is_github_fork_of_org_repo "$repo"; then
       echo "  Failed to fork ${GITHUB_ORG}/${repo}. Skipping fork remote."
@@ -295,10 +348,28 @@ ensure_fork_remote() {
     if fork_remote_push_matches "$dir" "$FORK_REMOTE_NAME" "${GH_USER}/${repo}"; then
       return 0
     fi
-    echo "  Remote '${FORK_REMOTE_NAME}' already exists with a different URL. Skipping."
+    occupant=$(git -C "$dir" remote get-url "$FORK_REMOTE_NAME")
+    if remote_url_matches_suffix "$occupant" "${GITHUB_ORG}/${repo}"; then
+      old_url="$occupant"
+      target="upstream"
+      while git -C "$dir" remote get-url "$target" &>/dev/null; do
+        target="osac-${target}"
+      done
+      git -C "$dir" remote rename "$FORK_REMOTE_NAME" "$target"
+      renamed_to="$target"
+      echo "  Renamed existing '${FORK_REMOTE_NAME}' (${old_url}) → '${target}'"
+    else
+      echo "  Remote '${FORK_REMOTE_NAME}' already exists with a different URL. Skipping."
+      return 1
+    fi
+  fi
+  if ! git -C "$dir" remote add "$FORK_REMOTE_NAME" "$url"; then
+    if [[ -n "$renamed_to" ]]; then
+      git -C "$dir" remote rename "$renamed_to" "$FORK_REMOTE_NAME" 2>/dev/null || true
+    fi
+    echo "  Failed to add '${FORK_REMOTE_NAME}' remote for ${repo}."
     return 1
   fi
-  git -C "$dir" remote add "$FORK_REMOTE_NAME" "$url"
   git -C "$dir" fetch "$FORK_REMOTE_NAME" || {
     echo "  Fetch of ${FORK_REMOTE_NAME} failed for ${repo}. Remote was added."
     return 0
@@ -335,7 +406,9 @@ ensure_sibling() {
   fi
   if [[ -d "${dest}" ]] && is_expected_sibling "${dest}" "${repo}"; then
     echo "Updating ${dir}..."
-    update_git_repo "${dest}" "${dir}"
+    local update_remote
+    update_remote=$(sibling_update_remote "${dest}" "${repo}") || update_remote=origin
+    update_git_repo "${dest}" "${dir}" "$update_remote"
     maybe_fork_sibling "$repo" "$dest"
   elif [[ -d "${dest}" ]]; then
     echo "Skipping ${dir} — directory exists but is not a clone of ${GITHUB_ORG}/${repo}."

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -70,7 +70,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --no-fork) NO_FORK=true; shift ;;
     --fork-name)
-      [[ -n "${2:-}" ]] || { echo "Error: --fork-name requires a value" >&2; usage >&2; exit 1; }
+      [[ -n "${2:-}" && "$2" != --* ]] || { echo "Error: --fork-name requires a value" >&2; usage >&2; exit 1; }
       FORK_REMOTE_NAME="$2"
       shift 2
       ;;
@@ -361,6 +361,16 @@ fork_remote_push_matches() {
   return 0
 }
 
+# True when $remote already *is* the user fork: fetch URL and every push URL
+# match $expected_suffix. Push-only (org fetch + fork pushurl) is not enough.
+fork_remote_is_user_fork() {
+  local dir="$1" remote="$2" expected_suffix="$3"
+  local fetch_url
+  fetch_url=$(git -C "$dir" remote get-url "$remote" 2>/dev/null) || return 1
+  remote_url_matches_suffix "$fetch_url" "$expected_suffix" || return 1
+  fork_remote_push_matches "$dir" "$remote" "$expected_suffix"
+}
+
 # True when $GH_USER/$(fork_repo_for "$repo") is a GitHub fork of
 # osac-project/$repo (not an unrelated same-name repo — common for docs,
 # whose fork is osac-docs).
@@ -389,10 +399,10 @@ ensure_fork_remote() {
   fi
   url=$(get_fork_url "$repo")
   if git -C "$dir" remote get-url "$FORK_REMOTE_NAME" &>/dev/null; then
-    if fork_remote_push_matches "$dir" "$FORK_REMOTE_NAME" "${GH_USER}/${fork_repo}"; then
+    occupant=$(git -C "$dir" remote get-url "$FORK_REMOTE_NAME")
+    if fork_remote_is_user_fork "$dir" "$FORK_REMOTE_NAME" "${GH_USER}/${fork_repo}"; then
       return 0
     fi
-    occupant=$(git -C "$dir" remote get-url "$FORK_REMOTE_NAME")
     if remote_url_matches_suffix "$occupant" "${GITHUB_ORG}/${repo}"; then
       target="upstream"
       while git -C "$dir" remote get-url "$target" &>/dev/null; do
@@ -400,6 +410,9 @@ ensure_fork_remote() {
       done
       git -C "$dir" remote rename "$FORK_REMOTE_NAME" "$target"
       renamed_to="$target"
+      # Rename keeps a leftover pushurl (org fetch + fork push). Drop it so
+      # the org remote fetches and pushes to osac-project.
+      git -C "$dir" config --unset-all "remote.${target}.pushurl" 2>/dev/null || true
       echo "  Renamed existing '${FORK_REMOTE_NAME}' → '${target}'"
     else
       echo "  Remote '${FORK_REMOTE_NAME}' already exists with a different URL. Skipping."
@@ -431,7 +444,7 @@ should_fork_sibling() {
 maybe_fork_sibling() {
   local repo="$1" dest="$2"
   should_fork_sibling "$repo" || return 0
-  if fork_remote_push_matches "$dest" "$FORK_REMOTE_NAME" "${GH_USER}/$(fork_repo_for "$repo")"; then
+  if fork_remote_is_user_fork "$dest" "$FORK_REMOTE_NAME" "${GH_USER}/$(fork_repo_for "$repo")"; then
     return 0
   fi
   echo "Adding ${FORK_REMOTE_NAME} remote for ${repo}..."

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -45,7 +45,8 @@ By default, each writeable sibling is forked to your GitHub account:
 siblings only (origin = your fork, upstream = osac-project). Pick a name
 and stick with it — re-running with a different name mutates remotes.
 This checkout, osac-ux, and vendor clones are never renamed. Skills
-resolve remotes by URL, not by name.
+resolve remotes by URL, not by name. The GitHub fork of osac-project/docs
+is named osac-docs (override extra mappings in tools/fork-overrides.sh).
 
 osac-ux is a reference clone (no fork). Vendor checkouts (.osac-ai-skills,
 .ai-workflows) are never forked. --no-fork skips forking even when
@@ -242,6 +243,36 @@ echo "Installing ai-workflows skills..."
 AI_WORKFLOWS="bugfix,implement,prd,design,e2e"
 "${AI_WORKFLOWS_DIR}/install.sh" all --project "${PROJECT_ROOT}" --workflows "${AI_WORKFLOWS}"
 
+# Optional tools/fork-overrides.sh may replace or append FORK_OVERRIDE_PAIRS
+# entries ("upstream-repo:github-fork-name"). docs defaults to osac-docs.
+FORK_OVERRIDE_PAIRS=()
+if [[ -f "${SCRIPT_DIR}/fork-overrides.sh" ]]; then
+  # shellcheck disable=SC1091
+  source "${SCRIPT_DIR}/fork-overrides.sh"
+fi
+_fork_override_has_docs=false
+for _pair in "${FORK_OVERRIDE_PAIRS[@]+"${FORK_OVERRIDE_PAIRS[@]}"}"; do
+  if [[ "${_pair%%:*}" == "docs" ]]; then
+    _fork_override_has_docs=true
+    break
+  fi
+done
+if [[ "$_fork_override_has_docs" == false ]]; then
+  FORK_OVERRIDE_PAIRS+=("docs:osac-docs")
+fi
+unset _fork_override_has_docs _pair
+
+fork_repo_for() {
+  local repo="$1" pair
+  for pair in "${FORK_OVERRIDE_PAIRS[@]+"${FORK_OVERRIDE_PAIRS[@]}"}"; do
+    if [[ "${pair%%:*}" == "$repo" ]]; then
+      echo "${pair#*:}"
+      return 0
+    fi
+  done
+  echo "$repo"
+}
+
 # Skill-relative sibling checkouts (gitignored). Local dir name follows the
 # GitHub repo except docs → osac-docs (docs/ is in-tree conventions).
 # Format: "repo" or "repo:local-dir"
@@ -283,7 +314,7 @@ is_expected_sibling() {
   fi
   # --fork-name origin layout: origin is the user's fork, another remote is org.
   if [[ "$NO_FORK" == false && -n "$GH_USER" ]] \
-     && remote_url_matches_suffix "$url" "${GH_USER}/${repo}"; then
+     && remote_url_matches_suffix "$url" "${GH_USER}/$(fork_repo_for "$repo")"; then
     find_upstream_remote "$dir" "$repo" >/dev/null
     return $?
   fi
@@ -303,10 +334,12 @@ sibling_update_remote() {
 
 get_fork_url() {
   local repo="$1"
+  local fork_repo
+  fork_repo=$(fork_repo_for "$repo")
   if [[ "$GIT_PROTOCOL" == "ssh" ]]; then
-    echo "git@github.com:${GH_USER}/${repo}.git"
+    echo "git@github.com:${GH_USER}/${fork_repo}.git"
   else
-    echo "https://github.com/${GH_USER}/${repo}.git"
+    echo "https://github.com/${GH_USER}/${fork_repo}.git"
   fi
 }
 
@@ -329,15 +362,22 @@ fork_remote_push_matches() {
 # unrelated same-name repo — common for the docs sibling).
 is_github_fork_of_org_repo() {
   local repo="$1"
-  local parent
-  parent=$(gh repo view "${GH_USER}/${repo}" --json parent -q '.parent.nameWithOwner // empty' 2>/dev/null) || return 1
+  local parent fork_repo
+  fork_repo=$(fork_repo_for "$repo")
+  parent=$(gh repo view "${GH_USER}/${fork_repo}" --json parent -q '.parent.nameWithOwner // empty' 2>/dev/null) || return 1
   [[ "$parent" == "${GITHUB_ORG}/${repo}" ]]
 }
 
 ensure_fork_remote() {
   local repo="$1" dir="$2"
-  local url occupant old_url target renamed_to=""
-  if ! gh repo fork "${GITHUB_ORG}/${repo}" --clone=false --default-branch-only; then
+  local url occupant old_url target renamed_to="" fork_repo
+  local fork_name_args=()
+  fork_repo=$(fork_repo_for "$repo")
+  if [[ "$fork_repo" != "$repo" ]]; then
+    fork_name_args=(--fork-name "$fork_repo")
+  fi
+  if ! gh repo fork "${GITHUB_ORG}/${repo}" --clone=false --default-branch-only \
+       ${fork_name_args[@]+"${fork_name_args[@]}"}; then
     if ! is_github_fork_of_org_repo "$repo"; then
       echo "  Failed to fork ${GITHUB_ORG}/${repo}. Skipping fork remote."
       return 1
@@ -345,7 +385,7 @@ ensure_fork_remote() {
   fi
   url=$(get_fork_url "$repo")
   if git -C "$dir" remote get-url "$FORK_REMOTE_NAME" &>/dev/null; then
-    if fork_remote_push_matches "$dir" "$FORK_REMOTE_NAME" "${GH_USER}/${repo}"; then
+    if fork_remote_push_matches "$dir" "$FORK_REMOTE_NAME" "${GH_USER}/${fork_repo}"; then
       return 0
     fi
     occupant=$(git -C "$dir" remote get-url "$FORK_REMOTE_NAME")
@@ -388,7 +428,7 @@ should_fork_sibling() {
 maybe_fork_sibling() {
   local repo="$1" dest="$2"
   should_fork_sibling "$repo" || return 0
-  if fork_remote_push_matches "$dest" "$FORK_REMOTE_NAME" "${GH_USER}/${repo}"; then
+  if fork_remote_push_matches "$dest" "$FORK_REMOTE_NAME" "${GH_USER}/$(fork_repo_for "$repo")"; then
     return 0
   fi
   echo "Adding ${FORK_REMOTE_NAME} remote for ${repo}..."

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -358,8 +358,9 @@ fork_remote_push_matches() {
   return 0
 }
 
-# True when $GH_USER/$repo is a GitHub fork of osac-project/$repo (not an
-# unrelated same-name repo — common for the docs sibling).
+# True when $GH_USER/$(fork_repo_for "$repo") is a GitHub fork of
+# osac-project/$repo (not an unrelated same-name repo — common for docs,
+# whose fork is osac-docs).
 is_github_fork_of_org_repo() {
   local repo="$1"
   local parent fork_repo

--- a/tools/fork-overrides.sh.example
+++ b/tools/fork-overrides.sh.example
@@ -1,0 +1,8 @@
+# GitHub fork-name mappings: "upstream-repo:your-fork-name"
+# Copy to tools/fork-overrides.sh (gitignored) and uncomment/add entries.
+#
+# osac-project/docs already maps to osac-docs in tools/bootstrap.sh unless
+# this file sets a docs: pair.
+#
+# FORK_OVERRIDE_PAIRS=("docs:osac-docs")
+# FORK_OVERRIDE_PAIRS+=("enhancement-proposals:my-ep-fork")

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -663,6 +663,8 @@ test_unrelated_same_name_github_repo_is_not_used_as_fork() {
     || fail "bootstrap should continue when docs fork collides: $out"
   echo "$out" | grep -qi 'Failed to fork osac-project/docs' \
     || fail "expected skip for unrelated github.com/smokeuser/docs: $out"
+  grep -q 'repo view smokeuser/osac-docs' "${home}/gh.log" \
+    || fail "parent check must view smokeuser/osac-docs: $(cat "${home}/gh.log")"
   assert_no_fork_remote "${root}/osac-docs" "osac-docs after docs name collision"
   assert_fork_remote "${root}/enhancement-proposals" "enhancement-proposals"
   pass "does not point fork at an unrelated same-name GitHub repo"
@@ -721,13 +723,13 @@ test_fork_remote_match_requires_user_boundary() {
 
   run_bootstrap "$root" "$home" "$bin" >/dev/null
   "$REAL_GIT" -C "$docs_dest" remote add fork \
-    "https://github.com/evilsmokeuser/docs.git"
+    "https://github.com/evilsmokeuser/osac-docs.git"
 
   out=$(run_bootstrap_fork "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
   echo "$out" | grep -q 'already exists with a different URL' \
-    || fail "evilsmokeuser/docs must not count as smokeuser/docs: $out"
+    || fail "evilsmokeuser/osac-docs must not count as smokeuser/osac-docs: $out"
   url=$(git -C "$docs_dest" remote get-url fork)
-  [[ "$url" == *evilsmokeuser/docs* ]] \
+  [[ "$url" == *evilsmokeuser/osac-docs* ]] \
     || fail "must not overwrite an existing mismatched fork remote: $url"
   pass "fork-remote match requires / or : before \$GH_USER/repo"
 }
@@ -801,6 +803,13 @@ test_fork_name_origin_rerun_is_idempotent() {
     || fail "re-run must rebase onto upstream/main: $(cat "$git_log")"
   assert_origin_layout_writeable "$ep" "enhancement-proposals"
   assert_no_named_remote "$ep" osac-upstream "enhancement-proposals"
+  echo "$out" | grep -q 'Updating osac-docs' \
+    || fail "re-run should update origin-as-fork osac-docs: $out"
+  echo "$out" | grep -qi 'skipping osac-docs' \
+    && fail "must not skip osac-docs on --fork-name origin re-run: $out"
+  assert_remote_url "${root}/osac-docs" origin "smokeuser/osac-docs"
+  assert_remote_url "${root}/osac-docs" upstream "osac-project/docs"
+  assert_no_named_remote "${root}/osac-docs" fork "osac-docs"
   pass "--fork-name origin re-run updates via upstream and does not rename again"
 }
 

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -831,6 +831,26 @@ test_fork_name_origin_uses_osac_upstream_when_upstream_taken() {
   pass "--fork-name origin uses osac-upstream when upstream exists"
 }
 
+test_fork_name_origin_rename_does_not_log_remote_url() {
+  local home root bin home_skills home_workflows repo_skills clone_log out ep
+  local cred_url
+  prepare_fixture fork-name-origin-no-url-log
+  write_gh_wrapper "${bin}/gh"
+  ep="${root}/enhancement-proposals"
+  cred_url="https://user:s3cret@github.com/osac-project/enhancement-proposals.git"
+
+  run_bootstrap "$root" "$home" "$bin" >/dev/null
+  "$REAL_GIT" -C "$ep" remote set-url origin "$cred_url"
+  out=$(run_bootstrap_fork "$root" "$home" "$bin" --fork-name origin 2>&1) \
+    || fail "--fork-name origin with credential origin failed: $out"
+  echo "$out" | grep -q "s3cret" \
+    && fail "rename log must not print remote credentials: $out"
+  echo "$out" | grep -qE "Renamed existing 'origin' → 'upstream'" \
+    || fail "expected names-only rename log: $out"
+  assert_origin_layout_writeable "$ep" "enhancement-proposals"
+  pass "--fork-name origin rename log omits remote URL"
+}
+
 test_no_fork_with_fork_name_origin_is_read_only() {
   local home root bin home_skills home_workflows repo_skills clone_log out
   local skills_origin
@@ -1015,6 +1035,7 @@ test_fork_name_requires_value
 test_fork_name_origin_renames_org_origin
 test_fork_name_origin_rerun_is_idempotent
 test_fork_name_origin_uses_osac_upstream_when_upstream_taken
+test_fork_name_origin_rename_does_not_log_remote_url
 test_no_fork_with_fork_name_origin_is_read_only
 test_docs_fork_uses_osac_docs_github_name
 test_fork_overrides_file_can_remap_docs

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -64,6 +64,9 @@ if [[ " \$* " == *" clone "* ]]; then
   exit 0
 fi
 if [[ " \$* " == *" fetch "* ]] || [[ " \$* " == *" rebase "* ]]; then
+  if [[ -n "\${OSAC_SMOKE_GIT_LOG:-}" ]]; then
+    printf '%s\\n' "\$*" >> "\$OSAC_SMOKE_GIT_LOG"
+  fi
   exit 0
 fi
 exec "\$REAL" "\$@"
@@ -177,15 +180,18 @@ run_bootstrap() {
   HOME="$home" PATH="${bin}:${PATH}" \
     OSAC_SMOKE_CLONE_LOG="${home}/clone.log" \
     OSAC_SMOKE_GH_LOG="${home}/gh.log" \
+    OSAC_SMOKE_GIT_LOG="${home}/git.log" \
     bash "${root}/tools/bootstrap.sh" --no-fork "$@"
 }
 
 run_bootstrap_fork() {
   local root="$1" home="$2" bin="$3"
+  shift 3
   HOME="$home" PATH="${bin}:${PATH}" \
     OSAC_SMOKE_CLONE_LOG="${home}/clone.log" \
     OSAC_SMOKE_GH_LOG="${home}/gh.log" \
-    bash "${root}/tools/bootstrap.sh"
+    OSAC_SMOKE_GIT_LOG="${home}/git.log" \
+    bash "${root}/tools/bootstrap.sh" "$@"
 }
 
 assert_no_fork_remote() {
@@ -195,6 +201,22 @@ assert_no_fork_remote() {
   fi
 }
 
+assert_no_named_remote() {
+  local dest="$1" remote="$2" label="$3"
+  if git -C "$dest" remote get-url "$remote" >/dev/null 2>&1; then
+    fail "$label must not have remote ${remote}: $(git -C "$dest" remote -v)"
+  fi
+}
+
+assert_remote_url() {
+  local dest="$1" remote="$2" suffix="$3"
+  local url
+  url=$(git -C "$dest" remote get-url "$remote" 2>/dev/null) \
+    || fail "missing remote ${remote} on ${dest}: $(git -C "$dest" remote -v 2>/dev/null || true)"
+  [[ "${url%.git}" == *"/${suffix}" || "${url%.git}" == *":${suffix}" ]] \
+    || fail "remote ${remote} on ${dest} expected ${suffix}, got: $url"
+}
+
 assert_fork_remote() {
   local dest="$1" repo="$2"
   local url
@@ -202,6 +224,35 @@ assert_fork_remote() {
     || fail "missing fork remote on ${dest}: $(git -C "$dest" remote -v 2>/dev/null || true)"
   [[ "${url%.git}" == *"/smokeuser/${repo}" || "${url%.git}" == *":smokeuser/${repo}" ]] \
     || fail "fork remote on ${dest} expected smokeuser/${repo}, got: $url"
+}
+
+seed_osac_root_git() {
+  local root="$1"
+  "$REAL_GIT" init -q "$root"
+  "$REAL_GIT" -C "$root" checkout -q -b main
+  "$REAL_GIT" -C "$root" remote add origin "https://github.com/smokeuser/osac.git"
+}
+
+assert_osac_root_untouched() {
+  local root="$1"
+  assert_remote_url "$root" origin "smokeuser/osac"
+  assert_no_named_remote "$root" upstream "PROJECT_ROOT"
+  assert_no_named_remote "$root" fork "PROJECT_ROOT"
+}
+
+assert_vendor_untouched() {
+  local dest="$1" label="$2" orig="$3"
+  [[ "$(git -C "$dest" remote get-url origin)" == "$orig" ]] \
+    || fail "$label origin changed: $(git -C "$dest" remote -v)"
+  assert_no_named_remote "$dest" fork "$label"
+  assert_no_named_remote "$dest" upstream "$label"
+}
+
+assert_origin_layout_writeable() {
+  local dest="$1" repo="$2"
+  assert_remote_url "$dest" origin "smokeuser/${repo}"
+  assert_remote_url "$dest" upstream "osac-project/${repo}"
+  assert_no_named_remote "$dest" fork "$(basename "$dest")"
 }
 
 assert_expected_clones() {
@@ -421,20 +472,56 @@ test_expected_sibling_requires_origin_remote() {
   ep="${root}/enhancement-proposals"
 
   run_bootstrap "$root" "$home" "$bin" >/dev/null
+  setup_unrelated_origin_extra_org "$ep"
+  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
+  assert_unrelated_origin_skipped "$out" "$ep"
+  pass "expected-clone match uses origin only, not other remotes"
+}
+
+setup_unrelated_origin_extra_org() {
+  local ep="$1"
   "$REAL_GIT" -C "$ep" remote set-url origin \
     "https://github.com/unrelated/enhancement-proposals.git"
   "$REAL_GIT" -C "$ep" remote add extra \
     "https://github.com/osac-project/enhancement-proposals.git"
   echo keep > "${ep}/keep-me"
+}
 
-  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
+assert_unrelated_origin_skipped() {
+  local out="$1" ep="$2"
   echo "$out" | grep -qi 'skip' \
     || fail "non-origin osac-project remote must not count as expected clone: $out"
   echo "$out" | grep -q 'Updating enhancement-proposals' \
     && fail "must not update when origin is unrelated: $out"
   grep -q keep "${ep}/keep-me" \
     || fail "dir with unrelated origin was overwritten"
-  pass "expected-clone match uses origin only, not other remotes"
+}
+
+test_expected_sibling_requires_origin_remote_when_forking() {
+  local home root bin home_skills home_workflows repo_skills clone_log out ep
+  prepare_fixture origin-only-fork
+  write_gh_wrapper "${bin}/gh"
+  ep="${root}/enhancement-proposals"
+
+  run_bootstrap "$root" "$home" "$bin" >/dev/null
+  setup_unrelated_origin_extra_org "$ep"
+  out=$(run_bootstrap_fork "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
+  assert_unrelated_origin_skipped "$out" "$ep"
+  pass "expected-clone origin-only still holds on the default fork path"
+}
+
+test_expected_sibling_requires_origin_remote_with_fork_name_origin() {
+  local home root bin home_skills home_workflows repo_skills clone_log out ep
+  prepare_fixture origin-only-fork-name
+  write_gh_wrapper "${bin}/gh"
+  ep="${root}/enhancement-proposals"
+
+  run_bootstrap "$root" "$home" "$bin" >/dev/null
+  setup_unrelated_origin_extra_org "$ep"
+  out=$(run_bootstrap_fork "$root" "$home" "$bin" --fork-name origin 2>&1) \
+    || fail "bootstrap failed: $out"
+  assert_unrelated_origin_skipped "$out" "$ep"
+  pass "expected-clone origin-only still holds with --fork-name origin"
 }
 
 test_missing_gh_without_no_fork_exits() {
@@ -643,6 +730,117 @@ test_fork_remote_match_requires_user_boundary() {
   pass "fork-remote match requires / or : before \$GH_USER/repo"
 }
 
+test_fork_name_requires_value() {
+  local home root bin home_skills home_workflows repo_skills clone_log out rc
+  prepare_fixture fork-name-val
+  write_gh_wrapper "${bin}/gh"
+
+  set +e
+  out=$(HOME="$home" PATH="${bin}:${PATH}" bash "${root}/tools/bootstrap.sh" --fork-name 2>&1)
+  rc=$?
+  set -e
+  [[ "$rc" -ne 0 ]] || fail "expected non-zero for --fork-name without a value: $out"
+  echo "$out" | grep -qi 'fork-name requires a value' \
+    || fail "expected --fork-name value error: $out"
+  pass "--fork-name requires a value"
+}
+
+test_fork_name_origin_renames_org_origin() {
+  local home root bin home_skills home_workflows repo_skills clone_log out
+  local skills_origin wf_origin gh_log
+  prepare_fixture fork-name-origin
+  write_gh_wrapper "${bin}/gh"
+  seed_osac_root_git "$root"
+  skills_origin=$(git -C "$home_skills" remote get-url origin)
+  wf_origin=$(git -C "$home_workflows" remote get-url origin)
+  gh_log="${home}/gh.log"
+
+  out=$(run_bootstrap_fork "$root" "$home" "$bin" --fork-name origin 2>&1) \
+    || fail "bootstrap --fork-name origin failed: $out"
+
+  assert_origin_layout_writeable "${root}/enhancement-proposals" "enhancement-proposals"
+  assert_origin_layout_writeable "${root}/osac-ui" "osac-ui"
+  assert_origin_layout_writeable "${root}/osac-docs" "docs"
+  assert_remote_url "${root}/osac-ux" origin "osac-project/osac-ux"
+  assert_no_named_remote "${root}/osac-ux" fork "osac-ux"
+  assert_no_named_remote "${root}/osac-ux" upstream "osac-ux"
+  assert_vendor_untouched "$home_skills" "osac-ai-skills vendor" "$skills_origin"
+  assert_vendor_untouched "$home_workflows" "ai-workflows vendor" "$wf_origin"
+  assert_osac_root_untouched "$root"
+  if grep -q 'repo fork osac-project/osac-ux' "$gh_log"; then
+    fail "must not gh fork osac-ux: $(cat "$gh_log")"
+  fi
+  if grep -q 'repo fork osac-project/osac-ai-skills' "$gh_log"; then
+    fail "must not gh fork osac-ai-skills: $(cat "$gh_log")"
+  fi
+  pass "--fork-name origin renames org origin on writeable siblings only"
+}
+
+test_fork_name_origin_rerun_is_idempotent() {
+  local home root bin home_skills home_workflows repo_skills clone_log out ep git_log
+  prepare_fixture fork-name-origin-rerun
+  write_gh_wrapper "${bin}/gh"
+  git_log="${home}/git.log"
+
+  run_bootstrap_fork "$root" "$home" "$bin" --fork-name origin >/dev/null
+  ep="${root}/enhancement-proposals"
+  : > "$git_log"
+  out=$(run_bootstrap_fork "$root" "$home" "$bin" --fork-name origin 2>&1) \
+    || fail "re-run --fork-name origin failed: $out"
+  echo "$out" | grep -q 'Updating enhancement-proposals' \
+    || fail "re-run should update origin-as-fork siblings: $out"
+  echo "$out" | grep -qi 'skipping enhancement-proposals' \
+    && fail "must not skip writeable sibling on --fork-name origin re-run: $out"
+  grep -qE '(^| )fetch upstream( |$)' "$git_log" \
+    || fail "re-run must fetch upstream for origin-as-fork siblings: $(cat "$git_log")"
+  grep -qE '(^| )rebase upstream/main( |$)' "$git_log" \
+    || fail "re-run must rebase onto upstream/main: $(cat "$git_log")"
+  assert_origin_layout_writeable "$ep" "enhancement-proposals"
+  assert_no_named_remote "$ep" osac-upstream "enhancement-proposals"
+  pass "--fork-name origin re-run updates via upstream and does not rename again"
+}
+
+test_fork_name_origin_uses_osac_upstream_when_upstream_taken() {
+  local home root bin home_skills home_workflows repo_skills clone_log out ep url
+  prepare_fixture fork-name-osac-upstream
+  write_gh_wrapper "${bin}/gh"
+  ep="${root}/enhancement-proposals"
+
+  run_bootstrap "$root" "$home" "$bin" >/dev/null
+  "$REAL_GIT" -C "$ep" remote add upstream "https://github.com/example/placeholder.git"
+  out=$(run_bootstrap_fork "$root" "$home" "$bin" --fork-name origin 2>&1) \
+    || fail "--fork-name origin with upstream taken failed: $out"
+  assert_remote_url "$ep" origin "smokeuser/enhancement-proposals"
+  assert_remote_url "$ep" osac-upstream "osac-project/enhancement-proposals"
+  url=$(git -C "$ep" remote get-url upstream)
+  [[ "$url" == *example/placeholder* ]] \
+    || fail "pre-existing upstream must be left in place, got: $url"
+  pass "--fork-name origin uses osac-upstream when upstream exists"
+}
+
+test_no_fork_with_fork_name_origin_is_read_only() {
+  local home root bin home_skills home_workflows repo_skills clone_log out
+  local skills_origin
+  prepare_fixture nofork-fork-name
+  write_gh_wrapper "${bin}/gh"
+  seed_osac_root_git "$root"
+  skills_origin=$(git -C "$home_skills" remote get-url origin)
+
+  out=$(run_bootstrap "$root" "$home" "$bin" --fork-name origin 2>&1) \
+    || fail "--no-fork --fork-name origin failed: $out"
+  echo "$out" | grep -q 'read-only, no forks' \
+    || fail "expected read-only banner: $out"
+  assert_expected_clones "$root" "$clone_log"
+  assert_remote_url "${root}/osac-ui" origin "osac-project/osac-ui"
+  assert_no_named_remote "${root}/osac-ui" upstream "osac-ui"
+  assert_no_fork_remote "${root}/osac-ui" "osac-ui"
+  assert_remote_url "${root}/osac-ux" origin "osac-project/osac-ux"
+  assert_vendor_untouched "$home_skills" "osac-ai-skills vendor" "$skills_origin"
+  assert_osac_root_untouched "$root"
+  [[ ! -s "${home}/gh.log" ]] || fail "--no-fork --fork-name origin must not invoke gh: $(cat "${home}/gh.log")"
+  pass "--no-fork wins over --fork-name origin"
+}
+
 test_home_git_subdir_skills_falls_back_to_repo_local() {
   local home root bin home_skills home_workflows repo_skills clone_log out
   prepare_fixture leftover-home-skills
@@ -751,6 +949,8 @@ test_nested_abort_skips_sibling_clones
 test_failed_clone_cleans_dest
 test_expected_sibling_requires_org_boundary
 test_expected_sibling_requires_origin_remote
+test_expected_sibling_requires_origin_remote_when_forking
+test_expected_sibling_requires_origin_remote_with_fork_name_origin
 test_missing_gh_without_no_fork_exits
 test_empty_gh_user_without_no_fork_exits
 test_null_gh_user_without_no_fork_exits
@@ -761,6 +961,11 @@ test_unrelated_same_name_github_repo_is_not_used_as_fork
 test_home_worktree_vendor_is_updated_not_recloned
 test_skips_update_when_sibling_not_on_main
 test_fork_remote_match_requires_user_boundary
+test_fork_name_requires_value
+test_fork_name_origin_renames_org_origin
+test_fork_name_origin_rerun_is_idempotent
+test_fork_name_origin_uses_osac_upstream_when_upstream_taken
+test_no_fork_with_fork_name_origin_is_read_only
 test_home_git_subdir_skills_falls_back_to_repo_local
 test_repo_local_leftover_ai_workflows_errors_without_updating
 test_repo_local_leftover_osac_ai_skills_errors_without_updating

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -775,7 +775,8 @@ test_fork_name_rejects_option_as_value() {
   gh_log="${home}/gh.log"
 
   set +e
-  out=$(HOME="$home" PATH="${bin}:${PATH}" bash "${root}/tools/bootstrap.sh" --fork-name --no-fork 2>&1)
+  out=$(HOME="$home" PATH="${bin}:${PATH}" OSAC_SMOKE_GH_LOG="$gh_log" \
+    bash "${root}/tools/bootstrap.sh" --fork-name --no-fork 2>&1)
   rc=$?
   set -e
   [[ "$rc" -ne 0 ]] || fail "expected non-zero for --fork-name --no-fork: $out"

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -614,7 +614,7 @@ test_forks_writeable_siblings_not_osac_ux_or_vendors() {
   assert_expected_clones "$root" "$clone_log"
   assert_fork_remote "${root}/enhancement-proposals" "enhancement-proposals"
   assert_fork_remote "${root}/osac-ui" "osac-ui"
-  assert_fork_remote "${root}/osac-docs" "docs"
+  assert_fork_remote "${root}/osac-docs" "osac-docs"
   assert_no_fork_remote "${root}/osac-ux" "osac-ux"
   assert_no_fork_remote "$home_skills" "osac-ai-skills vendor"
   assert_no_fork_remote "$home_workflows" "ai-workflows vendor"
@@ -622,6 +622,8 @@ test_forks_writeable_siblings_not_osac_ux_or_vendors() {
     || fail "expected gh repo fork for enhancement-proposals: $(cat "$gh_log")"
   grep -q 'repo fork osac-project/docs' "$gh_log" \
     || fail "docs fork must use GitHub repo name docs: $(cat "$gh_log")"
+  grep -q 'fork-name osac-docs' "$gh_log" \
+    || fail "docs fork must pass --fork-name osac-docs: $(cat "$gh_log")"
   if grep -q 'repo fork osac-project/osac-ux' "$gh_log"; then
     fail "must not gh fork osac-ux: $(cat "$gh_log")"
   fi
@@ -645,7 +647,7 @@ test_rerun_adds_fork_remote_to_existing_clone() {
   : > "${home}/gh.log"
   out=$(run_bootstrap_fork "$root" "$home" "$bin" 2>&1) || fail "fork re-run failed: $out"
   assert_fork_remote "$ep" "enhancement-proposals"
-  assert_fork_remote "${root}/osac-docs" "docs"
+  assert_fork_remote "${root}/osac-docs" "osac-docs"
   assert_no_fork_remote "${root}/osac-ux" "osac-ux"
   echo "$out" | grep -q 'Adding fork remote for enhancement-proposals' \
     || fail "re-run should add missing fork remotes: $out"
@@ -760,7 +762,9 @@ test_fork_name_origin_renames_org_origin() {
 
   assert_origin_layout_writeable "${root}/enhancement-proposals" "enhancement-proposals"
   assert_origin_layout_writeable "${root}/osac-ui" "osac-ui"
-  assert_origin_layout_writeable "${root}/osac-docs" "docs"
+  assert_remote_url "${root}/osac-docs" origin "smokeuser/osac-docs"
+  assert_remote_url "${root}/osac-docs" upstream "osac-project/docs"
+  assert_no_named_remote "${root}/osac-docs" fork "osac-docs"
   assert_remote_url "${root}/osac-ux" origin "osac-project/osac-ux"
   assert_no_named_remote "${root}/osac-ux" fork "osac-ux"
   assert_no_named_remote "${root}/osac-ux" upstream "osac-ux"
@@ -839,6 +843,43 @@ test_no_fork_with_fork_name_origin_is_read_only() {
   assert_osac_root_untouched "$root"
   [[ ! -s "${home}/gh.log" ]] || fail "--no-fork --fork-name origin must not invoke gh: $(cat "${home}/gh.log")"
   pass "--no-fork wins over --fork-name origin"
+}
+
+test_docs_fork_uses_osac_docs_github_name() {
+  local home root bin home_skills home_workflows repo_skills clone_log out gh_log
+  local skills_origin
+  prepare_fixture docs-fork-name
+  write_gh_wrapper "${bin}/gh"
+  gh_log="${home}/gh.log"
+  skills_origin=$(git -C "$home_skills" remote get-url origin)
+
+  out=$(run_bootstrap_fork "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
+  assert_fork_remote "${root}/osac-docs" "osac-docs"
+  grep -q 'fork-name osac-docs' "$gh_log" \
+    || fail "expected gh repo fork --fork-name osac-docs: $(cat "$gh_log")"
+  assert_vendor_untouched "$home_skills" "osac-ai-skills vendor" "$skills_origin"
+  assert_no_fork_remote "${root}/osac-ux" "osac-ux"
+  pass "docs GitHub fork name is osac-docs, not docs"
+}
+
+test_fork_overrides_file_can_remap_docs() {
+  local home root bin home_skills home_workflows repo_skills clone_log out
+  local skills_origin
+  prepare_fixture docs-override
+  write_gh_wrapper "${bin}/gh"
+  skills_origin=$(git -C "$home_skills" remote get-url origin)
+  cat > "${root}/tools/fork-overrides.sh" <<'EOF'
+FORK_OVERRIDE_PAIRS=("docs:custom-docs")
+EOF
+
+  out=$(run_bootstrap_fork "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
+  assert_fork_remote "${root}/osac-docs" "custom-docs"
+  grep -q 'fork-name custom-docs' "${home}/gh.log" \
+    || fail "override must pass --fork-name custom-docs: $(cat "${home}/gh.log")"
+  assert_fork_remote "${root}/osac-ui" "osac-ui"
+  assert_vendor_untouched "$home_skills" "osac-ai-skills vendor" "$skills_origin"
+  assert_no_fork_remote "${root}/osac-ux" "osac-ux"
+  pass "tools/fork-overrides.sh can remap docs without affecting ux/vendors"
 }
 
 test_home_git_subdir_skills_falls_back_to_repo_local() {
@@ -966,6 +1007,8 @@ test_fork_name_origin_renames_org_origin
 test_fork_name_origin_rerun_is_idempotent
 test_fork_name_origin_uses_osac_upstream_when_upstream_taken
 test_no_fork_with_fork_name_origin_is_read_only
+test_docs_fork_uses_osac_docs_github_name
+test_fork_overrides_file_can_remap_docs
 test_home_git_subdir_skills_falls_back_to_repo_local
 test_repo_local_leftover_ai_workflows_errors_without_updating
 test_repo_local_leftover_osac_ai_skills_errors_without_updating

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -208,13 +208,31 @@ assert_no_named_remote() {
   fi
 }
 
+assert_url_suffix() {
+  local url="$1" suffix="$2" label="$3"
+  [[ "${url%.git}" == *"/${suffix}" || "${url%.git}" == *":${suffix}" ]] \
+    || fail "${label} expected ${suffix}, got: $url"
+}
+
+assert_remote_push_urls() {
+  local dest="$1" remote="$2" suffix="$3"
+  local push_urls push_url
+  push_urls=$(git -C "$dest" remote get-url --push --all "$remote" 2>/dev/null) \
+    || fail "missing push URL for ${remote} on ${dest}"
+  [[ -n "$push_urls" ]] || fail "empty push URL list for ${remote} on ${dest}"
+  while IFS= read -r push_url; do
+    [[ -n "$push_url" ]] || continue
+    assert_url_suffix "$push_url" "$suffix" "push URL for ${remote} on ${dest}"
+  done <<< "$push_urls"
+}
+
 assert_remote_url() {
   local dest="$1" remote="$2" suffix="$3"
   local url
   url=$(git -C "$dest" remote get-url "$remote" 2>/dev/null) \
     || fail "missing remote ${remote} on ${dest}: $(git -C "$dest" remote -v 2>/dev/null || true)"
-  [[ "${url%.git}" == *"/${suffix}" || "${url%.git}" == *":${suffix}" ]] \
-    || fail "remote ${remote} on ${dest} expected ${suffix}, got: $url"
+  assert_url_suffix "$url" "$suffix" "remote ${remote} on ${dest}"
+  assert_remote_push_urls "$dest" "$remote" "$suffix"
 }
 
 assert_fork_remote() {
@@ -222,8 +240,8 @@ assert_fork_remote() {
   local url
   url=$(git -C "$dest" remote get-url fork 2>/dev/null) \
     || fail "missing fork remote on ${dest}: $(git -C "$dest" remote -v 2>/dev/null || true)"
-  [[ "${url%.git}" == *"/smokeuser/${repo}" || "${url%.git}" == *":smokeuser/${repo}" ]] \
-    || fail "fork remote on ${dest} expected smokeuser/${repo}, got: $url"
+  assert_url_suffix "$url" "smokeuser/${repo}" "fork remote on ${dest}"
+  assert_remote_push_urls "$dest" fork "smokeuser/${repo}"
 }
 
 seed_osac_root_git() {
@@ -749,6 +767,26 @@ test_fork_name_requires_value() {
   pass "--fork-name requires a value"
 }
 
+test_fork_name_rejects_option_as_value() {
+  local home root bin home_skills home_workflows repo_skills clone_log out rc
+  local gh_log
+  prepare_fixture fork-name-opt-val
+  write_gh_wrapper "${bin}/gh"
+  gh_log="${home}/gh.log"
+
+  set +e
+  out=$(HOME="$home" PATH="${bin}:${PATH}" bash "${root}/tools/bootstrap.sh" --fork-name --no-fork 2>&1)
+  rc=$?
+  set -e
+  [[ "$rc" -ne 0 ]] || fail "expected non-zero for --fork-name --no-fork: $out"
+  echo "$out" | grep -qi 'fork-name requires a value' \
+    || fail "expected --fork-name value error for option-as-value: $out"
+  if [[ -f "$gh_log" ]] && grep -q 'repo fork' "$gh_log"; then
+    fail "must not call gh repo fork when --fork-name value is another option: $(cat "$gh_log")"
+  fi
+  pass "--fork-name rejects another option as its value"
+}
+
 test_fork_name_origin_renames_org_origin() {
   local home root bin home_skills home_workflows repo_skills clone_log out
   local skills_origin wf_origin gh_log
@@ -829,6 +867,21 @@ test_fork_name_origin_uses_osac_upstream_when_upstream_taken() {
   [[ "$url" == *example/placeholder* ]] \
     || fail "pre-existing upstream must be left in place, got: $url"
   pass "--fork-name origin uses osac-upstream when upstream exists"
+}
+
+test_fork_name_origin_renames_when_only_pushurl_is_fork() {
+  local home root bin home_skills home_workflows repo_skills clone_log out ep
+  prepare_fixture fork-name-origin-pushurl
+  write_gh_wrapper "${bin}/gh"
+  ep="${root}/enhancement-proposals"
+
+  run_bootstrap "$root" "$home" "$bin" >/dev/null
+  "$REAL_GIT" -C "$ep" remote set-url --push origin \
+    "https://github.com/smokeuser/enhancement-proposals.git"
+  out=$(run_bootstrap_fork "$root" "$home" "$bin" --fork-name origin 2>&1) \
+    || fail "--fork-name origin with fork-only pushurl failed: $out"
+  assert_origin_layout_writeable "$ep" "enhancement-proposals"
+  pass "--fork-name origin renames when only origin pushurl is the fork"
 }
 
 test_fork_name_origin_rename_does_not_log_remote_url() {
@@ -1032,9 +1085,11 @@ test_home_worktree_vendor_is_updated_not_recloned
 test_skips_update_when_sibling_not_on_main
 test_fork_remote_match_requires_user_boundary
 test_fork_name_requires_value
+test_fork_name_rejects_option_as_value
 test_fork_name_origin_renames_org_origin
 test_fork_name_origin_rerun_is_idempotent
 test_fork_name_origin_uses_osac_upstream_when_upstream_taken
+test_fork_name_origin_renames_when_only_pushurl_is_fork
 test_fork_name_origin_rename_does_not_log_remote_url
 test_no_fork_with_fork_name_origin_is_read_only
 test_docs_fork_uses_osac_docs_github_name

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -57,6 +57,8 @@ if [[ " \$* " == *" clone "* ]]; then
   "\$REAL" -C "\$dest" -c user.email=smoke@test -c user.name=smoke \
     commit -q --allow-empty -m seed
   "\$REAL" -C "\$dest" remote add origin "\$url"
+  "\$REAL" -C "\$dest" config branch.main.remote origin
+  "\$REAL" -C "\$dest" config branch.main.merge refs/heads/main
   if [[ "\$(basename "\$dest")" == "${AI_WORKFLOWS_NAME}" ]]; then
     printf '#!/bin/sh\\necho stub-install\\nexit 0\\n' > "\$dest/install.sh"
     chmod +x "\$dest/install.sh"
@@ -266,11 +268,20 @@ assert_vendor_untouched() {
   assert_no_named_remote "$dest" upstream "$label"
 }
 
+assert_branch_tracks() {
+  local dest="$1" branch="$2" remote="$3"
+  local got
+  got=$(git -C "$dest" config --get "branch.${branch}.remote" 2>/dev/null || true)
+  [[ "$got" == "$remote" ]] \
+    || fail "${dest} branch ${branch} should track ${remote}, got: ${got:-unset}"
+}
+
 assert_origin_layout_writeable() {
   local dest="$1" repo="$2"
   assert_remote_url "$dest" origin "smokeuser/${repo}"
   assert_remote_url "$dest" upstream "osac-project/${repo}"
   assert_no_named_remote "$dest" fork "$(basename "$dest")"
+  assert_branch_tracks "$dest" main origin
 }
 
 assert_expected_clones() {
@@ -867,6 +878,7 @@ test_fork_name_origin_uses_osac_upstream_when_upstream_taken() {
   url=$(git -C "$ep" remote get-url upstream)
   [[ "$url" == *example/placeholder* ]] \
     || fail "pre-existing upstream must be left in place, got: $url"
+  assert_branch_tracks "$ep" main origin
   pass "--fork-name origin uses osac-upstream when upstream exists"
 }
 


### PR DESCRIPTION
## [OSAC-4818](https://redhat.atlassian.net/browse/OSAC-4818): port --fork-name and docs fork-overrides to bootstrap.sh

**Jira:** https://redhat.atlassian.net/browse/OSAC-4818
**Story type:** Task (Epic [OSAC-3558](https://redhat.atlassian.net/browse/OSAC-3558); predecessor [OSAC-3958](https://redhat.atlassian.net/browse/OSAC-3958) / #579)

### Summary

Port workspace `--fork-name` and docs fork-overrides into `tools/bootstrap.sh` so writeable siblings get a usable push remote without changing how skills resolve remotes. `--fork-name origin` performs an occupant-guarded rename of org `origin` to `upstream` (or `osac-upstream` if taken) and adds the developer fork as `origin`. `osac-project/docs` maps to GitHub fork `$USER/osac-docs` by default. Flags only rearrange remotes on writeable siblings; this checkout, `osac-ux`, and vendors are never renamed. `--no-fork` still wins.

### Changes

- **`tools/bootstrap.sh`:** `--fork-name NAME` (default `fork`); occupant-URL rename dance; URL-based sibling update (origin-or-fork layout); default `docs` → `osac-docs` mapping; optional `tools/fork-overrides.sh`; `gh repo fork --fork-name` when names differ.
- **`tools/test/bootstrap-sibling-clone-smoke.sh`:** smokes for `--fork-name origin`, docs mapping, `--no-fork` wins, occupant skip, vendor/`osac-ux`/root non-interference.
- **`tools/fork-overrides.sh.example`:** extra `FORK_OVERRIDE_PAIRS` mappings; `tools/fork-overrides.sh` gitignored.
- **`AGENTS.md` / `README.md`:** sibling-only contract, pick-a-name, `--no-fork` wins, worktree extra args.

### Testing

- **Unit tests:** PATH-stubbed sibling-clone smokes (`bash tools/test/bootstrap-sibling-clone-smoke.sh`) — all passed.
- **Integration tests:** N/A (bootstrap harness only).
- **Coverage:** Public CLI paths for this story are covered (default `fork`, `--fork-name origin` fresh/re-run/collision, `--no-fork`, docs `osac-docs`, overrides file, never-fork ux/vendors).

### Acceptance Criteria

- [ ] AC-1: `--fork-name NAME` (default `fork`); skills resolve remotes by URL.
- [ ] AC-2: `--fork-name origin` on a fresh writeable sibling renames org `origin` → `upstream` (or `osac-upstream` if taken) and adds the fork as `origin`.
- [ ] AC-3: Only rename if occupant URL is `osac-project/<repo>`. No-op if the target remote already points at the fork. Document: pick a name and stick with it.
- [ ] AC-4: Map `osac-project/docs` GitHub fork to `$USER/osac-docs`.
- [ ] AC-5: Never fork `osac-ux` or vendors (`.osac-ai-skills`, `.ai-workflows`) regardless of `--fork-name`.
- [ ] AC-6: AGENTS.md / README updated; smokes for `--fork-name origin` and the docs override.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Areas affected

- **Bootstrap tooling:** Adds `--fork-name`, validation, fork overrides, upstream URL detection, and remote renaming for writable sibling repositories.
- **Repository setup:** Maps `osac-project/docs` to the default `$USER/osac-docs` fork.
- **Scope controls:** Excludes the root checkout, `osac-ux`, and vendor repositories. Gives `--no-fork` precedence.
- **Configuration:** Adds an ignored local override path and an example configuration file.
- **Tests:** Expands sibling-clone smoke tests for URL validation, fetch and push URL handling, remote fallback, overrides, renaming, logging, and exclusions.
- **Documentation:** Updates bootstrap, worktree, fork, and external-repository guidance.
- **API, controllers, database, auth, deployment, and CI:** No implementation changes.

## Backward compatibility

Existing bootstrap usage remains supported. Fork behavior changes only for writable sibling repositories. Bootstrap can rename or update Git remotes when fork configuration requires it. `--no-fork` prevents fork operations but does not restore remotes changed by an earlier run.

## Risk classification

**risk:show** — The change affects local bootstrap behavior and Git remote configuration. It includes input validation, focused smoke tests, explicit repository exclusions, credential-safe logging, and an opt-out with `--no-fork`.

It does not qualify for **risk:ship** because the change can rename or update Git remotes. It does not qualify for **risk:ask** because it does not affect production services, deployed artifacts, authentication systems, or persistent application data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->