### PR TITLE
NO ISSUE: Enable Slack notify on scheduled E2E failures

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -246,6 +246,7 @@ jobs:
       # is fork-originated and gets no OIDC/WIF access at all by GitHub
       # Actions policy. merge_group is excluded the same way (its
       # github.ref is the readonly-queue ref).
+      notify-on-failure: ${{ github.event_name == 'schedule' }}
       enable-ai-diagnostic: ${{ github.ref == 'refs/heads/main' }}
 
   # Skip this required check on unreadiness so it stays pending (not red).

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -258,6 +258,7 @@ jobs:
       # is fork-originated and gets no OIDC/WIF access at all by GitHub
       # Actions policy. merge_group is excluded the same way (its
       # github.ref is the readonly-queue ref).
+      notify-on-failure: ${{ github.event_name == 'schedule' }}
       enable-ai-diagnostic: ${{ github.ref == 'refs/heads/main' }}
 
   # Skip this required check on unreadiness so it stays pending (not red).

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -254,6 +254,7 @@ jobs:
       # is fork-originated and gets no OIDC/WIF access at all by GitHub
       # Actions policy. merge_group is excluded the same way (its
       # github.ref is the readonly-queue ref).
+      notify-on-failure: ${{ github.event_name == 'schedule' }}
       enable-ai-diagnostic: ${{ github.ref == 'refs/heads/main' }}
 
   # Skip this required check on unreadiness so it stays pending (not red).


### PR DESCRIPTION
## Summary
- Pass `notify-on-failure: ${{ github.event_name == 'schedule' }}` from osac full-install callers (CaaS, VMaaS, BMaaS)
- Matches osac-test-infra caller behavior so scheduled failures post to `#osac-ci`

## Test plan
- [ ] Merge and wait for next scheduled CaaS full-install failure (or temporarily break a scheduled run)
- [ ] Confirm **Notify Slack on failure** step runs (not skipped) and message lands in `#osac-ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## CI

- CaaS, VMaaS, and BMaaS scheduled full-install workflows now set `notify-on-failure` to `true`.
- Other event types set `notify-on-failure` to `false`.
- Scheduled failures now send Slack notifications to `#osac-ci`, consistent with the osac-test-infra caller.

## Compatibility

- No API, runtime, database, authentication, deployment, test, or documentation changes.
- No backward-compatibility impact outside scheduled CI notification behavior.

## Risk classification

- `risk:ship`: The change is limited to CI workflow configuration and enables notifications only for scheduled failures.
- It does not alter product behavior, interfaces, credentials, or deployment logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->