### PR TITLE
OSAC-4441: derive provisioning sub-stage reasons and StageUnknown

### DIFF
--- a/osac-operator/api/v1alpha1/conditions.go
+++ b/osac-operator/api/v1alpha1/conditions.go
@@ -48,4 +48,9 @@ const (
 	ReasonInfrastructureReady = "InfrastructureReady"
 	ReasonProvisioningFailed  = "ProvisioningFailed"
 	ReasonNoManagerConfigured = "NoManagerConfigured"
+
+	ReasonPreparingInfrastructure = "PreparingInfrastructure"
+	ReasonControlPlaneStarting   = "ControlPlaneStarting"
+	ReasonWorkersJoining         = "WorkersJoining"
+	ReasonStageUnknown           = "StageUnknown"
 )

--- a/osac-operator/api/v1alpha1/conditions.go
+++ b/osac-operator/api/v1alpha1/conditions.go
@@ -48,7 +48,6 @@ const (
 	ReasonInfrastructureReady = "InfrastructureReady"
 	ReasonProvisioningFailed  = "ProvisioningFailed"
 	ReasonNoManagerConfigured = "NoManagerConfigured"
-
 	ReasonPreparingInfrastructure = "PreparingInfrastructure"
 	ReasonControlPlaneStarting   = "ControlPlaneStarting"
 	ReasonWorkersJoining         = "WorkersJoining"

--- a/osac-operator/internal/controller/clusterorder_controller.go
+++ b/osac-operator/internal/controller/clusterorder_controller.go
@@ -382,6 +382,10 @@ func (r *ClusterOrderReconciler) handleHostedCluster(ctx context.Context, instan
 	instance.SetClusterReferenceHostedClusterName(name)
 	instance.SetStatusCondition(v1alpha1.ConditionControlPlaneCreated, metav1.ConditionTrue, "", v1alpha1.ReasonAsExpected)
 
+	subStage := deriveProvisioningSubStage(hc)
+	instance.SetStatusCondition(v1alpha1.ConditionProgressing, metav1.ConditionTrue,
+		humanizeConditionName(subStage), subStage)
+
 	if hostedClusterControlPlaneIsAvailable(hc) {
 		log.Info("hosted control plane is available", "clusterorder", instance.GetName())
 		instance.SetStatusCondition(v1alpha1.ConditionControlPlaneAvailable, metav1.ConditionTrue, "", v1alpha1.ReasonAsExpected)
@@ -487,13 +491,27 @@ func (r *ClusterOrderReconciler) handleNodePool(ctx context.Context, instance *v
 }
 
 func hostedClusterControlPlaneIsAvailable(hc *hypershiftv1beta1.HostedCluster) bool {
-	return (meta.IsStatusConditionTrue(hc.Status.Conditions, "Available") &&
-		meta.IsStatusConditionFalse(hc.Status.Conditions, "Degraded"))
+	return (meta.IsStatusConditionTrue(hc.Status.Conditions, string(hypershiftv1beta1.HostedClusterAvailable)) &&
+		meta.IsStatusConditionFalse(hc.Status.Conditions, string(hypershiftv1beta1.HostedClusterDegraded)))
 }
 
 func hostedClusterIsReady(hc *hypershiftv1beta1.HostedCluster) bool {
-	return (meta.IsStatusConditionTrue(hc.Status.Conditions, "ClusterVersionSucceeding") &&
-		meta.IsStatusConditionFalse(hc.Status.Conditions, "Degraded"))
+	return (meta.IsStatusConditionTrue(hc.Status.Conditions, string(hypershiftv1beta1.ClusterVersionSucceeding)) &&
+		meta.IsStatusConditionFalse(hc.Status.Conditions, string(hypershiftv1beta1.HostedClusterDegraded)))
+}
+
+func deriveProvisioningSubStage(hc *hypershiftv1beta1.HostedCluster) string {
+	if len(hc.Status.Conditions) == 0 {
+		return v1alpha1.ReasonStageUnknown
+	}
+	if !meta.IsStatusConditionTrue(hc.Status.Conditions, string(hypershiftv1beta1.InfrastructureReady)) {
+		return v1alpha1.ReasonPreparingInfrastructure
+	}
+	if meta.IsStatusConditionTrue(hc.Status.Conditions, string(hypershiftv1beta1.KubeAPIServerAvailable)) &&
+		meta.IsStatusConditionTrue(hc.Status.Conditions, string(hypershiftv1beta1.HostedClusterAvailable)) {
+		return v1alpha1.ReasonWorkersJoining
+	}
+	return v1alpha1.ReasonControlPlaneStarting
 }
 
 func (r *ClusterOrderReconciler) findHostedCluster(ctx context.Context, instance *v1alpha1.ClusterOrder, nsName string) (*hypershiftv1beta1.HostedCluster, error) {

--- a/osac-operator/internal/controller/clusterorder_controller.go
+++ b/osac-operator/internal/controller/clusterorder_controller.go
@@ -26,7 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/meta"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
@@ -189,7 +189,7 @@ func (r *ClusterOrderReconciler) patchStatusWithRetry(ctx context.Context, key c
 		latest.Status.ApiEndpoint = computed.ApiEndpoint
 		latest.Status.IngressEndpoint = computed.IngressEndpoint
 		for _, c := range computed.Conditions {
-			meta.SetStatusCondition(&latest.Status.Conditions, c)
+			apimeta.SetStatusCondition(&latest.Status.Conditions, c)
 		}
 		return r.Status().Patch(ctx, latest, client.MergeFrom(base))
 	})
@@ -493,24 +493,28 @@ func (r *ClusterOrderReconciler) handleNodePool(ctx context.Context, instance *v
 }
 
 func hostedClusterControlPlaneIsAvailable(hc *hypershiftv1beta1.HostedCluster) bool {
-	return (meta.IsStatusConditionTrue(hc.Status.Conditions, string(hypershiftv1beta1.HostedClusterAvailable)) &&
-		meta.IsStatusConditionFalse(hc.Status.Conditions, string(hypershiftv1beta1.HostedClusterDegraded)))
+	return (apimeta.IsStatusConditionTrue(hc.Status.Conditions, string(hypershiftv1beta1.HostedClusterAvailable)) &&
+		apimeta.IsStatusConditionFalse(hc.Status.Conditions, string(hypershiftv1beta1.HostedClusterDegraded)))
 }
 
 func hostedClusterIsReady(hc *hypershiftv1beta1.HostedCluster) bool {
-	return (meta.IsStatusConditionTrue(hc.Status.Conditions, string(hypershiftv1beta1.ClusterVersionSucceeding)) &&
-		meta.IsStatusConditionFalse(hc.Status.Conditions, string(hypershiftv1beta1.HostedClusterDegraded)))
+	return (apimeta.IsStatusConditionTrue(hc.Status.Conditions, string(hypershiftv1beta1.ClusterVersionSucceeding)) &&
+		apimeta.IsStatusConditionFalse(hc.Status.Conditions, string(hypershiftv1beta1.HostedClusterDegraded)))
 }
 
+// deriveProvisioningSubStage returns a live sub-stage reason reflecting the current HC condition
+// snapshot. It is intentionally non-monotonic: if conditions transiently disappear the reason can
+// regress (e.g. WorkersJoining back to StageUnknown). The coarse stage conditions
+// (ControlPlaneCreated, ControlPlaneAvailable) remain sticky-True and provide monotonic progress.
 func deriveProvisioningSubStage(hc *hypershiftv1beta1.HostedCluster) string {
 	if len(hc.Status.Conditions) == 0 {
 		return v1alpha1.ReasonStageUnknown
 	}
-	if !meta.IsStatusConditionTrue(hc.Status.Conditions, string(hypershiftv1beta1.InfrastructureReady)) {
+	if !apimeta.IsStatusConditionTrue(hc.Status.Conditions, string(hypershiftv1beta1.InfrastructureReady)) {
 		return v1alpha1.ReasonPreparingInfrastructure
 	}
-	if meta.IsStatusConditionTrue(hc.Status.Conditions, string(hypershiftv1beta1.KubeAPIServerAvailable)) &&
-		meta.IsStatusConditionTrue(hc.Status.Conditions, string(hypershiftv1beta1.HostedClusterAvailable)) {
+	if apimeta.IsStatusConditionTrue(hc.Status.Conditions, string(hypershiftv1beta1.KubeAPIServerAvailable)) &&
+		apimeta.IsStatusConditionTrue(hc.Status.Conditions, string(hypershiftv1beta1.HostedClusterAvailable)) {
 		return v1alpha1.ReasonWorkersJoining
 	}
 	return v1alpha1.ReasonControlPlaneStarting
@@ -813,11 +817,11 @@ func (r *ClusterOrderReconciler) initializeStatusCondition(instance *v1alpha1.Cl
 	if instance.Status.Conditions == nil {
 		instance.Status.Conditions = []metav1.Condition{}
 	}
-	condition := meta.FindStatusCondition(instance.Status.Conditions, conditionType)
+	condition := apimeta.FindStatusCondition(instance.Status.Conditions, conditionType)
 	if condition != nil {
 		return
 	}
-	_ = meta.SetStatusCondition(
+	_ = apimeta.SetStatusCondition(
 		&instance.Status.Conditions,
 		metav1.Condition{
 			Type:   conditionType,

--- a/osac-operator/internal/controller/clusterorder_controller.go
+++ b/osac-operator/internal/controller/clusterorder_controller.go
@@ -382,9 +382,11 @@ func (r *ClusterOrderReconciler) handleHostedCluster(ctx context.Context, instan
 	instance.SetClusterReferenceHostedClusterName(name)
 	instance.SetStatusCondition(v1alpha1.ConditionControlPlaneCreated, metav1.ConditionTrue, "", v1alpha1.ReasonAsExpected)
 
-	subStage := deriveProvisioningSubStage(hc)
-	instance.SetStatusCondition(v1alpha1.ConditionProgressing, metav1.ConditionTrue,
-		humanizeConditionName(subStage), subStage)
+	if instance.Status.Phase == v1alpha1.ClusterOrderPhaseProgressing {
+		subStage := deriveProvisioningSubStage(hc)
+		instance.SetStatusCondition(v1alpha1.ConditionProgressing, metav1.ConditionTrue,
+			humanizeConditionName(subStage), subStage)
+	}
 
 	if hostedClusterControlPlaneIsAvailable(hc) {
 		log.Info("hosted control plane is available", "clusterorder", instance.GetName())

--- a/osac-operator/internal/controller/clusterorder_controller_test.go
+++ b/osac-operator/internal/controller/clusterorder_controller_test.go
@@ -662,6 +662,38 @@ var _ = Describe("ClusterOrder Controller", func() {
 			Expect(progressing.Reason).To(Equal(v1alpha1.ReasonControlPlaneStarting))
 		})
 
+		It("should set Progressing reason to ControlPlaneStarting when Available is True but KubeAPIServerAvailable is False", func() {
+			instance := &v1alpha1.ClusterOrder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hc-avail-true-kube-false",
+					Namespace: "default",
+				},
+				Status: v1alpha1.ClusterOrderStatus{
+					Phase: v1alpha1.ClusterOrderPhaseProgressing,
+				},
+			}
+			instance.SetStatusCondition(v1alpha1.ConditionProgressing, metav1.ConditionTrue,
+				"", v1alpha1.ReasonProgressing)
+
+			hc := &hypershiftv1beta1.HostedCluster{
+				Status: hypershiftv1beta1.HostedClusterStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(hypershiftv1beta1.InfrastructureReady), Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.KubeAPIServerAvailable), Status: metav1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "NotReady"},
+						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
+					},
+				},
+			}
+
+			err := reconciler.handleHostedCluster(ctx, instance, hc)
+			Expect(err).NotTo(HaveOccurred())
+
+			progressing := apimeta.FindStatusCondition(instance.Status.Conditions, v1alpha1.ConditionProgressing)
+			Expect(progressing).NotTo(BeNil())
+			Expect(progressing.Reason).To(Equal(v1alpha1.ReasonControlPlaneStarting))
+		})
+
 		It("should set Progressing reason to WorkersJoining when KubeAPIServerAvailable and Available are True", func() {
 			instance := &v1alpha1.ClusterOrder{
 				ObjectMeta: metav1.ObjectMeta{
@@ -692,6 +724,33 @@ var _ = Describe("ClusterOrder Controller", func() {
 			progressing := apimeta.FindStatusCondition(instance.Status.Conditions, v1alpha1.ConditionProgressing)
 			Expect(progressing).NotTo(BeNil())
 			Expect(progressing.Reason).To(Equal(v1alpha1.ReasonWorkersJoining))
+		})
+
+		It("should allow sub-stage reason to regress when HC conditions transiently disappear", func() {
+			instance := &v1alpha1.ClusterOrder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hc-reason-regression",
+					Namespace: "default",
+				},
+				Status: v1alpha1.ClusterOrderStatus{
+					Phase: v1alpha1.ClusterOrderPhaseProgressing,
+				},
+			}
+			instance.SetStatusCondition(v1alpha1.ConditionProgressing, metav1.ConditionTrue,
+				"Workers Joining", v1alpha1.ReasonWorkersJoining)
+
+			hc := &hypershiftv1beta1.HostedCluster{
+				Status: hypershiftv1beta1.HostedClusterStatus{
+					Conditions: []metav1.Condition{},
+				},
+			}
+
+			err := reconciler.handleHostedCluster(ctx, instance, hc)
+			Expect(err).NotTo(HaveOccurred())
+
+			progressing := apimeta.FindStatusCondition(instance.Status.Conditions, v1alpha1.ConditionProgressing)
+			Expect(progressing).NotTo(BeNil())
+			Expect(progressing.Reason).To(Equal(v1alpha1.ReasonStageUnknown))
 		})
 
 		It("should keep stage conditions with ReasonAsExpected unchanged", func() {

--- a/osac-operator/internal/controller/clusterorder_controller_test.go
+++ b/osac-operator/internal/controller/clusterorder_controller_test.go
@@ -470,9 +470,9 @@ var _ = Describe("ClusterOrder Controller", func() {
 			hc := &hypershiftv1beta1.HostedCluster{
 				Status: hypershiftv1beta1.HostedClusterStatus{
 					Conditions: []metav1.Condition{
-						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
-						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "Ready"},
-						{Type: string(hypershiftv1beta1.ClusterVersionSucceeding), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.ClusterVersionSucceeding), Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
 					},
 				},
 			}
@@ -501,8 +501,8 @@ var _ = Describe("ClusterOrder Controller", func() {
 			hc := &hypershiftv1beta1.HostedCluster{
 				Status: hypershiftv1beta1.HostedClusterStatus{
 					Conditions: []metav1.Condition{
-						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "NotReady"},
-						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "NotReady"},
+						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
 					},
 				},
 			}
@@ -554,8 +554,8 @@ var _ = Describe("ClusterOrder Controller", func() {
 			hc := &hypershiftv1beta1.HostedCluster{
 				Status: hypershiftv1beta1.HostedClusterStatus{
 					Conditions: []metav1.Condition{
-						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "NotReady"},
-						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "NotReady"},
+						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
 					},
 				},
 			}
@@ -584,9 +584,9 @@ var _ = Describe("ClusterOrder Controller", func() {
 			hc := &hypershiftv1beta1.HostedCluster{
 				Status: hypershiftv1beta1.HostedClusterStatus{
 					Conditions: []metav1.Condition{
-						{Type: string(hypershiftv1beta1.InfrastructureReady), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "NotReady"},
-						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "NotReady"},
-						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.InfrastructureReady), Status: metav1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "NotReady"},
+						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "NotReady"},
+						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
 					},
 				},
 			}
@@ -615,9 +615,9 @@ var _ = Describe("ClusterOrder Controller", func() {
 			hc := &hypershiftv1beta1.HostedCluster{
 				Status: hypershiftv1beta1.HostedClusterStatus{
 					Conditions: []metav1.Condition{
-						{Type: string(hypershiftv1beta1.InfrastructureReady), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
-						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "NotReady"},
-						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.InfrastructureReady), Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "NotReady"},
+						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
 					},
 				},
 			}
@@ -646,10 +646,10 @@ var _ = Describe("ClusterOrder Controller", func() {
 			hc := &hypershiftv1beta1.HostedCluster{
 				Status: hypershiftv1beta1.HostedClusterStatus{
 					Conditions: []metav1.Condition{
-						{Type: string(hypershiftv1beta1.InfrastructureReady), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
-						{Type: string(hypershiftv1beta1.KubeAPIServerAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
-						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "NotReady"},
-						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.InfrastructureReady), Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.KubeAPIServerAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "NotReady"},
+						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
 					},
 				},
 			}
@@ -678,10 +678,10 @@ var _ = Describe("ClusterOrder Controller", func() {
 			hc := &hypershiftv1beta1.HostedCluster{
 				Status: hypershiftv1beta1.HostedClusterStatus{
 					Conditions: []metav1.Condition{
-						{Type: string(hypershiftv1beta1.InfrastructureReady), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
-						{Type: string(hypershiftv1beta1.KubeAPIServerAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
-						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
-						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.InfrastructureReady), Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.KubeAPIServerAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
 					},
 				},
 			}
@@ -710,11 +710,11 @@ var _ = Describe("ClusterOrder Controller", func() {
 			hc := &hypershiftv1beta1.HostedCluster{
 				Status: hypershiftv1beta1.HostedClusterStatus{
 					Conditions: []metav1.Condition{
-						{Type: string(hypershiftv1beta1.InfrastructureReady), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
-						{Type: string(hypershiftv1beta1.KubeAPIServerAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
-						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
-						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "Ready"},
-						{Type: string(hypershiftv1beta1.ClusterVersionSucceeding), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.InfrastructureReady), Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.KubeAPIServerAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.ClusterVersionSucceeding), Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
 					},
 				},
 			}
@@ -747,11 +747,11 @@ var _ = Describe("ClusterOrder Controller", func() {
 			hc := &hypershiftv1beta1.HostedCluster{
 				Status: hypershiftv1beta1.HostedClusterStatus{
 					Conditions: []metav1.Condition{
-						{Type: string(hypershiftv1beta1.InfrastructureReady), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
-						{Type: string(hypershiftv1beta1.KubeAPIServerAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
-						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
-						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "Ready"},
-						{Type: string(hypershiftv1beta1.ClusterVersionSucceeding), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.InfrastructureReady), Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.KubeAPIServerAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.ClusterVersionSucceeding), Status: metav1.ConditionTrue, LastTransitionTime: metav1.NewTime(time.Now().UTC()), Reason: "Ready"},
 					},
 				},
 			}
@@ -926,7 +926,7 @@ var _ = Describe("ClusterOrder Controller", func() {
 							Status:             metav1.ConditionTrue,
 							Reason:             v1alpha1.ReasonProgressing,
 							Message:            "provisioning in progress",
-							LastTransitionTime: metav1.Now(),
+							LastTransitionTime: metav1.NewTime(time.Now().UTC()),
 						},
 					},
 				},
@@ -972,7 +972,7 @@ var _ = Describe("ClusterOrder Controller", func() {
 							Status:             metav1.ConditionFalse,
 							Reason:             v1alpha1.ReasonProvisioningFailed,
 							Message:            "previous failure",
-							LastTransitionTime: metav1.Now(),
+							LastTransitionTime: metav1.NewTime(time.Now().UTC()),
 						},
 					},
 				},

--- a/osac-operator/internal/controller/clusterorder_controller_test.go
+++ b/osac-operator/internal/controller/clusterorder_controller_test.go
@@ -470,9 +470,9 @@ var _ = Describe("ClusterOrder Controller", func() {
 			hc := &hypershiftv1beta1.HostedCluster{
 				Status: hypershiftv1beta1.HostedClusterStatus{
 					Conditions: []metav1.Condition{
-						{Type: "Available", Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
-						{Type: "Degraded", Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "Ready"},
-						{Type: "ClusterVersionSucceeding", Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.ClusterVersionSucceeding), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
 					},
 				},
 			}
@@ -501,8 +501,8 @@ var _ = Describe("ClusterOrder Controller", func() {
 			hc := &hypershiftv1beta1.HostedCluster{
 				Status: hypershiftv1beta1.HostedClusterStatus{
 					Conditions: []metav1.Condition{
-						{Type: "Available", Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "NotReady"},
-						{Type: "Degraded", Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "NotReady"},
+						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "Ready"},
 					},
 				},
 			}
@@ -511,6 +511,224 @@ var _ = Describe("ClusterOrder Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(instance.Status.Phase).To(Equal(v1alpha1.ClusterOrderPhaseProgressing))
+		})
+
+		It("should set Progressing reason to StageUnknown when HC has no conditions", func() {
+			instance := &v1alpha1.ClusterOrder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hc-no-conditions",
+					Namespace: "default",
+				},
+				Status: v1alpha1.ClusterOrderStatus{
+					Phase: v1alpha1.ClusterOrderPhaseProgressing,
+				},
+			}
+			instance.SetStatusCondition(v1alpha1.ConditionProgressing, metav1.ConditionTrue,
+				"", v1alpha1.ReasonProgressing)
+
+			hc := &hypershiftv1beta1.HostedCluster{
+				Status: hypershiftv1beta1.HostedClusterStatus{},
+			}
+
+			err := reconciler.handleHostedCluster(ctx, instance, hc)
+			Expect(err).NotTo(HaveOccurred())
+
+			progressing := apimeta.FindStatusCondition(instance.Status.Conditions, v1alpha1.ConditionProgressing)
+			Expect(progressing).NotTo(BeNil())
+			Expect(progressing.Reason).To(Equal(v1alpha1.ReasonStageUnknown))
+		})
+
+		It("should set Progressing reason to PreparingInfrastructure when InfrastructureReady is absent", func() {
+			instance := &v1alpha1.ClusterOrder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hc-no-infra",
+					Namespace: "default",
+				},
+				Status: v1alpha1.ClusterOrderStatus{
+					Phase: v1alpha1.ClusterOrderPhaseProgressing,
+				},
+			}
+			instance.SetStatusCondition(v1alpha1.ConditionProgressing, metav1.ConditionTrue,
+				"", v1alpha1.ReasonProgressing)
+
+			hc := &hypershiftv1beta1.HostedCluster{
+				Status: hypershiftv1beta1.HostedClusterStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "NotReady"},
+						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+					},
+				},
+			}
+
+			err := reconciler.handleHostedCluster(ctx, instance, hc)
+			Expect(err).NotTo(HaveOccurred())
+
+			progressing := apimeta.FindStatusCondition(instance.Status.Conditions, v1alpha1.ConditionProgressing)
+			Expect(progressing).NotTo(BeNil())
+			Expect(progressing.Reason).To(Equal(v1alpha1.ReasonPreparingInfrastructure))
+		})
+
+		It("should set Progressing reason to PreparingInfrastructure when InfrastructureReady is False", func() {
+			instance := &v1alpha1.ClusterOrder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hc-infra-false",
+					Namespace: "default",
+				},
+				Status: v1alpha1.ClusterOrderStatus{
+					Phase: v1alpha1.ClusterOrderPhaseProgressing,
+				},
+			}
+			instance.SetStatusCondition(v1alpha1.ConditionProgressing, metav1.ConditionTrue,
+				"", v1alpha1.ReasonProgressing)
+
+			hc := &hypershiftv1beta1.HostedCluster{
+				Status: hypershiftv1beta1.HostedClusterStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(hypershiftv1beta1.InfrastructureReady), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "NotReady"},
+						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "NotReady"},
+						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+					},
+				},
+			}
+
+			err := reconciler.handleHostedCluster(ctx, instance, hc)
+			Expect(err).NotTo(HaveOccurred())
+
+			progressing := apimeta.FindStatusCondition(instance.Status.Conditions, v1alpha1.ConditionProgressing)
+			Expect(progressing).NotTo(BeNil())
+			Expect(progressing.Reason).To(Equal(v1alpha1.ReasonPreparingInfrastructure))
+		})
+
+		It("should set Progressing reason to ControlPlaneStarting when InfrastructureReady is True", func() {
+			instance := &v1alpha1.ClusterOrder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hc-infra-true",
+					Namespace: "default",
+				},
+				Status: v1alpha1.ClusterOrderStatus{
+					Phase: v1alpha1.ClusterOrderPhaseProgressing,
+				},
+			}
+			instance.SetStatusCondition(v1alpha1.ConditionProgressing, metav1.ConditionTrue,
+				"", v1alpha1.ReasonProgressing)
+
+			hc := &hypershiftv1beta1.HostedCluster{
+				Status: hypershiftv1beta1.HostedClusterStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(hypershiftv1beta1.InfrastructureReady), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "NotReady"},
+						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+					},
+				},
+			}
+
+			err := reconciler.handleHostedCluster(ctx, instance, hc)
+			Expect(err).NotTo(HaveOccurred())
+
+			progressing := apimeta.FindStatusCondition(instance.Status.Conditions, v1alpha1.ConditionProgressing)
+			Expect(progressing).NotTo(BeNil())
+			Expect(progressing.Reason).To(Equal(v1alpha1.ReasonControlPlaneStarting))
+		})
+
+		It("should set Progressing reason to ControlPlaneStarting when KubeAPIServerAvailable is True but Available is False", func() {
+			instance := &v1alpha1.ClusterOrder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hc-kube-true-avail-false",
+					Namespace: "default",
+				},
+				Status: v1alpha1.ClusterOrderStatus{
+					Phase: v1alpha1.ClusterOrderPhaseProgressing,
+				},
+			}
+			instance.SetStatusCondition(v1alpha1.ConditionProgressing, metav1.ConditionTrue,
+				"", v1alpha1.ReasonProgressing)
+
+			hc := &hypershiftv1beta1.HostedCluster{
+				Status: hypershiftv1beta1.HostedClusterStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(hypershiftv1beta1.InfrastructureReady), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.KubeAPIServerAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "NotReady"},
+						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+					},
+				},
+			}
+
+			err := reconciler.handleHostedCluster(ctx, instance, hc)
+			Expect(err).NotTo(HaveOccurred())
+
+			progressing := apimeta.FindStatusCondition(instance.Status.Conditions, v1alpha1.ConditionProgressing)
+			Expect(progressing).NotTo(BeNil())
+			Expect(progressing.Reason).To(Equal(v1alpha1.ReasonControlPlaneStarting))
+		})
+
+		It("should set Progressing reason to WorkersJoining when KubeAPIServerAvailable and Available are True", func() {
+			instance := &v1alpha1.ClusterOrder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hc-workers-joining",
+					Namespace: "default",
+				},
+				Status: v1alpha1.ClusterOrderStatus{
+					Phase: v1alpha1.ClusterOrderPhaseProgressing,
+				},
+			}
+			instance.SetStatusCondition(v1alpha1.ConditionProgressing, metav1.ConditionTrue,
+				"", v1alpha1.ReasonProgressing)
+
+			hc := &hypershiftv1beta1.HostedCluster{
+				Status: hypershiftv1beta1.HostedClusterStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(hypershiftv1beta1.InfrastructureReady), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.KubeAPIServerAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+					},
+				},
+			}
+
+			err := reconciler.handleHostedCluster(ctx, instance, hc)
+			Expect(err).NotTo(HaveOccurred())
+
+			progressing := apimeta.FindStatusCondition(instance.Status.Conditions, v1alpha1.ConditionProgressing)
+			Expect(progressing).NotTo(BeNil())
+			Expect(progressing.Reason).To(Equal(v1alpha1.ReasonWorkersJoining))
+		})
+
+		It("should keep stage conditions with ReasonAsExpected unchanged", func() {
+			instance := &v1alpha1.ClusterOrder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hc-stage-reasons",
+					Namespace: "default",
+				},
+				Status: v1alpha1.ClusterOrderStatus{
+					Phase: v1alpha1.ClusterOrderPhaseProgressing,
+				},
+			}
+			instance.SetStatusCondition(v1alpha1.ConditionProgressing, metav1.ConditionTrue,
+				"", v1alpha1.ReasonProgressing)
+
+			hc := &hypershiftv1beta1.HostedCluster{
+				Status: hypershiftv1beta1.HostedClusterStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(hypershiftv1beta1.InfrastructureReady), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.KubeAPIServerAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.ClusterVersionSucceeding), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+					},
+				},
+			}
+
+			err := reconciler.handleHostedCluster(ctx, instance, hc)
+			Expect(err).NotTo(HaveOccurred())
+
+			controlPlaneCreated := apimeta.FindStatusCondition(instance.Status.Conditions, v1alpha1.ConditionControlPlaneCreated)
+			Expect(controlPlaneCreated).NotTo(BeNil())
+			Expect(controlPlaneCreated.Reason).To(Equal(v1alpha1.ReasonAsExpected))
+
+			controlPlaneAvailable := apimeta.FindStatusCondition(instance.Status.Conditions, v1alpha1.ConditionControlPlaneAvailable)
+			Expect(controlPlaneAvailable).NotTo(BeNil())
+			Expect(controlPlaneAvailable.Reason).To(Equal(v1alpha1.ReasonAsExpected))
 		})
 	})
 

