### PR TITLE
OSAC-4917: Skip default networking for reserved tenants

### DIFF
--- a/fulfillment-service/internal/controllers/tenant/tenant_reconciler_function.go
+++ b/fulfillment-service/internal/controllers/tenant/tenant_reconciler_function.go
@@ -743,11 +743,19 @@ const (
 )
 
 func (t *task) checkDefaultNetworkingReadiness(ctx context.Context) error {
+	tenantName := t.tenant.GetMetadata().GetName()
+	condType := privatev1.TenantConditionType_TENANT_CONDITION_TYPE_DEFAULT_NETWORKING_READY
+
+	if tenantName == auth.SystemTenant || tenantName == auth.SharedTenant {
+		t.updateCondition(condType, privatev1.ConditionStatus_CONDITION_STATUS_TRUE,
+			"ReservedTenant", "Reserved tenants do not require default networking")
+		return nil
+	}
+
 	if t.r.virtualNetworksClient == nil {
 		return nil
 	}
-	tenantName := t.tenant.GetMetadata().GetName()
-	condType := privatev1.TenantConditionType_TENANT_CONDITION_TYPE_DEFAULT_NETWORKING_READY
+
 	filter := fmt.Sprintf("%s && this.metadata.tenant == %q", defaultLabelFilter, tenantName)
 
 	var pending, failed []string

--- a/fulfillment-service/internal/controllers/tenant/tenant_reconciler_function_test.go
+++ b/fulfillment-service/internal/controllers/tenant/tenant_reconciler_function_test.go
@@ -2041,6 +2041,30 @@ var _ = Describe("Default networking readiness", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	DescribeTable("sets DefaultNetworkingReady=TRUE for reserved tenants even when VN client is nil",
+		func(tenantName string) {
+			nilVNReconciler := &function{
+				logger:     logger,
+				idpManager: reconciler.idpManager,
+				// virtualNetworksClient intentionally nil
+			}
+
+			tenant := newSyncedTenant(tenantName)
+			t := &task{r: nilVNReconciler, tenant: tenant}
+			t.setDefaults()
+			t.setConditionDefaults()
+			err := t.checkDefaultNetworkingReadiness(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			cond := findCondition(tenant)
+			Expect(cond).ToNot(BeNil())
+			Expect(cond.GetStatus()).To(Equal(privatev1.ConditionStatus_CONDITION_STATUS_TRUE))
+			Expect(cond.GetReason()).To(Equal("ReservedTenant"))
+		},
+		Entry("system tenant", auth.SystemTenant),
+		Entry("shared tenant", auth.SharedTenant),
+	)
+
 	It("initializes DefaultNetworkingReady condition as FALSE for deleted tenant", func() {
 		tenant := privatev1.Tenant_builder{
 			Id: "deleting-tenant",

--- a/fulfillment-service/internal/servers/default_networking_provisioner.go
+++ b/fulfillment-service/internal/servers/default_networking_provisioner.go
@@ -239,6 +239,12 @@ func (b *DefaultNetworkingProvisionerBuilder) Build() (result *DefaultNetworking
 // transaction so a failure rolls back the entire set. The gRPC interceptor provides this when
 // called from an RPC handler.
 func (p *DefaultNetworkingProvisioner) Provision(ctx context.Context, tenantName string) error {
+	if tenantName == auth.SystemTenant || tenantName == auth.SharedTenant {
+		p.logger.InfoContext(ctx, "Skipping default networking for reserved tenant",
+			slog.String("tenant", tenantName))
+		return nil
+	}
+
 	nc, err := findDefaultNetworkClass(ctx, p.logger, p.networkClassDao)
 	if err != nil {
 		return fmt.Errorf("failed to find default NetworkClass: %w", err)

--- a/fulfillment-service/internal/servers/default_networking_provisioner_test.go
+++ b/fulfillment-service/internal/servers/default_networking_provisioner_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/osac/fulfillment-service/internal/auth"
 	"github.com/osac-project/osac/fulfillment-service/internal/database/dao"
 )
 
@@ -385,6 +386,85 @@ var _ = Describe("Default networking provisioner", func() {
 				Do(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vnList.GetItems()).To(BeEmpty())
+		})
+	})
+
+	Context("when called with a reserved tenant", func() {
+		BeforeEach(func() {
+			createNetworkClass(privatev1.NetworkDefaults_builder{
+				VirtualNetworkIpv4Cidr: "10.0.0.0/16",
+				SubnetIpv4Cidr:         "10.0.1.0/24",
+			}.Build())
+		})
+
+		It("skips provisioning for the system tenant", func() {
+			err := provisioner.Provision(ctx, auth.SystemTenant)
+			Expect(err).ToNot(HaveOccurred())
+
+			vnList, err := provisioner.virtualNetworkDao.List().
+				SetFilter("this.metadata.tenant == 'system'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vnList.GetItems()).To(BeEmpty())
+
+			subnetList, err := provisioner.subnetDao.List().
+				SetFilter("this.metadata.tenant == 'system'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(subnetList.GetItems()).To(BeEmpty())
+
+			sgList, err := provisioner.securityGroupDao.List().
+				SetFilter("this.metadata.tenant == 'system'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sgList.GetItems()).To(BeEmpty())
+		})
+
+		It("skips provisioning for the shared tenant", func() {
+			err := provisioner.Provision(ctx, auth.SharedTenant)
+			Expect(err).ToNot(HaveOccurred())
+
+			vnList, err := provisioner.virtualNetworkDao.List().
+				SetFilter("this.metadata.tenant == 'shared'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vnList.GetItems()).To(BeEmpty())
+
+			subnetList, err := provisioner.subnetDao.List().
+				SetFilter("this.metadata.tenant == 'shared'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(subnetList.GetItems()).To(BeEmpty())
+
+			sgList, err := provisioner.securityGroupDao.List().
+				SetFilter("this.metadata.tenant == 'shared'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sgList.GetItems()).To(BeEmpty())
+		})
+
+		It("still provisions networking for regular tenants", func() {
+			createTenant("customer-tenant")
+			err := provisioner.Provision(ctx, "customer-tenant")
+			Expect(err).ToNot(HaveOccurred())
+
+			vnList, err := provisioner.virtualNetworkDao.List().
+				SetFilter("this.metadata.tenant == 'customer-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vnList.GetItems()).To(HaveLen(1))
+
+			subnetList, err := provisioner.subnetDao.List().
+				SetFilter("this.metadata.tenant == 'customer-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(subnetList.GetItems()).To(HaveLen(1))
+
+			sgList, err := provisioner.securityGroupDao.List().
+				SetFilter("this.metadata.tenant == 'customer-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sgList.GetItems()).To(HaveLen(1))
 		})
 	})
 


### PR DESCRIPTION
Reserved tenants ("system" and "shared") should never receive default networking resources. Add early-return guards to both the provisioner's Provision() method and the reconciler's checkDefaultNetworkingReadiness() so these tenants are skipped during tenant onboarding.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **Controllers:** Skip default networking readiness checks for `system` and `shared` tenants.
- **Provisioning:** Skip default networking creation for `system` and `shared` tenants.
- **Tests:** Add coverage for reserved and regular tenants.
- **API, database, authentication, deployment, CI, and documentation:** No changes.

## Backward compatibility

Regular tenants keep existing behavior. Reserved tenants no longer receive default networking resources.

## Risk classification

**risk:ship** — The change is small, scoped, and covered by tests. It does not change public APIs, schemas, authentication, deployment, or CI. It does not qualify for **risk:show** because it affects only reserved-tenant onboarding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->