### PR TITLE
NO-ISSUE: Use backend-provided BMH SSH hosts

### DIFF
--- a/tests/e2e/bmaas/regression/networking/bmi_ssh.py
+++ b/tests/e2e/bmaas/regression/networking/bmi_ssh.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 import logging
 import subprocess
+from collections.abc import Mapping
 
 log = logging.getLogger(__name__)
 
@@ -32,53 +34,57 @@ def _timeout_output(exc: subprocess.TimeoutExpired, timeout: int) -> str:
     return f"{output}\nssh timed out after {timeout}s".strip()
 
 
-def _log_command(bmi_ip: str, command: str, output: str, rc: int) -> None:
-    log.info("BMI command (%s): %s; ssh_rc=%d; output=%r", bmi_ip, command, rc, output)
+def _log_command(ssh_host: str, command: str, output: str, rc: int) -> None:
+    log.info("BMI command (%s): %s; ssh_rc=%d; output=%r", ssh_host, command, rc, output)
 
 
-def get_bmc_ip(bmh_name: str) -> str:
-    domiflist = subprocess.run(["virsh", "domiflist", bmh_name], capture_output=True, text=True, timeout=10, check=True)
-    bmc_mac = ""
-    for line in domiflist.stdout.splitlines():
-        if "bmc-net" in line:
-            bmc_mac = line.split()[4]
-            break
-    if not bmc_mac:
-        raise RuntimeError(f"No bmc-net interface found for VM {bmh_name}")
+def parse_ssh_hosts(raw: str) -> dict[str, str]:
+    try:
+        parsed: object = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("OSAC_BMH_SSH_HOSTS must be valid JSON") from exc
 
-    leases = subprocess.run(
-        ["virsh", "net-dhcp-leases", "bmc-net"], capture_output=True, text=True, timeout=10, check=True
-    )
-    for line in leases.stdout.splitlines():
-        if bmc_mac in line:
-            ip_with_prefix = line.split()[4]
-            return ip_with_prefix.split("/")[0]
-    raise RuntimeError(f"No DHCP lease found for MAC {bmc_mac} on bmc-net")
+    if not isinstance(parsed, dict):
+        raise RuntimeError("OSAC_BMH_SSH_HOSTS must be a JSON object")
+
+    hosts: dict[str, str] = {}
+    for bmh_name, ssh_host in parsed.items():
+        if not isinstance(bmh_name, str) or not bmh_name.strip() or not isinstance(ssh_host, str) or not ssh_host:
+            raise RuntimeError("OSAC_BMH_SSH_HOSTS must map non-empty BMH names to SSH hosts")
+        hosts[bmh_name] = ssh_host
+    return hosts
 
 
-def ssh_bmi(bmc_ip: str, command: str, timeout: int = 30) -> subprocess.CompletedProcess[str]:
+def get_ssh_host(bmh_name: str, hosts: Mapping[str, str]) -> str:
+    try:
+        return hosts[bmh_name]
+    except KeyError as exc:
+        raise RuntimeError(f"No SSH host configured for BMH {bmh_name}") from exc
+
+
+def ssh_bmi(ssh_host: str, command: str, timeout: int = 30) -> subprocess.CompletedProcess[str]:
     try:
         result = subprocess.run(
-            ["ssh", *_SSH_OPTS, f"fedora@{bmc_ip}", command],
+            ["ssh", *_SSH_OPTS, f"fedora@{ssh_host}", command],
             capture_output=True,
             text=True,
             timeout=timeout,
             check=True,
         )
     except subprocess.CalledProcessError as exc:
-        _log_command(bmc_ip, command, _combined_output(exc.stdout or "", exc.stderr or ""), exc.returncode)
+        _log_command(ssh_host, command, _combined_output(exc.stdout or "", exc.stderr or ""), exc.returncode)
         raise
     except subprocess.TimeoutExpired as exc:
-        _log_command(bmc_ip, command, _timeout_output(exc, timeout), 255)
+        _log_command(ssh_host, command, _timeout_output(exc, timeout), 255)
         raise
-    _log_command(bmc_ip, command, _combined_output(result.stdout, result.stderr), result.returncode)
+    _log_command(ssh_host, command, _combined_output(result.stdout, result.stderr), result.returncode)
     return result
 
 
