### PR TITLE
OSAC-1710: Pass storage tier in instance-type e2e

### DIFF
--- a/tests/e2e/vmaas/regression/test_compute_instance_instance_type.py
+++ b/tests/e2e/vmaas/regression/test_compute_instance_instance_type.py
@@ -25,6 +25,9 @@ def _build_create_ci_args(
     args = [cli.binary, "--config", cli.config_dir, "create", "computeinstance"]
     if ci_name is not None:
         args += ["--name", ci_name]
+    storage_tier = cli.default_storage_tier
+    if not storage_tier:
+        raise ValueError("cli.default_storage_tier must be set")
     args += [
         "--template",
         vm_template,
@@ -36,6 +39,8 @@ def _build_create_ci_args(
         "20",
         "--disk-image",
         disk_image,
+        "--boot-disk-storage-tier",
+        storage_tier,
         "--run-strategy",
         "Always",
     ]


### PR DESCRIPTION
## Summary
- Follow-up to #740: `_build_create_ci_args` still created ComputeInstances without `--boot-disk-storage-tier`
- That broke `test_compute_instance_deprecated_warning` and `test_compute_instance_obsolete_instance_type` (`InvalidArgument: boot_disk.storage_tier is required`)
- Helper now uses `cli.default_storage_tier` (already wired by the VMaaS session fixture)

## Test plan
- [ ] Instance-type regression creates include `--boot-disk-storage-tier`
- [ ] VMaaS e2e no longer fails those two tests on merge-queue overlays (e.g. osac-test-infra#472)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Tests
- Updated `_build_create_ci_args` in the ComputeInstance instance-type end-to-end tests.
- The helper now validates `cli.default_storage_tier`.
- The helper adds `--boot-disk-storage-tier` to the create-instance arguments.
- This supports tests that require `boot_disk.storage_tier`, including deprecated and obsolete instance-type warning tests.

### Backward compatibility
- No production API or public entity changes.
- Test callers must provide `cli.default_storage_tier`.
- Missing configuration now raises `ValueError`.

### Risk classification
- **risk:ship** — The change is limited to test argument construction. It has a small, localized scope and does not affect production behavior, APIs, databases, authentication, or deployment.
- It does not qualify for **risk:show** because it does not change user-visible runtime behavior.
- It does not qualify for **risk:ask** because it does not introduce production or security risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->