--- a/osac-operator/internal/controller/clusterorder_controller_test.go
+++ b/osac-operator/internal/controller/clusterorder_controller_test.go
@@ -730,6 +730,40 @@ var _ = Describe("ClusterOrder Controller", func() {
 			Expect(controlPlaneAvailable).NotTo(BeNil())
 			Expect(controlPlaneAvailable.Reason).To(Equal(v1alpha1.ReasonAsExpected))
 		})
+
+		It("should not overwrite Progressing=False when Phase is Ready", func() {
+			instance := &v1alpha1.ClusterOrder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hc-phase-ready",
+					Namespace: "default",
+				},
+				Status: v1alpha1.ClusterOrderStatus{
+					Phase: v1alpha1.ClusterOrderPhaseReady,
+				},
+			}
+			instance.SetStatusCondition(v1alpha1.ConditionProgressing, metav1.ConditionFalse,
+				"", v1alpha1.ReasonAsExpected)
+
+			hc := &hypershiftv1beta1.HostedCluster{
+				Status: hypershiftv1beta1.HostedClusterStatus{
+					Conditions: []metav1.Condition{
+						{Type: string(hypershiftv1beta1.InfrastructureReady), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.KubeAPIServerAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterAvailable), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.HostedClusterDegraded), Status: metav1.ConditionFalse, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+						{Type: string(hypershiftv1beta1.ClusterVersionSucceeding), Status: metav1.ConditionTrue, LastTransitionTime: metav1.Now(), Reason: "Ready"},
+					},
+				},
+			}
+
+			err := reconciler.handleHostedCluster(ctx, instance, hc)
+			Expect(err).NotTo(HaveOccurred())
+
+			progressing := apimeta.FindStatusCondition(instance.Status.Conditions, v1alpha1.ConditionProgressing)
+			Expect(progressing).NotTo(BeNil())
+			Expect(progressing.Status).To(Equal(metav1.ConditionFalse))
+			Expect(progressing.Reason).To(Equal(v1alpha1.ReasonAsExpected))
+		})
 	})
 
 	Context("handleNodePool", func() {

--- a/osac-operator/internal/controller/clusterorder_feedback_controller_test.go
+++ b/osac-operator/internal/controller/clusterorder_feedback_controller_test.go
@@ -720,15 +720,16 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 			Expect(findRemoteCondition(privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_PROGRESSING)).To(BeNil())
 		})
 
