### PR TITLE
OSAC-4771: Accept hub kubeconfig secret refs

### DIFF
--- a/fulfillment-service/internal/api/osac/private/v1/hub_type.pb.go
+++ b/fulfillment-service/internal/api/osac/private/v1/hub_type.pb.go
@@ -191,7 +191,7 @@ type HubSpec struct {
 	// Reference to a Secret resource containing kubeconfig credentials.
 	//
 	// Mutually exclusive with `kubeconfig`. When set, the system resolves the referenced Secret and reads the
-	// `kubeconfig` data key. The referenced Secret must exist in the same tenant.
+	// `kubeconfig` data key. The referenced Secret must belong to the `shared` tenant.
 	KubeconfigSecret *SecretLocalReference `protobuf:"bytes,5,opt,name=kubeconfig_secret,json=kubeconfigSecret,proto3" json:"kubeconfig_secret,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
@@ -281,7 +281,7 @@ type HubSpec_builder struct {
 	// Reference to a Secret resource containing kubeconfig credentials.
 	//
 	// Mutually exclusive with `kubeconfig`. When set, the system resolves the referenced Secret and reads the
-	// `kubeconfig` data key. The referenced Secret must exist in the same tenant.
+	// `kubeconfig` data key. The referenced Secret must belong to the `shared` tenant.
 	KubeconfigSecret *SecretLocalReference
 }
 

--- a/fulfillment-service/internal/api/osac/private/v1/hub_type_protoopaque.pb.go
+++ b/fulfillment-service/internal/api/osac/private/v1/hub_type_protoopaque.pb.go
@@ -268,7 +268,7 @@ type HubSpec_builder struct {
 	// Reference to a Secret resource containing kubeconfig credentials.
 	//
 	// Mutually exclusive with `kubeconfig`. When set, the system resolves the referenced Secret and reads the
-	// `kubeconfig` data key. The referenced Secret must exist in the same tenant.
+	// `kubeconfig` data key. The referenced Secret must belong to the `shared` tenant.
 	KubeconfigSecret *SecretLocalReference
 }
 

--- a/fulfillment-service/internal/cmd/cli/create/hub/create_hub_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/hub/create_hub_cmd.go
@@ -15,7 +15,6 @@ package hub
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/proto"
@@ -85,10 +84,7 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("namespace name is required")
 	}
 	if c.kubeconfig == "" {
-		return fmt.Errorf("kubeconfig file is required")
-	}
-	if c.namespace == "" {
-		return fmt.Errorf("namespace name is required")
+		return fmt.Errorf("kubeconfig secret name is required")
 	}
 
 	// Create the gRPC connection from the configuration:
@@ -101,20 +97,8 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	// Create the client:
 	client := privatev1.NewHubsClient(conn)
 
-	// Read the kubeconfig file:
-	kubeconfig, err := os.ReadFile(c.kubeconfig)
-	if err != nil {
-		return fmt.Errorf("failed to read kubeconfig file '%s': %w", c.kubeconfig, err)
-	}
-
 	// Prepare the hub:
-	hub := privatev1.Hub_builder{
-		Id: c.id,
-		Spec: privatev1.HubSpec_builder{
-			Kubeconfig: kubeconfig,
-			Namespace:  c.namespace,
-		}.Build(),
-	}.Build()
+	hub := c.hub()
 
 	// Create the hub:
 	response, err := client.Create(ctx, privatev1.HubsCreateRequest_builder{
@@ -131,10 +115,29 @@ func (c *runnerContext) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func (c *runnerContext) hub() *privatev1.Hub {
+	return privatev1.Hub_builder{
+		Id: c.id,
+		Spec: privatev1.HubSpec_builder{
+			KubeconfigSecret: privatev1.SecretLocalReference_builder{
+				Name: c.kubeconfig,
+			}.Build(),
+			Namespace: c.namespace,
+		}.Build(),
+	}.Build()
+}
+
 const shortHelp = `Create a hub`
 
 const longHelp = `
 Create a hub.
+
+Create a Secret containing the kubeconfig, then reference it when creating the hub:
+
+{{ bt 3 }}shell
+{{ binary }} create secret --name hub-kubeconfig --from-file=kubeconfig=/path/to/kubeconfig
+{{ binary }} create hub --id my-hub --kubeconfig hub-kubeconfig --namespace osac
+{{ bt 3 }}
 `
 
 const idFlagHelp = `
@@ -142,8 +145,9 @@ _ID_ - Unique identifier of the hub.
 `
 
 const kubeconfigFlagHelp = `
-_FILE_ - Kubeconfig file containing the details to connect to the Kubernetes
-API.
+_NAME_ - Name of a Secret resource containing the kubeconfig in its
+{{ bt }}kubeconfig{{ bt }} data key. The secret must exist in the same tenant.
+See also {{ bt }}osac create secret{{ bt }}.
 `
 
 const namespaceFlagHelp = `

--- a/fulfillment-service/internal/cmd/cli/create/hub/create_hub_cmd.go
+++ b/fulfillment-service/internal/cmd/cli/create/hub/create_hub_cmd.go
@@ -135,7 +135,7 @@ Create a hub.
 Create a Secret containing the kubeconfig, then reference it when creating the hub:
 
 {{ bt 3 }}shell
-{{ binary }} create secret --name hub-kubeconfig --from-file=kubeconfig=/path/to/kubeconfig
+{{ binary }} --tenant shared create secret --name hub-kubeconfig --from-file=kubeconfig=/path/to/kubeconfig
 {{ binary }} create hub --id my-hub --kubeconfig hub-kubeconfig --namespace osac
 {{ bt 3 }}
 `
@@ -146,7 +146,8 @@ _ID_ - Unique identifier of the hub.
 
 const kubeconfigFlagHelp = `
 _NAME_ - Name of a Secret resource containing the kubeconfig in its
-{{ bt }}kubeconfig{{ bt }} data key. The secret must exist in the same tenant.
+{{ bt }}kubeconfig{{ bt }} data key. The Secret must belong to the
+{{ bt }}shared{{ bt }} tenant and can only be managed by a platform administrator.
 See also {{ bt }}osac create secret{{ bt }}.
 `
 

--- a/fulfillment-service/internal/cmd/cli/create/hub/create_hub_cmd_test.go
+++ b/fulfillment-service/internal/cmd/cli/create/hub/create_hub_cmd_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package hub
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Create hub", func() {
+	It("registers --kubeconfig as a secret name flag", func() {
+		cmd := Cmd()
+		flag := cmd.Flags().Lookup("kubeconfig")
+
+		Expect(flag).NotTo(BeNil())
+		Expect(flag.DefValue).To(BeEmpty())
+		Expect(flag.Usage).To(ContainSubstring("Secret resource"))
+	})
+
+	It("builds a kubeconfig secret reference without inline credentials", func() {
+		runner := &runnerContext{
+			id:         "test-hub",
+			kubeconfig: "hub-kubeconfig",
+			namespace:  "clusters",
+		}
+
+		hub := runner.hub()
+
+		Expect(hub.GetId()).To(Equal("test-hub"))
+		Expect(hub.GetSpec().GetNamespace()).To(Equal("clusters"))
+		Expect(hub.GetSpec().GetKubeconfigSecret().GetName()).To(Equal("hub-kubeconfig"))
+		Expect(hub.GetSpec().GetKubeconfig()).To(BeEmpty())
+	})
+})

--- a/fulfillment-service/internal/cmd/cli/create/hub/create_hub_suite_test.go
+++ b/fulfillment-service/internal/cmd/cli/create/hub/create_hub_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package hub
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCreateHub(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Create Hub Suite")
+}

--- a/fulfillment-service/internal/cmd/service/start/grpcserver/register_servers.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/register_servers.go
@@ -404,7 +404,7 @@ func RegisterResourceServers(ctx context.Context, registrar grpc.ServiceRegistra
 		return nil, fmt.Errorf("failed to create secrets DAO for hub lookup: %w", err)
 	}
 
-	hubLookup := servers.NewHubLookupWithDAO(privateHubsServer, secretsDAO)
+	hubLookup := servers.NewHubLookupWithDAO(privateHubsServer, secretsDAO, deps.SecretStore)
 	hubClientFactory := servers.NewDefaultHubClientFactory(deps.HubScheme)
 	hubClientProvider, err := servers.NewHubClientProvider().
 		SetHubLookup(hubLookup).

--- a/fulfillment-service/internal/servers/hub_client_provider.go
+++ b/fulfillment-service/internal/servers/hub_client_provider.go
@@ -29,6 +29,7 @@ import (
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/controllers"
 	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
+	"github.com/osac-project/osac/fulfillment-service/internal/vault"
 )
 
 //go:generate mockgen -destination=hub_lookup_mock.go -package=servers . HubLookup
@@ -37,15 +38,20 @@ import (
 // hubLookupWithDAO implements HubLookup using a DAO for secret resolution.
 // This avoids circular dependencies between HubClientProvider and SecretsServer.
 type hubLookupWithDAO struct {
-	hubServer  privatev1.HubsServer
-	secretsDAO *dao.GenericDAO[*privatev1.Secret]
+	hubServer   privatev1.HubsServer
+	secretsDAO  *dao.GenericDAO[*privatev1.Secret]
+	secretStore vault.SecretStore
 }
 
 // NewHubLookupWithDAO creates a HubLookup backed by the private Hubs server.
-func NewHubLookupWithDAO(hubServer privatev1.HubsServer, secretsDAO *dao.GenericDAO[*privatev1.Secret]) HubLookup {
+// The secret store is used to hydrate Vault-backed secret data, which isn't persisted in the
+// metadata DAO. This keeps the lookup independent of the Secrets server and avoids a dependency
+// cycle with the hub secret fetcher.
+func NewHubLookupWithDAO(hubServer privatev1.HubsServer, secretsDAO *dao.GenericDAO[*privatev1.Secret], secretStore vault.SecretStore) HubLookup {
 	return &hubLookupWithDAO{
-		hubServer:  hubServer,
-		secretsDAO: secretsDAO,
+		hubServer:   hubServer,
+		secretsDAO:  secretsDAO,
+		secretStore: secretStore,
 	}
 }
 
@@ -72,7 +78,16 @@ func (l *hubLookupWithDAO) getSecret(ctx context.Context, id string) (*privatev1
 	if err != nil {
 		return nil, err
 	}
-	return resp.GetObject(), nil
+	secret := resp.GetObject()
+	if l.secretStore != nil && secret.GetBackend() == privatev1.SecretBackend_SECRET_BACKEND_VAULT {
+		metadata := secret.GetMetadata()
+		data, err := l.secretStore.Fetch(ctx, metadata.GetTenant(), metadata.GetProject(), metadata.GetName())
+		if err != nil {
+			return nil, vault.ToGrpcError(err)
+		}
+		secret.SetData(data)
+	}
+	return secret, nil
 }
 
 // HubClientInfo holds the cached Kubernetes client and associated hub metadata.

--- a/fulfillment-service/internal/servers/hub_client_provider.go
+++ b/fulfillment-service/internal/servers/hub_client_provider.go
@@ -27,6 +27,7 @@ import (
 	clnt "sigs.k8s.io/controller-runtime/pkg/client"
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/osac/fulfillment-service/internal/auth"
 	"github.com/osac-project/osac/fulfillment-service/internal/controllers"
 	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 	"github.com/osac-project/osac/fulfillment-service/internal/vault"
@@ -74,14 +75,21 @@ func (l *hubLookupWithDAO) GetKubeconfig(ctx context.Context, hubID string) (kub
 }
 
 func (l *hubLookupWithDAO) getSecret(ctx context.Context, id string) (*privatev1.Secret, error) {
-	resp, err := l.secretsDAO.Get().SetId(id).Do(ctx)
+	// The caller is already authorized to retrieve the hub-backed Secret. Hub credentials are
+	// platform-scoped shared Secrets, so resolve this implementation detail using shared visibility
+	// rather than the caller's tenant visibility.
+	lookupCtx := auth.ContextWithSubject(ctx, &auth.Subject{
+		User:    auth.SystemTenant,
+		Tenants: auth.SharedTenants,
+	})
+	resp, err := l.secretsDAO.Get().SetId(id).Do(lookupCtx)
 	if err != nil {
 		return nil, err
 	}
 	secret := resp.GetObject()
 	if l.secretStore != nil && secret.GetBackend() == privatev1.SecretBackend_SECRET_BACKEND_VAULT {
 		metadata := secret.GetMetadata()
-		data, err := l.secretStore.Fetch(ctx, metadata.GetTenant(), metadata.GetProject(), metadata.GetName())
+		data, err := l.secretStore.Fetch(lookupCtx, metadata.GetTenant(), metadata.GetProject(), metadata.GetName())
 		if err != nil {
 			return nil, vault.ToGrpcError(err)
 		}

--- a/fulfillment-service/internal/servers/private_hubs_server.go
+++ b/fulfillment-service/internal/servers/private_hubs_server.go
@@ -287,6 +287,10 @@ func (s *PrivateHubsServer) validateKubeconfigSecret(ctx context.Context, spec *
 		s.logger.ErrorContext(ctx, "Failed to resolve kubeconfig_secret reference", "error", err)
 		return grpcstatus.Errorf(grpccodes.Internal, "failed to resolve kubeconfig_secret reference")
 	}
+	if resolved.Tenant != auth.SharedTenant {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"kubeconfig_secret must reference a shared Secret")
+	}
 	resolvedRef := &privatev1.SecretLocalReference{}
 	resolvedRef.SetId(resolved.ID)
 	resolvedRef.SetName(resolved.Name)

--- a/fulfillment-service/internal/servers/private_hubs_server_test.go
+++ b/fulfillment-service/internal/servers/private_hubs_server_test.go
@@ -345,7 +345,7 @@ var _ = Describe("Private hubs server", func() {
 					Id: "tenant-secret-id",
 					Metadata: privatev1.Metadata_builder{
 						Name:   "tenant-secret-name",
-						Tenant: "tenant-a",
+						Tenant: testTenant,
 					}.Build(),
 				}.Build()).Do(ctx)
 				Expect(err).ToNot(HaveOccurred())

--- a/fulfillment-service/internal/servers/private_hubs_server_test.go
+++ b/fulfillment-service/internal/servers/private_hubs_server_test.go
@@ -340,6 +340,34 @@ var _ = Describe("Private hubs server", func() {
 				Expect(ref.GetName()).To(Equal("my-secret-name"))
 			})
 
+			It("Rejects a hub with a tenant-scoped kubeconfig_secret", func() {
+				_, err := secretsDao.Create().SetObject(privatev1.Secret_builder{
+					Id: "tenant-secret-id",
+					Metadata: privatev1.Metadata_builder{
+						Name:   "tenant-secret-name",
+						Tenant: "tenant-a",
+					}.Build(),
+				}.Build()).Do(ctx)
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = server.Create(ctx, privatev1.HubsCreateRequest_builder{
+					Object: privatev1.Hub_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name: fmt.Sprintf("test-%s", uuid.NewString()[:8]),
+						}.Build(),
+						Spec: privatev1.HubSpec_builder{
+							Namespace: "my_ns",
+							KubeconfigSecret: privatev1.SecretLocalReference_builder{
+								Id: "tenant-secret-id",
+							}.Build(),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).To(HaveOccurred())
+				Expect(grpcstatus.Code(err)).To(Equal(grpccodes.InvalidArgument))
+				Expect(grpcstatus.Convert(err).Message()).To(ContainSubstring("shared Secret"))
+			})
+
 			It("Rejects create when kubeconfig and kubeconfig_secret are both set", func() {
 				_, err := server.Create(ctx, privatev1.HubsCreateRequest_builder{
 					Object: privatev1.Hub_builder{

--- a/fulfillment-service/it/it_hub_kubeconfig_secret_test.go
+++ b/fulfillment-service/it/it_hub_kubeconfig_secret_test.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/osac/fulfillment-service/internal/auth"
 	"github.com/osac-project/osac/fulfillment-service/internal/uuid"
 )
 
@@ -53,37 +54,12 @@ var _ = Describe("Hub kubeconfig_secret", Label("secrets", "hub"), func() {
 		ctx           context.Context
 		hubsClient    privatev1.HubsClient
 		secretsClient privatev1.SecretsClient
-		tenantsClient privatev1.TenantsClient
-		tenantName    string
-		tenantID      string
 	)
 
 	BeforeEach(func() {
 		ctx = context.Background()
 		hubsClient = privatev1.NewHubsClient(tool.InternalView().AdminConn())
 		secretsClient = privatev1.NewSecretsClient(tool.InternalView().AdminConn())
-		tenantsClient = privatev1.NewTenantsClient(tool.InternalView().AdminConn())
-
-		// A fresh, SYNCED tenant guarantees a Vault namespace exists so the kubeconfig secret can be
-		// stored. Hubs live in the shared tenant, but the create-time kubeconfig_secret validation
-		// resolves the reference by id/name via the admin-scoped secrets DAO, which is tenant-agnostic
-		// -- so the secret's tenant does not affect these assertions.
-		tenantName = fmt.Sprintf("hub-sec-%s", uuid.New())
-		createResponse, err := tenantsClient.Create(ctx, privatev1.TenantsCreateRequest_builder{
-			Object: privatev1.Tenant_builder{
-				Metadata: privatev1.Metadata_builder{
-					Name: tenantName,
-				}.Build(),
-			}.Build(),
-		}.Build())
-		Expect(err).ToNot(HaveOccurred())
-		tenantID = createResponse.GetObject().GetId()
-		DeferCleanup(func() {
-			_, _ = tenantsClient.Delete(ctx, privatev1.TenantsDeleteRequest_builder{
-				Id: tenantID,
-			}.Build())
-		})
-		waitForTenantSynced(ctx, tenantsClient, tenantID)
 	})
 
 	// createKubeconfigSecret creates a Vault-backed secret carrying a kubeconfig payload and returns
@@ -94,7 +70,7 @@ var _ = Describe("Hub kubeconfig_secret", Label("secrets", "hub"), func() {
 			Object: privatev1.Secret_builder{
 				Metadata: privatev1.Metadata_builder{
 					Name:   name,
-					Tenant: tenantName,
+					Tenant: auth.SharedTenant,
 				}.Build(),
 				Data: data,
 			}.Build(),

--- a/fulfillment-service/it/it_tool.go
+++ b/fulfillment-service/it/it_tool.go
@@ -1337,6 +1337,31 @@ func (t *Tool) createHubNamespace(ctx context.Context) error {
 func (t *Tool) registerHub(ctx context.Context) error {
 	t.logger.DebugContext(ctx, "Registering hub")
 
+	// Create the hubs client:
+	hubsClient := privatev1.NewHubsClient(t.internalView.adminConn)
+
+	// Wait for the API to be ready:
+	var err error
+	for range 30 {
+		_, err = hubsClient.List(ctx, privatev1.HubsListRequest_builder{}.Build())
+		if err == nil {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+	if err != nil {
+		return fmt.Errorf("API not ready after waiting: %w", err)
+	}
+
+	// Keep repeated setup idempotent. The existing registration already has usable credentials.
+	_, err = hubsClient.Get(ctx, privatev1.HubsGetRequest_builder{Id: hubId}.Build())
+	if err == nil {
+		return nil
+	}
+	if grpcstatus.Code(err) != grpccodes.NotFound {
+		return fmt.Errorf("failed to check for existing hub: %w", err)
+	}
+
 	// Prepare the kubeconfig for the hub:
 	hubKcBytes, err := os.ReadFile(t.kcFile)
 	if err != nil {
@@ -1354,19 +1379,22 @@ func (t *Tool) registerHub(ctx context.Context) error {
 		return fmt.Errorf("failed to write hub Kc: %w", err)
 	}
 
-	// Create the hubs client:
-	hubsClient := privatev1.NewHubsClient(t.internalView.adminConn)
-
-	// Wait for the API to be ready:
-	for range 30 {
-		_, err = hubsClient.List(ctx, privatev1.HubsListRequest_builder{}.Build())
-		if err == nil {
-			break
-		}
-		time.Sleep(time.Second)
-	}
+	// Store the kubeconfig in a tenant-scoped Secret. The hub server resolves Secret references
+	// with its admin-scoped DAO, so the credential can live in an existing synchronized test tenant.
+	secretsClient := privatev1.NewSecretsClient(t.internalView.adminConn)
+	secretResponse, err := secretsClient.Create(ctx, privatev1.SecretsCreateRequest_builder{
+		Object: privatev1.Secret_builder{
+			Metadata: privatev1.Metadata_builder{
+				Name:   fmt.Sprintf("local-hub-kubeconfig-%s", uuid.New()[24:32]),
+				Tenant: usersGroup,
+			}.Build(),
+			Data: map[string][]byte{
+				"kubeconfig": hubKcBytes,
+			},
+		}.Build(),
+	}.Build())
 	if err != nil {
-		return fmt.Errorf("API not ready after waiting: %w", err)
+		return fmt.Errorf("failed to create hub kubeconfig secret: %w", err)
 	}
 
 	// Create the hub:
@@ -1377,16 +1405,14 @@ func (t *Tool) registerHub(ctx context.Context) error {
 				Name: hubId,
 			}.Build(),
 			Spec: privatev1.HubSpec_builder{
-				Kubeconfig: hubKcBytes,
-				Namespace:  hubNamespace,
+				KubeconfigSecret: privatev1.SecretLocalReference_builder{
+					Id: secretResponse.GetObject().GetId(),
+				}.Build(),
+				Namespace: hubNamespace,
 			}.Build(),
 		}.Build(),
 	}.Build())
 	if err != nil {
-		status, ok := grpcstatus.FromError(err)
-		if ok && status.Code() == grpccodes.AlreadyExists {
-			return nil
-		}
 		return fmt.Errorf("failed to create hub: %w", err)
 	}
 	return nil

--- a/fulfillment-service/it/it_tool.go
+++ b/fulfillment-service/it/it_tool.go
@@ -1347,7 +1347,11 @@ func (t *Tool) registerHub(ctx context.Context) error {
 		if err == nil {
 			break
 		}
-		time.Sleep(time.Second)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Second):
+		}
 	}
 	if err != nil {
 		return fmt.Errorf("API not ready after waiting: %w", err)

--- a/fulfillment-service/it/it_tool.go
+++ b/fulfillment-service/it/it_tool.go
@@ -1383,14 +1383,14 @@ func (t *Tool) registerHub(ctx context.Context) error {
 		return fmt.Errorf("failed to write hub Kc: %w", err)
 	}
 
-	// Store the kubeconfig in a tenant-scoped Secret. The hub server resolves Secret references
-	// with its admin-scoped DAO, so the credential can live in an existing synchronized test tenant.
+	// Hub credentials are platform-scoped, shared Secrets. They are never exposed to tenant users;
+	// the hub client provider resolves them with its internal shared visibility.
 	secretsClient := privatev1.NewSecretsClient(t.internalView.adminConn)
 	secretResponse, err := secretsClient.Create(ctx, privatev1.SecretsCreateRequest_builder{
 		Object: privatev1.Secret_builder{
 			Metadata: privatev1.Metadata_builder{
 				Name:   fmt.Sprintf("local-hub-kubeconfig-%s", uuid.New()[24:32]),
-				Tenant: usersGroup,
+				Tenant: auth.SharedTenant,
 			}.Build(),
 			Data: map[string][]byte{
 				"kubeconfig": hubKcBytes,

--- a/fulfillment-service/proto/private/osac/private/v1/hub_type.proto
+++ b/fulfillment-service/proto/private/osac/private/v1/hub_type.proto
@@ -49,7 +49,7 @@ message HubSpec {
   // Reference to a Secret resource containing kubeconfig credentials.
   //
   // Mutually exclusive with `kubeconfig`. When set, the system resolves the referenced Secret and reads the
-  // `kubeconfig` data key. The referenced Secret must exist in the same tenant.
+  // `kubeconfig` data key. The referenced Secret must belong to the `shared` tenant.
   SecretLocalReference kubeconfig_secret = 5;
 }
 

--- a/osac-installer/OSAC-CLI-HOWTO.md
+++ b/osac-installer/OSAC-CLI-HOWTO.md
@@ -613,8 +613,8 @@ EOF
 
 **Step 2: Register the Hub**
 ```bash
-# Store the kubeconfig in an OSAC Secret
-./osac create secret \
+# Store the kubeconfig in a platform-managed shared OSAC Secret
+./osac --tenant shared create secret \
   --name production-hub-kubeconfig \
   --from-file=kubeconfig=/tmp/hub-kubeconfig.yaml
 
@@ -679,12 +679,12 @@ EOF
 
 **Scenario: Multiple Environment Hubs**
 ```bash
-# Store each hub kubeconfig in its own OSAC Secret
-./osac create secret --name dev-hub-kubeconfig \
+# Store each hub kubeconfig in its own shared OSAC Secret
+./osac --tenant shared create secret --name dev-hub-kubeconfig \
   --from-file=kubeconfig=/tmp/dev-hub-kubeconfig.yaml
-./osac create secret --name staging-hub-kubeconfig \
+./osac --tenant shared create secret --name staging-hub-kubeconfig \
   --from-file=kubeconfig=/tmp/staging-hub-kubeconfig.yaml
-./osac create secret --name prod-hub-kubeconfig \
+./osac --tenant shared create secret --name prod-hub-kubeconfig \
   --from-file=kubeconfig=/tmp/prod-hub-kubeconfig.yaml
 
 # Development hub
@@ -1581,7 +1581,7 @@ oc exec deployment/fulfillment-service -n fulfillment-system -c server -- lsof -
 **Hub Management:**
 ```bash
 # Store the kubeconfig before creating the hub
-./osac create secret --name KUBECONFIG_SECRET \
+./osac --tenant shared create secret --name KUBECONFIG_SECRET \
   --from-file=kubeconfig=KUBECONFIG_FILE
 
 # Create hub

--- a/osac-installer/OSAC-CLI-HOWTO.md
+++ b/osac-installer/OSAC-CLI-HOWTO.md
@@ -613,10 +613,15 @@ EOF
 
 **Step 2: Register the Hub**
 ```bash
+# Store the kubeconfig in an OSAC Secret
+./osac create secret \
+  --name production-hub-kubeconfig \
+  --from-file=kubeconfig=/tmp/hub-kubeconfig.yaml
+
 # Register hub with fulfillment service
 ./osac create hub \
   --id production-hub-01 \
-  --kubeconfig /tmp/hub-kubeconfig.yaml \
+  --kubeconfig production-hub-kubeconfig \
   --namespace osac
 
 # Verify hub registration
@@ -657,11 +662,8 @@ EOF
 
 **Update Hub Configuration:**
 ```bash
-# Update hub kubeconfig (if token expires)
-./osac edit hub production-hub-01 --kubeconfig /tmp/new-hub-kubeconfig.yaml
-
-# Update hub namespace
-./osac edit hub production-hub-01 --namespace new-namespace
+# Edit the hub, then update spec.kubeconfig_secret.name or spec.namespace
+./osac edit hub production-hub-01
 ```
 
 **Remove Hub:**
@@ -677,22 +679,30 @@ EOF
 
 **Scenario: Multiple Environment Hubs**
 ```bash
+# Store each hub kubeconfig in its own OSAC Secret
+./osac create secret --name dev-hub-kubeconfig \
+  --from-file=kubeconfig=/tmp/dev-hub-kubeconfig.yaml
+./osac create secret --name staging-hub-kubeconfig \
+  --from-file=kubeconfig=/tmp/staging-hub-kubeconfig.yaml
+./osac create secret --name prod-hub-kubeconfig \
+  --from-file=kubeconfig=/tmp/prod-hub-kubeconfig.yaml
+
 # Development hub
 ./osac create hub \
   --id dev-hub \
-  --kubeconfig /tmp/dev-hub-kubeconfig.yaml \
+  --kubeconfig dev-hub-kubeconfig \
   --namespace osac
 
 # Staging hub
 ./osac create hub \
   --id staging-hub \
-  --kubeconfig /tmp/staging-hub-kubeconfig.yaml \
+  --kubeconfig staging-hub-kubeconfig \
   --namespace osac
 
 # Production hub
 ./osac create hub \
   --id prod-hub \
-  --kubeconfig /tmp/prod-hub-kubeconfig.yaml \
+  --kubeconfig prod-hub-kubeconfig \
   --namespace osac
 
 # List all registered hubs
@@ -1570,8 +1580,12 @@ oc exec deployment/fulfillment-service -n fulfillment-system -c server -- lsof -
 
 **Hub Management:**
 ```bash
+# Store the kubeconfig before creating the hub
+./osac create secret --name KUBECONFIG_SECRET \
+  --from-file=kubeconfig=KUBECONFIG_FILE
+
 # Create hub
-./osac create hub --id HUB_ID --kubeconfig KUBECONFIG_FILE --namespace NAMESPACE
+./osac create hub --id HUB_ID --kubeconfig KUBECONFIG_SECRET --namespace NAMESPACE
 
 # List hubs
 ./osac get hubs [--output table|json|yaml] [--filter KEY=VALUE]
@@ -1582,8 +1596,8 @@ oc exec deployment/fulfillment-service -n fulfillment-system -c server -- lsof -
 # Describe hub (detailed info)
 ./osac describe hub HUB_ID
 
-# Update hub configuration
-./osac edit hub HUB_ID [--kubeconfig KUBECONFIG_FILE] [--namespace NAMESPACE]
+# Update hub configuration interactively
+./osac edit hub HUB_ID
 
 # Delete hub
 ./osac delete hub HUB_ID [--force]

--- a/osac-installer/README.md
+++ b/osac-installer/README.md
@@ -290,9 +290,14 @@ for a hub.
 # Generate the kubeconfig
 $ ./scripts/create-hub-access-kubeconfig.sh
 
+# Store the kubeconfig in an OSAC Secret
+$ osac create secret \
+    --name hub-kubeconfig \
+    --from-file=kubeconfig=kubeconfig.hub-access
+
 # Register the Hub
 $ osac create hub \
-    --kubeconfig=kubeconfig.hub-access \
+    --kubeconfig=hub-kubeconfig \
     --id <hub-name> \
     --namespace <project-name>
 ```

--- a/osac-installer/README.md
+++ b/osac-installer/README.md
@@ -290,8 +290,8 @@ for a hub.
 # Generate the kubeconfig
 $ ./scripts/create-hub-access-kubeconfig.sh
 
-# Store the kubeconfig in an OSAC Secret
-$ osac create secret \
+# Store the kubeconfig in a platform-managed shared OSAC Secret
+$ osac --tenant shared create secret \
     --name hub-kubeconfig \
     --from-file=kubeconfig=kubeconfig.hub-access
 

--- a/osac-metering/metering-service/internal/api/osac/private/v1/hub_type.pb.go
+++ b/osac-metering/metering-service/internal/api/osac/private/v1/hub_type.pb.go
@@ -121,7 +121,7 @@ type HubSpec struct {
 	// Reference to a Secret resource containing kubeconfig credentials.
 	//
 	// Mutually exclusive with `kubeconfig`. When set, the system resolves the referenced Secret and reads the
-	// `kubeconfig` data key. The referenced Secret must exist in the same tenant.
+	// `kubeconfig` data key. The referenced Secret must belong to the `shared` tenant.
 	KubeconfigSecret *SecretLocalReference `protobuf:"bytes,5,opt,name=kubeconfig_secret,json=kubeconfigSecret,proto3" json:"kubeconfig_secret,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache

--- a/osac-operator/internal/api/osac/private/v1/hub_type.pb.go
+++ b/osac-operator/internal/api/osac/private/v1/hub_type.pb.go
@@ -191,7 +191,7 @@ type HubSpec struct {
 	// Reference to a Secret resource containing kubeconfig credentials.
 	//
 	// Mutually exclusive with `kubeconfig`. When set, the system resolves the referenced Secret and reads the
-	// `kubeconfig` data key. The referenced Secret must exist in the same tenant.
+	// `kubeconfig` data key. The referenced Secret must belong to the `shared` tenant.
 	KubeconfigSecret *SecretLocalReference `protobuf:"bytes,5,opt,name=kubeconfig_secret,json=kubeconfigSecret,proto3" json:"kubeconfig_secret,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
@@ -281,7 +281,7 @@ type HubSpec_builder struct {
 	// Reference to a Secret resource containing kubeconfig credentials.
 	//
 	// Mutually exclusive with `kubeconfig`. When set, the system resolves the referenced Secret and reads the
-	// `kubeconfig` data key. The referenced Secret must exist in the same tenant.
+	// `kubeconfig` data key. The referenced Secret must belong to the `shared` tenant.
 	KubeconfigSecret *SecretLocalReference
 }
 

--- a/osac-operator/internal/api/osac/private/v1/hub_type_protoopaque.pb.go
+++ b/osac-operator/internal/api/osac/private/v1/hub_type_protoopaque.pb.go
@@ -268,7 +268,7 @@ type HubSpec_builder struct {
 	// Reference to a Secret resource containing kubeconfig credentials.
 	//
 	// Mutually exclusive with `kubeconfig`. When set, the system resolves the referenced Secret and reads the
-	// `kubeconfig` data key. The referenced Secret must exist in the same tenant.
+	// `kubeconfig` data key. The referenced Secret must belong to the `shared` tenant.
 	KubeconfigSecret *SecretLocalReference
 }
 

--- a/tests/e2e/core/osac_cli.py
+++ b/tests/e2e/core/osac_cli.py
@@ -63,8 +63,11 @@ class OsacCLI:
         assert match is not None, f"Failed to parse UUID from CLI output: {stdout}"
         return match.group(1)
 
-    def create_hub(self, *, hub_id: str, kubeconfig: str) -> None:
-        self._run("create", "hub", "--id", hub_id, "--kubeconfig", kubeconfig, "--namespace", self.namespace)
+    def create_hub(self, *, hub_id: str, kubeconfig_secret: str) -> None:
+        self._run("create", "hub", "--id", hub_id, "--kubeconfig", kubeconfig_secret, "--namespace", self.namespace)
+
+    def delete_hub(self, *, hub_id: str) -> None:
+        self._run("delete", "hub", hub_id)
 
     def create_compute_instance(
         self,
@@ -236,6 +239,9 @@ class OsacCLI:
         for key, path in from_files.items():
             args.extend(["--from-file", f"{key}={path}"])
         self._run(*args)
+
+    def delete_secret(self, *, name: str) -> None:
+        self._run("delete", "secret", name)
 
     def get(self, resource: str, *, output: str | None = None) -> str:
         args: list[str] = ["get", resource]

--- a/tests/e2e/vmaas/conftest.py
+++ b/tests/e2e/vmaas/conftest.py
@@ -31,8 +31,12 @@ DEFAULT_DISK_IMAGE_SOURCE_REF: str = "quay.io/containerdisks/fedora:41"
 
 
 @pytest.fixture(scope="session")
-def k8s_virt_client(namespace: str) -> K8sClient:
-    vm_kubeconfig: str = os.environ["OSAC_VM_KUBECONFIG"]
+def vm_kubeconfig() -> str:
+    return os.environ["OSAC_VM_KUBECONFIG"]
+
+
+@pytest.fixture(scope="session")
+def k8s_virt_client(namespace: str, vm_kubeconfig: str) -> K8sClient:
     return K8sClient(namespace=namespace, kubeconfig=vm_kubeconfig)
 
 


### PR DESCRIPTION
Change the CLI and documentation to accept Secret references for hub kubeconfig objects rather than inline credentials.

Hub registrations and credentials are platform-managed. The referenced kubeconfig Secret must belong to the `shared` tenant; the runtime lookup therefore uses shared-tenant visibility rather than universal tenant visibility.

Usage:

```sh
osac --tenant shared create secret --name my-hub-kubeconfig --from-file=kubeconfig=/path/to/kubeconfig
osac create hub --id my-hub --kubeconfig my-hub-kubeconfig --namespace osac
```

Existing workflows that pass a local kubeconfig file directly to `osac create hub --kubeconfig` must first store it as a shared OSAC Secret and pass the Secret name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **API surface:** `create hub` now accepts a shared-tenant Secret name through `--kubeconfig`.
- **Security:** Tenant-scoped kubeconfig Secrets are rejected. Hub lookup resolves Secret references through the configured Secret store.
- **Service integration:** Hub registration stores kubeconfig data in the shared tenant. It waits for API readiness and handles existing hubs, lookup errors, and cancellation.
- **Tests:** Added unit, integration, and E2E coverage for Secret-based hub creation, shared-tenant validation, hub cleanup, and VM kubeconfig fixtures.
- **Documentation:** Updated hub registration, multi-hub setup, hub updates, and Secret creation instructions.
- **Unaffected areas:** No controller, database, deployment, or authentication changes are included.
- **Backward compatibility:** Workflows that pass local kubeconfig files must migrate to shared-tenant Secret references. Hub update workflows must edit `spec.kubeconfig_secret.name` or `spec.namespace`.

## Risk classification

**risk:show** — The change modifies user-facing CLI behavior, Secret validation, service integration, integration tests, E2E helpers, and documentation. It does not qualify for **risk:ship** because existing local-file workflows are not backward compatible and Secret resolution behavior changes. It does not qualify for **risk:ask** because it introduces no controller, database, deployment, or authentication changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->