### PR TITLE
NO-ISSUE: Add graphify CLI installation to bootstrap.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,7 +306,7 @@ OSAC requires a **Component** on every created issue — Jira rejects creates wi
 
 CI keeps a structural code graph of this mono-repo fresh (`.github/workflows/graphify-brain-refresh.yaml`) and publishes it for pickup. After `graphify` is installed (see below), a `SessionStart` hook (`.claude/hooks/fetch-graphify-brain.sh`) fetches the latest published bundle into `graphify-out/` automatically at the start of every session — no manual fetch step — and it fails open (falls back to normal cold exploration with a one-line warning) if the fetch fails, `graphify` isn't installed, or the graph is otherwise unavailable.
 
-`graphify` itself needs to be installed once per developer machine before any of this does anything useful:
+`tools/bootstrap.sh` now installs `graphify` automatically (idempotent — skips if already present). It prefers `uv tool install graphifyy`, falls back to `pipx install graphifyy`, and warns if neither tool manager is available. Manual install is only needed as a fallback:
 
 ```bash
 uv tool install graphifyy   # recommended

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -99,6 +99,30 @@ if [[ "${OSAC_ALLOW_NESTED_BOOTSTRAP:-}" != "1" ]] \
   fi
 fi
 
+# --- graphify (codebase knowledge graph CLI) ---
+# The pip package is "graphifyy" (double y); the CLI command is "graphify".
+# Used by the SessionStart hook (.claude/hooks/fetch-graphify-brain.sh) to
+# fetch and query the CI-published knowledge graph. Idempotent: skips if
+# graphify is already on PATH. Fail-open: a missing graphify never blocks
+# bootstrap — sessions will fall back to cold exploration.
+if command -v graphify &>/dev/null; then
+  echo "graphify already installed ($(graphify --version 2>/dev/null || echo 'unknown version'))."
+elif command -v uv &>/dev/null; then
+  echo "Installing graphify (uv tool install graphifyy)..."
+  if ! uv tool install graphifyy; then
+    echo "  Warning: graphify installation via uv failed. Install manually: uv tool install graphifyy" >&2
+  fi
+elif command -v pipx &>/dev/null; then
+  echo "Installing graphify (pipx install graphifyy)..."
+  if ! pipx install graphifyy; then
+    echo "  Warning: graphify installation via pipx failed. Install manually: pipx install graphifyy" >&2
+  fi
+else
+  echo "Warning: neither uv nor pipx found — cannot install graphify automatically." >&2
+  echo "  Install manually: uv tool install graphifyy (or: pipx install graphifyy)" >&2
+  echo "  The knowledge graph will be unavailable until graphify is installed." >&2
+fi
+
 if [[ "$NO_FORK" == false ]]; then
   if ! command -v gh &>/dev/null; then
     echo "ERROR: gh CLI is not installed." >&2


### PR DESCRIPTION
tools/bootstrap.sh now installs graphify automatically during dev environment setup. The install is idempotent (skips if graphify is already on PATH), prefers uv over pipx, and fails open if neither tool manager is available — matching the fail-open pattern used by the SessionStart hook (.claude/hooks/fetch-graphify-brain.sh).

AGENTS.md updated to reflect that bootstrap handles installation so manual install is no longer required (kept as a fallback reference).


Assisted-by: Claude Code (Anthropic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

- **Development setup:** `tools/bootstrap.sh` now installs the `graphify` CLI when it is not on `PATH`.
- The script prefers `uv`, then uses `pipx`.
- The script continues when neither package manager is available or installation fails.
- **Documentation:** `AGENTS.md` documents automatic installation and the manual fallback.

## Impact

- No API, controller, database, authentication, deployment, CI, or test changes.
- Existing environments remain compatible because the script skips installation when `graphify` is already available.
- Bootstrap may now install a development dependency when `graphify` is missing.

## Risk classification

**risk:ship** — The change is limited to development bootstrap behavior, is idempotent, prefers established package managers, and fails open. It does not modify production code or public APIs.

This is not close to **risk:show** because the installation is optional and bootstrap does not fail when installation is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->