### PR TITLE
OSAC-1710: Require storage tiers for ComputeInstance disks

### DIFF
--- a/fulfillment-service/docs/CATALOG_ITEMS.md
+++ b/fulfillment-service/docs/CATALOG_ITEMS.md
@@ -212,6 +212,10 @@ field_definitions:
     default: 20
     display_name: Boot Disk Size (GiB)
     editable: true
+  - path: boot_disk.storage_tier
+    default: standard
+    display_name: Boot Disk Storage Tier
+    editable: true
   - path: instance_type
     display_name: Instance Type
     editable: true
@@ -304,6 +308,7 @@ catalog item, the server rejects any spec field not listed in `field_definitions
 | `user_data` | Cloud-init or ignition user data |
 | `disk_image` | DiskImage reference (name or ID) |
 | `boot_disk.size_gib` | Boot disk size in GiB |
+| `boot_disk.storage_tier` | Boot disk storage tier |
 | `additional_disks` | Additional disk configurations |
 | `network_attachments` | Network attachments (subnet + security groups per NIC) |
 | `template_parameters.<name>` | Custom template parameter forwarded to AAP as an Ansible extra variable |

--- a/fulfillment-service/docs/VM_CONSOLE.md
+++ b/fulfillment-service/docs/VM_CONSOLE.md
@@ -491,6 +491,7 @@ osac create computeinstance \
   --catalog-item <catalog-item-id> \
   --name my-vm \
   --boot-disk-size 20 \
+  --boot-disk-storage-tier standard \
   --disk-image fedora \
   --run-strategy Always \
   -p cloud_init_config="$(base64 < cloud-init.yaml | tr -d '\n')"

--- a/fulfillment-service/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd.go
@@ -770,6 +770,7 @@ func (c *runnerContext) buildSpec(templateID string,
 }
 
 // buildBootDisk returns a boot disk from CLI flags, or nil if neither size nor storage tier was set.
+// A size-only boot disk is allowed because the server may resolve its tier from a catalog item or template.
 func (c *runnerContext) buildBootDisk() (*publicv1.ComputeInstanceDisk, error) {
 	if c.args.bootDiskSizeGiB <= 0 && c.args.bootDiskStorageTier == "" {
 		return nil, nil
@@ -912,11 +913,8 @@ func (c *runnerContext) buildSpecFromCatalogItem(catalogItemID string) (*publicv
 	return spec.Build(), nil
 }
 
-// parseAdditionalDisks parses disk specifications in two formats:
-//  1. Bare integer (legacy): "100" specifies size in GiB
-//  2. Key=value format: "size=100,storage-tier=standard"
-//
-// The storage-tier field is optional in the key=value format for backward compatibility.
+// parseAdditionalDisks parses disk specifications in key=value format:
+// "size=100,storage-tier=standard".
 func parseAdditionalDisks(diskArgs []string) ([]*publicv1.ComputeInstanceDisk, error) {
 	disks := make([]*publicv1.ComputeInstanceDisk, 0, len(diskArgs))
 	for _, arg := range diskArgs {
@@ -925,22 +923,16 @@ func parseAdditionalDisks(diskArgs []string) ([]*publicv1.ComputeInstanceDisk, e
 			return nil, fmt.Errorf("empty --additional-disk value")
 		}
 
-		// Legacy format: bare integer is interpreted as size in GiB
+		// Additional disks must name their storage tier because they have no catalog or
+		// template defaulting step at the CLI boundary.
 		if !strings.Contains(arg, "=") {
-			sizeGiB, err := strconv.ParseInt(arg, 10, 32)
-			if err != nil {
-				return nil, fmt.Errorf("invalid --additional-disk value %q: expected an integer or key=value format", arg)
-			}
-			disk := publicv1.ComputeInstanceDisk_builder{
-				SizeGib: proto.Int32(int32(sizeGiB)),
-			}.Build()
-			disks = append(disks, disk)
-			continue
+			return nil, fmt.Errorf("invalid --additional-disk value %q: use size=<GiB>,storage-tier=<name>", arg)
 		}
 
 		// Key=value format
 		disk := publicv1.ComputeInstanceDisk_builder{}
 		var hasSize bool
+		var storageTier string
 
 		for _, fragment := range strings.Split(arg, ",") {
 			fragment = strings.TrimSpace(fragment)
@@ -970,6 +962,7 @@ func parseAdditionalDisks(diskArgs []string) ([]*publicv1.ComputeInstanceDisk, e
 				hasSize = true
 			case "storage-tier":
 				disk.StorageTier = proto.String(value)
+				storageTier = value
 			default:
 				return nil, fmt.Errorf("unknown --additional-disk key %q (expected 'size' or 'storage-tier')", key)
 			}
@@ -977,6 +970,9 @@ func parseAdditionalDisks(diskArgs []string) ([]*publicv1.ComputeInstanceDisk, e
 
 		if !hasSize {
 			return nil, fmt.Errorf("--additional-disk %q must include size=<value>", arg)
+		}
+		if strings.TrimSpace(storageTier) == "" {
+			return nil, fmt.Errorf("--additional-disk %q must include storage-tier=<name>", arg)
 		}
 
 		disks = append(disks, disk.Build())
@@ -1093,8 +1089,8 @@ _TIER_ - Storage tier for the boot disk.
 
 const additionalDiskFlagHelp = `
 _SPEC_ - Additional disk specification. Accepts two formats:
