### PR TITLE
OSAC-4911: move bundledVault config to instance.yaml for CI profiles

### DIFF
--- a/osac-installer/values/bmaas-ci/infra.yaml
+++ b/osac-installer/values/bmaas-ci/infra.yaml
@@ -34,10 +34,3 @@ bundledPostgres:
   database:
     name: service
     user: service
-
-# --- Bundled OpenBao ---
-# Single-pod ephemeral Vault-compatible secret store for testing. Dev mode --
-# data is lost on restart. Not for production.
-bundledVault:
-  enabled: true
-  devRootToken: "dev-root-token"

--- a/osac-installer/values/bmaas-ci/instance.yaml
+++ b/osac-installer/values/bmaas-ci/instance.yaml
@@ -183,3 +183,10 @@ lvms:
 # Uses fsync=off — data is lost on restart. Not for production.
 bundledPostgres:
   enabled: true
+
+# --- Bundled OpenBao ---
+# Single-pod ephemeral Vault-compatible secret store for testing. Dev mode --
+# data is lost on restart. Not for production.
+bundledVault:
+  enabled: true
+  devRootToken: "dev-root-token"

--- a/osac-installer/values/caas-ci/infra.yaml
+++ b/osac-installer/values/caas-ci/infra.yaml
@@ -40,10 +40,3 @@ bundledPostgres:
   enabled: true
   database:
     name: service
-
-# --- Bundled OpenBao ---
-# Single-pod ephemeral Vault-compatible secret store for testing. Dev mode --
-# data is lost on restart. Not for production.
-bundledVault:
-  enabled: true
-  devRootToken: "dev-root-token"

--- a/osac-installer/values/caas-ci/instance.yaml
+++ b/osac-installer/values/caas-ci/instance.yaml
@@ -204,3 +204,10 @@ metering:
 # --- LVMS StorageBackend registration ---
 lvms:
   enabled: true
+
+# --- Bundled OpenBao ---
+# Single-pod ephemeral Vault-compatible secret store for testing. Dev mode --
+# data is lost on restart. Not for production.
+bundledVault:
+  enabled: true
+  devRootToken: "dev-root-token"

--- a/osac-installer/values/full-ci/infra.yaml
+++ b/osac-installer/values/full-ci/infra.yaml
@@ -37,10 +37,3 @@ bundledPostgres:
   database:
     name: service
     user: service
-
-# --- Bundled OpenBao ---
-# Single-pod ephemeral Vault-compatible secret store for testing. Dev mode --
-# data is lost on restart. Not for production.
-bundledVault:
-  enabled: true
-  devRootToken: "dev-root-token"

--- a/osac-installer/values/full-ci/instance.yaml
+++ b/osac-installer/values/full-ci/instance.yaml
@@ -195,3 +195,10 @@ metering:
           param: sslkey
         - key: ca.crt
           param: sslrootcert
+
+# --- Bundled OpenBao ---
+# Single-pod ephemeral Vault-compatible secret store for testing. Dev mode --
+# data is lost on restart. Not for production.
+bundledVault:
+  enabled: true
+  devRootToken: "dev-root-token"

--- a/osac-installer/values/vmaas-ci/infra.yaml
+++ b/osac-installer/values/vmaas-ci/infra.yaml
@@ -36,10 +36,3 @@ bundledPostgres:
   database:
     name: service
     user: service
-
-# --- Bundled OpenBao ---
-# Single-pod ephemeral Vault-compatible secret store for testing. Dev mode --
-# data is lost on restart. Not for production.
-bundledVault:
-  enabled: true
-  devRootToken: "dev-root-token"

--- a/osac-installer/values/vmaas-ci/instance.yaml
+++ b/osac-installer/values/vmaas-ci/instance.yaml
@@ -227,3 +227,10 @@ networkClass:
   fabricManager: ""
   k8sManager: "k8s_only"
   isDefault: true
