### PR TITLE
OSAC-4913,OSAC-4915: fix bundled OpenBao OIDC issuer + vault endpoint namespace mismatch on OpenShift

### DIFF
--- a/osac-installer/Makefile
+++ b/osac-installer/Makefile
@@ -236,7 +236,7 @@ endif
 	helm upgrade --install osac $(OSAC_CHART) \
 		-f $(INSTANCE_VALUES) $(INSTANCE_VALUES_EXTRA) \
 		--namespace $(NS) --create-namespace \
-		$(if $(DOMAIN),--set service.externalHostname=fulfillment-api-$(NS).$(DOMAIN) --set service.internalHostname=fulfillment-internal-api-$(NS).$(DOMAIN) --set service.auth.issuerUrl=https://keycloak-keycloak.$(DOMAIN)/realms/osac --set service.idp.url=https://keycloak-keycloak.$(DOMAIN)) \
+		$(if $(DOMAIN),--set service.externalHostname=fulfillment-api-$(NS).$(DOMAIN) --set service.internalHostname=fulfillment-internal-api-$(NS).$(DOMAIN) --set service.auth.issuerUrl=https://keycloak-keycloak.$(DOMAIN)/realms/osac --set service.idp.url=https://keycloak-keycloak.$(DOMAIN) --set service.vault.keycloakIssuerUrl=https://keycloak-keycloak.$(DOMAIN)/realms/osac) \
 		$(EXTRA_HELM_ARGS) \
 		--wait --timeout 40m
 

--- a/osac-installer/Makefile
+++ b/osac-installer/Makefile
@@ -236,7 +236,7 @@ endif
 	helm upgrade --install osac $(OSAC_CHART) \
 		-f $(INSTANCE_VALUES) $(INSTANCE_VALUES_EXTRA) \
 		--namespace $(NS) --create-namespace \
-		$(if $(DOMAIN),--set service.externalHostname=fulfillment-api-$(NS).$(DOMAIN) --set service.internalHostname=fulfillment-internal-api-$(NS).$(DOMAIN) --set service.auth.issuerUrl=https://keycloak-keycloak.$(DOMAIN)/realms/osac --set service.idp.url=https://keycloak-keycloak.$(DOMAIN) --set service.vault.keycloakIssuerUrl=https://keycloak-keycloak.$(DOMAIN)/realms/osac) \
+		$(if $(DOMAIN),--set service.externalHostname=fulfillment-api-$(NS).$(DOMAIN) --set service.internalHostname=fulfillment-internal-api-$(NS).$(DOMAIN) --set service.auth.issuerUrl=https://keycloak-keycloak.$(DOMAIN)/realms/osac --set service.idp.url=https://keycloak-keycloak.$(DOMAIN) --set service.vault.keycloakIssuerUrl=https://keycloak-keycloak.$(DOMAIN)/realms/osac --set service.vault.endpoint=https://openbao.$(NS).svc.cluster.local:8200) \
 		$(EXTRA_HELM_ARGS) \
 		--wait --timeout 40m
 


### PR DESCRIPTION
## Summary

- On OpenShift, Keycloak is deliberately configured to always report the external route hostname as its OIDC `issuer` (portable tokens), and `install-osac`'s `install-osac` target already overrides `service.auth.issuerUrl`/`service.idp.url` at install time to match. However `service.vault.keycloakIssuerUrl` — the OIDC issuer URL the bundled OpenBao's `init.sh` uses for `auth/jwt/config oidc_discovery_url=...` — was missing from that same `$(DOMAIN)`-based override list, so it stayed pinned to the static internal cluster-local hostname from each CI profile's `instance.yaml`. This mismatched Keycloak's actual discovery-document issuer and made OpenBao's OIDC discovery validation fail forever (`issuer did not match the returned issuer`), so the `lifecycle` JWT auth role never got created on any OpenShift-deployed cluster.
- Fix: extend the existing `$(if $(DOMAIN), ...)` `--set` block in `osac-installer/Makefile`'s `install-osac` target to also set `service.vault.keycloakIssuerUrl=https://keycloak-keycloak.$(DOMAIN)/realms/osac`, matching the pattern already used for `service.auth.issuerUrl`. The static per-profile `instance.yaml` values become dead defaults at install time, same as `service.auth.issuerUrl` today — left as-is for consistency/fallback.

## Test plan

- [x] `yamllint --strict -c .yamllint.yaml osac-installer` passes
- [x] `pre-commit run --all-files` passes
- [x] `make helm-lint` / `make helm-validate` fail only with the pre-existing, unrelated `service.externalHostname`/`service.internalHostname` schema error already present on `main` (confirmed before this change)
- [x] `helm template charts/osac -f values/vmaas-ci/instance.yaml` with the same `--set` flags `install-osac` would pass (mocked `DOMAIN`) confirms `KEYCLOAK_ISSUER_URL` in `bundled-openbao.yaml`'s init container now renders as the external route URL (`https://keycloak-keycloak.<domain>/realms/osac`), matching Keycloak's actual discovery-document issuer

Fixes: https://redhat.atlassian.net/browse/OSAC-4913

Assisted-by: Claude Code <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Deployment and authentication

- Updated `install-osac` Helm overrides.
- OpenBao now uses the external Keycloak issuer on OpenShift.
- OpenBao now uses the service endpoint in the install namespace through `$(NS)`.
- This fixes OIDC discovery validation and fulfillment-controller login failures.

## Tests and CI

- YAML linting and pre-commit checks pass.
- Helm template testing confirms the issuer override.
- Helm lint and validation still report a pre-existing schema error.

## API surface, controllers, database, and documentation

- No API, controller, database, or documentation changes.

## Backward compatibility

- The overrides apply only when `DOMAIN` is available.
- Other deployment paths keep their existing configuration.

## Risk classification

- **risk:ship** — The change is limited to deployment configuration and has focused template validation.
- It does not qualify as **risk:show** because it adds no broad user-visible feature.
- It does not qualify as **risk:ask** because it changes no application logic or data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->