### PR TITLE
OSAC-4742: BCM label-based host selection

### DIFF
--- a/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_bcm_integration_test.go
+++ b/bare-metal-fulfillment-operator/internal/controller/baremetalinstance_bcm_integration_test.go
@@ -249,13 +249,15 @@ func bmhExistsInNS(name string) bool {
 	return err == nil
 }
 
-func createBCMBMI(name, hostType string) {
+func createBCMBMI(name, resourceClass string) {
 	bmi := &v1alpha1.BareMetalInstance{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: bcmTestNS},
 		Spec: v1alpha1.BareMetalInstanceSpec{
 			Selector: v1alpha1.HostSelectorSpec{
+				// The BCM backend matches selector keys against a device's
+				// extra_values, where resource_class lives.
 				HostSelector: map[string]string{
-					"hostType": hostType,
+					"resource_class": resourceClass,
 				},
 			},
 			TemplateID: shared.OsacNoopTemplate,

--- a/bare-metal-fulfillment-operator/internal/inventory/bcm.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/bcm.go
@@ -23,6 +23,7 @@ import (
 	"math/rand"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -165,19 +166,43 @@ func (c *BCMClient) CertWatcher() *certwatcher.CertWatcher {
 	return c.client.CertWatcher()
 }
 
-// FindFreeHost queries BCM for all devices and returns a randomly selected
-// free LiteNode matching the requested hostType. All filtering is client-side
-// because the BCM JSON API has no server-side filtering.
-func (c *BCMClient) FindFreeHost(ctx context.Context, matchExpressions map[string]string) (*Host, error) {
-	log := ctrllog.FromContext(ctx)
-	log.Info("Finding free BCM host")
+// Selector keys with dedicated handling, excluded from the generic label match.
+const (
+	managedByKey      = "managedBy"
+	provisionStateKey = "provisionState"
+)
 
-	matchManagedBy := matchExpressions["managedBy"]
+// reservedExtraValueKeys are OSAC-internal extra_values, never matchable as labels.
+var reservedExtraValueKeys = map[string]bool{
+	bcmclient.ExtraValueInstanceID:     true,
+	bcmclient.ExtraValueBMCAddress:     true,
+	bcmclient.ExtraValueBMCCredentials: true,
+}
+
+// FindFreeHost returns a randomly selected free LiteNode whose extra_values
+// satisfy the selector labels (arbitrary key=value, matched client-side against
+// extra_values — the BCM JSON API has no server-side filtering). managedBy is a
+// default-aware ownership guard; provisionState is excluded (no BCM analog).
+func (c *BCMClient) FindFreeHost(ctx context.Context, matchExpressions map[string]string) (*Host, error) {
+	if err := validateBCMMatchExpressions(matchExpressions); err != nil {
+		return nil, err
+	}
+
+	log := ctrllog.FromContext(ctx)
+	log.Info("Finding free BCM host", "selectorKeys", sortedKeys(matchExpressions))
+
+	matchManagedBy := matchExpressions[managedByKey]
 	if matchManagedBy == "" {
 		matchManagedBy = shared.OsacDefaultManagedByValue
 	}
-	if matchManagedBy != shared.OsacDefaultManagedByValue {
-		return nil, nil
+
+	// Generic label match: the selector minus keys with dedicated handling.
+	labelMatchExpressions := make(map[string]string, len(matchExpressions))
+	for key, value := range matchExpressions {
+		if key == managedByKey || key == provisionStateKey {
+			continue
+		}
+		labelMatchExpressions[key] = value
 	}
 
 	devices, err := c.client.GetDevices(ctx)
@@ -185,24 +210,13 @@ func (c *BCMClient) FindFreeHost(ctx context.Context, matchExpressions map[strin
 		return nil, fmt.Errorf("FindFreeHost: %w", err)
 	}
 
-	hostType := matchExpressions["hostType"]
-
+	// available holds every valid, unassigned LiteNode regardless of the selector;
+	// it feeds the availability gauge (the total free pool by resource_class).
+	// candidates narrows that pool by the selector labels and managedBy ownership.
+	available := make([]bcmclient.Device, 0, len(devices))
 	candidates := make([]bcmclient.Device, 0, len(devices))
 	for _, d := range devices {
-		if d.ChildType != "LiteNode" {
-			continue
-		}
-
-		if d.ExtraValues == nil {
-			continue
-		}
-
-		resourceClass, _ := d.ExtraValues[bcmclient.ExtraValueResourceClass].(string)
-		if resourceClass == "" {
-			continue
-		}
-
-		if hostType != "" && resourceClass != hostType {
+		if d.ChildType != "LiteNode" || d.ExtraValues == nil {
 			continue
 		}
 
@@ -218,9 +232,92 @@ func (c *BCMClient) FindFreeHost(ctx context.Context, matchExpressions map[strin
 			continue
 		}
 
+		available = append(available, d)
+
+		if !deviceMatchesLabels(d, labelMatchExpressions) {
+			continue
+		}
+
+		if deviceManagedBy(d) != matchManagedBy {
+			continue
+		}
+
 		candidates = append(candidates, d)
 	}
 
+	updateAvailableMetric(available)
+
+	if len(candidates) == 0 {
+		log.Info("no free BCM host matches selector", "selectorKeys", sortedKeys(labelMatchExpressions))
+		return nil, nil
+	}
+
+	rand.Shuffle(len(candidates), func(i, j int) {
+		candidates[i], candidates[j] = candidates[j], candidates[i]
+	})
+
+	selected := &candidates[0]
+	// Report the selected device's resource_class as HostType (observability only;
+	// resource_class is also matchable as an ordinary label).
+	resourceClass, _ := selected.ExtraValues[bcmclient.ExtraValueResourceClass].(string)
+
+	return &Host{
+		InventoryHostID: fmt.Sprintf("%s/%s", c.bmhManager.Namespace(), selected.Hostname),
+		Name:            selected.Hostname,
+		HostType:        resourceClass,
+		HostClass:       c.hostClass,
+		ManagedBy:       matchManagedBy,
+	}, nil
+}
+
+// validateBCMMatchExpressions rejects an empty selector, empty keys, keys with
+// spaces, empty values, and OSAC-internal reserved keys.
+func validateBCMMatchExpressions(matchExpressions map[string]string) error {
+	if len(matchExpressions) == 0 {
+		return fmt.Errorf("invalid matchExpressions: empty map")
+	}
+	for key, value := range matchExpressions {
+		if key == "" {
+			return fmt.Errorf("invalid matchExpression: empty key not allowed")
+		}
+		if strings.Contains(key, " ") {
+			return fmt.Errorf("invalid matchExpression: key %q contains spaces", key)
+		}
+		if reservedExtraValueKeys[key] {
+			return fmt.Errorf("invalid matchExpression: %q is a reserved OSAC key", key)
+		}
+		if value == "" {
+			return fmt.Errorf("invalid matchExpression: empty value not allowed for key %q", key)
+		}
+	}
+	return nil
+}
+
+// deviceMatchesLabels reports whether the device's extra_values satisfy every
+// selector key=value (AND). Reserved keys are rejected by
+// validateBCMMatchExpressions before this is reached.
+func deviceMatchesLabels(d bcmclient.Device, matchExpressions map[string]string) bool {
+	for key, want := range matchExpressions {
+		got, ok := d.ExtraValues[key].(string)
+		if !ok || got != want {
+			return false
+		}
+	}
+	return true
+}
+
+// deviceManagedBy returns the device's managedBy label, defaulting to the
+// standard owner when absent or empty.
+func deviceManagedBy(d bcmclient.Device) string {
+	if v, ok := d.ExtraValues[managedByKey].(string); ok && v != "" {
+		return v
+	}
+	return shared.OsacDefaultManagedByValue
+}
+
+// updateAvailableMetric refreshes the available-hosts gauge, keyed by
+// resource_class as a best-effort reporting dimension.
+func updateAvailableMetric(candidates []bcmclient.Device) {
 	bcmHostsAvailable.Reset()
 	availableByType := map[string]float64{}
 	for _, cd := range candidates {
@@ -230,25 +327,17 @@ func (c *BCMClient) FindFreeHost(ctx context.Context, matchExpressions map[strin
 	for t, count := range availableByType {
 		bcmHostsAvailable.WithLabelValues(t).Set(count)
 	}
+}
 
-	if len(candidates) == 0 {
-		return nil, nil
+// sortedKeys returns the map's keys sorted, for stable, value-free logging.
+// Selector values may be sensitive and are never logged.
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
 	}
-
-	rand.Shuffle(len(candidates), func(i, j int) {
-		candidates[i], candidates[j] = candidates[j], candidates[i]
-	})
-
-	selected := &candidates[0]
-	resourceClass, _ := selected.ExtraValues[bcmclient.ExtraValueResourceClass].(string)
-
-	return &Host{
-		InventoryHostID: fmt.Sprintf("%s/%s", c.bmhManager.Namespace(), selected.Hostname),
-		Name:            selected.Hostname,
-		HostType:        resourceClass,
-		HostClass:       c.hostClass,
-		ManagedBy:       shared.OsacDefaultManagedByValue,
-	}, nil
+	sort.Strings(keys)
+	return keys
 }
 
 // AssignHost records the assignment identifier in BCM, resolves the BMC

--- a/bare-metal-fulfillment-operator/internal/inventory/bcm_test.go
+++ b/bare-metal-fulfillment-operator/internal/inventory/bcm_test.go
@@ -826,7 +826,7 @@ var _ = Describe("BCM Inventory Adapter", func() {
 			}
 
 			client := newTestClient()
-			host, err := client.FindFreeHost(ctx, map[string]string{"hostType": "h100"})
+			host, err := client.FindFreeHost(ctx, map[string]string{"resource_class": "h100"})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(host).NotTo(BeNil())
 			Expect(host.InventoryHostID).To(Equal("osac-baremetal/node001"))
@@ -846,7 +846,7 @@ var _ = Describe("BCM Inventory Adapter", func() {
 			}
 
 			client := newTestClient()
-			host, err := client.FindFreeHost(ctx, map[string]string{"hostType": "h100"})
+			host, err := client.FindFreeHost(ctx, map[string]string{"resource_class": "h100"})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(host).To(BeNil())
 		})
@@ -861,12 +861,12 @@ var _ = Describe("BCM Inventory Adapter", func() {
 			}
 
 			client := newTestClient()
-			host, err := client.FindFreeHost(ctx, map[string]string{"hostType": "h100"})
+			host, err := client.FindFreeHost(ctx, map[string]string{"resource_class": "h100"})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(host).To(BeNil())
 		})
 
-		It("should skip devices without resource_class", func() {
+		It("should skip devices whose extra_values lack the selector label", func() {
 			bcmDevices = func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				_, err := fmt.Fprint(w, `[
@@ -876,7 +876,7 @@ var _ = Describe("BCM Inventory Adapter", func() {
 			}
 
 			client := newTestClient()
-			host, err := client.FindFreeHost(ctx, map[string]string{"hostType": "h100"})
+			host, err := client.FindFreeHost(ctx, map[string]string{"resource_class": "h100"})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(host).To(BeNil())
 		})
@@ -891,12 +891,12 @@ var _ = Describe("BCM Inventory Adapter", func() {
 			}
 
 			client := newTestClient()
-			host, err := client.FindFreeHost(ctx, map[string]string{"hostType": "h100"})
+			host, err := client.FindFreeHost(ctx, map[string]string{"resource_class": "h100"})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(host).To(BeNil())
 		})
 
-		It("should filter by hostType from matchExpressions", func() {
+		It("should filter by an extra_values label (resource_class)", func() {
 			bcmDevices = func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				_, err := fmt.Fprint(w, `[
@@ -907,7 +907,7 @@ var _ = Describe("BCM Inventory Adapter", func() {
 			}
 
 			client := newTestClient()
-			host, err := client.FindFreeHost(ctx, map[string]string{"hostType": "h100"})
+			host, err := client.FindFreeHost(ctx, map[string]string{"resource_class": "h100"})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(host).NotTo(BeNil())
 			Expect(host.Name).To(Equal("node002"))
@@ -922,26 +922,30 @@ var _ = Describe("BCM Inventory Adapter", func() {
 			}
 
 			client := newTestClient()
-			host, err := client.FindFreeHost(ctx, map[string]string{"hostType": "h100"})
+			host, err := client.FindFreeHost(ctx, map[string]string{"resource_class": "h100"})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(host).To(BeNil())
 		})
 
-		It("should return any matching host when hostType is empty", func() {
-			bcmDevices = func(w http.ResponseWriter, _ *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				_, err := fmt.Fprint(w, `[
-					{"baseType":"Device","childType":"LiteNode","uuid":"u1","hostname":"node001","mac":"aa:bb:cc:dd:ee:01","extra_values":{"resource_class":"h100"}}
-				]`)
-				Expect(err).NotTo(HaveOccurred())
-			}
+		DescribeTable("should reject invalid selectors without querying BCM",
+			func(selector map[string]string) {
+				bcmDevices = func(_ http.ResponseWriter, _ *http.Request) {
+					Fail("GetDevices should not be called for an invalid selector")
+				}
 
-			client := newTestClient()
-			host, err := client.FindFreeHost(ctx, map[string]string{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(host).NotTo(BeNil())
-			Expect(host.Name).To(Equal("node001"))
-		})
+				client := newTestClient()
+				host, err := client.FindFreeHost(ctx, selector)
+				Expect(err).To(HaveOccurred())
+				Expect(host).To(BeNil())
+			},
+			Entry("empty map", map[string]string{}),
+			Entry("empty key", map[string]string{"": "h100"}),
+			Entry("key with spaces", map[string]string{"resource class": "h100"}),
+			Entry("empty value", map[string]string{"resource_class": ""}),
+			Entry("reserved key osac_instance_id", map[string]string{"osac_instance_id": "x"}),
+			Entry("reserved key osac_bmc_address", map[string]string{"osac_bmc_address": "x"}),
+			Entry("reserved key osac_bmc_credentials_secret", map[string]string{"osac_bmc_credentials_secret": "x"}),
+		)
 
 		It("should skip devices with missing MAC address", func() {
 			bcmDevices = func(w http.ResponseWriter, _ *http.Request) {
@@ -953,7 +957,7 @@ var _ = Describe("BCM Inventory Adapter", func() {
 			}
 
 			client := newTestClient()
-			host, err := client.FindFreeHost(ctx, map[string]string{"hostType": "h100"})
+			host, err := client.FindFreeHost(ctx, map[string]string{"resource_class": "h100"})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(host).To(BeNil())
 		})
@@ -968,7 +972,7 @@ var _ = Describe("BCM Inventory Adapter", func() {
 			}
 
 			client := newTestClient()
-			host, err := client.FindFreeHost(ctx, map[string]string{"hostType": "h100"})
+			host, err := client.FindFreeHost(ctx, map[string]string{"resource_class": "h100"})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(host).To(BeNil())
 		})
@@ -983,7 +987,7 @@ var _ = Describe("BCM Inventory Adapter", func() {
 			}
 
 			client := newTestClient()
-			host, err := client.FindFreeHost(ctx, map[string]string{"hostType": "h100"})
+			host, err := client.FindFreeHost(ctx, map[string]string{"resource_class": "h100"})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(host).To(BeNil())
 		})
@@ -998,20 +1002,58 @@ var _ = Describe("BCM Inventory Adapter", func() {
 			}
 
 			client := newTestClient()
-			host, err := client.FindFreeHost(ctx, map[string]string{"hostType": "h100"})
+			host, err := client.FindFreeHost(ctx, map[string]string{"resource_class": "h100"})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(host).To(BeNil())
 		})
 
-		It("should return nil when managedBy does not match default", func() {
-			bcmDevices = func(_ http.ResponseWriter, _ *http.Request) {
-				Fail("GetDevices should not be called when managedBy filter excludes BCM")
+		It("should skip hosts whose managedBy differs from the requested owner", func() {
+			bcmDevices = func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				// Device defaults to managedBy=baremetal (no managedBy label).
+				_, err := fmt.Fprint(w, `[
+					{"baseType":"Device","childType":"LiteNode","uuid":"u1","hostname":"node001","mac":"aa:bb:cc:dd:ee:01","extra_values":{"resource_class":"h100"}}
+				]`)
+				Expect(err).NotTo(HaveOccurred())
 			}
 
 			client := newTestClient()
-			host, err := client.FindFreeHost(ctx, map[string]string{"managedBy": "other-manager"})
+			host, err := client.FindFreeHost(ctx, map[string]string{"resource_class": "h100", "managedBy": "other-manager"})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(host).To(BeNil())
+		})
+
+		It("should match a free host by an arbitrary extra_values label", func() {
+			bcmDevices = func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, err := fmt.Fprint(w, `[
+					{"baseType":"Device","childType":"LiteNode","uuid":"u1","hostname":"node001","mac":"aa:bb:cc:dd:ee:01","extra_values":{"gpu":"a100","datacenter":"west"}}
+				]`)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			client := newTestClient()
+			host, err := client.FindFreeHost(ctx, map[string]string{"gpu": "a100"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(host).NotTo(BeNil())
+			Expect(host.Name).To(Equal("node001"))
+		})
+
+		It("should require all selector labels to match (AND semantics)", func() {
+			bcmDevices = func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, err := fmt.Fprint(w, `[
+					{"baseType":"Device","childType":"LiteNode","uuid":"u1","hostname":"node001","mac":"aa:bb:cc:dd:ee:01","extra_values":{"gpu":"a100","datacenter":"east"}},
+					{"baseType":"Device","childType":"LiteNode","uuid":"u2","hostname":"node002","mac":"aa:bb:cc:dd:ee:02","extra_values":{"gpu":"a100","datacenter":"west"}}
+				]`)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			client := newTestClient()
+			host, err := client.FindFreeHost(ctx, map[string]string{"gpu": "a100", "datacenter": "west"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(host).NotTo(BeNil())
+			Expect(host.Name).To(Equal("node002"))
 		})
 
 		It("should match when managedBy is the default value", func() {


### PR DESCRIPTION
## [OSAC-4742](https://redhat.atlassian.net/browse/OSAC-4742): BCM Label Filtering

**Story:** [DEV] · **Epic:** [OSAC-2857](https://redhat.atlassian.net/browse/OSAC-2857) Label-Based Host Selection · **Design:** [OSAC-1201](https://github.com/osac-project/enhancement-proposals/blob/main/enhancements/OSAC-1201-baremetal-instance-types/design.md)

Completes the label-based host selection epic for the **BCM** inventory backend, alongside the OpenStack/Metal3 backends delivered in #404 (now merged; this branch is rebased on top of it).

### Summary
`BCMClient.FindFreeHost` now matches the `BareMetalInstanceType` `host_label_selector` as **arbitrary key=value equality (AND across keys)** instead of the legacy single-dimension `hostType`/`resource_class` filter.

### Approach
Filtering is client-side (the BCM JSON API has no server-side filtering). Selector keys are matched **directly against the device's `extra_values`** — BCM's native metadata bag, where `resource_class` already lives — so existing devices remain selectable with no migration and arbitrary multi-label selectors are supported. `resource_class` is no longer special-cased: it is matchable like any other label and reported as `HostType`.

- OSAC-internal keys (`osac_instance_id`, `osac_bmc_address`, `osac_bmc_credentials_secret`) are excluded from matching.
- `managedBy`: default-aware ownership guard (excluded from the generic match).
- `provisionState`: excluded (no BCM analog).
- Already-assigned hosts (`osac_instance_id` set) skipped; invalid selectors rejected before any BCM API call.

### Scope
`internal/inventory/bcm.go` (+ unit tests) and a one-line fix to the BCM controller integration test's `createBCMBMI` helper (select by `resource_class`).

### Testing
- `go test ./internal/inventory/...` — pass (validation, arbitrary-label match, multi-label AND, OSAC-internal keys not matchable, per-device `managedBy` guard, no BCM query on invalid input).
- Controller suite via envtest — **145 specs pass**; BCM integration focused run **10 Passed | 0 Failed**.
- `go build` / `go vet` / `gofmt` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Affected areas

- **API surface:** `BCMClient.FindFreeHost` now supports arbitrary `key=value` selectors from BCM `extra_values`. Multiple selectors use AND semantics.
- **Controllers:** The BCM integration-test helper now uses `resource_class` for host selection.
- **Tests:** Added coverage for selector validation, reserved keys, metadata errors, hostname validation, `managedBy`, arbitrary labels, and multi-label matching.
- **CI:** Inventory tests, controller integration tests, build, vet, and formatting checks pass.

## Backward compatibility

- Existing BCM devices remain supported.
- `resource_class` remains reported as `HostType` and is now a regular matchable label.
- `hostType` is no longer a selector. Selectors must use `resource_class`.
- Assigned hosts remain excluded.
- Invalid selectors fail before BCM API calls.
- `managedBy` checks support default-aware ownership values.
- OSAC-internal fields and `provisionState` are excluded from selector matching.

## Risk classification

**risk:show** — The change modifies runtime BCM host-selection behavior and selector validation. The scope is limited to inventory selection, with focused unit and integration test coverage.

The change does not qualify as **risk:ship** because selector behavior and compatibility semantics changed. It does not qualify as **risk:ask** because it does not change authentication, deployment configuration, persistent data, or security boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->