### PR TITLE
NO-ISSUE: Use OSAC AI GitHub App secrets instead of retired AI_DIAGNOSTIC_TOKEN

### DIFF
--- a/.github/workflows/ai-diagnostic-e2e.yml
+++ b/.github/workflows/ai-diagnostic-e2e.yml
@@ -40,4 +40,5 @@ jobs:
       id-token: write
     uses: osac-project/osac-test-infra/.github/workflows/ai-diagnostic-e2e.yml@main
     secrets:
-      AI_DIAGNOSTIC_TOKEN: ${{ secrets.AI_DIAGNOSTIC_TOKEN }}
+      OSAC_AI_APP_ID: ${{ secrets.OSAC_AI_APP_ID }}
+      OSAC_AI_APP_PRIVATE_KEY: ${{ secrets.OSAC_AI_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

osac-test-infra's `ai-diagnostic-e2e.yml` migrated from a fine-grained PAT (`AI_DIAGNOSTIC_TOKEN`) to the OSAC AI GitHub App (`OSAC_AI_APP_ID` / `OSAC_AI_APP_PRIVATE_KEY`) in [osac-project/osac-test-infra#492](https://github.com/osac-project/osac-test-infra/pull/492), but this wrapper was never updated to match — its `workflow_call` still referenced the now-nonexistent `AI_DIAGNOSTIC_TOKEN` secret, breaking the AI diagnostic pipeline for every `osac` PR (confirmed live: [run 33937142510](https://github.com/osac-project/osac/actions/runs/33937142510) — "Secret OSAC_AI_APP_ID is required, but not provided while calling").

`OSAC_AI_APP_ID`/`OSAC_AI_APP_PRIVATE_KEY` are already org-level secrets scoped to include this repo, so no further secret setup is needed — this is just the wrapper's own reference catching up to the new names.