### PR TITLE
NO-ISSUE: Fix is-not-none bug in vendored netris collection

### DIFF
--- a/osac-aap/collections/ansible_collections/netris/controller/roles/acl/tasks/create.yaml
+++ b/osac-aap/collections/ansible_collections/netris/controller/roles/acl/tasks/create.yaml
@@ -45,14 +45,14 @@
 
 - name: Find ACL rule by name
   ansible.builtin.set_fact:
-    _existing_acl: "{{ (_acl_list_resp.json.data | default([])) | selectattr('name', 'equalto', acl_name) | list | first | default(none) }}"
+    _existing_acl_list: "{{ (_acl_list_resp.json.data | default([])) | selectattr('name', 'equalto', acl_name) | list }}"
   when: _acl_list_resp.json is mapping
 
 - name: Set ACL facts from existing rule (skip creation)
   ansible.builtin.set_fact:
-    acl_id: "{{ _existing_acl.id }}"
+    acl_id: "{{ _existing_acl_list[0].id }}"
     acl_already_existed: true
-  when: _existing_acl is defined and _existing_acl is not none
+  when: _existing_acl_list | default([]) | length > 0
 
 - name: Create ACL rule
   ansible.builtin.uri:
@@ -68,7 +68,7 @@
     timeout: "{{ netris_timeout | default(30) }}"
     validate_certs: "{{ netris_validate_certs | default(true) }}"
   register: _acl_create_resp
-  when: _existing_acl is not defined or _existing_acl is none
+  when: _existing_acl_list | default([]) | length == 0
   no_log: true
 
 - name: Display ACL creation error
@@ -86,7 +86,7 @@
     acl_id: "{{ _acl_create_resp.json.data.id | default(_acl_create_resp.json.data) }}"
     acl_already_existed: false
   when:
-    - _existing_acl is not defined or _existing_acl is none
+    - _existing_acl_list | default([]) | length == 0
     - _acl_create_resp is not skipped
     - _acl_create_resp is changed or (_acl_create_resp.status | default(0)) in [200, 201]
     - _acl_create_resp.json is mapping

--- a/osac-aap/collections/ansible_collections/netris/controller/roles/acl/tasks/delete.yaml
+++ b/osac-aap/collections/ansible_collections/netris/controller/roles/acl/tasks/delete.yaml
@@ -34,7 +34,7 @@
     body:
       id:
         - "{{ _existing_acl.id }}"
-    status_code: [200, 204]
+    status_code: [200, 204, 404]
     timeout: "{{ netris_timeout | default(30) }}"
     validate_certs: "{{ netris_validate_certs | default(true) }}"
   no_log: true

--- a/osac-aap/collections/ansible_collections/netris/controller/roles/ipam/tasks/delete_allocation.yaml
+++ b/osac-aap/collections/ansible_collections/netris/controller/roles/ipam/tasks/delete_allocation.yaml
@@ -32,7 +32,7 @@
   when: _ipam_tree_resp.json is defined and _ipam_tree_resp.json is mapping
 
 - name: Delete IPAM allocation
-  when: _existing_ipam_alloc is defined and _existing_ipam_alloc is not none
+  when: _existing_ipam_alloc is defined and _existing_ipam_alloc is mapping
   ansible.builtin.uri:
     url: "{{ netris_controller_url }}/api/v2/ipam/allocation/{{ _existing_ipam_alloc.id }}"
     method: DELETE

--- a/osac-aap/collections/ansible_collections/netris/controller/roles/ipam/tasks/delete_subnet.yaml
+++ b/osac-aap/collections/ansible_collections/netris/controller/roles/ipam/tasks/delete_subnet.yaml
@@ -25,7 +25,7 @@
          | list | first | default(none) }}
 
 - name: Delete IPAM subnet
-  when: _existing_ipam_subnet is not none
+  when: _existing_ipam_subnet is defined and _existing_ipam_subnet is mapping
   ansible.builtin.uri:
     url: "{{ netris_controller_url }}/api/v2/ipam/subnet/{{ _existing_ipam_subnet.id }}"
     method: DELETE

--- a/osac-aap/collections/ansible_collections/netris/controller/roles/nat/tasks/delete.yaml
+++ b/osac-aap/collections/ansible_collections/netris/controller/roles/nat/tasks/delete.yaml
@@ -10,6 +10,7 @@
     method: GET
     headers:
       Cookie: "connect.sid={{ netris_session_cookie }}"
+      Cache-Control: "no-cache"
     return_content: true
     status_code: 200
     validate_certs: "{{ netris_validate_certs | default(true) }}"
@@ -22,12 +23,12 @@
   when: _nat_list_resp.json is mapping
 
 - name: Delete NAT rule
-  when: _existing_nat is defined and _existing_nat is not none
+  when: _existing_nat is defined and _existing_nat is mapping
   ansible.builtin.uri:
     url: "{{ netris_controller_url }}/api/v2/nat/{{ _existing_nat.id }}"
     method: DELETE
     headers:
       Cookie: "connect.sid={{ netris_session_cookie }}"
-    status_code: [200, 204]
+    status_code: [200, 204, 404]
     validate_certs: "{{ netris_validate_certs | default(true) }}"
   no_log: true


### PR DESCRIPTION
## Summary

- Fix Jinja2 `is not none` test in vendored `netris.controller` collection roles — the Netris API returns the string `"None"` on empty results, which passes `is not none` and causes tasks to act on non-existent resources
- Replace with `is mapping` checks (or list-length patterns for ACL) across 5 files in 3 roles (acl, ipam, nat)
- Add `404` to accepted DELETE status codes for idempotent deletes
- Add `Cache-Control: no-cache` header on NAT list GET to avoid stale cached responses

## Roles fixed

| Role | File | Fix |
|------|------|-----|
| `acl` | `create.yaml` | `_existing_acl` → `_existing_acl_list`, list-length pattern |
| `acl` | `delete.yaml` | Accept 404 on DELETE |
| `ipam` | `delete_allocation.yaml` | `is not none` → `is mapping` |
| `ipam` | `delete_subnet.yaml` | `is not none` → `is defined and is mapping` |
| `nat` | `delete.yaml` | `is not none` → `is mapping`, accept 404, add Cache-Control |

## Test plan

- [x] Fixes validated in osac-test-infra E2E runs (PR osac-project/osac-test-infra#411)
- [ ] Verify ansible-lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

- **Controllers/API:** Fixed empty-result handling in Netris ACL, IPAM, and NAT roles.
- **Idempotency:** ACL and NAT DELETE requests now accept HTTP 404 responses.
- **NAT API requests:** Added `Cache-Control: no-cache` to NAT list requests.
- **CI and tests:** Added configurable BMI RUNNING retries. Netris networking regression tests use 240 retries. The default remains 120.
- **Validation:** E2E validation passed. Ansible-lint verification remains pending.

## Compatibility

No public API, authentication, database, deployment, or schema changes were made. The changes prevent actions on non-existent resources and support repeated deletes. No backward-compatibility impact is expected.

## Risk classification

**risk:ship** — The changes are narrow, defensive, and covered by E2E validation. They do not modify public interfaces, authentication, schemas, or deployment behavior.

The PR was close to **risk:show** because it changes controller execution and API request handling. It does not qualify because the changes reduce incorrect actions on empty API results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->