### PR TITLE
OSAC-4035:fix(ci): exclude TestBmaasNetworking from nightly e2e-bmaas ci

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -573,6 +573,7 @@ jobs:
     uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-full-install.yml@main
     with:
       test-suite: bmaas
+      test-filter: 'not TestBmaasNetworking'
       installer-repo: ${{ github.repository }}
       installer-ref: ${{ needs.prepare.outputs.temp-branch }}
       test-infra-repository: osac-project/osac-test-infra


### PR DESCRIPTION
## Problem

The nightly build (`nightly-build.yaml`) calls the reusable workflow
`osac-test-infra/.github/workflows/e2e-bmaas-full-install.yml` without
passing `test-filter`. The reusable workflow defaults it to `""`, so
`TestBmaasNetworking` is collected by pytest.

These tests require Netris lab hardware (eth9, virsh, 3 dedicated BMIs)
and a pre-provisioned SSH key at `/root/.ssh/id_rsa.pub` — neither is
available in GHA, causing:

1. `test_05_create_three_bmis` → `ERROR at setup` (FileNotFoundError)
2. `test_19_delete_external_ip_pool` → timeout (resources never created)

The separate caller workflow `[e2e-bmaas-full-install.yml](https://github.com/osac-project/osac/blob/main/.github/workflows/e2e-bmaas-full-install.yml#L210-#L213)` already
excludes these tests with `test-filter: 'not TestBmaasNetworking'`. 

## Fix

Add `test-filter: 'not TestBmaasNetworking'` to the nightly's
`e2e-bmaas-test` job, matching the existing caller exclusion.

## Related

- osac-test-infra#444 — mounts SSH key (defence-in-depth)
- osac-test-infra#426 — dedicated Netris lab workflow (long-term)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

- **CI:** Updated the nightly BMaaS E2E workflow to exclude `TestBmaasNetworking`.
- The excluded tests require Netris lab hardware that is unavailable in GitHub Actions.
- This prevents `FileNotFoundError` and related cascading failures.
- **API, controllers, database, authentication, deployment, documentation:** No changes.

## Compatibility

This change affects nightly CI coverage only. It does not change product behavior or public interfaces. `TestBmaasNetworking` remains available in environments with the required hardware.

## Risk classification

The change qualifies for **risk:ship** because it modifies only CI test selection and does not affect runtime code, APIs, deployment behavior, data, or security. It does not qualify for **risk:show** because it introduces no user-visible product change. It does not qualify for **risk:ask** because it does not alter runtime behavior or create a material operational risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->