+
+# --- Bundled OpenBao ---
+# Single-pod ephemeral Vault-compatible secret store for testing. Dev mode --
+# data is lost on restart. Not for production.
+bundledVault:
+  enabled: true
+  devRootToken: "dev-root-token"


### PR DESCRIPTION
## Summary

- `bundledVault` (OpenBao) config was set in each CI profile's `infra.yaml`, which feeds the `osac-infra` chart (Phase 2) — a chart that has no `bundledVault` template at all, so the value was silently ignored.
- The actual OpenBao manifests live in `charts/osac/templates/bundled-openbao.yaml` (Phase 3, the `osac` chart), fed by `instance.yaml`. Since `charts/osac/values.yaml` defaults `bundledVault.enabled` to `false` and no override existed in `instance.yaml`, OpenBao was never deployed for vmaas-ci, bmaas-ci, caas-ci, or full-ci — breaking tenant creation (fulfillment-service couldn't reach the vault at `https://openbao.osac.svc.cluster.local:8200`).
- Fix: moved the `bundledVault: {enabled: true, devRootToken: "dev-root-token"}` block (with its comment) from each profile's `infra.yaml` to its `instance.yaml`, matching the pattern already used in `values/dev/kind-instance.yaml`.

## Test plan

- [x] `helm template osac-deps charts/osac-deps -f infra.yaml` and `helm template osac-infra charts/osac-infra -f infra.yaml` still render cleanly for all 4 profiles after removing the dead `bundledVault` value
- [x] `helm template osac charts/osac -f instance.yaml` (with `service.externalHostname`/`internalHostname` set, matching what `make install-osac` does at runtime) now renders the `openbao` Deployment and Service for vmaas-ci, bmaas-ci, caas-ci, and full-ci — confirmed 0 openbao manifests pre-fix, 2 (Deployment + Service) post-fix, for each profile
- [x] `yamllint --strict .` via `pre-commit run --all-files` passes; standalone `yamllint --strict .` shows only pre-existing failures in Helm template files (unchanged before/after this diff, verified via `git stash` diff)
- [x] `pre-commit run --all-files` passes (yamllint, golangci-lint, buf-lint, secret detection, etc.)
- [x] `make helm-lint`/`make helm-validate` fail with a pre-existing, unrelated schema error (`service.externalHostname`/`internalHostname` empty in default `values.yaml`) present on `main` before this change too — confirmed via `git stash` comparison
- [x] Fix independently validated on a real running dev cluster: manually applying the same `instance.yaml` change and re-running `make install-osac` successfully deployed OpenBao

Fixes: https://redhat.atlassian.net/browse/OSAC-4911

Assisted-by: Claude Code <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **Deployment:** Moved `bundledVault` from `infra.yaml` to `instance.yaml` for the `vmaas-ci`, `bmaas-ci`, `caas-ci`, and `full-ci` profiles.
- **OpenBao:** Preserved the enabled, ephemeral, single-pod development configuration and development root token.
- **CI and tenant creation:** Allows the `osac` chart to deploy OpenBao before tenant creation. This prevents failures caused by unavailable vault connectivity.
- **Database:** The bundled PostgreSQL configuration remains unchanged.
- **API, controllers, auth, tests, and documentation:** No changes.

### Backward compatibility

The change affects configuration placement only. It preserves the bundled OpenBao behavior for the affected CI profiles. The development store remains ephemeral and is not production-ready. Data is lost when the pod restarts.

Validation passed for Helm template rendering, pre-commit checks, and a development-cluster deployment. Reported Helm schema failures are pre-existing and unrelated.

## Risk classification

**risk:ship** — The change is limited to CI deployment values, preserves existing OpenBao settings, and passed rendering and development-cluster validation. It does not change application APIs, controllers, production data handling, or authentication behavior.

The change does not qualify for **risk:show** because it does not introduce a user-facing product or production behavior change. It does not qualify for **risk:ask** because the configuration remains limited to ephemeral CI environments and has validation evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->