### PR TITLE
NO-ISSUE: Log BMaaS Netris command output

### DIFF
--- a/tests/e2e/bmaas/regression/networking/bmi_ssh.py
+++ b/tests/e2e/bmaas/regression/networking/bmi_ssh.py
@@ -17,6 +17,25 @@ _SSH_OPTS = [
 ]
 
 
+def _as_text(value: str | bytes | None) -> str:
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    return value or ""
+
+
+def _combined_output(stdout: str | bytes | None, stderr: str | bytes | None) -> str:
+    return (_as_text(stdout).strip() + "\n" + _as_text(stderr).strip()).strip()
+
+
+def _timeout_output(exc: subprocess.TimeoutExpired, timeout: int) -> str:
+    output = _combined_output(exc.stdout, exc.stderr)
+    return f"{output}\nssh timed out after {timeout}s".strip()
+
+
+def _log_command(bmi_ip: str, command: str, output: str, rc: int) -> None:
+    log.info("BMI command (%s): %s; ssh_rc=%d; output=%r", bmi_ip, command, rc, output)
+
+
 def get_bmc_ip(bmh_name: str) -> str:
     domiflist = subprocess.run(["virsh", "domiflist", bmh_name], capture_output=True, text=True, timeout=10, check=True)
     bmc_mac = ""
@@ -38,9 +57,22 @@ def get_bmc_ip(bmh_name: str) -> str:
 
 
 def ssh_bmi(bmc_ip: str, command: str, timeout: int = 30) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["ssh", *_SSH_OPTS, f"fedora@{bmc_ip}", command], capture_output=True, text=True, timeout=timeout, check=True
-    )
+    try:
+        result = subprocess.run(
+            ["ssh", *_SSH_OPTS, f"fedora@{bmc_ip}", command],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        _log_command(bmc_ip, command, _combined_output(exc.stdout or "", exc.stderr or ""), exc.returncode)
+        raise
+    except subprocess.TimeoutExpired as exc:
+        _log_command(bmc_ip, command, _timeout_output(exc, timeout), 255)
+        raise
+    _log_command(bmc_ip, command, _combined_output(result.stdout, result.stderr), result.returncode)
+    return result
 
 
 def ssh_bmi_unchecked(bmc_ip: str, command: str, timeout: int = 30) -> tuple[str, int]:
@@ -52,10 +84,13 @@ def ssh_bmi_unchecked(bmc_ip: str, command: str, timeout: int = 30) -> tuple[str
             timeout=timeout,
             check=False,
         )
-    except subprocess.TimeoutExpired:
-        log.warning("ssh_bmi_unchecked: subprocess timed out after %ds", timeout)
-        return f"ssh timed out after {timeout}s", 255
-    return (result.stdout.strip() + "\n" + result.stderr.strip()).strip(), result.returncode
+    except subprocess.TimeoutExpired as exc:
+        output = _timeout_output(exc, timeout)
+        _log_command(bmc_ip, command, output, 255)
+        return output, 255
+    output = _combined_output(result.stdout, result.stderr)
+    _log_command(bmc_ip, command, output, result.returncode)
+    return output, result.returncode
 
 
 def arping(bmc_ip: str, target_ip: str, count: int = 3) -> bool:
@@ -69,10 +104,9 @@ def ping(bmc_ip: str, target_ip: str, count: int = 3, wait: int = 3) -> bool:
 
 
 def curl_status(bmc_ip: str, url: str, timeout: int = 15) -> int:
-    output, rc = ssh_bmi_unchecked(
+    output, _ = ssh_bmi_unchecked(
         bmc_ip, f"curl -s -o /dev/null -w '%{{http_code}}' --connect-timeout {timeout} {url}", timeout=timeout + 30
     )
-    log.info("curl_status(%s, %s): ssh_rc=%d, output=%r", bmc_ip, url, rc, output[-200:])
     for line in output.strip().splitlines():
         line = line.strip()
         if line.isdigit() and len(line) == 3:
@@ -82,23 +116,26 @@ def curl_status(bmc_ip: str, url: str, timeout: int = 15) -> int:
 
 
 def ssh_via_external_ip(external_ip: str, command: str = "hostname", timeout: int = 15) -> str:
-    result = subprocess.run(
-        [
-            "ssh",
-            "-o",
-            f"ConnectTimeout={timeout}",
-            "-o",
-            "StrictHostKeyChecking=no",
-            "-o",
-            "UserKnownHostsFile=/dev/null",
-            "-i",
-            "/root/.ssh/id_rsa",
-            f"fedora@{external_ip}",
-            command,
-        ],
-        capture_output=True,
-        text=True,
-        timeout=timeout + 10,
-        check=True,
-    )
+    args = [
+        "ssh",
+        "-o",
+        f"ConnectTimeout={timeout}",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-i",
+        "/root/.ssh/id_rsa",
+        f"fedora@{external_ip}",
+        command,
+    ]
+    try:
+        result = subprocess.run(args, capture_output=True, text=True, timeout=timeout + 10, check=True)
+    except subprocess.CalledProcessError as exc:
+        _log_command(external_ip, command, _combined_output(exc.stdout or "", exc.stderr or ""), exc.returncode)
+        raise
+    except subprocess.TimeoutExpired as exc:
+        _log_command(external_ip, command, _timeout_output(exc, timeout + 10), 255)
+        raise
+    _log_command(external_ip, command, _combined_output(result.stdout, result.stderr), result.returncode)
     return result.stdout.strip()


### PR DESCRIPTION
## Summary

- Log BMaaS Netris remote command text, SSH return codes, and stdout/stderr.
- Preserve output for failed and timed-out SSH commands.
- Cover arping, ping, curl, and external-IP SSH diagnostics.

## Validation

- All checks passed!
- 1 file already formatted

Related test-infra PR: osac-project/osac-test-infra#426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **Tests:** Added shared helpers for decoding and combining SSH output and formatting timeout messages.
- **BMaaS diagnostics:** Log commands, return codes, stdout, and stderr for successful, failed, and timed-out SSH commands.
- Covered `arping`, `ping`, `curl`, and external-IP SSH diagnostics.
- Preserved existing exception behavior.
- **API surface:** No public API changes.
- **Backward compatibility:** No functional or compatibility impact is expected. The changes affect diagnostic logging only.

## Risk classification

**risk:ship** — The change is limited to test diagnostic logging. It does not change production APIs, data, authentication, deployment, or command outcomes.

It does not qualify for **risk:show** because it adds no production user-visible behavior. It does not qualify for **risk:ask** because it does not affect security, data integrity, or production execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->