### PR TITLE
OSAC-4875: block networking provisioning without dispatcher manager

### DIFF
--- a/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/README.md
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/README.md
@@ -26,9 +26,10 @@ it composes the existing, independently-tested k8s-native roles:
 
 `k8s_only` is an explicit Kubernetes-only profile, not a substitute for a
 unified fabric manager. The operator dispatcher permits the Kubernetes fallback
-for SecurityGroup and ExternalIP-family resources only when the NetworkClass
-selects the manager named `k8s_only`. Other Kubernetes managers are overlay
-bridges and still require a `fabricManager` for those resources.
+for VirtualNetwork, Subnet, SecurityGroup, and ExternalIP-family resources only
+when the NetworkClass selects the manager named `k8s_only`. Other Kubernetes
+managers are overlay bridges and still require a `fabricManager` for those
+resources.
 
 As a result, this profile provides Kubernetes-native behavior for VMaaS
 deployments without a physical fabric; it does not provide fabric-wide ACLs,

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/README.md
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/k8s_only/README.md
@@ -22,6 +22,18 @@ it composes the existing, independently-tested k8s-native roles:
 - **SecurityGroup** → `network_policy` (Kubernetes NetworkPolicy)
 - **ExternalIPPool / ExternalIP / ExternalIPAttachment** → `metallb_l2` (MetalLB L2 advertisement)
 
+## Dispatcher contract
+
+`k8s_only` is an explicit Kubernetes-only profile, not a substitute for a
+unified fabric manager. The operator dispatcher permits the Kubernetes fallback
+for SecurityGroup and ExternalIP-family resources only when the NetworkClass
+selects the manager named `k8s_only`. Other Kubernetes managers are overlay
+bridges and still require a `fabricManager` for those resources.
+
+As a result, this profile provides Kubernetes-native behavior for VMaaS
+deployments without a physical fabric; it does not provide fabric-wide ACLs,
+IPAM, DNAT/SNAT, or bare-metal networking semantics.
+
 ## Task Files
 
 Every task file is a single `ansible.builtin.include_role` delegation — no logic of

--- a/osac-operator/internal/controller/constants_common.go
+++ b/osac-operator/internal/controller/constants_common.go
@@ -49,6 +49,7 @@ const (
 
 	conditionReasonConfigurationApplied  = "ConfigurationApplied"
 	conditionMessageConfigurationApplied = "Controller has processed the current spec"
+	conditionMessageNoManagerConfigured  = "No dispatcher-resolvable network manager is configured"
 
 	labelValueTrue = "true"
 )

--- a/osac-operator/internal/controller/dispatcher_helpers.go
+++ b/osac-operator/internal/controller/dispatcher_helpers.go
@@ -43,7 +43,7 @@ const networkClassListPageSize = 1000
 //
 // Returns (nil, nil) when the dispatcher path is not active: resolver is nil,
 // networkClassID is empty, or the NetworkClass has neither a fabricManager nor a
-// k8sManager set (dispatcher.ErrNoManagerConfigured) — all cases where the caller
+// k8sManager set (dispatcher.ErrNoManagerConfigured) — the case where the caller
 // should block until dispatcher configuration is available. Any other resolution error (e.g. a
 // fabricManager or k8sManager referencing an unregistered manager ConfigMap) is
 // returned to the caller as a real reconcile error, since that indicates a
@@ -90,8 +90,8 @@ func resolveImplementationStrategy(
 	}
 	target := plan.FabricTarget()
 	if target == nil {
-		// A K8sFallback kind (e.g. VirtualNetwork, SecurityGroup) with no fabricManager
-		// resolves its fabric role to a k8s-role target instead (see Dispatch), so check
+		// A fallback-enabled kind with no fabricManager resolves its fabric role to
+		// the explicitly allowed k8s-only target instead (see Dispatch), so check
 		// K8sTarget before giving up.
 		target = plan.K8sTarget()
 	}

--- a/osac-operator/internal/controller/dispatcher_helpers.go
+++ b/osac-operator/internal/controller/dispatcher_helpers.go
@@ -44,7 +44,7 @@ const networkClassListPageSize = 1000
 // Returns (nil, nil) when the dispatcher path is not active: resolver is nil,
 // networkClassID is empty, or the NetworkClass has neither a fabricManager nor a
 // k8sManager set (dispatcher.ErrNoManagerConfigured) — all cases where the caller
-// should fall back to its own legacy behavior. Any other resolution error (e.g. a
+// should block until dispatcher configuration is available. Any other resolution error (e.g. a
 // fabricManager or k8sManager referencing an unregistered manager ConfigMap) is
 // returned to the caller as a real reconcile error, since that indicates a
 // misconfiguration rather than an expected pre-migration state.
@@ -73,33 +73,30 @@ func resolveDispatchPlan(
 // write into osacImplementationStrategyAnnotation for AAP playbook selection.
 //
 // When the dispatcher path is active (see resolveDispatchPlan) it returns the resolved
-// plan's fabric manager name. Otherwise it returns legacyStrategy unchanged. Most
-// callers pass "" for legacyStrategy now that NetworkClass/VirtualNetwork no longer
-// carry a stored implementation_strategy field; the parameter remains for callers
-// that still have a caller-specific fallback (e.g. a resource-level default).
+// plan's fabric manager name. Otherwise it returns an empty string so callers can
+// block provisioning until dispatcher configuration is available.
 func resolveImplementationStrategy(
 	ctx context.Context,
 	resolver *dispatcher.Resolver,
 	kind string,
 	networkClassID string,
-	legacyStrategy string,
 ) (string, error) {
 	plan, err := resolveDispatchPlan(ctx, resolver, kind, networkClassID)
 	if err != nil {
 		return "", err
 	}
 	if plan == nil {
-		return legacyStrategy, nil
+		return "", nil
 	}
 	target := plan.FabricTarget()
 	if target == nil {
 		// A K8sFallback kind (e.g. VirtualNetwork, SecurityGroup) with no fabricManager
 		// resolves its fabric role to a k8s-role target instead (see Dispatch), so check
-		// K8sTarget before giving up and falling back to legacyStrategy.
+		// K8sTarget before giving up.
 		target = plan.K8sTarget()
 	}
 	if target == nil {
-		return legacyStrategy, nil
+		return "", nil
 	}
 	return target.Manager.Name, nil
 }
@@ -139,8 +136,7 @@ func listAllNetworkClasses(
 //
 // Returns ("", nil) when the dispatcher path is not available (nil client, no live
 // NetworkClass, or more than one live NetworkClass with none marked default) so the
-// caller falls through to its legacy implementation-strategy. List errors are returned
-// as real reconcile errors.
+// caller can block provisioning. List errors are returned as real reconcile errors.
 //
 // Selection order: a non-deleted NetworkClass with is_default=true (the first match in
 // list order if multiple are marked default — fulfillment-service enforces at most one

--- a/osac-operator/internal/controller/dispatcher_helpers_test.go
+++ b/osac-operator/internal/controller/dispatcher_helpers_test.go
@@ -187,7 +187,7 @@ var _ = Describe("resolveImplementationStrategy", func() {
 		// VirtualNetwork's dispatch config is Fabric-role-only with K8sFallback: true, so a
 		// NetworkClass with only a k8sManager set resolves the fabric role's target to the k8s
 		// manager (see dispatch.go's Dispatch), and this should NOT fall back to legacyStrategy.
-		strategy, err := resolveImplementationStrategy(ctx, resolver, "VirtualNetwork", "nc-k8s-fallback", "legacy-strategy")
+		strategy, err := resolveImplementationStrategy(ctx, resolver, "VirtualNetwork", "nc-k8s-fallback")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(strategy).To(Equal("cudn_net"))
 	})
@@ -199,15 +199,15 @@ var _ = Describe("resolveImplementationStrategy", func() {
 			[]*privatev1.NetworkClass{{Id: "nc-fabric", FabricManager: ptr.To("netris")}}, &[]*privatev1.NetworkClass{},
 		)), disc)
 
-		strategy, err := resolveImplementationStrategy(ctx, resolver, "VirtualNetwork", "nc-fabric", "legacy-strategy")
+		strategy, err := resolveImplementationStrategy(ctx, resolver, "VirtualNetwork", "nc-fabric")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(strategy).To(Equal("netris"))
 	})
 
 	It("returns legacyStrategy when the dispatcher path is not active", func() {
-		strategy, err := resolveImplementationStrategy(ctx, nil, "VirtualNetwork", "nc-any", "legacy-strategy")
+		strategy, err := resolveImplementationStrategy(ctx, nil, "VirtualNetwork", "nc-any")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(strategy).To(Equal("legacy-strategy"))
+		Expect(strategy).To(BeEmpty())
 	})
 })
 

--- a/osac-operator/internal/controller/dispatcher_helpers_test.go
+++ b/osac-operator/internal/controller/dispatcher_helpers_test.go
@@ -52,6 +52,7 @@ var _ = Describe("resolveDispatchPlan", func() {
 		fakeDiscoveryClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(
 			newFabricManagerConfigMap("fm-netris", "osac", "netris"),
 			newK8sManagerConfigMap("km-cudn", "osac", "cudn_net", "ipv4"),
+			newK8sManagerConfigMap("km-k8s-only", "osac", "k8s_only", "ipv4"),
 		).Build()
 	})
 
@@ -172,10 +173,26 @@ var _ = Describe("resolveImplementationStrategy", func() {
 		fakeDiscoveryClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(
 			newFabricManagerConfigMap("fm-netris", "osac", "netris"),
 			newK8sManagerConfigMap("km-cudn", "osac", "cudn_net", "ipv4"),
+			newK8sManagerConfigMap("km-k8s-only", "osac", "k8s_only", "ipv4"),
 		).Build()
 	})
 
