### PR TITLE
OSAC-4820: Install pre-commit hooks during bootstrap

### DIFF
--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -517,23 +517,29 @@ elif command -v pre-commit &>/dev/null; then
 fi
 
 install_pre_commit_hooks() {
-  local dir="$1"
+  local dir="$1" label="$2"
   [[ -f "${dir}/.pre-commit-config.yaml" && -n "$PRE_COMMIT_INSTALLER" ]] || return 0
   if [[ "$PRE_COMMIT_INSTALLER" == "rh-multi-pre-commit" ]]; then
-    rh-multi-pre-commit install --path "$dir"
-  else
-    (cd "$dir" && pre-commit install)
+    if ! rh-multi-pre-commit install --path "$dir"; then
+      echo "  ${label}: failed to install hooks. Continuing."
+    fi
+  elif ! (cd "$dir" && pre-commit install); then
+    echo "  ${label}: failed to install hooks. Continuing."
   fi
 }
 
-install_pre_commit_hooks "$PROJECT_ROOT"
-for entry in "${SIBLINGS[@]}"; do
-  repo="${entry%%:*}"
-  dir="${entry#*:}"
-  if is_expected_sibling "${PROJECT_ROOT}/${dir}" "$repo"; then
-    install_pre_commit_hooks "${PROJECT_ROOT}/${dir}"
-  fi
-done
+if [[ -z "$PRE_COMMIT_INSTALLER" ]]; then
+  echo "WARNING: pre-commit not found — skipping hook installation."
+else
+  install_pre_commit_hooks "$PROJECT_ROOT" "osac"
+  for entry in "${SIBLINGS[@]}"; do
+    repo="${entry%%:*}"
+    dir="${entry#*:}"
+    if is_expected_sibling "${PROJECT_ROOT}/${dir}" "$repo"; then
+      install_pre_commit_hooks "${PROJECT_ROOT}/${dir}" "$dir"
+    fi
+  done
+fi
 
 echo ""
 echo "AI workflows and OSAC skills installed."

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -509,5 +509,31 @@ for entry in "${SIBLINGS[@]}"; do
   ensure_sibling "${repo}" "${dir}"
 done
 
+PRE_COMMIT_INSTALLER=""
+if command -v rh-multi-pre-commit &>/dev/null; then
+  PRE_COMMIT_INSTALLER="rh-multi-pre-commit"
+elif command -v pre-commit &>/dev/null; then
+  PRE_COMMIT_INSTALLER="pre-commit"
+fi
+
+install_pre_commit_hooks() {
+  local dir="$1"
+  [[ -f "${dir}/.pre-commit-config.yaml" && -n "$PRE_COMMIT_INSTALLER" ]] || return 0
+  if [[ "$PRE_COMMIT_INSTALLER" == "rh-multi-pre-commit" ]]; then
+    rh-multi-pre-commit install --path "$dir"
+  else
+    (cd "$dir" && pre-commit install)
+  fi
+}
+
+install_pre_commit_hooks "$PROJECT_ROOT"
+for entry in "${SIBLINGS[@]}"; do
+  repo="${entry%%:*}"
+  dir="${entry#*:}"
+  if is_expected_sibling "${PROJECT_ROOT}/${dir}" "$repo"; then
+    install_pre_commit_hooks "${PROJECT_ROOT}/${dir}"
+  fi
+done
+
 echo ""
 echo "AI workflows and OSAC skills installed."

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -214,6 +214,18 @@ run_bootstrap() {
     bash "${root}/tools/bootstrap.sh" --no-fork "$@"
 }
 