-def ssh_bmi_unchecked(bmc_ip: str, command: str, timeout: int = 30) -> tuple[str, int]:
+def ssh_bmi_unchecked(ssh_host: str, command: str, timeout: int = 30) -> tuple[str, int]:
     try:
         result = subprocess.run(
-            ["ssh", *_SSH_OPTS, f"fedora@{bmc_ip}", command],
+            ["ssh", *_SSH_OPTS, f"fedora@{ssh_host}", command],
             capture_output=True,
             text=True,
             timeout=timeout,
@@ -86,26 +92,26 @@ def ssh_bmi_unchecked(bmc_ip: str, command: str, timeout: int = 30) -> tuple[str
         )
     except subprocess.TimeoutExpired as exc:
         output = _timeout_output(exc, timeout)
-        _log_command(bmc_ip, command, output, 255)
+        _log_command(ssh_host, command, output, 255)
         return output, 255
     output = _combined_output(result.stdout, result.stderr)
-    _log_command(bmc_ip, command, output, result.returncode)
+    _log_command(ssh_host, command, output, result.returncode)
     return output, result.returncode
 
 
-def arping(bmc_ip: str, target_ip: str, count: int = 3) -> bool:
-    _, rc = ssh_bmi_unchecked(bmc_ip, f"arping -c {count} {target_ip}", timeout=30)
+def arping(ssh_host: str, target_ip: str, count: int = 3) -> bool:
+    _, rc = ssh_bmi_unchecked(ssh_host, f"arping -c {count} {target_ip}", timeout=30)
     return rc == 0
 
 
-def ping(bmc_ip: str, target_ip: str, count: int = 3, wait: int = 3) -> bool:
-    _, rc = ssh_bmi_unchecked(bmc_ip, f"ping -c {count} -W {wait} {target_ip}", timeout=30)
+def ping(ssh_host: str, target_ip: str, count: int = 3, wait: int = 3) -> bool:
+    _, rc = ssh_bmi_unchecked(ssh_host, f"ping -c {count} -W {wait} {target_ip}", timeout=30)
     return rc == 0
 
 
-def curl_status(bmc_ip: str, url: str, timeout: int = 15) -> int:
+def curl_status(ssh_host: str, url: str, timeout: int = 15) -> int:
     output, _ = ssh_bmi_unchecked(
-        bmc_ip, f"curl -s -o /dev/null -w '%{{http_code}}' --connect-timeout {timeout} {url}", timeout=timeout + 30
+        ssh_host, f"curl -s -o /dev/null -w '%{{http_code}}' --connect-timeout {timeout} {url}", timeout=timeout + 30
     )
     for line in output.strip().splitlines():
         line = line.strip()

--- a/tests/e2e/bmaas/regression/networking/conftest.py
+++ b/tests/e2e/bmaas/regression/networking/conftest.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from tests.e2e.bmaas.regression.networking import bmi_ssh
 from tests.e2e.core.runner import env
 
 
@@ -41,6 +42,11 @@ def bmi_template() -> str:
 @pytest.fixture(scope="session")
 def bmh_namespace() -> str:
     return env("OSAC_BMH_NAMESPACE", "host-inventory")
+
+
+@pytest.fixture(scope="session")
+def bmh_ssh_hosts() -> dict[str, str]:
+    return bmi_ssh.parse_ssh_hosts(env("OSAC_BMH_SSH_HOSTS"))
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/bmaas/regression/networking/test_bmaas_networking.py
+++ b/tests/e2e/bmaas/regression/networking/test_bmaas_networking.py
@@ -160,6 +160,7 @@ class TestBmaasNetworking:
         net_ssh_public_key: str,
         bmh_namespace: str,
         net_test_run_id: str,
+        bmh_ssh_hosts: dict[str, str],
     ) -> None:
         _require(self.state, "subnet_a_id", "subnet_b_id", "sg_id")
 
@@ -201,8 +202,8 @@ class TestBmaasNetworking:
 
             ext_host = k8s_hub_client.get_baremetal_instance_external_host_id(name=bmi["cr"])
             bmi["bmh"] = ext_host.split("/", 1)[1]
-            bmi["bmc_ip"] = bmi_ssh.get_bmc_ip(bmi["bmh"])
-            print(f"BMI {bmi['name']}: tenant_ip={bmi['ip']}, bmh={bmi['bmh']}, bmc_ip={bmi['bmc_ip']}")
+            bmi["ssh_host"] = bmi_ssh.get_ssh_host(bmi["bmh"], bmh_ssh_hosts)
+            print(f"BMI {bmi['name']}: tenant_ip={bmi['ip']}, bmh={bmi['bmh']}, ssh_host={bmi['ssh_host']}")
 
         for bmi in bmis:
             if bmi["subnet"] == "a":