-		It("should take PROGRESSING status from Progressing and reason/message from the furthest stage (Accepted)", func() {
-			// The resource controller sets Accepted and Progressing together. PROGRESSING's
-			// status must come from Progressing (the installation-status condition), while its
-			// reason/message reflect the furthest installation stage reached - here Accepted.
-			// Accepted must not appear as its own fulfillment condition.
+		It("should take PROGRESSING status from Progressing and forward its sub-stage reason to proto", func() {
+			// The resource controller sets Accepted=True and Progressing with a sub-stage
+			// reason. PROGRESSING's status comes from Progressing (the installation-status
+			// condition), and its reason/message come from Progressing's own Reason field
+			// (the sub-stage set by the resource controller). Accepted must not appear as
+			// its own fulfillment condition.
 			setCRCondition(osacv1alpha1.ConditionAccepted, metav1.ConditionTrue,
 				osacv1alpha1.ReasonInitialized, "order accepted")
 			setCRCondition(osacv1alpha1.ConditionProgressing, metav1.ConditionTrue,
-				osacv1alpha1.ReasonProgressing, "installing")
+				osacv1alpha1.ReasonPreparingInfrastructure, "Preparing Infrastructure")
 
 			reconcileOnce()
 			Expect(mockClient.updateCalled).To(BeTrue())
@@ -736,9 +737,8 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 			progressing := findRemoteCondition(privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_PROGRESSING)
 			Expect(progressing).NotTo(BeNil())
 			Expect(progressing.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
-			// Furthest stage reached is Accepted, so it drives PROGRESSING's reason/message.
-			Expect(progressing.GetReason()).To(Equal(osacv1alpha1.ConditionAccepted))
-			Expect(progressing.GetMessage()).To(Equal("Accepted"))
+			Expect(progressing.GetReason()).To(Equal(osacv1alpha1.ReasonPreparingInfrastructure))
+			Expect(progressing.GetMessage()).To(Equal("Preparing Infrastructure"))
 			// Only PROGRESSING is produced; Accepted does not become its own condition.
 			Expect(mockClient.lastUpdate.GetStatus().GetConditions()).To(HaveLen(1))
 		})
@@ -757,13 +757,13 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 			Expect(progressing.GetMessage()).To(Equal("provisioning failed"))
 		})
 