-1. Bare integer: {{ bt }}<GiB>{{ bt }} specifies disk size in GiB (temporary, backward compatibility only)
-2. Key=value: {{ bt }}size=<GiB>,storage-tier=<name>{{ bt }} specifies disk size and storage tier name
+{{ bt }}size=<GiB>,storage-tier=<name>{{ bt }} specifies disk size and storage tier name.
+The storage tier is required for every additional disk.
 
 Can be specified multiple times to add more than one disk.
 `

--- a/fulfillment-service/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/create/computeinstance/create_compute_instance_cmd_test.go
@@ -298,18 +298,46 @@ var _ = Describe("--additional-disk flag parsing", func() {
 		Expect(disks[0].GetStorageTier()).To(Equal("e2e-x"))
 	})
 
-	It("should treat each flag occurrence as a distinct disk", func() {
+	It("should parse multiple disks with different storage tiers", func() {
+		raw := rawDisks(
+			"--additional-disk", "size=50,storage-tier=fast",
+			"--additional-disk", "size=100,storage-tier=archive",
+		)
+		Expect(raw).To(Equal([]string{
+			"size=50,storage-tier=fast",
+			"size=100,storage-tier=archive",
+		}))
+
+		disks, err := parseAdditionalDisks(raw)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(disks).To(HaveLen(2))
+		Expect(disks[0].GetSizeGib()).To(Equal(int32(50)))
+		Expect(disks[0].GetStorageTier()).To(Equal("fast"))
+		Expect(disks[1].GetSizeGib()).To(Equal(int32(100)))
+		Expect(disks[1].GetStorageTier()).To(Equal("archive"))
+	})
+
+	It("should reject a bare integer additional disk", func() {
 		raw := rawDisks(
 			"--additional-disk", "size=50,storage-tier=e2e-x",
 			"--additional-disk", "100",
 		)
 		Expect(raw).To(Equal([]string{"size=50,storage-tier=e2e-x", "100"}))
 
-		disks, err := parseAdditionalDisks(raw)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(disks).To(HaveLen(2))
-		Expect(disks[0].GetSizeGib()).To(Equal(int32(50)))
-		Expect(disks[0].GetStorageTier()).To(Equal("e2e-x"))
-		Expect(disks[1].GetSizeGib()).To(Equal(int32(100)))
+		_, err := parseAdditionalDisks(raw)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("storage-tier=<name>"))
+	})
+
+	It("should reject an additional disk without a storage tier", func() {
+		_, err := parseAdditionalDisks([]string{"size=100"})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("storage-tier=<name>"))
+	})
+
+	It("should reject an additional disk with an empty storage tier", func() {
+		_, err := parseAdditionalDisks([]string{"size=100,storage-tier="})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("value is empty"))
 	})
 })

--- a/fulfillment-service/internal/servers/private_compute_instances_server_test.go
+++ b/fulfillment-service/internal/servers/private_compute_instances_server_test.go
@@ -1042,6 +1042,7 @@ var _ = Describe("Private compute instances server", func() {
 			Expect(spec.GetRunStrategy()).To(Equal(privatev1.ComputeInstanceRunStrategy_COMPUTE_INSTANCE_RUN_STRATEGY_ALWAYS))
 			Expect(spec.GetDiskImage().GetId()).To(Equal("test-disk-image"))
 			Expect(spec.GetBootDisk().GetSizeGib()).To(Equal(int32(10)))
+			Expect(spec.GetBootDisk().GetStorageTier()).To(Equal("standard"))
 			// Template reference should be preserved:
 			Expect(spec.GetTemplate().GetId()).To(Equal("defaults-template"))
 		})
@@ -1076,6 +1077,111 @@ var _ = Describe("Private compute instances server", func() {
 			Expect(spec.GetInstanceType().GetId()).To(Equal("standard-4-16"))
 			Expect(spec.GetDiskImage().GetId()).To(Equal("test-disk-image"))
 			Expect(spec.GetBootDisk().GetSizeGib()).To(Equal(int32(10)))
+			Expect(spec.GetBootDisk().GetStorageTier()).To(Equal("standard"))
+		})
+
+		It("Rejects creation when the resolved boot disk storage tier is absent or empty", func() {
+			templatesDao, err := dao.NewGenericDAO[*privatev1.ComputeInstanceTemplate]().
+				SetLogger(logger).
+				SetTenancyLogic(tenancy).
+				Build()
+			Expect(err).ToNot(HaveOccurred())
+
+			const templateID = "missing-boot-tier-template"
+			_, err = templatesDao.Create().SetObject(privatev1.ComputeInstanceTemplate_builder{
+				Id:          templateID,
+				Title:       "Missing Boot Tier Template",
+				Description: "Template with a boot disk but no storage tier",
+				Metadata: privatev1.Metadata_builder{
+					Name:   templateID,
+					Tenant: testTenant,
+				}.Build(),
+				SpecDefaults: privatev1.ComputeInstanceTemplateSpecDefaults_builder{
+					InstanceType: privatev1.InstanceTypeReference_builder{Id: "standard-4-16"}.Build(),
+					DiskImage:    &privatev1.DiskImageReference{Id: "test-disk-image"},
+					BootDisk: privatev1.ComputeInstanceDisk_builder{
+						SizeGib: proto.Int32(10),
+					}.Build(),
+					RunStrategy: privatev1.ComputeInstanceRunStrategy_COMPUTE_INSTANCE_RUN_STRATEGY_ALWAYS.Enum(),
+				}.Build(),
+			}.Build()).Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			for _, bootDisk := range []*privatev1.ComputeInstanceDisk{
+				nil,
+				privatev1.ComputeInstanceDisk_builder{
+					SizeGib:     proto.Int32(20),
+					StorageTier: new(""),
+				}.Build(),
+			} {
+				name := fmt.Sprintf("test-%s", uuid.NewString()[:8])
+				response, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
+					Object: privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{Name: name}.Build(),
+						Spec: privatev1.ComputeInstanceSpec_builder{
+							Template: privatev1.ComputeInstanceTemplateReference_builder{Id: templateID}.Build(),
+							BootDisk: bootDisk,
+							NetworkAttachments: []*privatev1.ComputeNetworkAttachment{
+								privatev1.ComputeNetworkAttachment_builder{
+									Subnet: privatev1.SubnetLocalReference_builder{Id: "test-subnet"}.Build(),
+								}.Build(),
+							},
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				Expect(response).To(BeNil())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(status.Message()).To(Equal("boot_disk.storage_tier is required"))
+
+				listResponse, err := server.List(ctx, privatev1.ComputeInstancesListRequest_builder{
+					Filter: new(fmt.Sprintf("this.metadata.name == '%s'", name)),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(listResponse.GetSize()).To(Equal(int32(0)))
+			}
+		})
+
+		It("Rejects creation when an additional disk storage tier is absent or empty", func() {
+			createTemplate("additional-tier-template")
+
+			for _, storageTier := range []*string{nil, new("")} {
+				name := fmt.Sprintf("test-%s", uuid.NewString()[:8])
+				additionalDisk := privatev1.ComputeInstanceDisk_builder{SizeGib: proto.Int32(50)}
+				if storageTier != nil {
+					additionalDisk.StorageTier = storageTier
+				}
+				response, err := server.Create(ctx, privatev1.ComputeInstancesCreateRequest_builder{
+					Object: privatev1.ComputeInstance_builder{
+						Metadata: privatev1.Metadata_builder{Name: name}.Build(),
+						Spec: privatev1.ComputeInstanceSpec_builder{
+							Template: privatev1.ComputeInstanceTemplateReference_builder{Id: "additional-tier-template"}.Build(),
+							AdditionalDisks: []*privatev1.ComputeInstanceDisk{
+								additionalDisk.Build(),
+							},
+							NetworkAttachments: []*privatev1.ComputeNetworkAttachment{
+								privatev1.ComputeNetworkAttachment_builder{
+									Subnet: privatev1.SubnetLocalReference_builder{Id: "test-subnet"}.Build(),
+								}.Build(),
+							},
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				Expect(response).To(BeNil())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.InvalidArgument))
+				Expect(status.Message()).To(Equal("additional_disks[0].storage_tier is required"))
+
+				listResponse, err := server.List(ctx, privatev1.ComputeInstancesListRequest_builder{
+					Filter: new(fmt.Sprintf("this.metadata.name == '%s'", name)),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(listResponse.GetSize()).To(Equal(int32(0)))
+			}
 		})
 
 		It("Rejects creation when required spec fields are missing", func() {
@@ -3004,7 +3110,8 @@ var _ = Describe("Private compute instances server", func() {
 							InstanceType: privatev1.InstanceTypeReference_builder{Id: "standard-4-16"}.Build(),
 							DiskImage:    &privatev1.DiskImageReference{Id: diskImageKey},
 							BootDisk: privatev1.ComputeInstanceDisk_builder{
-								SizeGib: proto.Int32(20),
+								SizeGib:     proto.Int32(20),
+								StorageTier: new("standard"),
 							}.Build(),
 							RunStrategy: privatev1.ComputeInstanceRunStrategy_COMPUTE_INSTANCE_RUN_STRATEGY_ALWAYS.Enum(),
 							NetworkAttachments: []*privatev1.ComputeNetworkAttachment{
@@ -3103,7 +3210,8 @@ var _ = Describe("Private compute instances server", func() {
 							InstanceType: privatev1.InstanceTypeReference_builder{Id: "standard-4-16"}.Build(),
 							DiskImage:    &privatev1.DiskImageReference{Name: "di-by-name"},
 							BootDisk: privatev1.ComputeInstanceDisk_builder{
-								SizeGib: proto.Int32(20),
+								SizeGib:     proto.Int32(20),
+								StorageTier: new("standard"),
 							}.Build(),
 							RunStrategy: privatev1.ComputeInstanceRunStrategy_COMPUTE_INSTANCE_RUN_STRATEGY_ALWAYS.Enum(),
 							NetworkAttachments: []*privatev1.ComputeNetworkAttachment{

--- a/fulfillment-service/internal/utils/spec_defaults.go
+++ b/fulfillment-service/internal/utils/spec_defaults.go
@@ -136,5 +136,8 @@ func validateDisk(disk *privatev1.ComputeInstanceDisk) error {
 	if disk.GetSizeGib() <= 0 {
 		return fmt.Errorf("size_gib must be greater than 0")
 	}
+	if !disk.HasStorageTier() || strings.TrimSpace(disk.GetStorageTier()) == "" {
+		return fmt.Errorf("storage_tier is required")
+	}
 	return nil
 }

--- a/fulfillment-service/internal/utils/spec_defaults_test.go
+++ b/fulfillment-service/internal/utils/spec_defaults_test.go
@@ -421,7 +421,7 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 		Expect(err.Error()).To(ContainSubstring("boot_disk.size_gib"))
 	})
 
-	It("Accepts boot_disk with empty storage_tier", func() {
+	It("Rejects boot_disk with empty storage_tier", func() {
 		spec := privatev1.ComputeInstanceSpec_builder{
 			Template:     privatev1.ComputeInstanceTemplateReference_builder{Id: "test.template"}.Build(),
 			InstanceType: privatev1.InstanceTypeReference_builder{Id: "standard-4-16"}.Build(),
@@ -433,10 +433,13 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 			RunStrategy: privatev1.ComputeInstanceRunStrategy_COMPUTE_INSTANCE_RUN_STRATEGY_ALWAYS.Enum(),
 		}.Build()
 
-		Expect(ValidateRequiredSpecFields(spec)).To(Succeed())
+		err := ValidateRequiredSpecFields(spec)
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+		Expect(err.Error()).To(ContainSubstring("boot_disk.storage_tier is required"))
 	})
 
-	It("Accepts boot_disk without storage_tier", func() {
+	It("Rejects boot_disk without storage_tier", func() {
 		spec := privatev1.ComputeInstanceSpec_builder{
 			Template:     privatev1.ComputeInstanceTemplateReference_builder{Id: "test.template"}.Build(),
 			InstanceType: privatev1.InstanceTypeReference_builder{Id: "standard-4-16"}.Build(),
@@ -447,10 +450,13 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 			RunStrategy: privatev1.ComputeInstanceRunStrategy_COMPUTE_INSTANCE_RUN_STRATEGY_ALWAYS.Enum(),
 		}.Build()
 
-		Expect(ValidateRequiredSpecFields(spec)).To(Succeed())
+		err := ValidateRequiredSpecFields(spec)
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+		Expect(err.Error()).To(ContainSubstring("boot_disk.storage_tier is required"))
 	})
 
-	It("Accepts additional_disk with empty storage_tier", func() {
+	It("Rejects additional_disk with empty storage_tier", func() {
 		spec := privatev1.ComputeInstanceSpec_builder{
 			Template:     privatev1.ComputeInstanceTemplateReference_builder{Id: "test.template"}.Build(),
 			InstanceType: privatev1.InstanceTypeReference_builder{Id: "standard-4-16"}.Build(),
@@ -472,10 +478,13 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 			RunStrategy: privatev1.ComputeInstanceRunStrategy_COMPUTE_INSTANCE_RUN_STRATEGY_ALWAYS.Enum(),
 		}.Build()
 
-		Expect(ValidateRequiredSpecFields(spec)).To(Succeed())
+		err := ValidateRequiredSpecFields(spec)
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+		Expect(err.Error()).To(ContainSubstring("additional_disks[1].storage_tier is required"))
 	})
 
-	It("Accepts additional_disk without storage_tier", func() {
+	It("Rejects additional_disk without storage_tier", func() {
 		spec := privatev1.ComputeInstanceSpec_builder{
 			Template:     privatev1.ComputeInstanceTemplateReference_builder{Id: "test.template"}.Build(),
 			InstanceType: privatev1.InstanceTypeReference_builder{Id: "standard-4-16"}.Build(),
@@ -496,6 +505,27 @@ var _ = Describe("ValidateRequiredSpecFields", func() {
 			RunStrategy: privatev1.ComputeInstanceRunStrategy_COMPUTE_INSTANCE_RUN_STRATEGY_ALWAYS.Enum(),
 		}.Build()
 
-		Expect(ValidateRequiredSpecFields(spec)).To(Succeed())
+		err := ValidateRequiredSpecFields(spec)
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+		Expect(err.Error()).To(ContainSubstring("additional_disks[1].storage_tier is required"))
+	})
+
+	It("Rejects whitespace-only storage_tier values", func() {
+		spec := privatev1.ComputeInstanceSpec_builder{
+			Template:     privatev1.ComputeInstanceTemplateReference_builder{Id: "test.template"}.Build(),
+			InstanceType: privatev1.InstanceTypeReference_builder{Id: "standard-4-16"}.Build(),
+			DiskImage:    &privatev1.DiskImageReference{Id: "test-disk-image"},
+			BootDisk: privatev1.ComputeInstanceDisk_builder{
+				SizeGib:     proto.Int32(20),
+				StorageTier: new(" \t\n"),
+			}.Build(),
+			RunStrategy: privatev1.ComputeInstanceRunStrategy_COMPUTE_INSTANCE_RUN_STRATEGY_ALWAYS.Enum(),
+		}.Build()
+
+		err := ValidateRequiredSpecFields(spec)
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.InvalidArgument))
+		Expect(err.Error()).To(ContainSubstring("boot_disk.storage_tier is required"))
 	})
 })

--- a/osac-aap/tests/integration/fixtures/computeinstance-windows-test.yaml
+++ b/osac-aap/tests/integration/fixtures/computeinstance-windows-test.yaml
@@ -13,6 +13,7 @@ spec:
   memoryGiB: 4
   bootDisk:
     sizeGiB: 40
+    storageTier: local
   image:
     sourceType: registry
     # Example path for tests/docs only — replace with a Windows container disk from your registry.

--- a/osac-operator/api/v1alpha1/computeinstance_types.go
+++ b/osac-operator/api/v1alpha1/computeinstance_types.go
@@ -53,11 +53,12 @@ type DiskSpec struct {
 	// +kubebuilder:validation:Minimum=1
 	SizeGiB int32 `json:"sizeGiB"`
 
-	// StorageTier is the name of the storage tier for this disk
+	// StorageTier is the name of the storage tier for this disk. Every disk must name a tier.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$`
-	// +optional
-	StorageTier string `json:"storageTier,omitempty"`
+	StorageTier string `json:"storageTier"`
 }
 
 // GpuSpec defines GPU passthrough configuration resolved from the InstanceType.