-	It("returns the resolved k8s manager's name for a K8sFallback kind with no fabricManager set", func() {
+	It("returns the resolved k8s-only manager's name for a fallback kind with no fabricManager set", func() {
+		disc, err := networkmanager.NewDiscovery(fakeDiscoveryClient, "osac")
+		Expect(err).NotTo(HaveOccurred())
+		k8sManagerName := dispatcher.K8sOnlyManagerName
+		resolver := dispatcher.NewResolver(dispatcheradapter.NewNetworkClassAdapter(newListingNetworkClassClient(
+			[]*privatev1.NetworkClass{{Id: "nc-k8s-fallback", K8SManager: &k8sManagerName}},
+			&[]*privatev1.NetworkClass{},
+		)), disc)
+
+		// VirtualNetwork's fallback is restricted to the explicit k8s_only profile.
+		strategy, err := resolveImplementationStrategy(ctx, resolver, "VirtualNetwork", "nc-k8s-fallback")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strategy).To(Equal(dispatcher.K8sOnlyManagerName))
+	})
+
+	It("rejects an arbitrary k8s manager for a fabric-owned resource", func() {
 		disc, err := networkmanager.NewDiscovery(fakeDiscoveryClient, "osac")
 		Expect(err).NotTo(HaveOccurred())
 		k8sManagerName := "cudn_net"
@@ -184,13 +201,30 @@ var _ = Describe("resolveImplementationStrategy", func() {
 			&[]*privatev1.NetworkClass{},
 		)), disc)
 
-		// VirtualNetwork's dispatch config is Fabric-role-only with K8sFallback: true, so a
-		// NetworkClass with only a k8sManager set resolves the fabric role's target to the k8s
-		// manager (see dispatch.go's Dispatch), and this should NOT fall back to legacyStrategy.
-		strategy, err := resolveImplementationStrategy(ctx, resolver, "VirtualNetwork", "nc-k8s-fallback")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(strategy).To(Equal("cudn_net"))
+		_, err = resolveImplementationStrategy(ctx, resolver, "SecurityGroup", "nc-k8s-fallback")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("required network manager is unavailable"))
 	})