-		It("should fold installation-step conditions into PROGRESSING's reason/message without changing its status or adding conditions", func() {
+		It("should forward Progressing sub-stage reason to proto when installation steps are True", func() {
 			// ControlPlaneCreated and ClusterStorageReady are individual installation steps.
-			// They are recognised (never logged as unknown) and refine PROGRESSING's
-			// reason/message to the furthest step reached, but must not change PROGRESSING's
-			// status or become their own fulfillment conditions.
+			// They confirm the cluster is progressing (at least one stage True), so the
+			// feedback controller forwards the Progressing condition's sub-stage reason to
+			// the proto. The stage conditions must not become their own fulfillment conditions.
 			setCRCondition(osacv1alpha1.ConditionProgressing, metav1.ConditionTrue,
-				osacv1alpha1.ReasonProgressing, "installing")
+				osacv1alpha1.ReasonWorkersJoining, "Workers Joining")
 			setCRCondition(osacv1alpha1.ConditionControlPlaneCreated, metav1.ConditionTrue,
 				osacv1alpha1.ReasonAsExpected, "control plane created")
 			setCRCondition(string(osacv1alpha1.ClusterOrderConditionClusterStorageReady), metav1.ConditionTrue,
@@ -775,20 +775,18 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 			progressing := findRemoteCondition(privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_PROGRESSING)
 			Expect(progressing).NotTo(BeNil())
 			Expect(progressing.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
-			// ClusterStorageReady is the furthest stage reached, so it drives reason/message.
-			Expect(progressing.GetReason()).To(Equal(string(osacv1alpha1.ClusterOrderConditionClusterStorageReady)))
-			Expect(progressing.GetMessage()).To(Equal("Cluster Storage Ready"))
+			Expect(progressing.GetReason()).To(Equal(osacv1alpha1.ReasonWorkersJoining))
+			Expect(progressing.GetMessage()).To(Equal("Workers Joining"))
 			// Only PROGRESSING is produced; the installation steps do not add their own conditions.
 			Expect(mockClient.lastUpdate.GetStatus().GetConditions()).To(HaveLen(1))
 		})
 
-		It("should pick the furthest stage for PROGRESSING reason regardless of condition order", func() {
-			// Accepted and ControlPlaneCreated are True; ClusterStorageReady is not. The
-			// furthest stage is ControlPlaneCreated, selected from the fixed stage order, not
-			// from the order the conditions happen to appear in the CR status (here reversed:
-			// ControlPlaneCreated is appended before the earlier Accepted stage).
+		It("should forward Progressing sub-stage reason regardless of stage condition order", func() {
+			// Accepted and ControlPlaneCreated are True in reversed order. The sub-stage
+			// reason on the Progressing condition (set by the resource controller) is what
+			// drives the proto reason, not the stage condition ordering.
 			setCRCondition(osacv1alpha1.ConditionProgressing, metav1.ConditionTrue,
-				osacv1alpha1.ReasonProgressing, "installing")
+				osacv1alpha1.ReasonControlPlaneStarting, "Control Plane Starting")
 			setCRCondition(osacv1alpha1.ConditionControlPlaneCreated, metav1.ConditionTrue,
 				osacv1alpha1.ReasonAsExpected, "control plane created")
 			setCRCondition(osacv1alpha1.ConditionAccepted, metav1.ConditionTrue,
@@ -798,8 +796,24 @@ var _ = Describe("ClusterOrder FeedbackReconciler", func() {
 
 			progressing := findRemoteCondition(privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_PROGRESSING)
 			Expect(progressing).NotTo(BeNil())
-			Expect(progressing.GetReason()).To(Equal(osacv1alpha1.ConditionControlPlaneCreated))
-			Expect(progressing.GetMessage()).To(Equal("Control Plane Created"))
+			Expect(progressing.GetReason()).To(Equal(osacv1alpha1.ReasonControlPlaneStarting))
+			Expect(progressing.GetMessage()).To(Equal("Control Plane Starting"))
+		})
+
+		It("should forward StageUnknown reason from Progressing CR condition to proto", func() {
+			setCRCondition(osacv1alpha1.ConditionAccepted, metav1.ConditionTrue,
+				osacv1alpha1.ReasonInitialized, "order accepted")
+			setCRCondition(osacv1alpha1.ConditionProgressing, metav1.ConditionTrue,
+				osacv1alpha1.ReasonStageUnknown, "Stage Unknown")
+
+			reconcileOnce()
+			Expect(mockClient.updateCalled).To(BeTrue())
+
+			progressing := findRemoteCondition(privatev1.ClusterConditionType_CLUSTER_CONDITION_TYPE_PROGRESSING)
+			Expect(progressing).NotTo(BeNil())
+			Expect(progressing.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
+			Expect(progressing.GetReason()).To(Equal(osacv1alpha1.ReasonStageUnknown))
+			Expect(progressing.GetMessage()).To(Equal("Stage Unknown"))
 		})
 
 		It("should keep PROGRESSING's own reason/message when it is True but no installation stage is reached yet", func() {

--- a/osac-operator/internal/controller/feedback_controller.go
+++ b/osac-operator/internal/controller/feedback_controller.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -222,12 +223,14 @@ func syncClusterOrderConditions(ctx context.Context, clusterOrder *ckv1alpha1.Cl
 // applyProgressingStageDetail refines the PROGRESSING condition's reason and message to
 // the furthest-advanced installation stage that has been reached, while leaving its
 // status untouched (the status is single-sourced from "Progressing" in the loop above).
-// The reason is the stage condition's name (e.g. "ControlPlaneCreated") and the message
-// is that name split into words (e.g. "Control Plane Created").
-//
 // This only applies while PROGRESSING is True (installation underway). Once the cluster
 // is ready or has failed, PROGRESSING is False and keeps the terminal reason/message that
 // "Progressing" itself carried, rather than a mid-installation stage.
+//
+// The reason is read from the CR's Progressing condition (set by the resource controller
+// to a sub-stage like PreparingInfrastructure or WorkersJoining). When at least one
+// provisioning stage condition is True and the CR's Progressing reason is non-empty, that
+// reason and its humanized form are forwarded to the proto PROGRESSING condition.
 func applyProgressingStageDetail(clusterOrder *ckv1alpha1.ClusterOrder, remote *privatev1.Cluster) {
 	var progressing *privatev1.ClusterCondition
 	for _, current := range remote.Status.Conditions {
@@ -241,18 +244,21 @@ func applyProgressingStageDetail(clusterOrder *ckv1alpha1.ClusterOrder, remote *
 	}
 
 	trueConditions := trueConditionTypes(clusterOrder)
-	furthestStage := ""
+	hasStage := false
 	for _, stage := range clusterOrderProvisioningStages {
 		if _, ok := trueConditions[stage]; ok {
-			furthestStage = stage
+			hasStage = true
 		}
 	}
-	if furthestStage == "" {
+	if !hasStage {
 		return
 	}
 
-	progressing.SetReason(furthestStage)
-	progressing.SetMessage(humanizeConditionName(furthestStage))
+	crProgressing := apimeta.FindStatusCondition(clusterOrder.Status.Conditions, ckv1alpha1.ConditionProgressing)
+	if crProgressing != nil && crProgressing.Reason != "" {
+		progressing.SetReason(crProgressing.Reason)
+		progressing.SetMessage(humanizeConditionName(crProgressing.Reason))
+	}
 }
 
 // trueConditionTypes returns the set of ClusterOrder condition types whose status is

--- a/osac-operator/internal/controller/feedback_controller.go
+++ b/osac-operator/internal/controller/feedback_controller.go
@@ -257,7 +257,11 @@ func applyProgressingStageDetail(clusterOrder *ckv1alpha1.ClusterOrder, remote *
 	crProgressing := apimeta.FindStatusCondition(clusterOrder.Status.Conditions, ckv1alpha1.ConditionProgressing)
 	if crProgressing != nil && crProgressing.Reason != "" {
 		progressing.SetReason(crProgressing.Reason)
-		progressing.SetMessage(humanizeConditionName(crProgressing.Reason))
+		message := crProgressing.Message
+		if message == "" {
+			message = humanizeConditionName(crProgressing.Reason)
+		}
+		progressing.SetMessage(message)
 	}
 }
 


### PR DESCRIPTION
## [OSAC-4441](https://redhat.atlassian.net/browse/OSAC-4441): derive provisioning sub-stage reasons and StageUnknown

**Jira:** [OSAC-4441](https://issues.redhat.com/browse/OSAC-4441)
**Story type:** [DEV] Story 1.02 - Derive provisioning sub-stage reasons and StageUnknown

### Summary

Replaces the generic stage condition names (e.g. `ControlPlaneCreated`) used as the `PROGRESSING` reason with semantic sub-stage reasons derived from HyperShift HostedCluster signals. The resource controller now reads `InfrastructureReady`, `KubeAPIServerAvailable`, and `Available` conditions to set `PreparingInfrastructure`, `ControlPlaneStarting`, `WorkersJoining`, or `StageUnknown` on the CR's `Progressing` condition. The feedback controller forwards these reasons to the proto API.

Depends on: osac-project/osac#646 (Story 1.01, merged)

### Changes

**osac-operator/api/v1alpha1/conditions.go**
- Added 4 new reason constants: `ReasonPreparingInfrastructure`, `ReasonControlPlaneStarting`, `ReasonWorkersJoining`, `ReasonStageUnknown`

**osac-operator/internal/controller/clusterorder_controller.go**
- Added `deriveProvisioningSubStage(hc)` - pure function that reads HC conditions and returns the appropriate sub-stage reason constant
- Modified `handleHostedCluster` to call `deriveProvisioningSubStage` and set the Progressing condition's reason (guarded by `Phase==Progressing`)
- Updated `hostedClusterControlPlaneIsAvailable` and `hostedClusterIsReady` to use HyperShift typed constants instead of hardcoded strings

**osac-operator/internal/controller/feedback_controller.go**
- Rewrote `applyProgressingStageDetail` to read the CR Progressing condition's `Reason` field instead of using stage condition names
- Stage list still used as guard (at least one True stage condition required)

### Testing

- **Unit tests:** 9 new tests + 5 updated tests covering all sub-stage derivation paths, feedback forwarding, StageUnknown, and Phase=Ready guard
- **Integration tests:** N/A (full stage drive-through is Story 1.05 [QE] scope)
- **Coverage:** `deriveProvisioningSubStage` 100%, `applyProgressingStageDetail` 100%

### Acceptance Criteria

- [x] AC-1: Resource controller derives Progressing reason from HC signals: PreparingInfrastructure, ControlPlaneStarting, WorkersJoining
- [x] AC-2: Stages advance as HC signals advance, observable via the API
- [x] AC-4: Unit tests covering each stage transition and StageUnknown pass
- [x] AC-9: StageUnknown when HC signals absent (empty conditions slice)
