### PR TITLE
OSAC-4912: fix bundled OpenBao Deployment SCC rejection

### DIFF
--- a/osac-installer/charts/osac/templates/bundled-openbao.yaml
+++ b/osac-installer/charts/osac/templates/bundled-openbao.yaml
@@ -170,9 +170,6 @@ spec:
       automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
-        runAsUser: 100
-        runAsGroup: 1000
-        fsGroup: 1000
       volumes:
       - name: server-cert
         secret:


### PR DESCRIPTION
## Summary

- The bundled OpenBao `Deployment` in the `osac` Helm chart
  (`osac-installer/charts/osac/templates/bundled-openbao.yaml`) hardcoded
  pod-level `securityContext.runAsUser: 100`, `runAsGroup: 1000`, and
  `fsGroup: 1000`. On OpenShift, the pod's ServiceAccount (`default`) is
  only authorized for the `restricted-v2` SCC, which enforces
  `MustRunAsRange` from the namespace's allocated UID range, not these
  hardcoded values — so the ReplicaSet could never create a pod
  (`FailedCreate` / SCC admission rejection).
- Fix removes the hardcoded `runAsUser`/`runAsGroup`/`fsGroup`, keeping
  only `runAsNonRoot: true` — matching the pattern already used by other
  regular Deployments in the chart (e.g. `fulfillment-grpc-server`), which
  let OpenShift's SCC admission auto-assign a UID/fsGroup from the
  namespace's allocated range. OpenBao's `bao server -dev` mode uses only
  `emptyDir` volumes, so there is no fixed-ownership requirement that would
  need a pinned UID/GID.
- This is a separate bug from [OSAC-4911](https://redhat.atlassian.net/browse/OSAC-4911) (bundledVault values-file
  placement) — that PR (#750) only just fixed enabling OpenBao at all,
  which exposed this pod-admission bug for the first time.

## Test plan

- [x] Verified fix live on a running OpenShift dev cluster: `helm upgrade
      --install osac` succeeded and the openbao pod came up healthy (2/2
      Running, `server` and `bootstrap` containers), where before the fix
      the ReplicaSet was permanently stuck in `FailedCreate` due to SCC
      rejection.
- [x] `helm template osac charts/osac -f values/vmaas-ci/instance.yaml
      --set bundledVault.enabled=true --set
      bundledVault.devRootToken=dev-root-token` confirms the rendered
      openbao Deployment's pod securityContext now only sets
      `runAsNonRoot: true`.
- [x] `yamllint --strict .` passes (output identical before/after change).
- [x] `pre-commit run --all-files` passes.
- [x] `make helm-lint` / `make helm-validate` fail only on a pre-existing,
      unrelated `service.externalHostname`/`internalHostname` schema
      error in default values.yaml — confirmed present on `main` before
      this change too (not caused by this fix).

Fixes: https://redhat.atlassian.net/browse/OSAC-4912

Assisted-by: Claude Code <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

- **Deployment:** Removed hardcoded `runAsUser`, `runAsGroup`, and `fsGroup` values from the bundled OpenBao Deployment.
- Retained `runAsNonRoot: true`.
- OpenShift SCC admission can assign IDs from the namespace range.
- This addresses pod creation failures with `restricted-v2` SCC.
- No API, controller, database, authentication, test, or documentation changes.

## Compatibility

- OpenShift may assign different runtime user and group IDs.
- No public API changes are expected.
- Helm validation retains a pre-existing schema error.

## Risk classification

- **risk:ship** — The change is small, preserves non-root execution, and reported OpenShift deployment and validation checks passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->