### PR TITLE
OSAC-4874: enforce tenant isolation for private API networking references

### DIFF
--- a/fulfillment-service/internal/servers/private_baremetal_instances_server.go
+++ b/fulfillment-service/internal/servers/private_baremetal_instances_server.go
@@ -283,6 +283,12 @@ func (s *PrivateBareMetalInstancesServer) Create(ctx context.Context,
 	if err = s.applyDefaultNetworkAttachments(ctx, request.GetObject()); err != nil {
 		return
 	}
+	// Cross-tenant validation: BareMetalInstance must reference subnets and security groups
+	// from the same tenant. TotalVisibility on the private API bypasses DAO tenant filtering,
+	// so we must check explicitly.
+	if err = s.validateCrossTenantNetworkReferences(ctx, request.GetObject()); err != nil {
+		return
+	}
 	if err = s.validateNetworkAttachments(ctx, request.GetObject()); err != nil {
 		return
 	}
@@ -878,6 +884,56 @@ func compareNetworkAttachmentsImmutability(existing, updated []*privatev1.BareMe
 				"cannot change network_attachments[%d].primary: primary is immutable after creation", i)
 		}
 	}
+	return nil
+}
+
+// validateCrossTenantNetworkReferences explicitly checks that the BareMetalInstance's tenant
+// matches the tenants of all referenced Subnets and SecurityGroups. This is critical for the
+// private API where TotalVisibility bypasses DAO-level tenant filtering.
+func (s *PrivateBareMetalInstancesServer) validateCrossTenantNetworkReferences(ctx context.Context,
+	bmi *privatev1.BareMetalInstance) error {
+	attachments := bmi.GetSpec().GetNetworkAttachments()
+	if len(attachments) == 0 {
+		return nil
+	}
+
+	// Only validate when an explicit tenant is set (private API path).
+	if bmi.GetMetadata().GetTenant() == "" {
+		return nil
+	}
+
+	bmiTenant := bmi.GetMetadata().GetTenant()
+
+	for _, att := range attachments {
+		// Validate subnet tenant
+		subnetKey := refKey(att.GetSubnet())
+		if subnetKey != "" {
+			subnetResp, subnetErr := s.subnetsDao.Get().SetId(subnetKey).Do(ctx)
+			if subnetErr == nil {
+				if err := fetchAndValidateTenantMatch(bmiTenant, subnetResp.GetObject(), "Subnet", subnetKey); err != nil {
+					return err
+				}
+			}
+			// NotFound will be caught by validateNetworkAttachments
+		}
+
+		// Validate security group tenants
+		for _, sgRef := range att.GetSecurityGroups() {
+			if sgRef == nil {
+				continue
+			}
+			sgKey := refKey(sgRef)
+			if sgKey != "" {
+				sgResp, sgErr := s.securityGroupsDao.Get().SetId(sgKey).Do(ctx)
+				if sgErr == nil {
+					if err := fetchAndValidateTenantMatch(bmiTenant, sgResp.GetObject(), "SecurityGroup", sgKey); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/fulfillment-service/internal/servers/private_clusters_server.go
+++ b/fulfillment-service/internal/servers/private_clusters_server.go
@@ -326,6 +326,13 @@ func (s *PrivateClustersServer) Create(ctx context.Context,
 		networkAttachmentErr = s.injectDefaultNetworkAttachment(ctx, request.GetObject())
 	}
 
+	// Cross-tenant validation: Cluster must reference subnets and security groups from
+	// the same tenant. TotalVisibility on the private API bypasses DAO tenant filtering,
+	// so we must check explicitly.
+	if networkAttachmentErr == nil && request.GetObject().GetSpec().GetNetworkAttachment() != nil {
+		networkAttachmentErr = s.validateCrossTenantNetworkAttachment(ctx, request.GetObject())
+	}
+
 	// Validate network attachment references (subnet READY, SGs same-VN):
 	if networkAttachmentErr == nil && request.GetObject().GetSpec().GetNetworkAttachment() != nil {
 		networkAttachmentErr = s.validateNetworkAttachmentState(ctx, request.GetObject())
@@ -1060,6 +1067,57 @@ func (s *PrivateClustersServer) injectDefaultNetworkAttachment(ctx context.Conte
 		attrs = append(attrs, slog.String("security_group_id", sg.GetId()))
 	}
 	s.logger.LogAttrs(ctx, slog.LevelInfo, "auto-injected default network attachment", attrs...)
+	return nil
+}
+
+// validateCrossTenantNetworkAttachment explicitly checks that the Cluster's tenant matches
+// the tenants of all referenced Subnets and SecurityGroups in its network attachment.
+// This is critical for the private API where TotalVisibility bypasses DAO-level tenant filtering.
+func (s *PrivateClustersServer) validateCrossTenantNetworkAttachment(ctx context.Context,
+	cluster *privatev1.Cluster) error {
+	if cluster == nil || cluster.GetSpec() == nil {
+		return nil
+	}
+	att := cluster.GetSpec().GetNetworkAttachment()
+	if att == nil {
+		return nil
+	}
+
+	// Only validate when an explicit tenant is set (private API path).
+	if cluster.GetMetadata().GetTenant() == "" {
+		return nil
+	}
+
+	clusterTenant := cluster.GetMetadata().GetTenant()
+
+	// Validate subnet tenant
+	subnetKey := refKey(att.GetSubnet())
+	if subnetKey != "" {
+		subnetResp, subnetErr := s.subnetsDao.Get().SetId(subnetKey).Do(ctx)
+		if subnetErr == nil {
+			if err := fetchAndValidateTenantMatch(clusterTenant, subnetResp.GetObject(), "Subnet", subnetKey); err != nil {
+				return err
+			}
+		}
+		// NotFound will be caught by validateNetworkAttachmentState
+	}
+
+	// Validate security group tenants
+	for _, sgRef := range att.GetSecurityGroups() {
+		if sgRef == nil {
+			continue
+		}
+		sgKey := refKey(sgRef)
+		if sgKey != "" {
+			sgResp, sgErr := s.securityGroupsDao.Get().SetId(sgKey).Do(ctx)
+			if sgErr == nil {
+				if err := fetchAndValidateTenantMatch(clusterTenant, sgResp.GetObject(), "SecurityGroup", sgKey); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/fulfillment-service/internal/servers/private_compute_instances_server.go
+++ b/fulfillment-service/internal/servers/private_compute_instances_server.go
@@ -890,10 +890,8 @@ func hasMaskPrefix(mask *fieldmaskpb.FieldMask, prefixes ...string) bool {
 // belong to the same tenant as the ComputeInstance.
 //
 // This validation MUST run even during deletion to prevent cross-tenant updates.
-// The DAO Get() calls enforce tenant isolation via TenancyLogic - cross-tenant resources
-// are filtered out and appear as NotFound. During deletion, NotFound is allowed (resources
-// may have been deleted during cleanup). This ensures tenant boundaries are always enforced
-// while allowing graceful deletion.
+// It performs explicit metadata.tenant comparison that works correctly even when the
+// private API caller has TotalVisibility (which bypasses DAO-level tenant filtering).
 //
 // Implements requirement VAL-04 (tenant isolation).
 func (s *PrivateComputeInstancesServer) validateNetworkReferencesTenancy(
@@ -917,6 +915,15 @@ func (s *PrivateComputeInstancesServer) validateNetworkReferencesTenancy(
 		return nil
 	}
 
+	// Only validate when an explicit tenant is set (private API path).
+	// When the tenant is empty, the DAO layer assigns it and provides isolation.
+	if vm.GetMetadata().GetTenant() == "" {
+		return nil
+	}
+
+	// Resolve the ComputeInstance's own tenant for explicit comparison.
+	vmTenant := vm.GetMetadata().GetTenant()
+
 	for _, att := range attachments {
 		subnetRef := att.GetSubnet()
 		securityGroupRefs := att.GetSecurityGroups()
@@ -925,24 +932,25 @@ func (s *PrivateComputeInstancesServer) validateNetworkReferencesTenancy(
 		// ValidateNetworkAttachments ensures all attachments have non-empty subnet.
 		subnetIDStr := refKey(subnetRef)
 
-		// Validate tenant isolation for subnet.
-		// TenancyLogic in DAO filters out cross-tenant resources, making them appear as NotFound.
-		// We allow NotFound during deletion (resource may be deleted or cross-tenant).
-		// The key is that we ALWAYS call DAO Get() so tenant filtering happens.
-		_, getErr := s.subnetsDao.Get().SetId(subnetIDStr).Do(ctx)
+		// Validate tenant isolation for subnet via explicit metadata.tenant comparison.
+		// This works correctly even with TotalVisibility (private API callers).
+		subnetResp, getErr := s.subnetsDao.Get().SetId(subnetIDStr).Do(ctx)
 		if getErr != nil {
 			var notFoundErr *dao.ErrNotFound
 			if errors.As(getErr, &notFoundErr) {
-				// Resource doesn't exist OR belongs to different tenant (filtered by TenancyLogic).
-				// During deletion this is allowed. During creation/normal update this is caught
-				// by validateNetworkReferencesState.
+				// Resource doesn't exist. During deletion this is allowed.
+				// During creation/normal update this is caught by validateNetworkReferencesState.
 				continue
 			}
-			// Other error - propagate
 			s.logger.ErrorContext(ctx, "Failed to query Subnet for tenancy check",
 				slog.String("subnet_id", subnetIDStr),
 				slog.Any("error", getErr))
 			return grpcstatus.Errorf(grpccodes.Internal, "failed to validate subnet")
+		}
+
+		// Explicit cross-tenant check on subnet metadata
+		if err := fetchAndValidateTenantMatch(vmTenant, subnetResp.GetObject(), "Subnet", subnetIDStr); err != nil {
+			return err
 		}
 
 		// Validate tenant isolation for security groups.
@@ -951,20 +959,23 @@ func (s *PrivateComputeInstancesServer) validateNetworkReferencesTenancy(
 				continue
 			}
 			sgIDStr := refKey(sgRef)
-			_, getErr := s.securityGroupsDao.Get().SetId(sgIDStr).Do(ctx)
+			sgResp, getErr := s.securityGroupsDao.Get().SetId(sgIDStr).Do(ctx)
 			if getErr != nil {
 				var notFoundErr *dao.ErrNotFound
 				if errors.As(getErr, &notFoundErr) {
-					// Resource doesn't exist OR belongs to different tenant (filtered by TenancyLogic).
-					// During deletion this is allowed. During creation/normal update this is caught
-					// by validateNetworkReferencesState.
+					// Resource doesn't exist. During deletion this is allowed.
+					// During creation/normal update this is caught by validateNetworkReferencesState.
 					continue
 				}
-				// Other error - propagate
 				s.logger.ErrorContext(ctx, "Failed to query SecurityGroup for tenancy check",
 					slog.String("security_group_id", sgIDStr),
 					slog.Any("error", getErr))
 				return grpcstatus.Errorf(grpccodes.Internal, "failed to validate security group")
+			}
+
+			// Explicit cross-tenant check on security group metadata
+			if err := fetchAndValidateTenantMatch(vmTenant, sgResp.GetObject(), "SecurityGroup", sgIDStr); err != nil {
+				return err
 			}
 		}
 	}

--- a/fulfillment-service/internal/servers/private_external_ip_attachments_server.go
+++ b/fulfillment-service/internal/servers/private_external_ip_attachments_server.go
@@ -45,6 +45,7 @@ type PrivateExternalIPAttachmentsServer struct {
 	privatev1.UnimplementedExternalIPAttachmentsServer
 
 	logger                  *slog.Logger
+	tenancyLogic            auth.TenancyLogic
 	generic                 *GenericServer[*privatev1.ExternalIPAttachment]
 	externalIPDao           *dao.GenericDAO[*privatev1.ExternalIP]
 	computeInstanceDao      *dao.GenericDAO[*privatev1.ComputeInstance]
@@ -157,6 +158,7 @@ func (b *PrivateExternalIPAttachmentsServerBuilder) Build() (*PrivateExternalIPA
 
 	result := &PrivateExternalIPAttachmentsServer{
 		logger:                  b.logger,
+		tenancyLogic:            b.tenancyLogic,
 		generic:                 generic,
 		externalIPDao:           externalIPDao,
 		computeInstanceDao:      computeInstanceDao,
@@ -193,6 +195,14 @@ func (s *PrivateExternalIPAttachmentsServer) Create(ctx context.Context,
 	externalIPKey := refKey(externalIPRef)
 
 	err = s.validateExternalIPReference(ctx, externalIPKey)
+	if err != nil {
+		return
+	}
+
+	// Cross-tenant validation: ExternalIPAttachment must reference an ExternalIP and
+	// target resource from the same tenant. TotalVisibility on the private API bypasses
+	// DAO tenant filtering, so we must check explicitly.
+	err = s.validateCrossTenantReferences(ctx, attachment)
 	if err != nil {
 		return
 	}
@@ -296,6 +306,76 @@ func (s *PrivateExternalIPAttachmentsServer) Signal(ctx context.Context,
 	request *privatev1.ExternalIPAttachmentsSignalRequest) (response *privatev1.ExternalIPAttachmentsSignalResponse, err error) {
 	err = s.generic.Signal(ctx, request, &response)
 	return
+}
+
+// validateCrossTenantReferences explicitly checks that the ExternalIPAttachment's tenant
+// matches the tenants of its ExternalIP and target resource (ComputeInstance, Cluster, or
+// BareMetalInstance). This is critical for the private API where TotalVisibility bypasses
+// DAO-level tenant filtering.
+//
+// This check only runs when the attachment has an explicit metadata.tenant set. When the
+// tenant is empty, the DAO layer assigns the tenant based on the caller's visibility, and
+// the regular DAO-level tenant filtering ensures isolation.
+func (s *PrivateExternalIPAttachmentsServer) validateCrossTenantReferences(ctx context.Context,
+	attachment *privatev1.ExternalIPAttachment) error {
+
+	// Only validate when an explicit tenant is set (private API path).
+	// Public API callers don't set metadata.tenant — the DAO assigns it.
+	if attachment.GetMetadata().GetTenant() == "" {
+		return nil
+	}
+
+	attachmentTenant := attachment.GetMetadata().GetTenant()
+
+	spec := attachment.GetSpec()
+
+	// Validate ExternalIP tenant matches
+	eipKey := refKey(spec.GetExternalIp())
+	if eipKey != "" {
+		eipResp, eipErr := s.externalIPDao.Get().SetId(eipKey).Do(ctx)
+		if eipErr == nil {
+			if err := fetchAndValidateTenantMatch(attachmentTenant, eipResp.GetObject(), "ExternalIP", eipKey); err != nil {
+				return err
+			}
+		}
+		// NotFound will be caught by validateExternalIPReference
+	}
+
+	// Validate target resource tenant matches
+	switch {
+	case spec.HasComputeInstance():
+		ciKey := refKey(spec.GetComputeInstance())
+		if ciKey != "" {
+			ciResp, ciErr := s.computeInstanceDao.Get().SetId(ciKey).Do(ctx)
+			if ciErr == nil {
+				if err := fetchAndValidateTenantMatch(attachmentTenant, ciResp.GetObject(), "ComputeInstance", ciKey); err != nil {
+					return err
+				}
+			}
+		}
+	case spec.HasCluster():
+		clusterKey := refKey(spec.GetCluster())
+		if clusterKey != "" {
+			clusterResp, clusterErr := s.clusterDao.Get().SetId(clusterKey).Do(ctx)
+			if clusterErr == nil {
+				if err := fetchAndValidateTenantMatch(attachmentTenant, clusterResp.GetObject(), "Cluster", clusterKey); err != nil {
+					return err
+				}
+			}
+		}
+	case spec.HasBaremetalInstance():
+		bmiKey := refKey(spec.GetBaremetalInstance())
+		if bmiKey != "" {
+			bmiResp, bmiErr := s.bareMetalInstanceDao.Get().SetId(bmiKey).Do(ctx)
+			if bmiErr == nil {
+				if err := fetchAndValidateTenantMatch(attachmentTenant, bmiResp.GetObject(), "BareMetalInstance", bmiKey); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 func (s *PrivateExternalIPAttachmentsServer) validateExternalIPAttachment(

--- a/fulfillment-service/internal/servers/private_external_ips_server.go
+++ b/fulfillment-service/internal/servers/private_external_ips_server.go
@@ -51,6 +51,7 @@ type PrivateExternalIPsServer struct {
 	privatev1.UnimplementedExternalIPsServer
 
 	logger            *slog.Logger
+	tenancyLogic      auth.TenancyLogic
 	generic           *GenericServer[*privatev1.ExternalIP]
 	externalIPPoolDao *dao.GenericDAO[*privatev1.ExternalIPPool]
 }
@@ -129,6 +130,7 @@ func (b *PrivateExternalIPsServerBuilder) Build() (result *PrivateExternalIPsSer
 
 	result = &PrivateExternalIPsServer{
 		logger:            b.logger,
+		tenancyLogic:      b.tenancyLogic,
 		generic:           generic,
 		externalIPPoolDao: externalIPPoolDao,
 	}
@@ -157,6 +159,15 @@ func (s *PrivateExternalIPsServer) Create(ctx context.Context,
 	}
 
 	poolKey := refKey(externalIP.GetSpec().GetPool())
+
+	// Cross-tenant validation: ExternalIP must reference a pool from the same tenant
+	// or the shared tenant. TotalVisibility on the private API bypasses DAO tenant
+	// filtering, so we must check explicitly.
+	err = s.validateCrossTenantPool(ctx, externalIP, poolKey)
+	if err != nil {
+		return
+	}
+
 	err = s.validatePoolReference(ctx, poolKey)
 	if err != nil {
 		return
@@ -271,6 +282,32 @@ func (s *PrivateExternalIPsServer) Signal(ctx context.Context,
 	request *privatev1.ExternalIPsSignalRequest) (response *privatev1.ExternalIPsSignalResponse, err error) {
 	err = s.generic.Signal(ctx, request, &response)
 	return
+}
+
+// validateCrossTenantPool explicitly checks that the ExternalIP's tenant matches
+// or shares a tenant with the referenced pool. ExternalIPPools may be in the shared
+// tenant, so we allow shared-tenant pools.
+func (s *PrivateExternalIPsServer) validateCrossTenantPool(ctx context.Context,
+	externalIP *privatev1.ExternalIP, poolKey string) error {
+
+	if poolKey == "" {
+		return nil
+	}
+
+	// Only validate when an explicit tenant is set (private API path).
+	if externalIP.GetMetadata().GetTenant() == "" {
+		return nil
+	}
+
+	eipTenant := externalIP.GetMetadata().GetTenant()
+
+	poolResp, poolErr := s.externalIPPoolDao.Get().SetId(poolKey).Do(ctx)
+	if poolErr != nil {
+		// NotFound will be caught by validatePoolReference
+		return nil
+	}
+
+	return fetchAndValidateTenantOrShared(eipTenant, poolResp.GetObject(), "ExternalIPPool", poolKey)
 }
 
 func (s *PrivateExternalIPsServer) validateExternalIP(ctx context.Context,

--- a/fulfillment-service/internal/servers/private_nat_gateways_server.go
+++ b/fulfillment-service/internal/servers/private_nat_gateways_server.go
@@ -44,6 +44,7 @@ type PrivateNATGatewaysServer struct {
 	privatev1.UnimplementedNATGatewaysServer
 
 	logger             *slog.Logger
+	tenancyLogic       auth.TenancyLogic
 	generic            *GenericServer[*privatev1.NATGateway]
 	externalIPDao      *dao.GenericDAO[*privatev1.ExternalIP]
 	virtualNetworksDao *dao.GenericDAO[*privatev1.VirtualNetwork]
@@ -142,6 +143,7 @@ func (b *PrivateNATGatewaysServerBuilder) Build() (result *PrivateNATGatewaysSer
 
 	result = &PrivateNATGatewaysServer{
 		logger:             b.logger,
+		tenancyLogic:       b.tenancyLogic,
 		generic:            generic,
 		externalIPDao:      externalIPDao,
 		virtualNetworksDao: virtualNetworksDao,
@@ -167,6 +169,14 @@ func (s *PrivateNATGatewaysServer) Create(ctx context.Context,
 	natGateway := request.GetObject()
 
 	err = s.validateNATGateway(natGateway)
+	if err != nil {
+		return
+	}
+
+	// Cross-tenant validation: NATGateway must belong to the same tenant as its
+	// VirtualNetwork and ExternalIP. TotalVisibility on the private API bypasses
+	// DAO tenant filtering, so we must check explicitly.
+	err = s.validateCrossTenantReferences(ctx, natGateway)
 	if err != nil {
 		return
 	}
@@ -263,6 +273,46 @@ func (s *PrivateNATGatewaysServer) Signal(ctx context.Context,
 	request *privatev1.NATGatewaysSignalRequest) (response *privatev1.NATGatewaysSignalResponse, err error) {
 	err = s.generic.Signal(ctx, request, &response)
 	return
+}
+
+// validateCrossTenantReferences explicitly checks that the NATGateway's tenant matches
+// its parent VirtualNetwork and ExternalIP tenants. This is critical for the private API
+// where TotalVisibility bypasses DAO-level tenant filtering.
+func (s *PrivateNATGatewaysServer) validateCrossTenantReferences(ctx context.Context,
+	natGateway *privatev1.NATGateway) error {
+
+	// Only validate when an explicit tenant is set (private API path).
+	if natGateway.GetMetadata().GetTenant() == "" {
+		return nil
+	}
+
+	gwTenant := natGateway.GetMetadata().GetTenant()
+
+	// Validate VirtualNetwork tenant matches
+	vnKey := refKey(natGateway.GetSpec().GetVirtualNetwork())
+	if vnKey != "" {
+		vnResp, vnErr := s.virtualNetworksDao.Get().SetId(vnKey).Do(ctx)
+		if vnErr == nil {
+			if err := fetchAndValidateTenantMatch(gwTenant, vnResp.GetObject(), "VirtualNetwork", vnKey); err != nil {
+				return err
+			}
+		}
+		// NotFound will be caught by validateNetworkClassHasFabricManager
+	}
+
+	// Validate ExternalIP tenant matches
+	eipKey := refKey(natGateway.GetSpec().GetExternalIp())
+	if eipKey != "" {
+		eipResp, eipErr := s.externalIPDao.Get().SetId(eipKey).Do(ctx)
+		if eipErr == nil {
+			if err := fetchAndValidateTenantMatch(gwTenant, eipResp.GetObject(), "ExternalIP", eipKey); err != nil {
+				return err
+			}
+		}
+		// NotFound will be caught by validateExternalIPReference
+	}
+
+	return nil
 }
 
 func (s *PrivateNATGatewaysServer) validateNATGateway(natGateway *privatev1.NATGateway) error {

--- a/fulfillment-service/internal/servers/private_security_groups_server.go
+++ b/fulfillment-service/internal/servers/private_security_groups_server.go
@@ -44,6 +44,7 @@ type PrivateSecurityGroupsServer struct {
 	privatev1.UnimplementedSecurityGroupsServer
 
 	logger            *slog.Logger
+	tenancyLogic      auth.TenancyLogic
 	generic           *GenericServer[*privatev1.SecurityGroup]
 	virtualNetworkDao *dao.GenericDAO[*privatev1.VirtualNetwork]
 }
@@ -128,6 +129,7 @@ func (b *PrivateSecurityGroupsServerBuilder) Build() (result *PrivateSecurityGro
 	// Create and populate the object:
 	result = &PrivateSecurityGroupsServer{
 		logger:            b.logger,
+		tenancyLogic:      b.tenancyLogic,
 		generic:           generic,
 		virtualNetworkDao: virtualNetworkDao,
 	}
@@ -236,6 +238,15 @@ func (s *PrivateSecurityGroupsServer) validateSecurityGroup(ctx context.Context,
 	// Check immutable fields (only on Update)
 	if err := validateImmutableFieldsSecurityGroup(newSecurityGroup, existingSecurityGroup); err != nil {
 		return err
+	}
+
+	// Cross-tenant validation: the SecurityGroup must belong to the same tenant as its
+	// parent VirtualNetwork. The private API operates with TotalVisibility, so DAO-level
+	// tenant filtering is bypassed — we must check explicitly.
+	if existingSecurityGroup == nil {
+		if err := s.validateCrossTenantVirtualNetwork(ctx, newSecurityGroup); err != nil {
+			return err
+		}
 	}
 
 	// Validate parent VirtualNetwork
@@ -369,6 +380,38 @@ func validateSecurityRule(rule *privatev1.SecurityRule, ruleType string, index i
 	}
 
 	return nil
+}
+
+// validateCrossTenantVirtualNetwork explicitly checks that the SecurityGroup's tenant matches
+// its parent VirtualNetwork's tenant. This is critical for the private API where
+// TotalVisibility bypasses DAO-level tenant filtering.
+//
+// This check only runs when the security group has an explicit metadata.tenant set.
+func (s *PrivateSecurityGroupsServer) validateCrossTenantVirtualNetwork(ctx context.Context,
+	sg *privatev1.SecurityGroup) error {
+
+	// Only validate when an explicit tenant is set (private API path).
+	if sg.GetMetadata().GetTenant() == "" {
+		return nil
+	}
+
+	vnRef := sg.GetSpec().GetVirtualNetwork()
+	if vnRef == nil {
+		return nil // Caught later by validateVirtualNetworkReference
+	}
+
+	sgTenant := sg.GetMetadata().GetTenant()
+
+	vnKey := refKey(vnRef)
+	getResponse, err := s.virtualNetworkDao.Get().
+		SetId(vnKey).
+		Do(ctx)
+	if err != nil {
+		// NotFound will be caught by validateVirtualNetworkReference
+		return nil
+	}
+
+	return fetchAndValidateTenantMatch(sgTenant, getResponse.GetObject(), "VirtualNetwork", vnKey)
 }
 
 // validateImmutableFieldsSecurityGroup validates that immutable fields have not been changed.

--- a/fulfillment-service/internal/servers/private_subnets_server.go
+++ b/fulfillment-service/internal/servers/private_subnets_server.go
@@ -46,6 +46,7 @@ type PrivateSubnetsServer struct {
 	privatev1.UnimplementedSubnetsServer
 
 	logger            *slog.Logger
+	tenancyLogic      auth.TenancyLogic
 	generic           *GenericServer[*privatev1.Subnet]
 	virtualNetworkDao *dao.GenericDAO[*privatev1.VirtualNetwork]
 }
@@ -126,6 +127,7 @@ func (b *PrivateSubnetsServerBuilder) Build() (result *PrivateSubnetsServer, err
 	// Create and populate the object:
 	result = &PrivateSubnetsServer{
 		logger:            b.logger,
+		tenancyLogic:      b.tenancyLogic,
 		generic:           generic,
 		virtualNetworkDao: virtualNetworkDao,
 	}
@@ -240,6 +242,15 @@ func (s *PrivateSubnetsServer) validateSubnet(ctx context.Context,
 		return err
 	}
 
+	// Cross-tenant validation: the Subnet must belong to the same tenant as its parent
+	// VirtualNetwork. The private API operates with TotalVisibility, so DAO-level tenant
+	// filtering is bypassed — we must check explicitly.
+	if existingSubnet == nil {
+		if err := s.validateCrossTenantVirtualNetwork(ctx, newSubnet); err != nil {
+			return err
+		}
+	}
+
 	// SUB-VAL-03: At least one CIDR must be provided
 	if spec.GetIpv4Cidr() == "" && spec.GetIpv6Cidr() == "" {
 		return grpcstatus.Errorf(grpccodes.InvalidArgument,
@@ -264,6 +275,39 @@ func (s *PrivateSubnetsServer) validateSubnet(ctx context.Context,
 	}
 
 	return nil
+}
+
+// validateCrossTenantVirtualNetwork explicitly checks that the Subnet's tenant matches
+// its parent VirtualNetwork's tenant. This is critical for the private API where
+// TotalVisibility bypasses DAO-level tenant filtering.
+//
+// This check only runs when the subnet has an explicit metadata.tenant set. When the
+// tenant is empty, the DAO layer assigns the tenant based on the caller's visibility.
+func (s *PrivateSubnetsServer) validateCrossTenantVirtualNetwork(ctx context.Context,
+	subnet *privatev1.Subnet) error {
+
+	// Only validate when an explicit tenant is set (private API path).
+	if subnet.GetMetadata().GetTenant() == "" {
+		return nil
+	}
+
+	vnRef := subnet.GetSpec().GetVirtualNetwork()
+	if vnRef == nil {
+		return nil // Caught later by validateVirtualNetworkReference
+	}
+
+	subnetTenant := subnet.GetMetadata().GetTenant()
+
+	vnKey := refKey(vnRef)
+	getResponse, err := s.virtualNetworkDao.Get().
+		SetId(vnKey).
+		Do(ctx)
+	if err != nil {
+		// NotFound will be caught by validateVirtualNetworkReference
+		return nil
+	}
+
+	return fetchAndValidateTenantMatch(subnetTenant, getResponse.GetObject(), "VirtualNetwork", vnKey)
 }
 
 // validateCIDRSubset validates that subnetCIDR is a proper subset of parentCIDR.

--- a/fulfillment-service/internal/servers/tenant_validation.go
+++ b/fulfillment-service/internal/servers/tenant_validation.go
@@ -1,0 +1,107 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"fmt"
+
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/osac/fulfillment-service/internal/auth"
+)
+
+// tenantMetadataObject is satisfied by any protobuf resource that exposes a Metadata message
+// containing a tenant field.
+type tenantMetadataObject interface {
+	GetMetadata() *privatev1.Metadata
+}
+
+// resolveObjectTenant returns the tenant that should be used for cross-tenant validation.
+// It prefers the explicit metadata.tenant field on the object. When that is empty it
+// falls back to TenancyLogic.DetermineDefaultTenant — which, for the private API, returns
+// the system tenant. Callers on the private API side should always set metadata.tenant
+// before calling this.
+func resolveObjectTenant(ctx context.Context, obj tenantMetadataObject, tl auth.TenancyLogic) (string, error) {
+	if obj != nil && obj.GetMetadata() != nil && obj.GetMetadata().GetTenant() != "" {
+		return obj.GetMetadata().GetTenant(), nil
+	}
+	tenant, err := tl.DetermineDefaultTenant(ctx)
+	if err != nil {
+		return "", grpcstatus.Errorf(grpccodes.Internal, "failed to determine target tenant")
+	}
+	return tenant, nil
+}
+
+// validateTenantMatch checks that referencedTenant matches parentTenant exactly.
+// It returns an InvalidArgument gRPC error on mismatch.
+//
+// Use this when the referenced resource MUST belong to the same tenant as the
+// parent resource. For resources that may also come from the shared tenant, use
+// validateTenantOrShared instead.
+func validateTenantMatch(parentTenant, referencedTenant, kind, id string) error {
+	if referencedTenant != parentTenant {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"%s '%s' belongs to tenant '%s', but the parent resource belongs to tenant '%s': "+
+				"cross-tenant references are not allowed",
+			kind, id, referencedTenant, parentTenant)
+	}
+	return nil
+}
+
+// validateTenantOrShared checks that referencedTenant matches either parentTenant
+// or the shared tenant. This is appropriate for references to resources like
+// ExternalIPPools which may be shared across tenants.
+func validateTenantOrShared(parentTenant, referencedTenant, kind, id string) error {
+	if referencedTenant != parentTenant && referencedTenant != auth.SharedTenant {
+		return grpcstatus.Errorf(grpccodes.InvalidArgument,
+			"%s '%s' belongs to tenant '%s', but the parent resource belongs to tenant '%s': "+
+				"cross-tenant references are not allowed (shared tenant resources are permitted)",
+			kind, id, referencedTenant, parentTenant)
+	}
+	return nil
+}
+
+// fetchAndValidateTenantMatch is a convenience wrapper that fetches a referenced
+// resource's tenant from its metadata and validates it matches the expected tenant.
+// The referencedObj must have already been fetched from the DAO.
+func fetchAndValidateTenantMatch(parentTenant string, referencedObj tenantMetadataObject, kind, id string) error {
+	if referencedObj == nil || referencedObj.GetMetadata() == nil {
+		return grpcstatus.Errorf(grpccodes.Internal,
+			"failed to validate tenant for %s '%s': object has no metadata", kind, id)
+	}
+	referencedTenant := referencedObj.GetMetadata().GetTenant()
+	return validateTenantMatch(parentTenant, referencedTenant, kind, id)
+}
+
+// fetchAndValidateTenantOrShared is like fetchAndValidateTenantMatch but also
+// allows the referenced resource to be in the shared tenant.
+func fetchAndValidateTenantOrShared(parentTenant string, referencedObj tenantMetadataObject, kind, id string) error {
+	if referencedObj == nil || referencedObj.GetMetadata() == nil {
+		return grpcstatus.Errorf(grpccodes.Internal,
+			"failed to validate tenant for %s '%s': object has no metadata", kind, id)
+	}
+	referencedTenant := referencedObj.GetMetadata().GetTenant()
+	return validateTenantOrShared(parentTenant, referencedTenant, kind, id)
+}
+
+// crossTenantError formats a descriptive error for cross-tenant reference violations.
+// It is a lower-level helper used by the validate* functions above.
+func crossTenantError(kind, id, referencedTenant, parentTenant string) error {
+	return fmt.Errorf(
+		"%s '%s' belongs to tenant '%s', but the parent resource belongs to tenant '%s'",
+		kind, id, referencedTenant, parentTenant)
+}

--- a/fulfillment-service/internal/servers/tenant_validation_test.go
+++ b/fulfillment-service/internal/servers/tenant_validation_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright (c) 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.
+*/
+
+package servers
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	grpccodes "google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
+	"github.com/osac-project/osac/fulfillment-service/internal/auth"
+)
+
+var _ = Describe("Tenant validation helpers", func() {
+
+	Describe("resolveObjectTenant", func() {
+		It("returns metadata.tenant when set", func() {
+			obj := privatev1.Subnet_builder{
+				Metadata: privatev1.Metadata_builder{
+					Tenant: "tenant-a",
+				}.Build(),
+			}.Build()
+
+			tenant, err := resolveObjectTenant(context.Background(), obj, tenancy)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(tenant).To(Equal("tenant-a"))
+		})
+
+		It("falls back to DetermineDefaultTenant when metadata.tenant is empty", func() {
+			mockCtrl := gomock.NewController(GinkgoT())
+			mockTenancy := auth.NewMockTenancyLogic(mockCtrl)
+			mockTenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).
+				Return("fallback-tenant", nil)
+
+			obj := privatev1.Subnet_builder{
+				Metadata: privatev1.Metadata_builder{}.Build(),
+			}.Build()
+
+			tenant, err := resolveObjectTenant(context.Background(), obj, mockTenancy)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(tenant).To(Equal("fallback-tenant"))
+		})
+
+		It("returns error when DetermineDefaultTenant fails", func() {
+			mockCtrl := gomock.NewController(GinkgoT())
+			mockTenancy := auth.NewMockTenancyLogic(mockCtrl)
+			mockTenancy.EXPECT().DetermineDefaultTenant(gomock.Any()).
+				Return("", fmt.Errorf("auth error"))
+
+			obj := privatev1.Subnet_builder{
+				Metadata: privatev1.Metadata_builder{}.Build(),
+			}.Build()
+
+			_, err := resolveObjectTenant(context.Background(), obj, mockTenancy)
+			Expect(err).To(HaveOccurred())
+			st, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(st.Code()).To(Equal(grpccodes.Internal))
+		})
+	})
+
+	Describe("validateTenantMatch", func() {
+		It("returns nil when tenants match", func() {
+			err := validateTenantMatch("tenant-a", "tenant-a", "Subnet", "sub-1")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns InvalidArgument when tenants differ", func() {
+			err := validateTenantMatch("tenant-a", "tenant-b", "Subnet", "sub-1")
+			Expect(err).To(HaveOccurred())
+			st, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(st.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(st.Message()).To(ContainSubstring("cross-tenant"))
+			Expect(st.Message()).To(ContainSubstring("tenant-a"))
+			Expect(st.Message()).To(ContainSubstring("tenant-b"))
+		})
+	})
+
+	Describe("validateTenantOrShared", func() {
+		It("returns nil when tenants match", func() {
+			err := validateTenantOrShared("tenant-a", "tenant-a", "ExternalIPPool", "pool-1")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns nil when referenced tenant is shared", func() {
+			err := validateTenantOrShared("tenant-a", auth.SharedTenant, "ExternalIPPool", "pool-1")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns InvalidArgument when tenants differ and not shared", func() {
+			err := validateTenantOrShared("tenant-a", "tenant-b", "ExternalIPPool", "pool-1")
+			Expect(err).To(HaveOccurred())
+			st, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(st.Code()).To(Equal(grpccodes.InvalidArgument))
+			Expect(st.Message()).To(ContainSubstring("cross-tenant"))
+		})
+	})
+
+	Describe("fetchAndValidateTenantMatch", func() {
+		It("returns nil for same-tenant object", func() {
+			obj := privatev1.Subnet_builder{
+				Metadata: privatev1.Metadata_builder{
+					Tenant: "tenant-a",
+				}.Build(),
+			}.Build()
+
+			err := fetchAndValidateTenantMatch("tenant-a", obj, "Subnet", "sub-1")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error for cross-tenant object", func() {
+			obj := privatev1.Subnet_builder{
+				Metadata: privatev1.Metadata_builder{
+					Tenant: "tenant-b",
+				}.Build(),
+			}.Build()
+
+			err := fetchAndValidateTenantMatch("tenant-a", obj, "Subnet", "sub-1")
+			Expect(err).To(HaveOccurred())
+			st, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(st.Code()).To(Equal(grpccodes.InvalidArgument))
+		})
+
+		It("returns Internal error for nil metadata", func() {
+			obj := privatev1.Subnet_builder{}.Build()
+
+			err := fetchAndValidateTenantMatch("tenant-a", obj, "Subnet", "sub-1")
+			Expect(err).To(HaveOccurred())
+			st, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(st.Code()).To(Equal(grpccodes.Internal))
+		})
+	})
+
+	Describe("fetchAndValidateTenantOrShared", func() {
+		It("returns nil for same-tenant object", func() {
+			obj := privatev1.ExternalIPPool_builder{
+				Metadata: privatev1.Metadata_builder{
+					Tenant: "tenant-a",
+				}.Build(),
+			}.Build()
+
+			err := fetchAndValidateTenantOrShared("tenant-a", obj, "ExternalIPPool", "pool-1")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns nil for shared-tenant object", func() {
+			obj := privatev1.ExternalIPPool_builder{
+				Metadata: privatev1.Metadata_builder{
+					Tenant: auth.SharedTenant,
+				}.Build(),
+			}.Build()
+
+			err := fetchAndValidateTenantOrShared("tenant-a", obj, "ExternalIPPool", "pool-1")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("returns error for cross-tenant non-shared object", func() {
+			obj := privatev1.ExternalIPPool_builder{
+				Metadata: privatev1.Metadata_builder{
+					Tenant: "tenant-b",
+				}.Build(),
+			}.Build()
+
+			err := fetchAndValidateTenantOrShared("tenant-a", obj, "ExternalIPPool", "pool-1")
+			Expect(err).To(HaveOccurred())
+			st, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(st.Code()).To(Equal(grpccodes.InvalidArgument))
+		})
+	})
+})


### PR DESCRIPTION
The private API servers receive TotalVisibility from osac-operator callers, which completely disables DAO-level tenant filtering. This allows resources created via the private API to reference networking objects from different tenants — a security issue.

Add explicit metadata.tenant comparison in all 8 affected private server files (BareMetalInstances, ComputeInstances, Clusters, Subnets, SecurityGroups, NATGateways, ExternalIPs, ExternalIPAttachments). The validation runs when the object has an explicit metadata.tenant set (which is always the case for private API callers), and is independent of DAO visibility filtering.

Create shared helper functions in tenant_validation.go:
- resolveObjectTenant: prefers metadata.tenant, falls back to default
- validateTenantMatch: strict same-tenant check
- validateTenantOrShared: allows shared tenant (for ExternalIPPools)
- fetchAndValidateTenantMatch/fetchAndValidateTenantOrShared: wrappers


Assisted-by: Chai Bot <chai-bot@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **Auth and tenant isolation:** Added explicit tenant validation for private API networking references across eight server types.
- **Validation architecture:** Added shared helpers for tenant resolution, exact matching, shared-tenant exceptions, validated lookups, and gRPC errors.
- **Tests:** Added coverage for tenant resolution, tenant mismatches, shared tenants, nil metadata, and error handling.
- **API surface:** No public API declarations changed.
- **Database, deployment, CI, and documentation:** No changes reported.
- **Backward compatibility:** Requests without explicit tenants and missing-reference handling retain existing behavior. Invalid cross-tenant references now fail.

## Risk classification

**risk:show** — The change modifies tenant-isolation and authorization behavior across multiple private APIs. It can reject requests that previously succeeded, but it does not change public API declarations, database schemas, or deployment configuration.

The repository does not contain risk-labeling criteria. Therefore, no repository-specific criteria were available to distinguish **risk:show** from **risk:ship** or **risk:ask**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->