### PR TITLE
NO-ISSUE: Pass notify-on-failure to the reusable E2E full-install workflows

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -234,6 +234,7 @@ jobs:
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
       test-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       test-ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      notify-on-failure: ${{ github.event_name == 'schedule' }}
       # Gated on ref, not event type: the real constraint is WIF trust
       # (main branch only), not which event triggered the run. This
       # correctly covers schedule (always main) AND a manual

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -242,6 +242,7 @@ jobs:
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
       test-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       test-ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      notify-on-failure: ${{ github.event_name == 'schedule' }}
       # CaaS-specific inputs (cluster-template, caas-domain, flavor-image,
       # flavor-name, namespace, etc.) are left at the reusable workflow's own
       # defaults -- none are required and this caller has no need to override

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -242,6 +242,7 @@ jobs:
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
       test-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       test-ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      notify-on-failure: ${{ github.event_name == 'schedule' }}
       # Gated on ref, not event type: the real constraint is WIF trust
       # (main branch only), not which event triggered the run. This
       # correctly covers schedule (always main) AND a manual


### PR DESCRIPTION
## Summary
- `e2e-vmaas-full-install.yml`, `e2e-caas-full-install.yml`, and `e2e-bmaas-full-install.yml` call into osac-test-infra's reusable E2E full-install workflows but never pass `notify-on-failure`, so it silently defaults to `false` -- Slack failure notifications (and the AI-diagnosis thread reply / chai-bot ping built on top of them) have never fired for any osac-triggered scheduled run.
- Adds `notify-on-failure: ${{ github.event_name == 'schedule' }}` to all three callers' `with:` blocks, matching the pattern already used correctly in osac-test-infra's own caller workflows.

## Test plan
- [ ] actionlint clean on all 3 changed files (verified locally)
- [ ] Confirm the next scheduled E2E run (any flavor) that fails produces a Slack notification with a threaded AI-diagnosis reply and chai-bot ping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzMWXNMZSHdSXNdYj3owPC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## CI

Updated VMaaS, CaaS, and BMaaS full-install workflow callers.

Scheduled runs now enable `notify-on-failure`. Other runs keep notifications disabled.

This enables Slack failure notifications, threaded AI diagnosis replies, and chai-bot notifications for scheduled E2E failures.

## Backward compatibility

No application, API, deployment, security, data, test, or documentation behavior changed. Non-scheduled workflow behavior remains unchanged.

## Risk classification

risk:ship. The change is limited to CI configuration and affects only scheduled failure notifications. No risk:show or risk:ask criteria apply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->