### PR TITLE
OSAC-3593: Remove test-source parameter from e2e caller workflows

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -197,7 +197,7 @@ jobs:
       id-token: write
     uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-full-install.yml@main
     with:
-      # test-source=osac prefixes tests/e2e/. PR/merge_group: sanity (-n 4).
+      # PR/merge_group: sanity (-n 4).
       # Schedule: serial (-n 0, inventory exhaust). workflow_dispatch: honor
       # input, else sanity (bmaas/regression for networking, bmaas for all).
       test-suite: >-
@@ -232,8 +232,6 @@ jobs:
       # Checkout osac-test-infra for tests/Containerfile (not the caller repo)
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
-      # OSAC-3593: Use tests from osac mono-repo instead of osac-test-infra
-      test-source: "osac"
       test-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       test-ref: ${{ github.event.pull_request.head.sha || github.sha }}
       # Gated on ref, not event type: the real constraint is WIF trust

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -240,8 +240,6 @@ jobs:
       # Checkout osac-test-infra for tests/Containerfile (not the caller repo)
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
-      # OSAC-3593: Use tests from osac mono-repo instead of osac-test-infra
-      test-source: "osac"
       test-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       test-ref: ${{ github.event.pull_request.head.sha || github.sha }}
       # CaaS-specific inputs (cluster-template, caas-domain, flavor-image,

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -240,8 +240,6 @@ jobs:
       # Checkout osac-test-infra for tests/Containerfile (not the caller repo)
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
-      # OSAC-3593: Use tests from osac mono-repo instead of osac-test-infra
-      test-source: "osac"
       test-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       test-ref: ${{ github.event.pull_request.head.sha || github.sha }}
       # Gated on ref, not event type: the real constraint is WIF trust

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -529,7 +529,6 @@ jobs:
       installer-ref: ${{ needs.prepare.outputs.temp-branch }}
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: main
-      test-source: osac
       test-ref: ${{ needs.prepare.outputs.temp-branch }}
       # This pipeline only runs via schedule/workflow_dispatch against
       # main, same safe WIF context as the regular e2e-*-full-install.yml
@@ -557,7 +556,6 @@ jobs:
       installer-ref: ${{ needs.prepare.outputs.temp-branch }}
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: main
-      test-source: osac
       test-ref: ${{ needs.prepare.outputs.temp-branch }}
       # See e2e-vmaas-test's identical input above for why this is set.
       enable-ai-diagnostic: ${{ github.ref == 'refs/heads/main' }}
@@ -578,7 +576,6 @@ jobs:
       installer-ref: ${{ needs.prepare.outputs.temp-branch }}
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: main
-      test-source: osac
       test-ref: ${{ needs.prepare.outputs.temp-branch }}
       # See e2e-vmaas-test's identical input above for why this is set.
       enable-ai-diagnostic: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
## Summary

Remove the test-source: "osac" parameter from all e2e caller workflows, completing the dual-source switch removal started in [osac-test-infra#469](https://github.com/osac-project/osac-test-infra/pull/469).

### What changed (4 files, +1 / −10)

- **Removed** test-source: "osac" (or test-source: osac) from with: blocks in:
  - .github/workflows/e2e-bmaas-full-install.yml
  - .github/workflows/e2e-caas-full-install.yml
  - .github/workflows/e2e-vmaas-full-install.yml
  - .github/workflows/nightly-build.yaml (3 occurrences — one per e2e job)
- **Preserved** test-ref, test-repository, and all other inputs
- **Updated** bmaas caller comment to remove outdated test-source=osac reference

### Review observations
- :white_check_mark: Pure line deletions — no new code, no behavioral change
- :white_check_mark: test-ref and test-repository correctly preserved in all callers
- :white_check_mark: nightly-build.yaml: all 3 e2e job invocations cleaned (bmaas, caas, vmaas)

### Merge order

> ⚠️ **Merge this PR first.** GitHub Actions reusable workflows reject callers that pass undeclared inputs (`"input is not defined in the referenced workflow"`). Removing `test-source` from callers first is safe because the reusable workflows still accept (and ignore) the default value. Then merge [osac-test-infra#469](https://github.com/osac-project/osac-test-infra/pull/469) to remove the input declaration.

- Diff: https://github.com/osac-project/osac/pull/729/files
- Companion PR: https://github.com/osac-project/osac-test-infra/pull/469

## Context

Part of [OSAC-3593](https://redhat.atlassian.net/browse/OSAC-3593) — e2e test suite migration from osac-test-infra to the osac mono-repo. The dual-source switch was introduced in [osac#662](https://github.com/osac-project/osac/pull/662) / [osac-test-infra#433](https://github.com/osac-project/osac-test-infra/pull/433) to allow a gradual cutover. With the default flipped and old tests removed, the switch is no longer needed.

## Test plan

- [x] No functional change — callers already use test-source: "osac" as default; removing it has no effect since the input no longer exists upstream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## CI

- Removed the deprecated `test-source: "osac"` input from four GitHub Actions caller workflows.
- Updated the BMaaS comment and nightly BMaaS filter.
- Preserved `test-repository`, `test-ref`, and other workflow inputs.
- Updated nightly E2E jobs for BMaaS, CaaS, and VMaaS.

## Backward compatibility

- No application API, controller, database, authentication, deployment, test, or documentation changes.
- Callers that still require `test-source` may fail workflow validation.
- The change completes removal of the dual-source switch.

## Risk classification

**risk:ship** — The change only updates CI workflow inputs and comments. It has no runtime or production impact. It does not qualify for **risk:show** or **risk:ask** because it does not change user-visible behavior, security controls, data, or deployment logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->