+
+	DescribeTable("resolves k8s-only kinds to the composite k8s manager",
+		func(kind string) {
+			disc, err := networkmanager.NewDiscovery(fakeDiscoveryClient, "osac")
+			Expect(err).NotTo(HaveOccurred())
+			k8sManagerName := "k8s_only"
+			resolver := dispatcher.NewResolver(dispatcheradapter.NewNetworkClassAdapter(newListingNetworkClassClient(
+				[]*privatev1.NetworkClass{{Id: "nc-k8s-only", K8SManager: &k8sManagerName}},
+				&[]*privatev1.NetworkClass{},
+			)), disc)
+
+			strategy, err := resolveImplementationStrategy(ctx, resolver, kind, "nc-k8s-only")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strategy).To(Equal("k8s_only"))
+		},
+		Entry("SecurityGroup", "SecurityGroup"),
+		Entry("ExternalIP", "ExternalIP"),
+		Entry("ExternalIPPool", "ExternalIPPool"),
+		Entry("ExternalIPAttachment", "ExternalIPAttachment"),
+	)
 
 	It("returns the resolved fabric manager's name when the NetworkClass has a fabricManager set", func() {
 		disc, err := networkmanager.NewDiscovery(fakeDiscoveryClient, "osac")
@@ -204,7 +238,7 @@ var _ = Describe("resolveImplementationStrategy", func() {
 		Expect(strategy).To(Equal("netris"))
 	})
 
-	It("returns legacyStrategy when the dispatcher path is not active", func() {
+	It("returns an empty strategy when the dispatcher path is not active", func() {
 		strategy, err := resolveImplementationStrategy(ctx, nil, "VirtualNetwork", "nc-any")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(strategy).To(BeEmpty())

--- a/osac-operator/internal/controller/externalip_controller.go
+++ b/osac-operator/internal/controller/externalip_controller.go
@@ -50,8 +50,7 @@ const (
 //
 // Each ExternalIP belongs to a parent ExternalIPPool (referenced by UUID in spec.pool).
 // The controller adds a finalizer, resolves the implementation strategy from the
-// default NetworkClass via the dispatcher (falling back to the parent pool's spec
-// and defaultExternalIPPoolImplementationStrategy), then delegates to the shared
+// default NetworkClass via the dispatcher, then delegates to the shared
 // provisioning lifecycle to trigger AAP jobs for allocation and deallocation.
 //
 // Attach/detach is handled by the ExternalIPAttachment controller.
@@ -69,7 +68,7 @@ type ExternalIPReconciler struct {
 	targetCluster        mc.ClusterName
 	// Resolver resolves a NetworkClass to its registered managers. Nil when the
 	// two-manager model isn't configured (no gRPC connection / networking namespace),
-	// in which case the controller always uses the legacy implementation-strategy path.
+	// in which case the controller blocks provisioning until dispatch is available.
 	Resolver *dispatcher.Resolver
 	// networkClassesClient lists NetworkClasses to find the default/singleton used
 	// as the dispatcher input. Nil when gRPC is not configured.
@@ -227,17 +226,21 @@ func (r *ExternalIPReconciler) handleUpdate(ctx context.Context, externalIP *v1a
 	pool := &poolList.Items[0]
 	log.Info("resolved parent ExternalIPPool", "poolName", pool.Name, "poolUUID", externalIP.Spec.Pool)
 
-	// Resolve implementation strategy from the default NetworkClass via the
-	// dispatcher. The parent pool's spec.implementationStrategy is only used as a
-	// fallback when the dispatcher path is not active.
+	// Resolve implementation strategy from the default NetworkClass via the dispatcher.
 	networkClassID, err := lookupDefaultNetworkClassID(ctx, r.networkClassesClient)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 	implementationStrategy, err := resolveImplementationStrategy(
-		ctx, r.Resolver, "ExternalIP", networkClassID, pool.Spec.ImplementationStrategy)
+		ctx, r.Resolver, "ExternalIP", networkClassID)
 	if err != nil {
 		return ctrl.Result{}, err
+	}
+	if implementationStrategy == "" {
+		setReadyConditionBlocked(&externalIP.Status.Conditions, v1alpha1.ReasonNoManagerConfigured,
+			conditionMessageNoManagerConfigured)
+		log.Info("implementation strategy not resolved, requeueing", "externalIP", externalIP.Name)
+		return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
 	}
 
 	if externalIP.Annotations == nil {

--- a/osac-operator/internal/controller/externalip_controller.go
+++ b/osac-operator/internal/controller/externalip_controller.go
@@ -239,8 +239,10 @@ func (r *ExternalIPReconciler) handleUpdate(ctx context.Context, externalIP *v1a
 	if implementationStrategy == "" {
 		setReadyConditionBlocked(&externalIP.Status.Conditions, v1alpha1.ReasonNoManagerConfigured,
 			conditionMessageNoManagerConfigured)
-		log.Info("implementation strategy not resolved, requeueing", "externalIP", externalIP.Name)
-		return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
+		log.Info("implementation strategy not resolved", "externalIP", externalIP.Name)
+		return ctrl.Result{}, fmt.Errorf(
+			"cannot reconcile ExternalIP %q: no fabric manager is configured for NetworkClass %q",
+			externalIP.Name, networkClassID)
 	}
 
 	if externalIP.Annotations == nil {

--- a/osac-operator/internal/controller/externalip_controller_test.go
+++ b/osac-operator/internal/controller/externalip_controller_test.go
@@ -862,10 +862,9 @@ var _ = Describe("ExternalIPReconciler", func() {
 			reconciler.networkClassesClient = ncClient
 
 			key := types.NamespacedName{Name: publicIP.Name, Namespace: publicIP.Namespace}
-			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
-			Expect(err).NotTo(HaveOccurred())
-			_, err = reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
-			Expect(err).NotTo(HaveOccurred())
+			result, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).To(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
 
 			updated := &osacv1alpha1.ExternalIP{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
@@ -882,10 +881,9 @@ var _ = Describe("ExternalIPReconciler", func() {
 			reconciler.networkClassesClient = ncClient
 
 			key := types.NamespacedName{Name: publicIP.Name, Namespace: publicIP.Namespace}
-			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
-			Expect(err).NotTo(HaveOccurred())
-			_, err = reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
-			Expect(err).NotTo(HaveOccurred())
+			result, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).To(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
 
 			updated := &osacv1alpha1.ExternalIP{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())

--- a/osac-operator/internal/controller/externalip_controller_test.go
+++ b/osac-operator/internal/controller/externalip_controller_test.go
@@ -136,7 +136,7 @@ var _ = Describe("ExternalIPReconciler", func() {
 
 		fakeClient = fake.NewClientBuilder().
 			WithScheme(testScheme).
-			WithObjects(publicIP, parentPool).
+			WithObjects(publicIP, parentPool, newFabricManagerConfigMap("fm-default", testNamespace, "netris")).
 			WithStatusSubresource(&osacv1alpha1.ExternalIP{}).
 			Build()
 
@@ -158,6 +158,11 @@ var _ = Describe("ExternalIPReconciler", func() {
 			MaxJobHistory:              10,
 			NetworkProvisioningEnabled: true,
 		}
+		reconciler.Resolver, reconciler.networkClassesClient = wireExternalIPDispatcher(
+			fakeClient, testNamespace, []*privatev1.NetworkClass{{
+				Id: "nc-default", FabricManager: ptr.To("netris"), IsDefault: ptr.To(true),
+			}},
+		)
 	})
 
 	Context("Reconcile", func() {
@@ -200,20 +205,20 @@ var _ = Describe("ExternalIPReconciler", func() {
 			Expect(updated.Status.Phase).To(Equal(osacv1alpha1.ExternalIPPhaseProgressing))
 		})
 
-		It("should set implementation-strategy annotation from parent pool", func() {
+		It("should set implementation-strategy annotation from the dispatcher", func() {
 			key := types.NamespacedName{Name: publicIP.Name, Namespace: publicIP.Namespace}
 
 			// Pass 1: adds finalizer
 			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Pass 2: resolves parent pool and copies its implementation strategy
+			// Pass 2: resolves the dispatcher strategy
 			_, err = reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 
 			updated := &osacv1alpha1.ExternalIP{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("metallb-l2"))
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("netris"))
 			Expect(updated.Annotations[osacExternalIPPoolNameAnnotation]).To(Equal("pool-k8s-name"))
 		})
 
@@ -244,9 +249,7 @@ var _ = Describe("ExternalIPReconciler", func() {
 			Expect(result.RequeueAfter).To(Equal(defaultPreconditionRequeueInterval))
 		})
 
-		It("should use empty implementation strategy when pool has none and no resolver is configured", func() {
-			// A pool with no ImplementationStrategy in its spec and no resolver
-			// configured results in an empty annotation (dispatcher must be configured).
+		It("should resolve strategy when the parent pool strategy is empty", func() {
 			poolNoStrategy := &osacv1alpha1.ExternalIPPool{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pool-no-strategy",
@@ -279,13 +282,13 @@ var _ = Describe("ExternalIPReconciler", func() {
 			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Pass 2: no pool spec.implementationStrategy and no resolver, so annotation is ""
+			// Pass 2: the dispatcher remains authoritative despite the empty pool field.
 			_, err = reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 
 			updated := &osacv1alpha1.ExternalIP{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(""))
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("netris"))
 			Expect(updated.Annotations[osacExternalIPPoolNameAnnotation]).To(Equal("pool-no-strategy"))
 		})
 
@@ -815,7 +818,6 @@ var _ = Describe("ExternalIPReconciler", func() {
 
 	Context("dispatcher path", func() {
 		It("uses the resolved fabric manager name from the default NetworkClass", func() {
-			Expect(fakeClient.Create(testCtx, newFabricManagerConfigMap("fm-netris", testNamespace, "netris"))).To(Succeed())
 			resolver, ncClient := wireExternalIPDispatcher(fakeClient, testNamespace, []*privatev1.NetworkClass{{
 				Id: "nc-dispatch", FabricManager: ptr.To("netris"), IsDefault: ptr.To(true),
 			}})
@@ -852,7 +854,7 @@ var _ = Describe("ExternalIPReconciler", func() {
 			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("k8s_only"))
 		})
 
-		It("falls back to the parent pool spec when the NetworkClass has no managers", func() {
+		It("blocks when the NetworkClass has no managers", func() {
 			resolver, ncClient := wireExternalIPDispatcher(fakeClient, testNamespace, []*privatev1.NetworkClass{{
 				Id: "nc-empty", IsDefault: ptr.To(true),
 			}})
@@ -867,10 +869,14 @@ var _ = Describe("ExternalIPReconciler", func() {
 
 			updated := &osacv1alpha1.ExternalIP{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("metallb-l2"))
+			condition := apimeta.FindStatusCondition(updated.Status.Conditions, osacv1alpha1.ConditionReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(condition.Reason).To(Equal(osacv1alpha1.ReasonNoManagerConfigured))
+			Expect(updated.Annotations).NotTo(HaveKey(osacImplementationStrategyAnnotation))
 		})
 
-		It("falls back to the parent pool spec when no NetworkClass is listed", func() {
+		It("blocks when no NetworkClass is listed", func() {
 			resolver, ncClient := wireExternalIPDispatcher(fakeClient, testNamespace, nil)
 			reconciler.Resolver = resolver
 			reconciler.networkClassesClient = ncClient
@@ -883,7 +889,11 @@ var _ = Describe("ExternalIPReconciler", func() {
 
 			updated := &osacv1alpha1.ExternalIP{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("metallb-l2"))
+			condition := apimeta.FindStatusCondition(updated.Status.Conditions, osacv1alpha1.ConditionReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(condition.Reason).To(Equal(osacv1alpha1.ReasonNoManagerConfigured))
+			Expect(updated.Annotations).NotTo(HaveKey(osacImplementationStrategyAnnotation))
 		})
 
 		It("returns a reconcile error when the NetworkClass references an unregistered manager", func() {

--- a/osac-operator/internal/controller/externalipattachment_controller.go
+++ b/osac-operator/internal/controller/externalipattachment_controller.go
@@ -269,8 +269,10 @@ func (r *ExternalIPAttachmentReconciler) handleUpdate(ctx context.Context, attac
 	if implementationStrategy == "" {
 		setReadyConditionBlocked(&attachment.Status.Conditions, v1alpha1.ReasonNoManagerConfigured,
 			conditionMessageNoManagerConfigured)
-		log.Info("implementation strategy not resolved, requeueing", "externalIPAttachment", attachment.Name)
-		return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
+		log.Info("implementation strategy not resolved", "externalIPAttachment", attachment.Name)
+		return ctrl.Result{}, fmt.Errorf(
+			"cannot reconcile ExternalIPAttachment %q: no fabric manager is configured for NetworkClass %q",
+			attachment.Name, networkClassID)
 	}
 
 	// BMI DNAT precondition: wait for primary IP to be discovered

--- a/osac-operator/internal/controller/externalipattachment_controller.go
+++ b/osac-operator/internal/controller/externalipattachment_controller.go
@@ -71,7 +71,7 @@ type ExternalIPAttachmentReconciler struct {
 	targetCluster              mc.ClusterName
 	// Resolver resolves a NetworkClass to its registered managers. Nil when the
 	// two-manager model isn't configured (no gRPC connection / networking namespace),
-	// in which case the controller always uses the legacy implementation-strategy path.
+	// in which case the controller blocks provisioning until dispatch is available.
 	Resolver *dispatcher.Resolver
 	// networkClassesClient lists NetworkClasses to find the default/singleton used
 	// as the dispatcher input. Nil when gRPC is not configured.
@@ -262,9 +262,15 @@ func (r *ExternalIPAttachmentReconciler) handleUpdate(ctx context.Context, attac
 		return ctrl.Result{}, err
 	}
 	implementationStrategy, err := resolveImplementationStrategy(
-		ctx, r.Resolver, "ExternalIPAttachment", networkClassID, pool.Spec.ImplementationStrategy)
+		ctx, r.Resolver, "ExternalIPAttachment", networkClassID)
 	if err != nil {
 		return ctrl.Result{}, err
+	}
+	if implementationStrategy == "" {
+		setReadyConditionBlocked(&attachment.Status.Conditions, v1alpha1.ReasonNoManagerConfigured,
+			conditionMessageNoManagerConfigured)
+		log.Info("implementation strategy not resolved, requeueing", "externalIPAttachment", attachment.Name)
+		return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
 	}
 
 	// BMI DNAT precondition: wait for primary IP to be discovered

--- a/osac-operator/internal/controller/externalipattachment_controller_test.go
+++ b/osac-operator/internal/controller/externalipattachment_controller_test.go
@@ -384,10 +384,9 @@ var _ = Describe("ExternalIPAttachmentReconciler", func() {
 			reconciler.Resolver = resolver
 			reconciler.networkClassesClient = ncClient
 
-			_, err := reconcileOnce()
-			Expect(err).NotTo(HaveOccurred())
-			_, err = reconcileOnce()
-			Expect(err).NotTo(HaveOccurred())
+			result, err := reconcileOnce()
+			Expect(err).To(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
 
 			updated := &osacv1alpha1.ExternalIPAttachment{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())

--- a/osac-operator/internal/controller/externalipattachment_controller_test.go
+++ b/osac-operator/internal/controller/externalipattachment_controller_test.go
@@ -76,6 +76,7 @@ var _ = Describe("ExternalIPAttachmentReconciler", func() {
 	)
 
 	buildClient := func(objs ...client.Object) client.Client {
+		objs = append(objs, newFabricManagerConfigMap("fm-default", testNetworkingNamespace, "netris"))
 		return fake.NewClientBuilder().
 			WithScheme(testScheme).
 			WithObjects(objs...).
@@ -173,6 +174,11 @@ var _ = Describe("ExternalIPAttachmentReconciler", func() {
 			MaxJobHistory:              10,
 			NetworkProvisioningEnabled: true,
 		}
+		reconciler.Resolver, reconciler.networkClassesClient = wireExternalIPDispatcher(
+			c, testNetworkingNamespace, []*privatev1.NetworkClass{{
+				Id: "nc-default", FabricManager: ptr.To("netris"), IsDefault: ptr.To(true),
+			}},
+		)
 	}
 
 	reconcileOnce := func() (ctrl.Result, error) {
@@ -301,13 +307,13 @@ var _ = Describe("ExternalIPAttachmentReconciler", func() {
 
 			updated := &osacv1alpha1.ExternalIPAttachment{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("metallb-l2"))
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("netris"))
 			Expect(updated.Annotations[osacExternalIPPoolNameAnnotation]).To(Equal("test-pool"))
 			Expect(updated.Annotations[osacExternalIPNameAnnotation]).To(Equal(testExternalIPName))
 			Expect(updated.Annotations[osacExternalIPTargetNamespaceAnnotation]).To(Equal(testVMNamespace))
 		})
 
-		It("should use default implementation strategy when pool has none", func() {
+		It("should resolve strategy when the pool strategy is empty", func() {
 			pool.Spec.ImplementationStrategy = ""
 			fakeClient = buildClient(attachment, publicIP, pool, ci)
 			setupReconciler(fakeClient)
@@ -325,8 +331,7 @@ var _ = Describe("ExternalIPAttachmentReconciler", func() {
 
 			updated := &osacv1alpha1.ExternalIPAttachment{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
-			// Pool has no spec.implementationStrategy and no resolver is configured, so annotation is ""
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(""))
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("netris"))
 		})
 	})
 
@@ -334,7 +339,6 @@ var _ = Describe("ExternalIPAttachmentReconciler", func() {
 		It("uses the resolved fabric manager name from the default NetworkClass", func() {
 			fakeClient = buildClient(attachment, publicIP, pool, ci)
 			setupReconciler(fakeClient)
-			Expect(fakeClient.Create(testCtx, newFabricManagerConfigMap("fm-netris", testNetworkingNamespace, "netris"))).To(Succeed())
 			resolver, ncClient := wireExternalIPDispatcher(fakeClient, testNetworkingNamespace, []*privatev1.NetworkClass{{
 				Id: "nc-dispatch", FabricManager: ptr.To("netris"), IsDefault: ptr.To(true),
 			}})
@@ -371,7 +375,7 @@ var _ = Describe("ExternalIPAttachmentReconciler", func() {
 			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("k8s_only"))
 		})
 
-		It("falls back to the parent pool spec when the NetworkClass has no managers", func() {
+		It("blocks when the NetworkClass has no managers", func() {
 			fakeClient = buildClient(attachment, publicIP, pool, ci)
 			setupReconciler(fakeClient)
 			resolver, ncClient := wireExternalIPDispatcher(fakeClient, testNetworkingNamespace, []*privatev1.NetworkClass{{
@@ -387,7 +391,11 @@ var _ = Describe("ExternalIPAttachmentReconciler", func() {
 
 			updated := &osacv1alpha1.ExternalIPAttachment{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("metallb-l2"))
+			condition := apimeta.FindStatusCondition(updated.Status.Conditions, osacv1alpha1.ConditionReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(condition.Reason).To(Equal(osacv1alpha1.ReasonNoManagerConfigured))
+			Expect(updated.Annotations).NotTo(HaveKey(osacImplementationStrategyAnnotation))
 		})
 
 		It("returns a reconcile error when the NetworkClass references an unregistered manager", func() {
@@ -1037,7 +1045,7 @@ var _ = Describe("ExternalIPAttachmentReconciler", func() {
 			updated := &osacv1alpha1.ExternalIPAttachment{}
 			Expect(fakeClient.Get(testCtx, clusterKey, updated)).To(Succeed())
 			Expect(updated.Annotations[osacExternalIPTargetIPAnnotation]).To(Equal(testAPIEndpoint))
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("metallb-l2"))
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("netris"))
 		})
 
 		It("should set target-ip annotation with resolved ingress endpoint", func() {

--- a/osac-operator/internal/controller/externalippool_controller.go
+++ b/osac-operator/internal/controller/externalippool_controller.go
@@ -198,8 +198,10 @@ func (r *ExternalIPPoolReconciler) handleUpdate(ctx context.Context, pool *v1alp
 	if implementationStrategy == "" {
 		setReadyConditionBlocked(&pool.Status.Conditions, v1alpha1.ReasonNoManagerConfigured,
 			conditionMessageNoManagerConfigured)
-		log.Info("implementation strategy not resolved, requeueing", "externalIPPool", pool.Name)
-		return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
+		log.Info("implementation strategy not resolved", "externalIPPool", pool.Name)
+		return ctrl.Result{}, fmt.Errorf(
+			"cannot reconcile ExternalIPPool %q: no fabric manager is configured for NetworkClass %q",
+			pool.Name, networkClassID)
 	}
 
 	// Stamp the implementation-strategy annotation so AAP playbooks can read it

--- a/osac-operator/internal/controller/externalippool_controller.go
+++ b/osac-operator/internal/controller/externalippool_controller.go
@@ -49,8 +49,7 @@ const (
 //
 // A ExternalIPPool defines a range of external IP addresses (CIDRs) that can be allocated
 // as individual ExternalIP resources. Implementation strategy is resolved from the default
-// NetworkClass via the dispatcher; pool spec.implementationStrategy is a backward-compat
-// fallback (along with defaultExternalIPPoolImplementationStrategy).
+// NetworkClass via the dispatcher.
 //
 // The controller adds a finalizer, triggers AAP provisioning/deprovisioning jobs via
 // the shared provisioning lifecycle, and transitions phases:
@@ -67,7 +66,7 @@ type ExternalIPPoolReconciler struct {
 	targetCluster        mc.ClusterName
 	// Resolver resolves a NetworkClass to its registered managers. Nil when the
 	// two-manager model isn't configured (no gRPC connection / networking namespace),
-	// in which case the controller always uses the legacy implementation-strategy path.
+	// in which case the controller blocks provisioning until dispatch is available.
 	Resolver *dispatcher.Resolver
 	// networkClassesClient lists NetworkClasses to find the default/singleton used
 	// as the dispatcher input. Nil when gRPC is not configured.
@@ -186,17 +185,21 @@ func (r *ExternalIPPoolReconciler) handleUpdate(ctx context.Context, pool *v1alp
 		return ctrl.Result{}, nil
 	}
 
-	// Resolve implementation strategy from the default NetworkClass via the
-	// dispatcher. pool spec.implementationStrategy is only used as a fallback
-	// when the dispatcher path is not active.
+	// Resolve implementation strategy from the default NetworkClass via the dispatcher.
 	networkClassID, err := lookupDefaultNetworkClassID(ctx, r.networkClassesClient)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 	implementationStrategy, err := resolveImplementationStrategy(
-		ctx, r.Resolver, "ExternalIPPool", networkClassID, pool.Spec.ImplementationStrategy)
+		ctx, r.Resolver, "ExternalIPPool", networkClassID)
 	if err != nil {
 		return ctrl.Result{}, err
+	}
+	if implementationStrategy == "" {
+		setReadyConditionBlocked(&pool.Status.Conditions, v1alpha1.ReasonNoManagerConfigured,
+			conditionMessageNoManagerConfigured)
+		log.Info("implementation strategy not resolved, requeueing", "externalIPPool", pool.Name)
+		return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
 	}
 
 	// Stamp the implementation-strategy annotation so AAP playbooks can read it

--- a/osac-operator/internal/controller/externalippool_controller_test.go
+++ b/osac-operator/internal/controller/externalippool_controller_test.go
@@ -43,8 +43,7 @@ import (
 // Key concepts for understanding these tests:
 //
 //   - Implementation strategy is resolved from the default NetworkClass via the dispatcher.
-//     pool spec.implementationStrategy (then metallb-l2) is a backward-compat fallback used
-//     when the dispatcher path is not active.
+//     When no manager resolves, provisioning blocks with a Ready=False condition.
 //
 //   - The reconcile loop requires multiple passes because each pass does one thing and
 //     returns: first pass adds the finalizer (metadata write), second pass processes the
@@ -86,7 +85,7 @@ var _ = Describe("ExternalIPPoolReconciler", func() {
 
 		fakeClient = fake.NewClientBuilder().
 			WithScheme(testScheme).
-			WithObjects(pool).
+			WithObjects(pool, newFabricManagerConfigMap("fm-default", "test-namespace", "netris")).
 			WithStatusSubresource(&osacv1alpha1.ExternalIPPool{}).
 			Build()
 
@@ -102,6 +101,11 @@ var _ = Describe("ExternalIPPoolReconciler", func() {
 			MaxJobHistory:              10,
 			NetworkProvisioningEnabled: true,
 		}
+		reconciler.Resolver, reconciler.networkClassesClient = wireExternalIPDispatcher(
+			fakeClient, "test-namespace", []*privatev1.NetworkClass{{
+				Id: "nc-default", FabricManager: ptr.To("netris"), IsDefault: ptr.To(true),
+			}},
+		)
 	})
 
 	Context("Reconcile", func() {
@@ -136,7 +140,7 @@ var _ = Describe("ExternalIPPoolReconciler", func() {
 			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Pass 2: reads strategy from spec, triggers provisioning, sets Progressing
+			// Pass 2: uses the dispatcher strategy, triggers provisioning, sets Progressing
 			_, err = reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -208,7 +212,7 @@ var _ = Describe("ExternalIPPoolReconciler", func() {
 			annotated := &osacv1alpha1.ExternalIPPool{}
 			Expect(fakeClient.Get(testCtx, key, annotated)).To(Succeed())
 			Expect(annotated.Annotations).To(HaveKeyWithValue(
-				osacImplementationStrategyAnnotation, "metallb-l2",
+				osacImplementationStrategyAnnotation, "netris",
 			))
 
 			// Pass 2: annotation is already set, provisioning is triggered.
@@ -217,10 +221,8 @@ var _ = Describe("ExternalIPPoolReconciler", func() {
 			Expect(provisionCalled).To(BeTrue(), "AAP provisioning must be triggered after annotation is stamped")
 		})
 
-		It("should not stamp annotation when no strategy is resolved and spec.implementationStrategy is empty", func() {
-			// Create a pool that omits ImplementationStrategy. With no resolver configured
-			// and no spec.implementationStrategy, no annotation is set (dispatcher must be
-			// configured for a real strategy).
+		It("should resolve strategy when spec.implementationStrategy is empty", func() {
+			// The resource-level legacy field does not participate in dispatch.
 			poolNoStrategy := &osacv1alpha1.ExternalIPPool{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "pool-no-strategy",
@@ -236,16 +238,12 @@ var _ = Describe("ExternalIPPoolReconciler", func() {
 
 			key := types.NamespacedName{Name: poolNoStrategy.Name, Namespace: poolNoStrategy.Namespace}
 
-			// Pass 1: finalizer. With no resolver and no spec.implementationStrategy,
-			// the resolved strategy is "" and no annotation update occurs (nil != "" is false
-			// because accessing a nil map returns the zero value).
 			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 
 			annotated := &osacv1alpha1.ExternalIPPool{}
 			Expect(fakeClient.Get(testCtx, key, annotated)).To(Succeed())
-			// Annotation is not set when the resolved strategy is empty
-			Expect(annotated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(""))
+			Expect(annotated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("netris"))
 		})
 
 		It("should set ConfigurationApplied condition to True", func() {
@@ -573,7 +571,6 @@ var _ = Describe("ExternalIPPoolReconciler", func() {
 		const ns = "test-namespace"
 
 		It("uses the resolved fabric manager name from the default NetworkClass", func() {
-			Expect(fakeClient.Create(testCtx, newFabricManagerConfigMap("fm-netris", ns, "netris"))).To(Succeed())
 			resolver, ncClient := wireExternalIPDispatcher(fakeClient, ns, []*privatev1.NetworkClass{{
 				Id: "nc-dispatch", FabricManager: ptr.To("netris"), IsDefault: ptr.To(true),
 			}})
@@ -606,7 +603,7 @@ var _ = Describe("ExternalIPPoolReconciler", func() {
 			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("k8s_only"))
 		})
 
-		It("falls back to spec.implementationStrategy when the NetworkClass has no managers", func() {
+		It("blocks when the NetworkClass has no managers", func() {
 			resolver, ncClient := wireExternalIPDispatcher(fakeClient, ns, []*privatev1.NetworkClass{{
 				Id: "nc-empty", IsDefault: ptr.To(true),
 			}})
@@ -619,10 +616,14 @@ var _ = Describe("ExternalIPPoolReconciler", func() {
 
 			updated := &osacv1alpha1.ExternalIPPool{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("metallb-l2"))
+			condition := apimeta.FindStatusCondition(updated.Status.Conditions, osacv1alpha1.ConditionReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(condition.Reason).To(Equal(osacv1alpha1.ReasonNoManagerConfigured))
+			Expect(updated.Annotations).NotTo(HaveKey(osacImplementationStrategyAnnotation))
 		})
 
-		It("falls back to spec.implementationStrategy when no NetworkClass is listed", func() {
+		It("blocks when no NetworkClass is listed", func() {
 			resolver, ncClient := wireExternalIPDispatcher(fakeClient, ns, nil)
 			reconciler.Resolver = resolver
 			reconciler.networkClassesClient = ncClient
@@ -633,7 +634,11 @@ var _ = Describe("ExternalIPPoolReconciler", func() {
 
 			updated := &osacv1alpha1.ExternalIPPool{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("metallb-l2"))
+			condition := apimeta.FindStatusCondition(updated.Status.Conditions, osacv1alpha1.ConditionReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(condition.Reason).To(Equal(osacv1alpha1.ReasonNoManagerConfigured))
+			Expect(updated.Annotations).NotTo(HaveKey(osacImplementationStrategyAnnotation))
 		})
 
 		It("returns a reconcile error when the NetworkClass references an unregistered manager", func() {

--- a/osac-operator/internal/controller/externalippool_controller_test.go
+++ b/osac-operator/internal/controller/externalippool_controller_test.go
@@ -611,8 +611,9 @@ var _ = Describe("ExternalIPPoolReconciler", func() {
 			reconciler.networkClassesClient = ncClient
 
 			key := types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}
-			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
-			Expect(err).NotTo(HaveOccurred())
+			result, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).To(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
 
 			updated := &osacv1alpha1.ExternalIPPool{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())
@@ -629,8 +630,9 @@ var _ = Describe("ExternalIPPoolReconciler", func() {
 			reconciler.networkClassesClient = ncClient
 
 			key := types.NamespacedName{Name: pool.Name, Namespace: pool.Namespace}
-			_, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
-			Expect(err).NotTo(HaveOccurred())
+			result, err := reconciler.Reconcile(testCtx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).To(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
 
 			updated := &osacv1alpha1.ExternalIPPool{}
 			Expect(fakeClient.Get(testCtx, key, updated)).To(Succeed())

--- a/osac-operator/internal/controller/securitygroup_controller.go
+++ b/osac-operator/internal/controller/securitygroup_controller.go
@@ -56,7 +56,7 @@ type SecurityGroupReconciler struct {
 	targetCluster        mc.ClusterName
 	// Resolver resolves a NetworkClass to its registered managers. Nil when the
 	// two-manager model isn't configured (no gRPC connection / networking namespace),
-	// in which case the controller always uses the legacy implementation-strategy path.
+	// in which case the controller blocks provisioning until dispatch is available.
 	Resolver *dispatcher.Resolver
 	// NetworkProvisioningEnabled controls whether the controller dispatches AAP
 	// provisioning jobs. When false, resources are set to Ready immediately.
@@ -206,15 +206,18 @@ func (r *SecurityGroupReconciler) handleUpdate(ctx context.Context, sg *v1alpha1
 			return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
 		}
 	} else {
-		log.Info("parent VirtualNetwork not found, using legacy implementation strategy", "uuid", sg.Spec.VirtualNetwork)
+		log.Info("parent VirtualNetwork not found", "uuid", sg.Spec.VirtualNetwork)
 	}
 
-	// resolveImplementationStrategy returns "" when the dispatcher path isn't available
-	// (resolver nil, networkClassID empty, or no manager configured). SecurityGroup
-	// has no resource-level fallback strategy — it exclusively uses the dispatcher.
-	implementationStrategy, err := resolveImplementationStrategy(ctx, r.Resolver, "SecurityGroup", networkClassID, "")
+	implementationStrategy, err := resolveImplementationStrategy(ctx, r.Resolver, "SecurityGroup", networkClassID)
 	if err != nil {
 		return ctrl.Result{}, err
+	}
+	if implementationStrategy == "" {
+		setReadyConditionBlocked(&sg.Status.Conditions, v1alpha1.ReasonNoManagerConfigured,
+			conditionMessageNoManagerConfigured)
+		log.Info("implementation strategy not resolved, requeueing", "securityGroup", sg.Name)
+		return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
 	}
 
 	// Add implementation-strategy annotation if not present or different

--- a/osac-operator/internal/controller/securitygroup_controller.go
+++ b/osac-operator/internal/controller/securitygroup_controller.go
@@ -207,6 +207,7 @@ func (r *SecurityGroupReconciler) handleUpdate(ctx context.Context, sg *v1alpha1
 		}
 	} else {
 		log.Info("parent VirtualNetwork not found", "uuid", sg.Spec.VirtualNetwork)
+		return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
 	}
 
 	implementationStrategy, err := resolveImplementationStrategy(ctx, r.Resolver, "SecurityGroup", networkClassID)
@@ -216,8 +217,10 @@ func (r *SecurityGroupReconciler) handleUpdate(ctx context.Context, sg *v1alpha1
 	if implementationStrategy == "" {
 		setReadyConditionBlocked(&sg.Status.Conditions, v1alpha1.ReasonNoManagerConfigured,
 			conditionMessageNoManagerConfigured)
-		log.Info("implementation strategy not resolved, requeueing", "securityGroup", sg.Name)
-		return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
+		log.Info("implementation strategy not resolved", "securityGroup", sg.Name)
+		return ctrl.Result{}, fmt.Errorf(
+			"cannot reconcile SecurityGroup %q: no fabric manager is configured for NetworkClass %q",
+			sg.Name, networkClassID)
 	}
 
 	// Add implementation-strategy annotation if not present or different

--- a/osac-operator/internal/controller/securitygroup_controller_test.go
+++ b/osac-operator/internal/controller/securitygroup_controller_test.go
@@ -120,7 +120,7 @@ var _ = Describe("SecurityGroupReconciler", func() {
 		// Create fake client with fixtures
 		fakeClient = fake.NewClientBuilder().
 			WithScheme(testScheme).
-			WithObjects(vnet, sg, readySubnet).
+			WithObjects(vnet, sg, readySubnet, newFabricManagerConfigMap("fm-default", "test-namespace", "netris")).
 			WithStatusSubresource(&osacv1alpha1.SecurityGroup{}, &osacv1alpha1.Subnet{}).
 			Build()
 
@@ -144,6 +144,11 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			MaxJobHistory:              10,
 			NetworkProvisioningEnabled: true,
 		}
+		reconciler.Resolver, _ = wireExternalIPDispatcher(
+			fakeClient, "test-namespace", []*privatev1.NetworkClass{{
+				Id: "cudn-net", FabricManager: ptr.To("netris"),
+			}},
+		)
 	})
 
 	Context("Reconcile", func() {
@@ -209,10 +214,10 @@ var _ = Describe("SecurityGroupReconciler", func() {
 				}, nil
 			}
 
-			// First reconcile: adds finalizer and triggers job (with no resolver,
-			// the annotation doesn't change so provisioning proceeds immediately).
-			// The concurrent modification must not prevent the job from being recorded.
+			// First reconcile stamps the dispatcher strategy; the second triggers the job.
 			_, err := reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify the job was persisted
@@ -249,7 +254,7 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			Expect(provisionCalled).To(BeTrue())
 		})
 
-		It("should not stamp annotation when no resolver is configured", func() {
+		It("should stamp the dispatcher strategy", func() {
 			key := types.NamespacedName{Name: sg.Name, Namespace: sg.Namespace}
 
 			mockProvider.triggerProvisionFunc = func(ctx context.Context, resource client.Object) (*provisioning.ProvisionResult, error) {
@@ -270,13 +275,11 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			updated := &osacv1alpha1.SecurityGroup{}
 			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
 
-			// With no resolver configured, the resolved strategy is "" and no annotation
-			// update occurs (the existing value "" matches the resolved value "").
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(""))
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("netris"))
 		})
 
 		It("should not update when annotation already matches implementation strategy", func() {
-			// Create SecurityGroup with annotation already set (no resolver, so "" is the resolved value)
+			// Create SecurityGroup with an empty strategy annotation.
 			sgWithAnnotation := &osacv1alpha1.SecurityGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "sg-with-annotation",
@@ -311,8 +314,7 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			updated := &osacv1alpha1.SecurityGroup{}
 			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
 
-			// Verify annotation still matches (no duplicate Update calls)
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(""))
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("netris"))
 		})
 
 		It("should update annotation when it differs from the resolved strategy", func() {
@@ -351,8 +353,7 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			updated := &osacv1alpha1.SecurityGroup{}
 			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
 
-			// With no resolver configured, annotation is updated to "" (dispatcher must be configured)
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(""))
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("netris"))
 		})
 
 		It("should trigger provision job when no job exists", func() {
@@ -377,9 +378,11 @@ var _ = Describe("SecurityGroupReconciler", func() {
 
 			req := mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}}
 
-			// First reconcile adds finalizer and triggers the provision job (with no resolver,
-			// annotation doesn't change so provisioning proceeds immediately). Returns with
-			// RequeueAfter for status polling.
+			// First reconcile stamps the dispatcher strategy.
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			// The next reconcile triggers provisioning and returns the polling interval.
 			result, err := reconciler.Reconcile(ctx, req)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(Equal(reconciler.StatusPollInterval))
@@ -839,7 +842,6 @@ var _ = Describe("SecurityGroupReconciler", func() {
 
 	Context("dispatcher path", func() {
 		It("uses the resolved fabric manager name from the parent VirtualNetwork's NetworkClass", func() {
-			Expect(fakeClient.Create(ctx, newFabricManagerConfigMap("fm-netris", "test-namespace", "netris"))).To(Succeed())
 			disc, err := networkmanager.NewDiscovery(fakeClient, "test-namespace")
 			Expect(err).NotTo(HaveOccurred())
 			reconciler.Resolver = dispatcher.NewResolver(dispatcheradapter.NewNetworkClassAdapter(newListingNetworkClassClient(
@@ -865,7 +867,7 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("netris"))
 		})
 
-		It("falls back to the default strategy when fabricManager is not set", func() {
+		It("blocks when no manager is configured", func() {
 			disc, err := networkmanager.NewDiscovery(fakeClient, "test-namespace")
 			Expect(err).NotTo(HaveOccurred())
 			reconciler.Resolver = dispatcher.NewResolver(dispatcheradapter.NewNetworkClassAdapter(newListingNetworkClassClient(
@@ -885,8 +887,11 @@ var _ = Describe("SecurityGroupReconciler", func() {
 
 			updated := &osacv1alpha1.SecurityGroup{}
 			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
-			// With no resolver configured, annotation is "" (dispatcher must be configured)
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(""))
+			condition := apimeta.FindStatusCondition(updated.Status.Conditions, osacv1alpha1.ConditionReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(condition.Reason).To(Equal(osacv1alpha1.ReasonNoManagerConfigured))
+			Expect(updated.Annotations).NotTo(HaveKey(osacImplementationStrategyAnnotation))
 		})
 
 		It("returns a reconcile error when the NetworkClass references an unregistered manager", func() {
@@ -907,7 +912,7 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("falls back to legacy strategy when the parent VirtualNetwork cannot be found", func() {
+		It("blocks when the parent VirtualNetwork cannot be found", func() {
 			disc, err := networkmanager.NewDiscovery(fakeClient, "test-namespace")
 			Expect(err).NotTo(HaveOccurred())
 			reconciler.Resolver = dispatcher.NewResolver(dispatcheradapter.NewNetworkClassAdapter(newListingNetworkClassClient(
@@ -934,8 +939,11 @@ var _ = Describe("SecurityGroupReconciler", func() {
 
 			updated := &osacv1alpha1.SecurityGroup{}
 			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
-			// Parent VirtualNetwork not found, so networkClassID is empty -> annotation is ""
-			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal(""))
+			condition := apimeta.FindStatusCondition(updated.Status.Conditions, osacv1alpha1.ConditionReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(condition.Reason).To(Equal(osacv1alpha1.ReasonNoManagerConfigured))
+			Expect(updated.Annotations).NotTo(HaveKey(osacImplementationStrategyAnnotation))
 		})
 
 		It("returns an error when multiple VirtualNetworks share the parent uuid label", func() {

--- a/osac-operator/internal/controller/securitygroup_controller_test.go
+++ b/osac-operator/internal/controller/securitygroup_controller_test.go
@@ -867,6 +867,28 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("netris"))
 		})
 
+		It("uses the composite k8s manager when the NetworkClass has no fabricManager", func() {
+			Expect(fakeClient.Create(ctx, newK8sManagerConfigMap("km-k8s-only", "test-namespace", "k8s_only", "ipv4"))).To(Succeed())
+			disc, err := networkmanager.NewDiscovery(fakeClient, "test-namespace")
+			Expect(err).NotTo(HaveOccurred())
+			reconciler.Resolver = dispatcher.NewResolver(dispatcheradapter.NewNetworkClassAdapter(newListingNetworkClassClient(
+				[]*privatev1.NetworkClass{{Id: "nc-k8s", K8SManager: ptr.To("k8s_only")}}, &[]*privatev1.NetworkClass{},
+			)), disc)
+
+			vnet.Spec.NetworkClass = "nc-k8s"
+			Expect(fakeClient.Update(ctx, vnet)).To(Succeed())
+
+			key := types.NamespacedName{Name: sg.Name, Namespace: sg.Namespace}
+			_, err = reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &osacv1alpha1.SecurityGroup{}
+			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
+			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("k8s_only"))
+		})
+
 		It("blocks when no manager is configured", func() {
 			disc, err := networkmanager.NewDiscovery(fakeClient, "test-namespace")
 			Expect(err).NotTo(HaveOccurred())
@@ -882,8 +904,9 @@ var _ = Describe("SecurityGroupReconciler", func() {
 				return &provisioning.ProvisionResult{JobID: "job-legacy", InitialState: osacv1alpha1.JobStatePending}, nil
 			}
 
-			_, err = reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
-			Expect(err).NotTo(HaveOccurred())
+			result, err := reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).To(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
 
 			updated := &osacv1alpha1.SecurityGroup{}
 			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
@@ -912,7 +935,7 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("blocks when the parent VirtualNetwork cannot be found", func() {
+		It("requeues when the parent VirtualNetwork cannot be found", func() {
 			disc, err := networkmanager.NewDiscovery(fakeClient, "test-namespace")
 			Expect(err).NotTo(HaveOccurred())
 			reconciler.Resolver = dispatcher.NewResolver(dispatcheradapter.NewNetworkClassAdapter(newListingNetworkClassClient(
@@ -928,21 +951,16 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			Expect(fakeClient.Create(ctx, orphanSG)).To(Succeed())
 
 			key := types.NamespacedName{Name: orphanSG.Name, Namespace: orphanSG.Namespace}
-			mockProvider.triggerProvisionFunc = func(ctx context.Context, resource client.Object) (*provisioning.ProvisionResult, error) {
-				return &provisioning.ProvisionResult{JobID: "job-orphan", InitialState: osacv1alpha1.JobStatePending}, nil
-			}
-
 			_, err = reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
-			_, err = reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			result, err := reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(defaultPreconditionRequeueInterval))
 
 			updated := &osacv1alpha1.SecurityGroup{}
 			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
 			condition := apimeta.FindStatusCondition(updated.Status.Conditions, osacv1alpha1.ConditionReady)
-			Expect(condition).NotTo(BeNil())
-			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(condition.Reason).To(Equal(osacv1alpha1.ReasonNoManagerConfigured))
+			Expect(condition).To(BeNil())
 			Expect(updated.Annotations).NotTo(HaveKey(osacImplementationStrategyAnnotation))
 		})
 

--- a/osac-operator/internal/controller/virtualnetwork_controller.go
+++ b/osac-operator/internal/controller/virtualnetwork_controller.go
@@ -179,8 +179,8 @@ func (r *VirtualNetworkReconciler) handleUpdate(ctx context.Context, vnet *v1alp
 	if implementationStrategy == "" {
 		msg := fmt.Sprintf("NetworkClass '%s' has no fabric_manager or k8s_manager configured", vnet.Spec.NetworkClass)
 		setReadyConditionBlocked(&vnet.Status.Conditions, v1alpha1.ReasonNoManagerConfigured, msg)
-		log.Info("implementation strategy not set, requeueing", "virtualNetwork", vnet.Name)
-		return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
+		log.Info("implementation strategy not set", "virtualNetwork", vnet.Name)
+		return ctrl.Result{}, fmt.Errorf("cannot reconcile VirtualNetwork %q: %s", vnet.Name, msg)
 	}
 
 	// Add implementation-strategy annotation if not present or different

--- a/osac-operator/internal/controller/virtualnetwork_controller.go
+++ b/osac-operator/internal/controller/virtualnetwork_controller.go
@@ -172,7 +172,7 @@ func (r *VirtualNetworkReconciler) handleUpdate(ctx context.Context, vnet *v1alp
 	// Determine implementation strategy from the dispatcher-resolved manager for this
 	// VirtualNetwork's NetworkClass (fabric_manager, falling back to k8s_manager).
 	implementationStrategy, err := resolveImplementationStrategy(
-		ctx, r.Resolver, "VirtualNetwork", vnet.Spec.NetworkClass, "")
+		ctx, r.Resolver, "VirtualNetwork", vnet.Spec.NetworkClass)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/osac-operator/internal/controller/virtualnetwork_controller_test.go
+++ b/osac-operator/internal/controller/virtualnetwork_controller_test.go
@@ -239,7 +239,7 @@ var _ = Describe("VirtualNetworkReconciler", func() {
 			Expect(latestJob.JobID).To(Equal("concurrent-job-123"))
 		})
 
-		It("should requeue and set a blocked Ready condition when the NetworkClass has no manager configured", func() {
+		It("should fail and set a blocked Ready condition when the NetworkClass has no manager configured", func() {
 			// "some-class" is registered with the dispatcher (see BeforeEach) but has
 			// neither a fabricManager nor a k8sManager set.
 			vnetNoStrategy := &osacv1alpha1.VirtualNetwork{
@@ -266,8 +266,8 @@ var _ = Describe("VirtualNetworkReconciler", func() {
 					Namespace: vnetNoStrategy.Namespace,
 				},
 			}})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.RequeueAfter).To(Equal(defaultPreconditionRequeueInterval))
+			Expect(err).To(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
 
 			updated := &osacv1alpha1.VirtualNetwork{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: vnetNoStrategy.Name, Namespace: vnetNoStrategy.Namespace}, updated)).To(Succeed())
@@ -847,7 +847,7 @@ var _ = Describe("VirtualNetworkReconciler", func() {
 			Expect(updated.Annotations[osacImplementationStrategyAnnotation]).To(Equal("netris"))
 		})
 
-		It("requeues and sets a blocked condition when the NetworkClass has no manager configured (no legacy fallback)", func() {
+		It("fails and sets a blocked condition when the NetworkClass has no manager configured (no legacy fallback)", func() {
 			disc, err := networkmanager.NewDiscovery(fakeDiscoveryClient, "osac")
 			Expect(err).NotTo(HaveOccurred())
 			reconciler.Resolver = dispatcher.NewResolver(dispatcheradapter.NewNetworkClassAdapter(newListingNetworkClassClient(
@@ -860,8 +860,8 @@ var _ = Describe("VirtualNetworkReconciler", func() {
 			result, err := reconciler.Reconcile(ctx, mcreconcile.Request{Request: reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: vnet.Name, Namespace: vnet.Namespace},
 			}})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.RequeueAfter).To(Equal(defaultPreconditionRequeueInterval))
+			Expect(err).To(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
 
 			updated := &osacv1alpha1.VirtualNetwork{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: vnet.Name, Namespace: vnet.Namespace}, updated)).To(Succeed())

--- a/osac-operator/pkg/dispatcher/dispatch.go
+++ b/osac-operator/pkg/dispatcher/dispatch.go
@@ -29,6 +29,12 @@ const (
 
 	// ManagerRoleK8s targets the k8s manager for overlay-to-fabric bridging.
 	ManagerRoleK8s ManagerRole = "k8s"
+
+	// K8sOnlyManagerName identifies the composite Kubernetes-only manager. It
+	// is the only manager allowed to satisfy a fabric-role fallback because it
+	// provides the Kubernetes-native SecurityGroup and ExternalIP family
+	// implementations used by the VMaaS-only profile.
+	K8sOnlyManagerName = "k8s_only"
 )
 
 // DispatchTarget pairs a manager role with its resolved manager details.
@@ -90,20 +96,29 @@ type ResourceDispatchConfig struct {
 	Roles []ManagerRole
 
 	// K8sFallback indicates that when no fabric manager is resolved, this kind's
-	// Fabric-role target is served by the k8s manager instead of erroring. Used
-	// for k8s-only deployments where the NetworkClass has no fabricManager.
+	// Fabric-role target may be served by an explicitly allowed k8s manager
+	// instead of erroring. Used only for the k8s-only deployment profile.
 	K8sFallback bool
+
+	// K8sFallbackManager restricts K8sFallback to a named composite manager.
+	// An empty value disables fallback even when K8sFallback is true, preventing
+	// arbitrary k8s managers from silently taking ownership of fabric operations.
+	K8sFallbackManager string
 }
 
 // dispatchTable maps Kubernetes resource kinds to the manager roles that handle
 // their provisioning operations.
+// The k8s fallback entries are restricted to the composite k8s_only manager,
+// which provides NetworkPolicy and MetalLB implementations when no physical
+// fabric is present. Other k8s managers only bridge overlays and cannot satisfy
+// the unified fabric-resource contract.
 var dispatchTable = map[string]ResourceDispatchConfig{
-	"VirtualNetwork":       {Roles: []ManagerRole{ManagerRoleFabric}, K8sFallback: true},
-	"Subnet":               {Roles: []ManagerRole{ManagerRoleFabric, ManagerRoleK8s}, K8sFallback: true},
-	"SecurityGroup":        {Roles: []ManagerRole{ManagerRoleFabric}, K8sFallback: true},
-	"ExternalIP":           {Roles: []ManagerRole{ManagerRoleFabric}, K8sFallback: true},
-	"ExternalIPPool":       {Roles: []ManagerRole{ManagerRoleFabric}, K8sFallback: true},
-	"ExternalIPAttachment": {Roles: []ManagerRole{ManagerRoleFabric}, K8sFallback: true},
+	"VirtualNetwork":       {Roles: []ManagerRole{ManagerRoleFabric}, K8sFallback: true, K8sFallbackManager: K8sOnlyManagerName},
+	"Subnet":               {Roles: []ManagerRole{ManagerRoleFabric, ManagerRoleK8s}, K8sFallback: true, K8sFallbackManager: K8sOnlyManagerName},
+	"SecurityGroup":        {Roles: []ManagerRole{ManagerRoleFabric}, K8sFallback: true, K8sFallbackManager: K8sOnlyManagerName},
+	"ExternalIP":           {Roles: []ManagerRole{ManagerRoleFabric}, K8sFallback: true, K8sFallbackManager: K8sOnlyManagerName},
+	"ExternalIPPool":       {Roles: []ManagerRole{ManagerRoleFabric}, K8sFallback: true, K8sFallbackManager: K8sOnlyManagerName},
+	"ExternalIPAttachment": {Roles: []ManagerRole{ManagerRoleFabric}, K8sFallback: true, K8sFallbackManager: K8sOnlyManagerName},
 	"NATGateway":           {Roles: []ManagerRole{ManagerRoleFabric}, K8sFallback: false},
 }
 
@@ -117,7 +132,11 @@ func LookupDispatchConfig(kind string) *ResourceDispatchConfig {
 	}
 	rolesCopy := make([]ManagerRole, len(cfg.Roles))
 	copy(rolesCopy, cfg.Roles)
-	return &ResourceDispatchConfig{Roles: rolesCopy, K8sFallback: cfg.K8sFallback}
+	return &ResourceDispatchConfig{
+		Roles:              rolesCopy,
+		K8sFallback:        cfg.K8sFallback,
+		K8sFallbackManager: cfg.K8sFallbackManager,
+	}
 }
 
 // KnownKinds returns a list of all resource kinds in the dispatch table.

--- a/osac-operator/pkg/dispatcher/dispatch_test.go
+++ b/osac-operator/pkg/dispatcher/dispatch_test.go
@@ -18,6 +18,7 @@ package dispatcher_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -37,6 +38,7 @@ var _ = Describe("DispatchTable", func() {
 		Expect(cfg).NotTo(BeNil())
 		Expect(cfg.Roles).To(ConsistOf(dispatcher.ManagerRoleFabric))
 		Expect(cfg.K8sFallback).To(BeTrue())
+		Expect(cfg.K8sFallbackManager).To(Equal(dispatcher.K8sOnlyManagerName))
 	})
 
 	It("returns config for Subnet with both roles", func() {
@@ -44,6 +46,7 @@ var _ = Describe("DispatchTable", func() {
 		Expect(cfg).NotTo(BeNil())
 		Expect(cfg.Roles).To(ConsistOf(dispatcher.ManagerRoleFabric, dispatcher.ManagerRoleK8s))
 		Expect(cfg.K8sFallback).To(BeTrue())
+		Expect(cfg.K8sFallbackManager).To(Equal(dispatcher.K8sOnlyManagerName))
 	})
 
 	It("returns config for SecurityGroup", func() {
@@ -51,6 +54,7 @@ var _ = Describe("DispatchTable", func() {
 		Expect(cfg).NotTo(BeNil())
 		Expect(cfg.Roles).To(ConsistOf(dispatcher.ManagerRoleFabric))
 		Expect(cfg.K8sFallback).To(BeTrue())
+		Expect(cfg.K8sFallbackManager).To(Equal(dispatcher.K8sOnlyManagerName))
 	})
 
 	It("returns config for ExternalIP", func() {
@@ -58,6 +62,7 @@ var _ = Describe("DispatchTable", func() {
 		Expect(cfg).NotTo(BeNil())
 		Expect(cfg.Roles).To(ConsistOf(dispatcher.ManagerRoleFabric))
 		Expect(cfg.K8sFallback).To(BeTrue())
+		Expect(cfg.K8sFallbackManager).To(Equal(dispatcher.K8sOnlyManagerName))
 	})
 
 	It("returns config for ExternalIPPool", func() {
@@ -65,6 +70,7 @@ var _ = Describe("DispatchTable", func() {
 		Expect(cfg).NotTo(BeNil())
 		Expect(cfg.Roles).To(ConsistOf(dispatcher.ManagerRoleFabric))
 		Expect(cfg.K8sFallback).To(BeTrue())
+		Expect(cfg.K8sFallbackManager).To(Equal(dispatcher.K8sOnlyManagerName))
 	})
 
 	It("returns config for ExternalIPAttachment", func() {
@@ -72,6 +78,7 @@ var _ = Describe("DispatchTable", func() {
 		Expect(cfg).NotTo(BeNil())
 		Expect(cfg.Roles).To(ConsistOf(dispatcher.ManagerRoleFabric))
 		Expect(cfg.K8sFallback).To(BeTrue())
+		Expect(cfg.K8sFallbackManager).To(Equal(dispatcher.K8sOnlyManagerName))
 	})
 
 	It("returns config for NATGateway with no k8s fallback", func() {
@@ -79,6 +86,7 @@ var _ = Describe("DispatchTable", func() {
 		Expect(cfg).NotTo(BeNil())
 		Expect(cfg.Roles).To(ConsistOf(dispatcher.ManagerRoleFabric))
 		Expect(cfg.K8sFallback).To(BeFalse())
+		Expect(cfg.K8sFallbackManager).To(BeEmpty())
 	})
 
 	It("returns nil for unknown kind", func() {
@@ -274,10 +282,10 @@ var _ = Describe("Dispatcher", func() {
 		Expect(err.Error()).To(ContainSubstring("UnknownKind"))
 	})
 
-	It("dispatches VirtualNetwork to k8s manager when no fabric manager is set (fallback)", func() {
-		stub := newStubWithManagers("", "cudn_localnet")
+	It("dispatches VirtualNetwork to the explicit k8s-only manager when no fabric manager is set", func() {
+		stub := newStubWithManagers("", dispatcher.K8sOnlyManagerName)
 		cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
-			newK8sManagerConfigMap("km-cudn", "cudn_localnet", "ipv4,ipv6,dualStack"),
+			newK8sManagerConfigMap("km-k8s-only", dispatcher.K8sOnlyManagerName, "ipv4,ipv6,dualStack"),
 		).Build()
 
 		disc, err := networkmanager.NewDiscovery(cl, "osac")
@@ -289,14 +297,30 @@ var _ = Describe("Dispatcher", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(plan.Targets).To(HaveLen(1))
 		Expect(plan.Targets[0].Role).To(Equal(dispatcher.ManagerRoleK8s))
-		Expect(plan.Targets[0].Manager.Name).To(Equal("cudn_localnet"))
+		Expect(plan.Targets[0].Manager.Name).To(Equal(dispatcher.K8sOnlyManagerName))
 	})
 
-	DescribeTable("dispatches fallback-eligible kinds to the k8s manager when no fabric manager is set",
+	It("rejects an arbitrary k8s manager for a fabric-owned resource", func() {
+		stub := newStubWithManagers("", "cudn_localnet")
+		cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			newK8sManagerConfigMap("km-cudn", "cudn_localnet", "ipv4,ipv6,dualStack"),
+		).Build()
+
+		disc, err := networkmanager.NewDiscovery(cl, "osac")
+		Expect(err).NotTo(HaveOccurred())
+
+		d := dispatcher.NewDispatcher(dispatcher.NewResolver(stub, disc))
+
+		_, err = d.Dispatch(ctx, "SecurityGroup", "nc-test")
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, dispatcher.ErrRequiredManagerUnavailable)).To(BeTrue())
+	})
+
+	DescribeTable("dispatches k8s-only kinds to the composite k8s manager",
 		func(kind string) {
-			stub := newStubWithManagers("", "cudn_localnet")
+			stub := newStubWithManagers("", "k8s_only")
 			cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
-				newK8sManagerConfigMap("km-cudn", "cudn_localnet", "ipv4,ipv6,dualStack"),
+				newK8sManagerConfigMap("km-k8s-only", "k8s_only", "ipv4,ipv6,dualStack"),
 			).Build()
 
 			disc, err := networkmanager.NewDiscovery(cl, "osac")
@@ -307,7 +331,7 @@ var _ = Describe("Dispatcher", func() {
 			plan, err := d.Dispatch(ctx, kind, "nc-test")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(plan.HasRole(dispatcher.ManagerRoleK8s)).To(BeTrue())
-			Expect(plan.K8sTarget().Manager.Name).To(Equal("cudn_localnet"))
+			Expect(plan.K8sTarget().Manager.Name).To(Equal("k8s_only"))
 		},
 		Entry("SecurityGroup", "SecurityGroup"),
 		Entry("ExternalIP", "ExternalIP"),
@@ -316,9 +340,9 @@ var _ = Describe("Dispatcher", func() {
 	)
 
 	It("dispatches Subnet to exactly one k8s target when no fabric manager is set (dedupe)", func() {
-		stub := newStubWithManagers("", "cudn_localnet")
+		stub := newStubWithManagers("", dispatcher.K8sOnlyManagerName)
 		cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
-			newK8sManagerConfigMap("km-cudn", "cudn_localnet", "ipv4,ipv6,dualStack"),
+			newK8sManagerConfigMap("km-k8s-only", dispatcher.K8sOnlyManagerName, "ipv4,ipv6,dualStack"),
 		).Build()
 
 		disc, err := networkmanager.NewDiscovery(cl, "osac")
@@ -330,7 +354,7 @@ var _ = Describe("Dispatcher", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(plan.Targets).To(HaveLen(1))
 		Expect(plan.Targets[0].Role).To(Equal(dispatcher.ManagerRoleK8s))
-		Expect(plan.Targets[0].Manager.Name).To(Equal("cudn_localnet"))
+		Expect(plan.Targets[0].Manager.Name).To(Equal(dispatcher.K8sOnlyManagerName))
 	})
 
 	It("returns an error dispatching NATGateway when no fabric manager is set (no fallback)", func() {
@@ -346,6 +370,7 @@ var _ = Describe("Dispatcher", func() {
 
 		_, err = d.Dispatch(ctx, "NATGateway", "nc-test")
 		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, dispatcher.ErrRequiredManagerUnavailable)).To(BeTrue())
 		Expect(err.Error()).To(ContainSubstring("no manager available"))
 	})
 

--- a/osac-operator/pkg/dispatcher/dispatcher.go
+++ b/osac-operator/pkg/dispatcher/dispatcher.go
@@ -75,12 +75,13 @@ func (d *Dispatcher) Dispatch(
 			switch {
 			case resolved.FabricManager != nil:
 				addTarget(DispatchTarget{Role: ManagerRoleFabric, Manager: *resolved.FabricManager})
-			case cfg.K8sFallback && resolved.K8sManager != nil:
+			case cfg.K8sFallback && cfg.K8sFallbackManager != "" && resolved.K8sManager != nil &&
+				resolved.K8sManager.Name == cfg.K8sFallbackManager:
 				addTarget(DispatchTarget{Role: ManagerRoleK8s, Manager: *resolved.K8sManager})
 			default:
 				return nil, fmt.Errorf(
-					"no manager available for %s: NetworkClass has neither a fabricManager nor a usable k8sManager fallback",
-					kind)
+					"no manager available for %s: NetworkClass has no usable manager for the required role: %w",
+					kind, ErrRequiredManagerUnavailable)
 			}
 		case ManagerRoleK8s:
 			if resolved.K8sManager != nil {

--- a/osac-operator/pkg/dispatcher/resolver.go
+++ b/osac-operator/pkg/dispatcher/resolver.go
@@ -30,6 +30,12 @@ import (
 // resolution failures.
 var ErrNoManagerConfigured = errors.New("neither fabricManager nor k8sManager is set")
 
+// ErrRequiredManagerUnavailable indicates that a resource's required manager
+// role is not available on the NetworkClass. This is distinct from
+// ErrNoManagerConfigured because a NetworkClass may have a k8sManager while a
+// fabric-only resource still requires a fabricManager.
+var ErrRequiredManagerUnavailable = errors.New("required network manager is unavailable")
+
 // ResolvedManagers holds the validated fabric and k8s managers extracted from a NetworkClass.
 type ResolvedManagers struct {
 	// FabricManager is the validated fabric manager, or nil when the NetworkClass


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Controllers

- Provisioning now requires a dispatcher-resolved implementation strategy.
- ExternalIP, ExternalIPAttachment, ExternalIPPool, SecurityGroup, and VirtualNetwork controllers block resources when dispatcher configuration is unavailable.
- Controllers set `Ready=False` with `ReasonNoManagerConfigured` and return reconciliation errors.
- Legacy resource and pool strategy fallbacks were removed.
- Kubernetes fallback now requires the explicitly named `k8s_only` manager.
- Missing required managers use `ErrRequiredManagerUnavailable`.

## API surface

- Added `dispatcher.K8sOnlyManagerName`.
- Added `ResourceDispatchConfig.K8sFallbackManager`.
- Added `dispatcher.ErrRequiredManagerUnavailable`.
- Resource schemas remain unchanged.

## Documentation

- Documented the `k8s_only` dispatcher contract and its Kubernetes-only scope.
- Documented Kubernetes-only fallback behavior for `VirtualNetwork` and `Subnet`.

## Tests

- Added coverage for explicit `k8s_only` fallback resolution.
- Rejected arbitrary Kubernetes managers for fabric-owned resources.
- Updated controller tests for dispatcher resolution, blocking conditions, errors, and no requeue behavior.

## Backward compatibility

- Resources that relied on legacy implementation-strategy fallback can remain unprovisioned until valid dispatcher configuration is present.
- Kubernetes fallback is narrower because only `k8s_only` can satisfy the fallback role.
- Controllers return reconciliation errors instead of periodically requeueing for missing dispatcher configuration.

## Unaffected areas

- No database, authentication, deployment, or CI changes were made.

## Risk classification

`risk:ask` — applied because the change alters provisioning behavior across multiple controllers, removes legacy fallbacks, and can block existing resources when dispatcher configuration is missing. The change is close to `risk:show`, but the cross-controller provisioning impact and backward-compatibility risk require explicit review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->