### PR TITLE
NO-ISSUE: Use route-selected interface for BMaaS networking checks

### DIFF
--- a/tests/e2e/bmaas/regression/networking/bmi_ssh.py
+++ b/tests/e2e/bmaas/regression/networking/bmi_ssh.py
@@ -58,8 +58,8 @@ def ssh_bmi_unchecked(bmc_ip: str, command: str, timeout: int = 30) -> tuple[str
     return (result.stdout.strip() + "\n" + result.stderr.strip()).strip(), result.returncode
 
 
-def arping(bmc_ip: str, target_ip: str, interface: str = "ens5", count: int = 3) -> bool:
-    _, rc = ssh_bmi_unchecked(bmc_ip, f"arping -c {count} -I {interface} {target_ip}", timeout=30)
+def arping(bmc_ip: str, target_ip: str, count: int = 3) -> bool:
+    _, rc = ssh_bmi_unchecked(bmc_ip, f"arping -c {count} {target_ip}", timeout=30)
     return rc == 0
 
 

--- a/tests/e2e/bmaas/regression/networking/test_bmaas_networking.py
+++ b/tests/e2e/bmaas/regression/networking/test_bmaas_networking.py
@@ -37,6 +37,8 @@ from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.osac_cli import OsacCLI
 from tests.e2e.core.runner import poll_until
 
+_NETRIS_BMI_RUNNING_RETRIES = 240
+
 
 def _require(state: dict[str, Any], *keys: str) -> None:
     missing = [k for k in keys if k not in state]
@@ -185,7 +187,7 @@ class TestBmaasNetworking:
             print(f"BMI {bmi['name']} CR: {bmi['cr']}")
 
         for bmi in bmis:
-            wait_for_bmi_running(grpc=grpc, bmi_id=bmi["id"])
+            wait_for_bmi_running(grpc=grpc, bmi_id=bmi["id"], retries=_NETRIS_BMI_RUNNING_RETRIES)
             print(f"BMI {bmi['name']} is RUNNING")
 
         for bmi in bmis:

--- a/tests/e2e/core/helpers.py
+++ b/tests/e2e/core/helpers.py
@@ -661,7 +661,7 @@ def wait_for_bmi_cr(*, k8s: K8sClient, uuid: str) -> str:
     )
 
 
-def wait_for_bmi_running(*, grpc: GRPCClient, bmi_id: str) -> None:
+def wait_for_bmi_running(*, grpc: GRPCClient, bmi_id: str, retries: int = _BMI_RUNNING_RETRIES) -> None:
     def _check_state() -> str:
         state: str = grpc.get_baremetal_instance_state(bmi_id=bmi_id)
         assert "FAILED" not in state, f"BareMetalInstance {bmi_id} entered {state}"
@@ -670,7 +670,7 @@ def wait_for_bmi_running(*, grpc: GRPCClient, bmi_id: str) -> None:
     poll_until(
         fn=_check_state,
         until=lambda v: v == "BARE_METAL_INSTANCE_STATE_RUNNING",
-        retries=_BMI_RUNNING_RETRIES,
+        retries=retries,
         delay=_BMI_RUNNING_DELAY,
         description=f"{bmi_id} RUNNING",
     )

--- a/tests/e2e/core/helpers.py
+++ b/tests/e2e/core/helpers.py
@@ -12,6 +12,8 @@ from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.runner import poll_until, run_unchecked
 
 _POOL_READY_STATE = "EXTERNAL_IP_POOL_STATE_READY"
+_BMI_RUNNING_RETRIES = 180
+_BMI_RUNNING_DELAY = 10
 
 
 def assert_grpc_rejected(exc_info: pytest.ExceptionInfo[subprocess.CalledProcessError], code: str) -> None:
@@ -668,8 +670,8 @@ def wait_for_bmi_running(*, grpc: GRPCClient, bmi_id: str) -> None:
     poll_until(
         fn=_check_state,
         until=lambda v: v == "BARE_METAL_INSTANCE_STATE_RUNNING",
-        retries=120,
-        delay=10,
+        retries=_BMI_RUNNING_RETRIES,
+        delay=_BMI_RUNNING_DELAY,
         description=f"{bmi_id} RUNNING",
     )
 
@@ -755,8 +757,8 @@ def wait_for_bmi_running_after_recovery(*, grpc: GRPCClient, bmi_id: str) -> Non
     poll_until(
         fn=lambda: grpc.get_baremetal_instance_state(bmi_id=bmi_id),
         until=lambda v: v == "BARE_METAL_INSTANCE_STATE_RUNNING",
-        retries=120,
-        delay=10,
+        retries=_BMI_RUNNING_RETRIES,
+        delay=_BMI_RUNNING_DELAY,
         description=f"{bmi_id} RUNNING after inventory recovery",
     )
 


### PR DESCRIPTION
## Summary

- Keep BMaaS Netris ping on its existing route-selected behavior.
- Make BMaaS Netris ARP checks use the guest routing table instead of an image-specific interface name.
- Extend BMI readiness polling from about 20 minutes to about 30 minutes for normal and recovery waits.

## Validation

- `uv run ruff check tests/e2e/core/helpers.py tests/e2e/bmaas/regression/networking/bmi_ssh.py`
- `uv run ruff format --check tests/e2e/core/helpers.py tests/e2e/bmaas/regression/networking/bmi_ssh.py`

Related test-infra PR: osac-project/osac-test-infra#426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Tests

- Updated BMaaS Netris ARP checks to use the guest routing table.
- Preserved route-selected behavior for ping checks.
- Increased BMI readiness polling to 240 retries with a 10-second delay.
- Applied the longer wait to normal Netris readiness checks.
- Shared polling defaults now cover normal and recovery waits.
- Ruff and formatting checks passed.

## API surface

- Removed the `interface` parameter from `arping`.
- Added optional `retries` support to `wait_for_bmi_running`.

## Backward compatibility

- Existing `wait_for_bmi_running` callers remain compatible.
- Callers that pass the removed `arping` interface parameter must be updated.
- The affected APIs are internal E2E test helpers. Production APIs are unchanged.

## Risk classification

- **risk:show** — The PR changes shared E2E helper behavior and network validation, but it does not change production controllers, databases, authentication, deployment, or runtime services.
- It does not qualify for **risk:ship** because it changes test-helper APIs and network-check behavior.
- It does not qualify for **risk:ask** because the scope is limited to test infrastructure and validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->