--- a/osac-operator/api/v1alpha1/computeinstance_types_test.go
+++ b/osac-operator/api/v1alpha1/computeinstance_types_test.go
@@ -115,7 +115,7 @@ var _ = Describe("ComputeInstanceSpec", func() {
 				},
 				Cores:     8,
 				MemoryGiB: 64,
-				BootDisk:  v1alpha1.DiskSpec{SizeGiB: 100},
+				BootDisk:  v1alpha1.DiskSpec{SizeGiB: 100, StorageTier: "standard"},
 				Gpu: &v1alpha1.GpuSpec{
 					PciDeviceSelector: "10DE:20B0",
 					ResourceName:      "nvidia.com/A100",

--- a/osac-operator/charts/operator-crds/templates/osac.openshift.io_computeinstances.yaml
+++ b/osac-operator/charts/operator-crds/templates/osac.openshift.io_computeinstances.yaml
@@ -81,12 +81,14 @@ spec:
                       type: integer
                     storageTier:
                       description: StorageTier is the name of the storage tier for
-                        this disk
+                        this disk. Every disk must name a tier.
                       maxLength: 63
+                      minLength: 1
                       pattern: ^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$
                       type: string
                   required:
                   - sizeGiB
+                  - storageTier
                   type: object
                 type: array
                 x-kubernetes-validations:
@@ -102,12 +104,14 @@ spec:
                     type: integer
                   storageTier:
                     description: StorageTier is the name of the storage tier for this
-                      disk
+                      disk. Every disk must name a tier.
                     maxLength: 63
+                    minLength: 1
                     pattern: ^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$
                     type: string
                 required:
                 - sizeGiB
+                - storageTier
                 type: object
                 x-kubernetes-validations:
                 - message: bootDisk is immutable

--- a/osac-operator/config/crd/bases/osac.openshift.io_computeinstances.yaml
+++ b/osac-operator/config/crd/bases/osac.openshift.io_computeinstances.yaml
@@ -79,12 +79,14 @@ spec:
                       type: integer
                     storageTier:
                       description: StorageTier is the name of the storage tier for
-                        this disk
+                        this disk. Every disk must name a tier.
                       maxLength: 63
+                      minLength: 1
                       pattern: ^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$
                       type: string
                   required:
                   - sizeGiB
+                  - storageTier
                   type: object
                 type: array
                 x-kubernetes-validations:
@@ -100,12 +102,14 @@ spec:
                     type: integer
                   storageTier:
                     description: StorageTier is the name of the storage tier for this
-                      disk
+                      disk. Every disk must name a tier.
                     maxLength: 63
+                    minLength: 1
                     pattern: ^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$
                     type: string
                 required:
                 - sizeGiB
+                - storageTier
                 type: object
                 x-kubernetes-validations:
                 - message: bootDisk is immutable

--- a/osac-operator/internal/controller/computeinstance_validation_test.go
+++ b/osac-operator/internal/controller/computeinstance_validation_test.go
@@ -24,6 +24,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	osacv1alpha1 "github.com/osac-project/osac/osac-operator/api/v1alpha1"
@@ -73,6 +75,26 @@ var _ = Describe("ComputeInstance CEL Validation", func() {
 				RunStrategy: osacv1alpha1.RunStrategyAlways,
 			},
 		}
+	}
+
+	instanceWithoutStorageTier := func(name string, additional bool) *unstructured.Unstructured {
+		instance := createValidInstance(name)
+		if additional {
+			instance.Spec.AdditionalDisks = []osacv1alpha1.DiskSpec{{SizeGiB: 50, StorageTier: "standard"}}
+		}
+		object, err := runtime.DefaultUnstructuredConverter.ToUnstructured(instance)
+		Expect(err).ToNot(HaveOccurred())
+		spec := object["spec"].(map[string]interface{})
+		if additional {
+			disks := spec["additionalDisks"].([]interface{})
+			delete(disks[0].(map[string]interface{}), "storageTier")
+		} else {
+			delete(spec["bootDisk"].(map[string]interface{}), "storageTier")
+		}
+		result := &unstructured.Unstructured{Object: object}
+		result.SetAPIVersion("osac.openshift.io/v1alpha1")
+		result.SetKind("ComputeInstance")
+		return result
 	}
 
 	It("should allow creation with networkAttachments", func() {
@@ -641,10 +663,38 @@ var _ = Describe("ComputeInstance CEL Validation", func() {
 	})
 
 	Describe("StorageTier validation", func() {
-		It("should accept a ComputeInstance without storageTier", func() {
-			instance := createValidInstance("test-tier-absent")
+		It("should reject a ComputeInstance without bootDisk storageTier", func() {
+			instance := instanceWithoutStorageTier("test-tier-absent", false)
+			err := k8sClient.Create(ctx, instance)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsInvalid(err)).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("storageTier"))
+		})
+
+		It("should reject an empty bootDisk storageTier", func() {
+			instance := createValidInstance("test-tier-empty")
 			instance.Spec.BootDisk.StorageTier = ""
-			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+			err := k8sClient.Create(ctx, instance)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsInvalid(err)).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("storageTier"))
+		})
+
+		It("should reject a ComputeInstance without additionalDisks storageTier", func() {
+			instance := instanceWithoutStorageTier("test-tier-additional-absent", true)
+			err := k8sClient.Create(ctx, instance)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsInvalid(err)).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("storageTier"))
+		})
+
+		It("should reject an empty additionalDisks storageTier", func() {
+			instance := createValidInstance("test-tier-additional-empty")
+			instance.Spec.AdditionalDisks = []osacv1alpha1.DiskSpec{{SizeGiB: 50}}
+			err := k8sClient.Create(ctx, instance)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsInvalid(err)).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("storageTier"))
 		})
 
 		DescribeTable("should accept valid storageTier values",

--- a/tests/e2e/core/osac_cli.py
+++ b/tests/e2e/core/osac_cli.py
@@ -124,8 +124,10 @@ class OsacCLI:
                     raise ValueError(f"additional_disks[{idx}]: 'size_gib' must be a positive integer, got {size!r}")
 
                 storage_tier = disk.get("storage_tier")
-                if storage_tier is None:
-                    raise ValueError(f"additional_disks[{idx}]: 'storage_tier' is required, got None")
+                if not isinstance(storage_tier, str) or not storage_tier.strip():
+                    raise ValueError(
+                        f"additional_disks[{idx}]: 'storage_tier' must be a non-empty string, got {storage_tier!r}"
+                    )
 
                 # Build --additional-disk flag value: size=<GiB>,storage-tier=<name>
                 disk_spec = f"size={size},storage-tier={storage_tier}"

--- a/tests/e2e/vmaas/regression/test_compute_instance_storage_tier.py
+++ b/tests/e2e/vmaas/regression/test_compute_instance_storage_tier.py
@@ -17,9 +17,8 @@ def verify_datavolume_storage_classes(
 ) -> None:
     """Verify that DataVolumes were created with correct StorageClasses.
 
-    NOTE: Commented out in all tests until osac PR #257 (OSAC-3632) merges.
-    AAP currently uses global _requested_storage_tier and ignores per-disk storageTier fields.
-    After PR #257 merges, uncomment the verify_datavolume_storage_classes() calls in tests.
+    The fulfillment service resolves a tier independently for the boot disk and each
+    additional disk; the resulting names determine the DataVolume StorageClasses.
     """
     _ = k8s_hub_client.get_compute_instance_vm_namespace(name=ci_name)
 
@@ -230,16 +229,20 @@ def test_compute_instance_tier_immutability(
             wait_for_deletion(k8s=k8s_hub_client, name=ci_name)
 
 
-@pytest.mark.skip(
-    reason="Requires mandatory storage_tier validation (follow-up osac PR after this test infrastructure lands)"
-)
+@pytest.mark.parametrize("storage_tier", [None, ""])
 def test_compute_instance_boot_disk_tier_required(
-    private_grpc: GRPCClient, vm_template: str, default_subnet: str, default_instance_type: str, default_disk_image: str
+    private_grpc: GRPCClient,
+    vm_template: str,
+    default_subnet: str,
+    default_instance_type: str,
+    default_disk_image: str,
+    storage_tier: str | None,
 ) -> None:
-    """Verify that missing boot disk tier returns INVALID_ARGUMENT.
+    """Verify that absent and empty boot disk tiers return INVALID_ARGUMENT."""
+    boot_disk = {"size_gib": 20}
+    if storage_tier is not None:
+        boot_disk["storage_tier"] = storage_tier
 
-    Skipped until follow-up PR makes storage_tier mandatory.
-    """
     with pytest.raises(subprocess.CalledProcessError) as exc_info:
         private_grpc.call(
             service="osac.private.v1.ComputeInstances/Create",
@@ -249,7 +252,7 @@ def test_compute_instance_boot_disk_tier_required(
                     "spec": {
                         "template": {"name": vm_template},
                         "instance_type": {"name": default_instance_type},
-                        "boot_disk": {"size_gib": 20},  # No storage_tier
+                        "boot_disk": boot_disk,
                         "network_attachments": [{"subnet": {"id": default_subnet}}],
                         "disk_image": {"name": default_disk_image},
                         "run_strategy": "Always",
@@ -262,9 +265,7 @@ def test_compute_instance_boot_disk_tier_required(
     assert "storage_tier is required" in str(exc_info.value.stderr).lower()
 
 
-@pytest.mark.skip(
-    reason="Requires mandatory storage_tier validation (follow-up osac PR after this test infrastructure lands)"
-)
+@pytest.mark.parametrize("storage_tier", [None, ""])
 def test_compute_instance_additional_disk_tier_required(
     private_grpc: GRPCClient,
     vm_template: str,
@@ -272,11 +273,13 @@ def test_compute_instance_additional_disk_tier_required(
     default_storage_tier: str,
     default_instance_type: str,
     default_disk_image: str,
+    storage_tier: str | None,
 ) -> None:
-    """Verify that missing additional disk tier returns INVALID_ARGUMENT.
+    """Verify that absent and empty additional disk tiers return INVALID_ARGUMENT."""
+    additional_disk = {"size_gib": 50}
+    if storage_tier is not None:
+        additional_disk["storage_tier"] = storage_tier
 
-    Skipped until follow-up PR makes storage_tier mandatory.
-    """
     with pytest.raises(subprocess.CalledProcessError) as exc_info:
         private_grpc.call(
             service="osac.private.v1.ComputeInstances/Create",
@@ -288,7 +291,7 @@ def test_compute_instance_additional_disk_tier_required(
                         "instance_type": {"name": default_instance_type},
                         "boot_disk": {"size_gib": 20, "storage_tier": default_storage_tier},
                         "additional_disks": [
-                            {"size_gib": 50}  # No storage_tier
+                            additional_disk,
                         ],
                         "network_attachments": [{"subnet": {"id": default_subnet}}],
                         "disk_image": {"name": default_disk_image},


### PR DESCRIPTION
## Summary

Make storage tiers mandatory for ComputeInstance boot disks and additional disks after CatalogItem and template defaults have been applied.

This implementation also fixes [OSAC-4701](https://issues.redhat.com/browse/OSAC-4701) by rejecting legacy bare-integer additional-disk arguments and explicit additional disks without a storage tier in the CLI.

Jira: [OSAC-1710](https://issues.redhat.com/browse/OSAC-1710)

## Changes

- Require non-empty, non-whitespace storage-tier values in fulfillment-service after default resolution.
- Preserve tier-existence validation, default precedence, persistence safeguards, and disk immutability.
- Enforce required and non-empty `storageTier` fields in the ComputeInstance CRD and regenerate the CRD charts.
- Require `storage-tier=<name>` for every explicit CLI additional disk while retaining boot-disk default resolution.
- Extend fulfillment-service, operator, CLI, and VMaaS E2E coverage for absent, empty, whitespace-only, explicit, defaulted, and multi-tier disks.
- Update documentation and valid test fixtures.

## Testing

- Fulfillment-service utility, server, and CLI tests pass.
- Fulfillment-service build passes.
- osac-operator tests and lint pass.
- Targeted osac-ui tests and checks pass; no UI source changes were required.
- E2E test sources compile successfully.
- Live VMaaS E2E execution remains to be run against a cluster deployed with these branch images.

## Acceptance Criteria

- [x] Storage tiers are required after user, CatalogItem, and template default resolution.
- [x] Missing, empty, and whitespace-only disk tiers are rejected with field-specific errors.
- [x] Existing tier-existence validation and disk immutability are preserved.
- [x] The ComputeInstance CRD enforces required non-empty storage tiers.
- [x] Additional-disk CLI input requires `storage-tier=<name>`.
- [x] Tests, fixtures, and documentation cover the updated contract.
- [ ] Live VMaaS E2E tests run against a deployment containing the branch images.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **API surface:** `DiskSpec.storageTier` is now required for boot and additional disks. It must be non-empty and retain the existing length and naming constraints.
- **Controllers and fulfillment service:** Validation now runs after CatalogItem and template defaults are applied. Missing, empty, or whitespace-only tiers return `InvalidArgument`. Existing default precedence, tier validation, persistence safeguards, and disk immutability remain unchanged.
- **CLI:** Additional disks must use key/value syntax and include a non-empty storage tier. Legacy bare-integer disk arguments are rejected.
- **Deployment:** Regenerated ComputeInstance CRDs and operator CRD charts mark `storageTier` as required with `minLength: 1`.
- **Tests and E2E:** Unit, server, controller, CLI, fixture, and regression coverage now verifies required tiers, default propagation, invalid inputs, and independent boot/additional-disk resolution. Live VMaaS E2E execution remains pending.
- **Documentation:** Catalog Item and VM console examples now show boot-disk storage tiers.

## Backward compatibility

This change is not backward compatible for ComputeInstance requests that omit a storage tier after default resolution. Bare-integer additional-disk CLI arguments are also no longer supported. Existing configurations remain valid when CatalogItem or template defaults provide a valid tier.

## Risk classification

**risk:show** — The change modifies a required API field and rejects previously accepted inputs, but it includes validation across the service, CRD, CLI, fixtures, and tests. It does not change authentication, persistence behavior, or disk immutability. It was close to **risk:ask** because of the backward-incompatible API and CLI validation changes, but the scope is limited to storage-tier requirements and the affected paths have targeted coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->