+run_bootstrap_isolated() {
+  local root="$1" home="$2" bin="$3"
+  shift 3
+  HOME="$home" PATH="$bin" \
+    OSAC_SMOKE_CLONE_LOG="${home}/clone.log" \
+    OSAC_SMOKE_GH_LOG="${home}/gh.log" \
+    OSAC_SMOKE_GIT_LOG="${home}/git.log" \
+    OSAC_SMOKE_HOOK_LOG="${home}/hooks.log" \
+    OSAC_SMOKE_HOOK_FAIL_MATCH="${OSAC_SMOKE_HOOK_FAIL_MATCH:-}" \
+    bash "${root}/tools/bootstrap.sh" --no-fork "$@"
+}
+
 run_bootstrap_fork() {
   local root="$1" home="$2" bin="$3"
   shift 3
@@ -1146,17 +1158,18 @@ test_hook_install_falls_back_to_pre_commit_and_is_repeatable() {
   local home root bin home_skills home_workflows repo_skills clone_log out hook_log
   prepare_fixture hooks-upstream
   root=$(realpath "$root")
+  add_isolated_bootstrap_commands "$bin"
   write_hook_installer_wrapper "${bin}/pre-commit" upstream
   seed_pre_commit_config "$root"
 
-  run_bootstrap "$root" "$home" "$bin" >/dev/null
+  run_bootstrap_isolated "$root" "$home" "$bin" >/dev/null
   seed_pre_commit_config "${root}/enhancement-proposals"
   seed_pre_commit_config "${root}/osac-ui"
   seed_pre_commit_config "${root}/osac-docs"
   : > "${home}/hooks.log"
 
-  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "fallback hook bootstrap failed: $out"
-  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "repeat hook bootstrap failed: $out"
+  out=$(run_bootstrap_isolated "$root" "$home" "$bin" 2>&1) || fail "fallback hook bootstrap failed: $out"
+  out=$(run_bootstrap_isolated "$root" "$home" "$bin" 2>&1) || fail "repeat hook bootstrap failed: $out"
   hook_log="${home}/hooks.log"
   [[ "$(grep -Fc "upstream|${root}|install" "$hook_log")" -eq 2 ]] \
     || fail "root pre-commit should run once per bootstrap: $(cat "$hook_log")"

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -1152,6 +1152,7 @@ test_hook_install_falls_back_to_pre_commit_and_is_repeatable() {
   run_bootstrap "$root" "$home" "$bin" >/dev/null
   seed_pre_commit_config "${root}/enhancement-proposals"
   seed_pre_commit_config "${root}/osac-ui"
+  seed_pre_commit_config "${root}/osac-docs"
   : > "${home}/hooks.log"
 
   out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "fallback hook bootstrap failed: $out"
@@ -1163,7 +1164,9 @@ test_hook_install_falls_back_to_pre_commit_and_is_repeatable() {
     || fail "enhancement-proposals pre-commit should run once per bootstrap: $(cat "$hook_log")"
   [[ "$(grep -Fc "upstream|${root}/osac-ui|install" "$hook_log")" -eq 2 ]] \
     || fail "configured osac-ui pre-commit should run once per bootstrap: $(cat "$hook_log")"
-  grep -q 'osac-ux\|osac-docs' "$hook_log" \
+  [[ "$(grep -Fc "upstream|${root}/osac-docs|install" "$hook_log")" -eq 2 ]] \
+    || fail "configured osac-docs pre-commit should run once per bootstrap: $(cat "$hook_log")"
+  grep -q 'osac-ux' "$hook_log" \
     && fail "config-less siblings must be skipped by fallback: $(cat "$hook_log")"
   pass "falls back to pre-commit and repeats installation safely"
 }

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -166,6 +166,9 @@ write_hook_installer_wrapper() {
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s|%s|%s\n' '${kind}' "\$PWD" "\$*" >> "\$OSAC_SMOKE_HOOK_LOG"
+if [[ -n "\${OSAC_SMOKE_HOOK_FAIL_MATCH:-}" && "\$PWD \$*" == *"\$OSAC_SMOKE_HOOK_FAIL_MATCH"* ]]; then
+  exit 1
+fi
 EOF
   chmod +x "$dest"
 }
@@ -173,6 +176,14 @@ EOF
 seed_pre_commit_config() {
   local dir="$1"
   printf 'repos: []\n' > "${dir}/.pre-commit-config.yaml"
+}
+
+add_isolated_bootstrap_commands() {
+  local bin="$1" command_path command_name
+  for command_name in bash basename chmod dirname mkdir readlink realpath rm; do
+    command_path=$(command -v "$command_name") || fail "missing required command: $command_name"
+    ln -sf "$command_path" "${bin}/${command_name}"
+  done
 }
 
 # Sets caller's home, root, bin, home_skills, home_workflows, repo_skills, clone_log.
@@ -199,6 +210,7 @@ run_bootstrap() {
     OSAC_SMOKE_GH_LOG="${home}/gh.log" \
     OSAC_SMOKE_GIT_LOG="${home}/git.log" \
     OSAC_SMOKE_HOOK_LOG="${home}/hooks.log" \
+    OSAC_SMOKE_HOOK_FAIL_MATCH="${OSAC_SMOKE_HOOK_FAIL_MATCH:-}" \
     bash "${root}/tools/bootstrap.sh" --no-fork "$@"
 }
 
@@ -210,6 +222,7 @@ run_bootstrap_fork() {
     OSAC_SMOKE_GH_LOG="${home}/gh.log" \
     OSAC_SMOKE_GIT_LOG="${home}/git.log" \
     OSAC_SMOKE_HOOK_LOG="${home}/hooks.log" \
+    OSAC_SMOKE_HOOK_FAIL_MATCH="${OSAC_SMOKE_HOOK_FAIL_MATCH:-}" \
     bash "${root}/tools/bootstrap.sh" "$@"
 }
 
@@ -1155,6 +1168,51 @@ test_hook_install_falls_back_to_pre_commit_and_is_repeatable() {
   pass "falls back to pre-commit and repeats installation safely"
 }
 
+test_missing_hook_installers_warns_and_continues() {
+  local home root bin home_skills home_workflows repo_skills clone_log out
+  prepare_fixture hooks-missing
+  add_isolated_bootstrap_commands "$bin"
+  seed_pre_commit_config "$root"
+
+  out=$(HOME="$home" PATH="$bin" \
+    OSAC_SMOKE_CLONE_LOG="${home}/clone.log" \
+    OSAC_SMOKE_GH_LOG="${home}/gh.log" \
+    OSAC_SMOKE_GIT_LOG="${home}/git.log" \
+    OSAC_SMOKE_HOOK_LOG="${home}/hooks.log" \
+    bash "${root}/tools/bootstrap.sh" --no-fork 2>&1) \
+    || fail "bootstrap without hook installers failed: $out"
+  echo "$out" | grep -q 'pre-commit not found.*skipping hook installation' \
+    || fail "missing installer warning not found: $out"
+  echo "$out" | grep -q 'AI workflows and OSAC skills installed' \
+    || fail "bootstrap must complete without hook installers: $out"
+  pass "warns and continues when no hook installer exists"
+}
+
+test_hook_installer_failure_warns_and_continues() {
+  local home root bin home_skills home_workflows repo_skills clone_log out hook_log
+  prepare_fixture hooks-failure
+  root=$(realpath "$root")
+  write_hook_installer_wrapper "${bin}/pre-commit" upstream
+  seed_pre_commit_config "$root"
+
+  run_bootstrap "$root" "$home" "$bin" >/dev/null
+  seed_pre_commit_config "${root}/enhancement-proposals"
+  seed_pre_commit_config "${root}/osac-ui"
+  : > "${home}/hooks.log"
+
+  out=$(OSAC_SMOKE_HOOK_FAIL_MATCH=enhancement-proposals \
+    run_bootstrap "$root" "$home" "$bin" 2>&1) \
+    || fail "hook failure must not fail bootstrap: $out"
+  hook_log="${home}/hooks.log"
+  echo "$out" | grep -q 'enhancement-proposals.*failed to install hooks' \
+    || fail "repository-specific hook warning not found: $out"
+  grep -Fq "upstream|${root}/osac-ui|install" "$hook_log" \
+    || fail "hook installs after a failure must continue: $(cat "$hook_log")"
+  echo "$out" | grep -q 'AI workflows and OSAC skills installed' \
+    || fail "bootstrap must complete after hook failure: $out"
+  pass "warns and continues after a hook installer failure"
+}
+
 test_clones_all_four_into_project_root
 test_rerun_updates_expected_clone
 test_skips_unrelated_existing_dir
@@ -1193,5 +1251,7 @@ test_repo_local_leftover_osac_ai_skills_errors_without_updating
 test_home_git_subdir_ai_workflows_falls_back_to_repo_local
 test_hook_install_prefers_rh_and_requires_config
 test_hook_install_falls_back_to_pre_commit_and_is_repeatable
+test_missing_hook_installers_warns_and_continues
+test_hook_installer_failure_warns_and_continues
 
 echo "All bootstrap sibling-clone smoke tests passed."

--- a/tools/test/bootstrap-sibling-clone-smoke.sh
+++ b/tools/test/bootstrap-sibling-clone-smoke.sh
@@ -160,6 +160,21 @@ EOF
   chmod +x "$dest"
 }
 
+write_hook_installer_wrapper() {
+  local dest="$1" kind="$2"
+  cat >"$dest" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s|%s|%s\n' '${kind}' "\$PWD" "\$*" >> "\$OSAC_SMOKE_HOOK_LOG"
+EOF
+  chmod +x "$dest"
+}
+
+seed_pre_commit_config() {
+  local dir="$1"
+  printf 'repos: []\n' > "${dir}/.pre-commit-config.yaml"
+}
+
 # Sets caller's home, root, bin, home_skills, home_workflows, repo_skills, clone_log.
 prepare_fixture() {
   home="${TMPDIR_ROOT}/home-$1"
@@ -183,6 +198,7 @@ run_bootstrap() {
     OSAC_SMOKE_CLONE_LOG="${home}/clone.log" \
     OSAC_SMOKE_GH_LOG="${home}/gh.log" \
     OSAC_SMOKE_GIT_LOG="${home}/git.log" \
+    OSAC_SMOKE_HOOK_LOG="${home}/hooks.log" \
     bash "${root}/tools/bootstrap.sh" --no-fork "$@"
 }
 
@@ -193,6 +209,7 @@ run_bootstrap_fork() {
     OSAC_SMOKE_CLONE_LOG="${home}/clone.log" \
     OSAC_SMOKE_GH_LOG="${home}/gh.log" \
     OSAC_SMOKE_GIT_LOG="${home}/git.log" \
+    OSAC_SMOKE_HOOK_LOG="${home}/hooks.log" \
     bash "${root}/tools/bootstrap.sh" "$@"
 }
 
@@ -338,9 +355,11 @@ test_rerun_updates_expected_clone() {
 test_skips_unrelated_existing_dir() {
   local home root bin home_skills home_workflows repo_skills clone_log out ux
   prepare_fixture skip
+  write_hook_installer_wrapper "${bin}/pre-commit" upstream
   ux="${root}/osac-ux"
   mkdir -p "$ux"
   echo leftover > "${ux}/not-the-repo"
+  seed_pre_commit_config "$ux"
 
   out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "bootstrap failed: $out"
   grep -q leftover "${ux}/not-the-repo" || fail "unrelated osac-ux/ dir was overwritten"
@@ -351,6 +370,9 @@ test_skips_unrelated_existing_dir() {
     || fail "skip of osac-ux must still clone later siblings (osac-ui)"
   [[ -d "${root}/osac-docs/.git" ]] \
     || fail "skip of osac-ux must still clone later siblings (osac-docs)"
+  if [[ -f "${home}/hooks.log" ]] && grep -Fq "${ux}|install" "${home}/hooks.log"; then
+    fail "unrelated osac-ux must not receive hooks: $(cat "${home}/hooks.log")"
+  fi
   pass "skips an existing dir that is not the expected clone"
 }
 
@@ -1075,6 +1097,64 @@ test_home_git_subdir_ai_workflows_falls_back_to_repo_local() {
   pass "HOME git checkout with plain .ai-workflows subdir falls back to repo-local"
 }
 
+test_hook_install_prefers_rh_and_requires_config() {
+  local home root bin home_skills home_workflows repo_skills clone_log out hook_log
+  prepare_fixture hooks-rh
+  root=$(realpath "$root")
+  write_hook_installer_wrapper "${bin}/rh-multi-pre-commit" rh
+  write_hook_installer_wrapper "${bin}/pre-commit" upstream
+  seed_pre_commit_config "$root"
+
+  run_bootstrap "$root" "$home" "$bin" >/dev/null
+  seed_pre_commit_config "${root}/enhancement-proposals"
+  seed_pre_commit_config "${root}/osac-ux"
+  seed_pre_commit_config "$home_skills"
+  seed_pre_commit_config "$home_workflows"
+  : > "${home}/hooks.log"
+
+  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "hook bootstrap failed: $out"
+  hook_log="${home}/hooks.log"
+  grep -Fq "|install --path ${root}" "$hook_log" \
+    || fail "root rh hook install missing: $(cat "$hook_log")"
+  grep -Fq "|install --path ${root}/enhancement-proposals" "$hook_log" \
+    || fail "enhancement-proposals rh hook install missing: $(cat "$hook_log")"
+  grep -Fq "|install --path ${root}/osac-ux" "$hook_log" \
+    || fail "configured osac-ux rh hook install missing: $(cat "$hook_log")"
+  grep -q '^upstream|' "$hook_log" \
+    && fail "standard pre-commit must not run when rh installer exists: $(cat "$hook_log")"
+  grep -q 'osac-ui\|osac-docs' "$hook_log" \
+    && fail "config-less siblings must be skipped: $(cat "$hook_log")"
+  grep -q "${OSAC_AI_SKILLS_NAME}\|${AI_WORKFLOWS_NAME}" "$hook_log" \
+    && fail "vendor checkouts must not receive hooks: $(cat "$hook_log")"
+  pass "prefers rh installer and only processes configured non-vendor repos"
+}
+
+test_hook_install_falls_back_to_pre_commit_and_is_repeatable() {
+  local home root bin home_skills home_workflows repo_skills clone_log out hook_log
+  prepare_fixture hooks-upstream
+  root=$(realpath "$root")
+  write_hook_installer_wrapper "${bin}/pre-commit" upstream
+  seed_pre_commit_config "$root"
+
+  run_bootstrap "$root" "$home" "$bin" >/dev/null
+  seed_pre_commit_config "${root}/enhancement-proposals"
+  seed_pre_commit_config "${root}/osac-ui"
+  : > "${home}/hooks.log"
+
+  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "fallback hook bootstrap failed: $out"
+  out=$(run_bootstrap "$root" "$home" "$bin" 2>&1) || fail "repeat hook bootstrap failed: $out"
+  hook_log="${home}/hooks.log"
+  [[ "$(grep -Fc "upstream|${root}|install" "$hook_log")" -eq 2 ]] \
+    || fail "root pre-commit should run once per bootstrap: $(cat "$hook_log")"
+  [[ "$(grep -Fc "upstream|${root}/enhancement-proposals|install" "$hook_log")" -eq 2 ]] \
+    || fail "enhancement-proposals pre-commit should run once per bootstrap: $(cat "$hook_log")"
+  [[ "$(grep -Fc "upstream|${root}/osac-ui|install" "$hook_log")" -eq 2 ]] \
+    || fail "configured osac-ui pre-commit should run once per bootstrap: $(cat "$hook_log")"
+  grep -q 'osac-ux\|osac-docs' "$hook_log" \
+    && fail "config-less siblings must be skipped by fallback: $(cat "$hook_log")"
+  pass "falls back to pre-commit and repeats installation safely"
+}
+
 test_clones_all_four_into_project_root
 test_rerun_updates_expected_clone
 test_skips_unrelated_existing_dir
@@ -1111,5 +1191,7 @@ test_home_git_subdir_skills_falls_back_to_repo_local
 test_repo_local_leftover_ai_workflows_errors_without_updating
 test_repo_local_leftover_osac_ai_skills_errors_without_updating
 test_home_git_subdir_ai_workflows_falls_back_to_repo_local
+test_hook_install_prefers_rh_and_requires_config
+test_hook_install_falls_back_to_pre_commit_and_is_repeatable
 
 echo "All bootstrap sibling-clone smoke tests passed."


### PR DESCRIPTION
## Summary

Install Git pre-commit hooks during bootstrap for the OSAC checkout and validated sibling repositories that contain `.pre-commit-config.yaml`.

- prefer `rh-multi-pre-commit`, with standard `pre-commit` as the fallback
- keep missing or failed hook installation non-fatal
- exclude vendor checkouts and unrelated sibling directories
- preserve repeatable bootstrap behavior

Jira: https://redhat.atlassian.net/browse/OSAC-4820

## Testing

- `bash tools/test/bootstrap-sibling-clone-smoke.sh`
- `pre-commit run --all-files`
- two consecutive `tools/bootstrap.sh --no-fork` runs

## Acceptance criteria

- [x] Bootstrap installs hooks in the root OSAC checkout when configured
- [x] Bootstrap installs hooks in configured, validated sibling repositories
- [x] `rh-multi-pre-commit` is preferred over `pre-commit`
- [x] Repositories without `.pre-commit-config.yaml` are skipped
- [x] Missing installers and installation failures warn without stopping bootstrap
- [x] Vendor and unrelated sibling directories are not modified
- [x] Repeated bootstrap runs remain successful


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **Bootstrap:** Installs pre-commit hooks for the OSAC checkout and valid sibling repositories with `.pre-commit-config.yaml`.
- **Tool selection:** Prefers `rh-multi-pre-commit` and falls back to `pre-commit`.
- **Failure handling:** Continues bootstrap when tools are missing or installation fails. It emits a warning.
- **Repository boundaries:** Excludes vendor and unrelated sibling directories.
- **Tests:** Adds smoke coverage for tool preference, fallback behavior, repeated bootstrap runs, missing tools, installation failures, and unrelated existing directories.

## Backward compatibility

The change preserves existing bootstrap behavior. Hook installation is optional and non-fatal. Repeated bootstrap runs remain supported. No API, database, authentication, deployment, CI configuration, or documentation surface changes.

## Risk classification

**risk:ship** — The change is limited to bootstrap tooling, validates repository boundaries, handles missing tools and installation failures without aborting, and includes focused smoke-test coverage. It does not qualify as **risk:show** because it does not change user-visible runtime behavior outside development setup. It does not qualify as **risk:ask** because it does not change production services, data, authentication, or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->