### PR TITLE
NO-ISSUE: test e2e readiness gate

### DIFF
--- a/osac-operator/cmd/main.go
+++ b/osac-operator/cmd/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 // Main entrypoint for the operator
 package main
 
+
 import (
 	"context"
 	"crypto/tls"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Areas affected

- **Code organization:** Added a blank line after `package main` in `osac-operator/cmd/main.go`.
- **API surface, controllers, database, authentication, deployment, CI, tests, documentation:** No changes.
- **Backward compatibility:** No impact.

## Risk classification

- **Applied risk label:** None is listed in the available PR data.
- The change is formatting-only and would meet `risk:ship` criteria if that label is available. It does not qualify for `risk:show` or `risk:ask` because it changes no behavior, interfaces, security controls, or deployment logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->