### PR TITLE
OSAC-4939: Disable h2c cleartext on REST gateway

### DIFF
--- a/fulfillment-service/internal/cmd/service/start/restgateway/start_rest_gateway_cmd.go
+++ b/fulfillment-service/internal/cmd/service/start/restgateway/start_rest_gateway_cmd.go
@@ -232,7 +232,6 @@ func (c *runnerContext) run(cmd *cobra.Command, argv []string) error {
 	var protocols http.Protocols
 	protocols.SetHTTP1(true)
 	protocols.SetHTTP2(true)
-	protocols.SetUnencryptedHTTP2(true)
 	http1Server := &http.Server{
 		Addr:              gwListener.Addr().String(),
 		Handler:           handler,


### PR DESCRIPTION
Stop advertising HTTP/2 over unencrypted connections on the REST gateway listener. TLS-terminated deployments still use HTTP/2 via SetHTTP2, only cleartext h2c is removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **API surface:** The REST gateway no longer advertises unencrypted HTTP/2 (h2c).
- **Deployment:** TLS-terminated deployments continue to use HTTP/2 through `SetHTTP2`.
- **Tests and documentation:** No test or documentation changes were included.
- **Backward compatibility:** Cleartext HTTP/2 clients are affected. HTTP/1 and TLS-based HTTP/2 remain available.

## Risk classification

**risk:ship** — The change is limited to one protocol configuration line. It removes only cleartext HTTP/2 advertisement and preserves TLS-based HTTP/2. It does not change exported APIs, authentication, data storage, or deployment interfaces. It does not qualify for **risk:show** because it does not alter a broad user-facing feature beyond the targeted h2c behavior, and it does not qualify for **risk:ask** because no high-risk security, data, or compatibility change is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->