### PR TITLE
NO-ISSUE: fix: stop merge-queue E2E runs from cancelling each other

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -34,10 +34,73 @@ on:
         default: "main"
 
 concurrency:
-  group: e2e-bmaas-full-install-${{ github.event.pull_request.number || (github.event_name == 'merge_group' && 'merge-queue') || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+  # pull_request: one run per PR; a newer push cancels the older run.
+  # merge_group: a UNIQUE group per run (github.run_id) -- NEVER a shared one.
+  # GitHub's merge queue tests entries speculatively in parallel (one run per
+  # queue position, re-fired on every reshuffle), so a shared group with
+  # cancel-in-progress makes those concurrent runs cancel each other; the
+  # survivors' required e2e-*-gate never reports and the whole queue deadlocks
+  # with every entry stuck on AWAITING_CHECKS. Stale runs left behind by a
+  # reshuffle are cancelled precisely, per queue entry, by the
+  # cancel-stale-merge-queue job below -- not by collapsing this group.
+  group: e2e-bmaas-full-install-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # merge_group only: cancel a superseded run for THIS PR's queue entry.
+  #
+  # GitHub tests queue entries speculatively in parallel and re-creates an
+  # entry's gh-readonly-queue branch (new sha) on every reshuffle, but does not
+  # reliably cancel the now-stale run for the entry it replaced -- so the old
+  # run keeps executing against a deleted ref until it hits the ~40-minute helm
+  # timeout. This job kills that stale run (the problem #712 targeted) WITHOUT
+  # cancelling other PRs' concurrent entries. It cannot be done in the
+  # concurrency block above: a per-PR key can't be extracted there (Actions
+  # concurrency expressions have no regex, and merge_group carries no PR number
+  # field), and `concurrency` is not an allowed key on the reusable-workflow
+  # caller job.
+  #
+  # A PR is in the queue at most once, so an OLDER run (lower run id) of THIS
+  # workflow for the same pr-<N> is by definition superseded. Run ids are
+  # monotonic, so cancelling only older runs means the newest run for the entry
+  # always survives -- no mutual-cancel race, even across back-to-back
+  # reshuffles. Every other PR has a different pr-<N> and is left untouched --
+  # that is what preserves parallel queue testing.
+  cancel-stale-merge-queue:
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel superseded runs for this queue entry
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.event.merge_group.head_ref }}
+          THIS_RUN: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # HEAD_REF: .../gh-readonly-queue/<base>/pr-<N>-<sha> -> take "pr-<N>".
+          entry="${HEAD_REF##*/}"   # pr-<N>-<sha>
+          pr="${entry%-*}"          # pr-<N>
+          case "$pr" in
+            pr-[0-9]*) ;;
+            *) echo "unexpected merge_group head_ref: '${HEAD_REF}'" >&2; exit 1 ;;
+          esac
+          echo "This entry: ${pr} (run ${THIS_RUN}); cancelling any older run for it."
+          # `gh run list` runs without a fallback: a failure here (auth/API) is
+          # real and must surface loudly. Only the per-run cancel tolerates the
+          # benign race where the target run finished between listing and cancel.
+          gh run list --workflow e2e-bmaas-full-install.yml --event merge_group \
+            --limit 100 --json databaseId,headBranch,status \
+            --jq ".[] | select(.headBranch | contains(\"/${pr}-\"))
+                      | select(.status == \"in_progress\" or .status == \"queued\")
+                      | select(.databaseId < ${THIS_RUN}) | .databaseId" \
+          | while read -r id; do
+              echo "Cancelling superseded run ${id}"
+              gh run cancel "${id}" || echo "run ${id} already finished; nothing to cancel"
+            done
+
   changes:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -34,10 +34,73 @@ on:
         default: "main"
 
 concurrency:
-  group: e2e-caas-full-install-${{ github.event.pull_request.number || (github.event_name == 'merge_group' && 'merge-queue') || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+  # pull_request: one run per PR; a newer push cancels the older run.
+  # merge_group: a UNIQUE group per run (github.run_id) -- NEVER a shared one.
+  # GitHub's merge queue tests entries speculatively in parallel (one run per
+  # queue position, re-fired on every reshuffle), so a shared group with
+  # cancel-in-progress makes those concurrent runs cancel each other; the
+  # survivors' required e2e-*-gate never reports and the whole queue deadlocks
+  # with every entry stuck on AWAITING_CHECKS. Stale runs left behind by a
+  # reshuffle are cancelled precisely, per queue entry, by the
+  # cancel-stale-merge-queue job below -- not by collapsing this group.
+  group: e2e-caas-full-install-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # merge_group only: cancel a superseded run for THIS PR's queue entry.
+  #
+  # GitHub tests queue entries speculatively in parallel and re-creates an
+  # entry's gh-readonly-queue branch (new sha) on every reshuffle, but does not
+  # reliably cancel the now-stale run for the entry it replaced -- so the old
+  # run keeps executing against a deleted ref until it hits the ~40-minute helm
+  # timeout. This job kills that stale run (the problem #712 targeted) WITHOUT
+  # cancelling other PRs' concurrent entries. It cannot be done in the
+  # concurrency block above: a per-PR key can't be extracted there (Actions
+  # concurrency expressions have no regex, and merge_group carries no PR number
+  # field), and `concurrency` is not an allowed key on the reusable-workflow
+  # caller job.
+  #
+  # A PR is in the queue at most once, so an OLDER run (lower run id) of THIS
+  # workflow for the same pr-<N> is by definition superseded. Run ids are
+  # monotonic, so cancelling only older runs means the newest run for the entry
+  # always survives -- no mutual-cancel race, even across back-to-back
+  # reshuffles. Every other PR has a different pr-<N> and is left untouched --
+  # that is what preserves parallel queue testing.
+  cancel-stale-merge-queue:
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel superseded runs for this queue entry
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.event.merge_group.head_ref }}
+          THIS_RUN: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # HEAD_REF: .../gh-readonly-queue/<base>/pr-<N>-<sha> -> take "pr-<N>".
+          entry="${HEAD_REF##*/}"   # pr-<N>-<sha>
+          pr="${entry%-*}"          # pr-<N>
+          case "$pr" in
+            pr-[0-9]*) ;;
+            *) echo "unexpected merge_group head_ref: '${HEAD_REF}'" >&2; exit 1 ;;
+          esac
+          echo "This entry: ${pr} (run ${THIS_RUN}); cancelling any older run for it."
+          # `gh run list` runs without a fallback: a failure here (auth/API) is
+          # real and must surface loudly. Only the per-run cancel tolerates the
+          # benign race where the target run finished between listing and cancel.
+          gh run list --workflow e2e-caas-full-install.yml --event merge_group \
+            --limit 100 --json databaseId,headBranch,status \
+            --jq ".[] | select(.headBranch | contains(\"/${pr}-\"))
+                      | select(.status == \"in_progress\" or .status == \"queued\")
+                      | select(.databaseId < ${THIS_RUN}) | .databaseId" \
+          | while read -r id; do
+              echo "Cancelling superseded run ${id}"
+              gh run cancel "${id}" || echo "run ${id} already finished; nothing to cancel"
+            done
+
   changes:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -34,10 +34,73 @@ on:
         default: "main"
 
 concurrency:
-  group: e2e-vmaas-full-install-${{ github.event.pull_request.number || (github.event_name == 'merge_group' && 'merge-queue') || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+  # pull_request: one run per PR; a newer push cancels the older run.
+  # merge_group: a UNIQUE group per run (github.run_id) -- NEVER a shared one.
+  # GitHub's merge queue tests entries speculatively in parallel (one run per
+  # queue position, re-fired on every reshuffle), so a shared group with
+  # cancel-in-progress makes those concurrent runs cancel each other; the
+  # survivors' required e2e-*-gate never reports and the whole queue deadlocks
+  # with every entry stuck on AWAITING_CHECKS. Stale runs left behind by a
+  # reshuffle are cancelled precisely, per queue entry, by the
+  # cancel-stale-merge-queue job below -- not by collapsing this group.
+  group: e2e-vmaas-full-install-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # merge_group only: cancel a superseded run for THIS PR's queue entry.
+  #
+  # GitHub tests queue entries speculatively in parallel and re-creates an
+  # entry's gh-readonly-queue branch (new sha) on every reshuffle, but does not
+  # reliably cancel the now-stale run for the entry it replaced -- so the old
+  # run keeps executing against a deleted ref until it hits the ~40-minute helm
+  # timeout. This job kills that stale run (the problem #712 targeted) WITHOUT
+  # cancelling other PRs' concurrent entries. It cannot be done in the
+  # concurrency block above: a per-PR key can't be extracted there (Actions
+  # concurrency expressions have no regex, and merge_group carries no PR number
+  # field), and `concurrency` is not an allowed key on the reusable-workflow
+  # caller job.
+  #
+  # A PR is in the queue at most once, so an OLDER run (lower run id) of THIS
+  # workflow for the same pr-<N> is by definition superseded. Run ids are
+  # monotonic, so cancelling only older runs means the newest run for the entry
+  # always survives -- no mutual-cancel race, even across back-to-back
+  # reshuffles. Every other PR has a different pr-<N> and is left untouched --
+  # that is what preserves parallel queue testing.
+  cancel-stale-merge-queue:
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel superseded runs for this queue entry
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.event.merge_group.head_ref }}
+          THIS_RUN: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # HEAD_REF: .../gh-readonly-queue/<base>/pr-<N>-<sha> -> take "pr-<N>".
+          entry="${HEAD_REF##*/}"   # pr-<N>-<sha>
+          pr="${entry%-*}"          # pr-<N>
+          case "$pr" in
+            pr-[0-9]*) ;;
+            *) echo "unexpected merge_group head_ref: '${HEAD_REF}'" >&2; exit 1 ;;
+          esac
+          echo "This entry: ${pr} (run ${THIS_RUN}); cancelling any older run for it."
+          # `gh run list` runs without a fallback: a failure here (auth/API) is
+          # real and must surface loudly. Only the per-run cancel tolerates the
+          # benign race where the target run finished between listing and cancel.
+          gh run list --workflow e2e-vmaas-full-install.yml --event merge_group \
+            --limit 100 --json databaseId,headBranch,status \
+            --jq ".[] | select(.headBranch | contains(\"/${pr}-\"))
+                      | select(.status == \"in_progress\" or .status == \"queued\")
+                      | select(.databaseId < ${THIS_RUN}) | .databaseId" \
+          | while read -r id; do
+              echo "Cancelling superseded run ${id}"
+              gh run cancel "${id}" || echo "run ${id} already finished; nothing to cancel"
+            done
+
   changes:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## What's broken

The `osac` merge queue is fully deadlocked. Every entry sits in `AWAITING_CHECKS` / combined status `pending`, and nothing merges. It looks like "the queue doesn't run E2Es," but it does — they start and then **cancel each other**.

### Root cause

PR #712 (`5a0e4045b`) gave the three `e2e-*-full-install` workflows a single **constant** concurrency group for `merge_group` events:

```yaml
group: ...-${{ ... || (github.event_name == 'merge_group' && 'merge-queue') || ... }}
cancel-in-progress: ${{ ... || github.event_name == 'merge_group' }}
```

For `merge_group`, `pull_request.number` is empty, so the group collapses to the literal string `merge-queue` — **one group shared by the entire queue**, with `cancel-in-progress: true`.

GitHub's merge queue tests entries **speculatively in parallel** — one workflow run per queue position, re-fired on every reshuffle. A shared group makes those concurrent runs cancel each other: only the last-started survives, the rest end `cancelled`, their required `e2e-*-gate` check never reports, and the queue deadlocks.

**Evidence at the time of the report:** 5 of the last 6 `merge_group` caas runs were `completed/cancelled`; all 6 real queue entries were `AWAITING_CHECKS`; the position-1 entry's commit had `changes` (success) but **no** `e2e-*-gate` check runs at all — combined status `pending`.

## The fix

#712's underlying goal was real — kill stale runs left by a reshuffle before they burn the ~40-minute helm timeout on a deleted ref. This keeps that goal but separates the two concerns #712 conflated:

- **Parallel isolation** — `merge_group` runs get a **unique group per run** (`github.run_id`) again, so different queue entries never cancel each other. `cancel-in-progress` stays on only for `pull_request`.
- **Stale cancellation** — a new `merge_group`-only **`cancel-stale-merge-queue`** job cancels older in-progress/queued runs of the same workflow whose `gh-readonly-queue` branch belongs to the **same PR** (`pr-<N>`), and only those. A PR is in the queue at most once, so any other run for the same `pr-<N>` is by definition superseded; every other PR has a different `pr-<N>` and keeps running.

### Why not just a per-PR concurrency key?

Because it can't be expressed:
- Actions concurrency expressions have no regex/split to extract the PR number, and `merge_group` carries no PR-number field.
- `concurrency` is **not** an allowed key on a reusable-workflow caller job (only `name, uses, with, secrets, needs, if, permissions` are — confirmed via `actionlint`), and the expensive E2E job is exactly such a caller.

Hence the dedicated job.

## Result

| | Different PRs (parallel entries) | Same PR after a reshuffle |
|---|---|---|
| Before #712 | run in parallel ✓ | stale run leaks to timeout ✗ |
| After #712 (current main) | **cancel each other → deadlock ✗** | cancelled ✓ |
| This PR | run in parallel ✓ | cancelled precisely ✓ |

## Validation

- `actionlint` v1.7.12 — clean on all three files.
- Unit-tested the ref parse and the `jq` selection against representative run data: matches only the stale same-PR run; excludes the current run, other PRs, completed runs, and the `pr-685` vs `pr-6850` prefix collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **CI:** Updated BMAAS, CAAS, and VMAAS E2E workflows.
- `merge_group` runs now use unique concurrency groups based on `github.run_id`.
- Added `cancel-stale-merge-queue` jobs to cancel older queued or in-progress runs for the same PR.
- Runs for different PRs continue in parallel.
- Pull request cancellation behavior remains unchanged.
- Scheduled runs remain unaffected.
- The cancellation logic validates merge-queue refs and avoids PR-number prefix collisions.
- **Tests:** Added coverage for ref parsing, stale-run selection, current and completed runs, other PRs, and prefix collisions.
- **Validation:** `actionlint` checks pass.
- **API surface, controllers, database, authentication, deployment, and documentation:** No changes.

## Backward compatibility

No application or production behavior changes. Existing pull request and scheduled workflow behavior remains unchanged. Merge-queue runs now cancel stale runs for the same PR while allowing independent PR runs to continue.

## Risk classification

**risk:show** applies because the change modifies shared CI workflow concurrency and can cancel queued or in-progress merge-queue runs.

This change does not qualify for **risk:ask** because it does not modify production code, APIs, data, authentication, or deployment behavior. It does not qualify for **risk:ship** because it changes cancellation behavior in shared CI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->