@@ -255,7 +256,7 @@ class TestBmaasNetworking:
         bmi2 = self.state["bmi2"]
 
         poll_until(
-            fn=lambda: bmi_ssh.arping(bmi1["bmc_ip"], bmi2["ip"]),
+            fn=lambda: bmi_ssh.arping(bmi1["ssh_host"], bmi2["ip"]),
             until=lambda ok: ok,
             retries=5,
             delay=10,
@@ -268,7 +269,7 @@ class TestBmaasNetworking:
         bmi2 = self.state["bmi2"]
 
         poll_until(
-            fn=lambda: bmi_ssh.ping(bmi1["bmc_ip"], bmi2["ip"]),
+            fn=lambda: bmi_ssh.ping(bmi1["ssh_host"], bmi2["ip"]),
             until=lambda ok: ok,
             retries=5,
             delay=10,
@@ -281,7 +282,7 @@ class TestBmaasNetworking:
         bmi3 = self.state["bmi3"]
 
         poll_until(
-            fn=lambda: bmi_ssh.ping(bmi1["bmc_ip"], bmi3["ip"]),
+            fn=lambda: bmi_ssh.ping(bmi1["ssh_host"], bmi3["ip"]),
             until=lambda ok: ok,
             retries=5,
             delay=10,
@@ -293,7 +294,7 @@ class TestBmaasNetworking:
         bmi1 = self.state["bmi1"]
         bmi3 = self.state["bmi3"]
 
-        assert not bmi_ssh.arping(bmi1["bmc_ip"], bmi3["ip"]), (
+        assert not bmi_ssh.arping(bmi1["ssh_host"], bmi3["ip"]), (
             f"arping from BMI1 ({bmi1['ip']}, subnet A) to BMI3 ({bmi3['ip']}, subnet B) "
             f"succeeded unexpectedly — different subnets should be different broadcast domains"
         )
@@ -302,7 +303,7 @@ class TestBmaasNetworking:
         _require(self.state, "bmi1")
         bmi1 = self.state["bmi1"]
 
-        assert not bmi_ssh.ping(bmi1["bmc_ip"], mgmt_cluster_ip), (
+        assert not bmi_ssh.ping(bmi1["ssh_host"], mgmt_cluster_ip), (
             f"ping from BMI1 ({bmi1['ip']}) to management cluster ({mgmt_cluster_ip}) "
             f"succeeded unexpectedly — tenant isolation should prevent cross-VNet traffic"
         )
@@ -312,11 +313,11 @@ class TestBmaasNetworking:
         bmi1 = self.state["bmi1"]
 
         poll_until(
-            fn=lambda: bmi_ssh.curl_status(bmi1["bmc_ip"], "https://quay.io"),
+            fn=lambda: bmi_ssh.curl_status(bmi1["ssh_host"], "https://quay.io"),
             until=lambda status: status == 200,
             retries=5,
             delay=15,
-            description=f"NAT gateway egress curl quay.io (bmc_ip={bmi1['bmc_ip']}, tenant_ip={bmi1['ip']})",
+            description=f"NAT gateway egress curl quay.io (ssh_host={bmi1['ssh_host']}, tenant_ip={bmi1['ip']})",
         )
 
     def test_12_external_ip_ingress(self, grpc: GRPCClient, k8s_hub_client: K8sClient, net_test_run_id: str) -> None:


### PR DESCRIPTION
## Summary

- Replace ambiguous `virsh net-dhcp-leases bmc-net` lookup with the generic `OSAC_BMH_SSH_HOSTS` JSON mapping.
- Resolve each BMI's consuming BMH from its status, then use the configured SSH host for connectivity checks.
- Rename the internal `bmc_ip` state/parameters to `ssh_host`.

The infrastructure backend should provide `OSAC_BMH_SSH_HOSTS` as a JSON object mapping BMH names to reachable management SSH hosts. Backend changes are intentionally out of scope for this PR.

## Root cause addressed

The failed networking run used the correct BMI1 → BMI2 pair, but the old helper selected the first duplicate libvirt DHCP lease. That was a stale `ubuntu` lease (`10.99.0.209`/`10.99.0.152`) rather than the live BMH host lease, so the SSH probe did not reach the intended BMH.

## Validation

- `ruff check` passed for all three changed files.
- `ruff format --check` passed.
- `git diff --check` passed.
- Python compilation and parser/lookup smoke checks passed.
- Full pytest collection was not run locally because pytest is not installed and offline uv could not download it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

### API surface
- Adds `parse_ssh_hosts()` and `get_ssh_host()`.
- Replaces `get_bmc_ip()` and libvirt DHCP lease lookup.
- Renames helper parameters and internal state from `bmc_ip` to `ssh_host`.
- Centralizes command logging through `_log_command`.

### Tests
- Adds a session-scoped `bmh_ssh_hosts` fixture.
- Resolves each BMI’s consuming BMH from status.
- Uses the configured SSH host for networking regression tests.

### Deployment and backend integration
- Requires `OSAC_BMH_SSH_HOSTS` to contain a JSON object that maps BMH names to reachable management SSH hosts.
- Backend changes are outside this pull request.

### Backward compatibility
- Callers of `get_bmc_ip()` must migrate to `get_ssh_host()`.
- Callers that use the old `bmc_ip` keyword parameters must use `ssh_host`.
- The change prevents stale duplicate DHCP leases from selecting the wrong SSH host.

### Validation
- Ruff, formatting, diff, Python compilation, and parser/lookup smoke checks passed.
- Full pytest collection was not run because pytest was unavailable locally.

## Risk classification

**risk:show** — The change modifies SSH host resolution, removes a lookup function, changes helper parameters, and adds an environment-variable integration contract. The impact is limited to networking test infrastructure. Focused validation passed, but full pytest collection was unavailable.

The change is close to **risk:ship**, but it does not qualify because it changes an integration contract and has incomplete test validation. It does not qualify for **risk:ask** because it does not change production services, authentication, data storage, or deployment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->