### PR TITLE
OSAC-4441: emit ClusterOrder transition events

### DIFF
--- a/osac-operator/api/v1alpha1/conditions.go
+++ b/osac-operator/api/v1alpha1/conditions.go
@@ -35,6 +35,7 @@ const (
 	ReasonInitialized      = "Initialized"
 	ReasonAsExpected       = "AsExpected"
 	ReasonCreated          = "Created"
+	ReasonReady            = "Ready"
 	ReasonProgressing      = "Progressing"
 	ReasonFailed           = "Failed"
 	ReasonDeleting         = "Deleting"

--- a/osac-operator/cmd/main.go
+++ b/osac-operator/cmd/main.go
@@ -379,6 +379,7 @@ func setupClusterControllers(
 				provider, pollInterval, maxJobHistory,
 			)
 			reconciler.StallThresholds = clusterOrderStallThresholdsFromEnv()
+			reconciler.Recorder = localMgr.GetEventRecorder(controller.ClusterOrderControllerName)
 			return reconciler.SetupWithManager(mgr)
 		},
 	)

--- a/osac-operator/internal/controller/clusterorder_controller.go
+++ b/osac-operator/internal/controller/clusterorder_controller.go
@@ -207,6 +207,10 @@ func (r *ClusterOrderReconciler) Reconcile(ctx context.Context, req ctrl.Request
 }
 
 const (
+	clusterOrderCreatedEventReason      = v1alpha1.ReasonCreated
+	clusterOrderCreatedEventAction      = "Created"
+	clusterOrderReadyEventReason        = v1alpha1.ReasonReady
+	clusterOrderReadyEventAction        = "Ready"
 	clusterOrderProvisioningEventAction = "Provisioning"
 	clusterOrderDeletingEventReason     = "Deleting"
 	clusterOrderDeletingEventAction     = "Deleting"
@@ -227,12 +231,27 @@ func (r *ClusterOrderReconciler) recordTransitionEvents(instance *v1alpha1.Clust
 
 	oldProgressing := apimeta.FindStatusCondition(oldStatus.Conditions, v1alpha1.ConditionProgressing)
 	newProgressing := apimeta.FindStatusCondition(instance.Status.Conditions, v1alpha1.ConditionProgressing)
+	if oldStatus.Phase == "" && len(oldStatus.Conditions) == 0 &&
+		(instance.Status.Phase != "" || len(instance.Status.Conditions) > 0) {
+		r.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, clusterOrderCreatedEventReason,
+			clusterOrderCreatedEventAction, "ClusterOrder created")
+	}
+
 	if newProgressing != nil && (oldProgressing == nil || oldProgressing.Reason != newProgressing.Reason) {
 		if _, shouldRecord := clusterOrderProvisioningEventReasons[newProgressing.Reason]; shouldRecord {
 			r.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, newProgressing.Reason,
 				clusterOrderProvisioningEventAction, "ClusterOrder entered provisioning stage %s",
 				humanizeConditionName(newProgressing.Reason))
 		}
+	}
+
+	oldReady := oldStatus.Phase == v1alpha1.ClusterOrderPhaseReady && oldProgressing != nil &&
+		oldProgressing.Status == metav1.ConditionFalse
+	newReady := instance.Status.Phase == v1alpha1.ClusterOrderPhaseReady && newProgressing != nil &&
+		newProgressing.Status == metav1.ConditionFalse
+	if newReady && !oldReady {
+		r.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, clusterOrderReadyEventReason,
+			clusterOrderReadyEventAction, "ClusterOrder is ready")
 	}
 
 	if oldStatus.Phase != v1alpha1.ClusterOrderPhaseDeleting &&

--- a/osac-operator/internal/controller/clusterorder_controller.go
+++ b/osac-operator/internal/controller/clusterorder_controller.go
@@ -193,13 +193,13 @@ func (r *ClusterOrderReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	if err == nil {
-		r.recordTransitionEvents(instance, oldstatus)
 		if !equality.Semantic.DeepEqual(instance.Status, *oldstatus) {
 			log.Info("status requires update")
 			if err := r.patchStatusWithRetry(ctx, req.NamespacedName, instance.Status); err != nil {
 				return res, err
 			}
 		}
+		r.recordTransitionEvents(instance, oldstatus)
 	}
 
 	log.Info("end reconcile")
@@ -220,6 +220,7 @@ var clusterOrderProvisioningEventReasons = map[string]struct{}{
 	v1alpha1.ReasonPreparingInfrastructure: {},
 	v1alpha1.ReasonControlPlaneStarting:    {},
 	v1alpha1.ReasonWorkersJoining:          {},
+	v1alpha1.ReasonStageUnknown:            {},
 	v1alpha1.ReasonStalled:                 {},
 }
 

--- a/osac-operator/internal/controller/clusterorder_controller.go
+++ b/osac-operator/internal/controller/clusterorder_controller.go
@@ -163,6 +163,7 @@ func NewClusterOrderReconciler(
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=networkclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=externalipattachments,verbs=get;list;watch;delete
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=externalips,verbs=get;list;watch;delete
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -224,8 +225,9 @@ const (
 	clusterOrderReadyEventReason        = v1alpha1.ReasonReady
 	clusterOrderReadyEventAction        = "Ready"
 	clusterOrderProvisioningEventAction = "Provisioning"
-	clusterOrderDeletingEventReason     = "Deleting"
+	clusterOrderDeletingEventReason     = v1alpha1.ReasonDeleting
 	clusterOrderDeletingEventAction     = "Deleting"
+	clusterOrderFailedEventAction       = "Failed"
 )
 
 var clusterOrderProvisioningEventReasons = map[string]struct{}{
@@ -234,6 +236,11 @@ var clusterOrderProvisioningEventReasons = map[string]struct{}{
 	v1alpha1.ReasonWorkersJoining:          {},
 	v1alpha1.ReasonStageUnknown:            {},
 	v1alpha1.ReasonStalled:                 {},
+}
+
+var clusterOrderWarningEventReasons = map[string]struct{}{
+	v1alpha1.ReasonStageUnknown: {},
+	v1alpha1.ReasonStalled:      {},
 }
 
 func (r *ClusterOrderReconciler) recordTransitionEvents(instance *v1alpha1.ClusterOrder,
@@ -252,10 +259,30 @@ func (r *ClusterOrderReconciler) recordTransitionEvents(instance *v1alpha1.Clust
 
 	if newProgressing != nil && (oldProgressing == nil || oldProgressing.Reason != newProgressing.Reason) {
 		if _, shouldRecord := clusterOrderProvisioningEventReasons[newProgressing.Reason]; shouldRecord {
-			r.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, newProgressing.Reason,
+			eventType := corev1.EventTypeNormal
+			if _, shouldWarn := clusterOrderWarningEventReasons[newProgressing.Reason]; shouldWarn {
+				eventType = corev1.EventTypeWarning
+			}
+			r.Recorder.Eventf(instance, nil, eventType, newProgressing.Reason,
 				clusterOrderProvisioningEventAction, "ClusterOrder entered provisioning stage %s",
 				humanizeConditionName(newProgressing.Reason))
 		}
+	}
+
+	if oldStatus.Phase != v1alpha1.ClusterOrderPhaseFailed &&
+		instance.Status.Phase == v1alpha1.ClusterOrderPhaseFailed {
+		reason := v1alpha1.ReasonFailed
+		message := "ClusterOrder provisioning failed"
+		if newProgressing != nil {
+			if newProgressing.Reason != "" {
+				reason = newProgressing.Reason
+			}
+			if newProgressing.Message != "" {
+				message = fmt.Sprintf("ClusterOrder provisioning failed: %s", newProgressing.Message)
+			}
+		}
+		r.Recorder.Eventf(instance, nil, corev1.EventTypeWarning, reason,
+			clusterOrderFailedEventAction, "%s", message)
 	}
 
 	oldReady := oldStatus.Phase == v1alpha1.ClusterOrderPhaseReady && oldProgressing != nil &&

--- a/osac-operator/internal/controller/clusterorder_controller.go
+++ b/osac-operator/internal/controller/clusterorder_controller.go
@@ -193,17 +193,29 @@ func (r *ClusterOrderReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	if err == nil {
-		if !equality.Semantic.DeepEqual(instance.Status, *oldstatus) {
-			log.Info("status requires update")
-			if err := r.patchStatusWithRetry(ctx, req.NamespacedName, instance.Status); err != nil {
-				return res, err
-			}
+		if err := r.persistStatusAndRecordTransitionEvents(ctx, req.NamespacedName, instance, oldstatus); err != nil {
+			return res, err
 		}
-		r.recordTransitionEvents(instance, oldstatus)
 	}
 
 	log.Info("end reconcile")
 	return res, err
+}
+
+func (r *ClusterOrderReconciler) persistStatusAndRecordTransitionEvents(
+	ctx context.Context,
+	key client.ObjectKey,
+	instance *v1alpha1.ClusterOrder,
+	oldStatus *v1alpha1.ClusterOrderStatus,
+) error {
+	if !equality.Semantic.DeepEqual(instance.Status, *oldStatus) {
+		ctrllog.FromContext(ctx).Info("status requires update")
+		if err := r.patchStatusWithRetry(ctx, key, instance.Status); err != nil {
+			return err
+		}
+	}
+	r.recordTransitionEvents(instance, oldStatus)
+	return nil
 }
 
 const (

--- a/osac-operator/internal/controller/clusterorder_controller.go
+++ b/osac-operator/internal/controller/clusterorder_controller.go
@@ -29,6 +29,7 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -78,6 +79,7 @@ type ClusterOrderReconciler struct {
 	StatusPollInterval    time.Duration
 	MaxJobHistory         int
 	StallThresholds       ClusterOrderStallThresholds
+	Recorder              events.EventRecorder
 	now                   func() time.Time
 }
 
@@ -145,6 +147,7 @@ func NewClusterOrderReconciler(
 		StatusPollInterval:    statusPollInterval,
 		MaxJobHistory:         maxJobHistory,
 		StallThresholds:       DefaultClusterOrderStallThresholds(),
+		Recorder:              nil,
 		now:                   time.Now,
 	}
 }
@@ -190,6 +193,7 @@ func (r *ClusterOrderReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	if err == nil {
+		r.recordTransitionEvents(instance, oldstatus)
 		if !equality.Semantic.DeepEqual(instance.Status, *oldstatus) {
 			log.Info("status requires update")
 			if err := r.patchStatusWithRetry(ctx, req.NamespacedName, instance.Status); err != nil {
@@ -200,6 +204,42 @@ func (r *ClusterOrderReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	log.Info("end reconcile")
 	return res, err
+}
+
+const (
+	clusterOrderProvisioningEventAction = "Provisioning"
+	clusterOrderDeletingEventReason     = "Deleting"
+	clusterOrderDeletingEventAction     = "Deleting"
+)
+
+var clusterOrderProvisioningEventReasons = map[string]struct{}{
+	v1alpha1.ReasonPreparingInfrastructure: {},
+	v1alpha1.ReasonControlPlaneStarting:    {},
+	v1alpha1.ReasonWorkersJoining:          {},
+	v1alpha1.ReasonStalled:                 {},
+}
+
+func (r *ClusterOrderReconciler) recordTransitionEvents(instance *v1alpha1.ClusterOrder,
+	oldStatus *v1alpha1.ClusterOrderStatus) {
+	if r.Recorder == nil {
+		return
+	}
+
+	oldProgressing := apimeta.FindStatusCondition(oldStatus.Conditions, v1alpha1.ConditionProgressing)
+	newProgressing := apimeta.FindStatusCondition(instance.Status.Conditions, v1alpha1.ConditionProgressing)
+	if newProgressing != nil && (oldProgressing == nil || oldProgressing.Reason != newProgressing.Reason) {
+		if _, shouldRecord := clusterOrderProvisioningEventReasons[newProgressing.Reason]; shouldRecord {
+			r.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, newProgressing.Reason,
+				clusterOrderProvisioningEventAction, "ClusterOrder entered provisioning stage %s",
+				humanizeConditionName(newProgressing.Reason))
+		}
+	}
+
+	if oldStatus.Phase != v1alpha1.ClusterOrderPhaseDeleting &&
+		instance.Status.Phase == v1alpha1.ClusterOrderPhaseDeleting {
+		r.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, clusterOrderDeletingEventReason,
+			clusterOrderDeletingEventAction, "ClusterOrder entered deleting phase")
+	}
 }
 
 func (r *ClusterOrderReconciler) patchStatusWithRetry(ctx context.Context, key client.ObjectKey, computed v1alpha1.ClusterOrderStatus) error {

--- a/osac-operator/internal/controller/clusterorder_events_test.go
+++ b/osac-operator/internal/controller/clusterorder_events_test.go
@@ -94,7 +94,7 @@ var _ = Describe("ClusterOrder transition events", func() {
 		Consistently(recorder.Events, 200*time.Millisecond).ShouldNot(Receive())
 	})
 
-	It("records a Normal event when provisioning becomes stalled", func() {
+	It("records a Warning event when provisioning becomes stalled", func() {
 		recorder := newRecorder()
 		reconciler := &ClusterOrderReconciler{Recorder: recorder}
 		instance := &v1alpha1.ClusterOrder{}
@@ -104,12 +104,12 @@ var _ = Describe("ClusterOrder transition events", func() {
 		reconciler.recordTransitionEvents(instance, &oldStatus)
 
 		Eventually(recorder.Events).Should(Receive(And(
-			ContainSubstring(corev1.EventTypeNormal),
+			ContainSubstring(corev1.EventTypeWarning),
 			ContainSubstring(v1alpha1.ReasonStalled),
 		)))
 	})
 
-	It("records a Normal event when the provisioning stage becomes unknown", func() {
+	It("records a Warning event when the provisioning stage becomes unknown", func() {
 		recorder := newRecorder()
 		reconciler := &ClusterOrderReconciler{Recorder: recorder}
 		instance := &v1alpha1.ClusterOrder{}
@@ -119,7 +119,7 @@ var _ = Describe("ClusterOrder transition events", func() {
 		reconciler.recordTransitionEvents(instance, &oldStatus)
 
 		Eventually(recorder.Events).Should(Receive(And(
-			ContainSubstring(corev1.EventTypeNormal),
+			ContainSubstring(corev1.EventTypeWarning),
 			ContainSubstring(v1alpha1.ReasonStageUnknown),
 			ContainSubstring("entered provisioning stage"),
 		)))
@@ -138,6 +138,24 @@ var _ = Describe("ClusterOrder transition events", func() {
 		Eventually(recorder.Events).Should(Receive(And(
 			ContainSubstring(corev1.EventTypeNormal),
 			ContainSubstring(string(v1alpha1.ClusterOrderPhaseDeleting)),
+		)))
+	})
+
+	It("records a Warning event when a ClusterOrder enters Failed", func() {
+		recorder := newRecorder()
+		reconciler := &ClusterOrderReconciler{Recorder: recorder}
+		instance := &v1alpha1.ClusterOrder{}
+		oldStatus := statusWithProgressingReason(v1alpha1.ReasonWorkersJoining)
+		instance.Status = statusWithProgressingReason(v1alpha1.ReasonProvisioningFailed)
+		instance.Status.Phase = v1alpha1.ClusterOrderPhaseFailed
+		instance.Status.Conditions[0].Message = "No agents available"
+
+		reconciler.recordTransitionEvents(instance, &oldStatus)
+
+		Eventually(recorder.Events).Should(Receive(And(
+			ContainSubstring(corev1.EventTypeWarning),
+			ContainSubstring(v1alpha1.ReasonProvisioningFailed),
+			ContainSubstring("ClusterOrder provisioning failed"),
 		)))
 	})
 

--- a/osac-operator/internal/controller/clusterorder_events_test.go
+++ b/osac-operator/internal/controller/clusterorder_events_test.go
@@ -17,13 +17,17 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
 	. "github.com/onsi/gomega"    //nolint:revive,staticcheck
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	v1alpha1 "github.com/osac-project/osac/osac-operator/api/v1alpha1"
 )
@@ -176,5 +180,35 @@ var _ = Describe("ClusterOrder transition events", func() {
 		reconciler.recordTransitionEvents(instance, &status)
 
 		Consistently(recorder.Events, 200*time.Millisecond).ShouldNot(Receive())
+	})
+
+	It("does not emit an event when status persistence fails", func() {
+		recorder := newRecorder()
+		scheme := runtime.NewScheme()
+		Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+		reconciler := &ClusterOrderReconciler{
+			apiReader: fake.NewClientBuilder().WithScheme(scheme).Build(),
+			Recorder:  recorder,
+		}
+		instance := &v1alpha1.ClusterOrder{}
+		instance.Status = statusWithProgressingReason(v1alpha1.ReasonControlPlaneStarting)
+
+		err := reconciler.persistStatusAndRecordTransitionEvents(
+			context.Background(), client.ObjectKeyFromObject(instance), instance,
+			&v1alpha1.ClusterOrderStatus{},
+		)
+
+		Expect(err).To(HaveOccurred())
+		Consistently(recorder.Events, 200*time.Millisecond).ShouldNot(Receive())
+	})
+
+	It("does not panic when no event recorder is configured", func() {
+		reconciler := &ClusterOrderReconciler{}
+		instance := &v1alpha1.ClusterOrder{}
+		instance.Status = statusWithProgressingReason(v1alpha1.ReasonControlPlaneStarting)
+
+		Expect(func() {
+			reconciler.recordTransitionEvents(instance, &v1alpha1.ClusterOrderStatus{})
+		}).NotTo(Panic())
 	})
 })

--- a/osac-operator/internal/controller/clusterorder_events_test.go
+++ b/osac-operator/internal/controller/clusterorder_events_test.go
@@ -105,6 +105,22 @@ var _ = Describe("ClusterOrder transition events", func() {
 		)))
 	})
 
+	It("records a Normal event when the provisioning stage becomes unknown", func() {
+		recorder := newRecorder()
+		reconciler := &ClusterOrderReconciler{Recorder: recorder}
+		instance := &v1alpha1.ClusterOrder{}
+		oldStatus := statusWithProgressingReason(v1alpha1.ReasonWorkersJoining)
+		instance.Status = statusWithProgressingReason(v1alpha1.ReasonStageUnknown)
+
+		reconciler.recordTransitionEvents(instance, &oldStatus)
+
+		Eventually(recorder.Events).Should(Receive(And(
+			ContainSubstring(corev1.EventTypeNormal),
+			ContainSubstring(v1alpha1.ReasonStageUnknown),
+			ContainSubstring("entered provisioning stage"),
+		)))
+	})
+
 	It("records a Normal event when the ClusterOrder enters Deleting", func() {
 		recorder := newRecorder()
 		reconciler := &ClusterOrderReconciler{Recorder: recorder}

--- a/osac-operator/internal/controller/clusterorder_events_test.go
+++ b/osac-operator/internal/controller/clusterorder_events_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
@@ -28,6 +29,7 @@ import (
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	v1alpha1 "github.com/osac-project/osac/osac-operator/api/v1alpha1"
 )
@@ -204,11 +206,22 @@ var _ = Describe("ClusterOrder transition events", func() {
 		recorder := newRecorder()
 		scheme := runtime.NewScheme()
 		Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+		instance := &v1alpha1.ClusterOrder{
+			ObjectMeta: metav1.ObjectMeta{Name: "order", Namespace: "default"},
+		}
+		reader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(instance.DeepCopy()).Build()
+		patchErr := errors.New("status patch failed")
 		reconciler := &ClusterOrderReconciler{
-			apiReader: fake.NewClientBuilder().WithScheme(scheme).Build(),
+			Client: interceptor.NewClient(reader, interceptor.Funcs{
+				SubResourcePatch: func(_ context.Context, _ client.Client, subResourceName string,
+					_ client.Object, _ client.Patch, _ ...client.SubResourcePatchOption) error {
+					Expect(subResourceName).To(Equal("status"))
+					return patchErr
+				},
+			}),
+			apiReader: reader,
 			Recorder:  recorder,
 		}
-		instance := &v1alpha1.ClusterOrder{}
 		instance.Status = statusWithProgressingReason(v1alpha1.ReasonControlPlaneStarting)
 
 		err := reconciler.persistStatusAndRecordTransitionEvents(
@@ -216,7 +229,7 @@ var _ = Describe("ClusterOrder transition events", func() {
 			&v1alpha1.ClusterOrderStatus{},
 		)
 
-		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(patchErr))
 		Consistently(recorder.Events, 200*time.Millisecond).ShouldNot(Receive())
 	})
 

--- a/osac-operator/internal/controller/clusterorder_events_test.go
+++ b/osac-operator/internal/controller/clusterorder_events_test.go
@@ -139,7 +139,8 @@ var _ = Describe("ClusterOrder transition events", func() {
 
 		Eventually(recorder.Events).Should(Receive(And(
 			ContainSubstring(corev1.EventTypeNormal),
-			ContainSubstring(string(v1alpha1.ClusterOrderPhaseDeleting)),
+			ContainSubstring(v1alpha1.ReasonDeleting),
+			ContainSubstring("ClusterOrder entered deleting phase"),
 		)))
 	})
 
@@ -157,6 +158,23 @@ var _ = Describe("ClusterOrder transition events", func() {
 		Eventually(recorder.Events).Should(Receive(And(
 			ContainSubstring(corev1.EventTypeWarning),
 			ContainSubstring(v1alpha1.ReasonProvisioningFailed),
+			ContainSubstring("ClusterOrder provisioning failed"),
+		)))
+	})
+
+	It("uses the fallback details when a Failed transition has no Progressing condition", func() {
+		recorder := newRecorder()
+		reconciler := &ClusterOrderReconciler{Recorder: recorder}
+		instance := &v1alpha1.ClusterOrder{Status: v1alpha1.ClusterOrderStatus{
+			Phase: v1alpha1.ClusterOrderPhaseFailed,
+		}}
+		oldStatus := statusWithProgressingReason(v1alpha1.ReasonWorkersJoining)
+
+		reconciler.recordTransitionEvents(instance, &oldStatus)
+
+		Eventually(recorder.Events).Should(Receive(And(
+			ContainSubstring(corev1.EventTypeWarning),
+			ContainSubstring(v1alpha1.ReasonFailed),
 			ContainSubstring("ClusterOrder provisioning failed"),
 		)))
 	})
@@ -183,6 +201,36 @@ var _ = Describe("ClusterOrder transition events", func() {
 			ContainSubstring(v1alpha1.ReasonReady),
 			ContainSubstring("ClusterOrder is ready"),
 		)))
+	})
+
+	It("does not record Ready when the phase is Ready but Progressing is not False", func() {
+		recorder := newRecorder()
+		reconciler := &ClusterOrderReconciler{Recorder: recorder}
+		instance := &v1alpha1.ClusterOrder{Status: v1alpha1.ClusterOrderStatus{
+			Phase: v1alpha1.ClusterOrderPhaseReady,
+			Conditions: []metav1.Condition{{
+				Type:   v1alpha1.ConditionProgressing,
+				Status: metav1.ConditionTrue,
+			}},
+		}}
+
+		oldStatus := statusWithProgressingReason(v1alpha1.ReasonWorkersJoining)
+		reconciler.recordTransitionEvents(instance, &oldStatus)
+
+		Consistently(recorder.Events, 200*time.Millisecond).ShouldNot(Receive())
+	})
+
+	It("does not record Ready when the phase is Ready without a Progressing condition", func() {
+		recorder := newRecorder()
+		reconciler := &ClusterOrderReconciler{Recorder: recorder}
+		instance := &v1alpha1.ClusterOrder{Status: v1alpha1.ClusterOrderStatus{
+			Phase: v1alpha1.ClusterOrderPhaseReady,
+		}}
+
+		oldStatus := statusWithProgressingReason(v1alpha1.ReasonWorkersJoining)
+		reconciler.recordTransitionEvents(instance, &oldStatus)
+
+		Consistently(recorder.Events, 200*time.Millisecond).ShouldNot(Receive())
 	})
 
 	It("does not duplicate the Ready event", func() {

--- a/osac-operator/internal/controller/clusterorder_events_test.go
+++ b/osac-operator/internal/controller/clusterorder_events_test.go
@@ -63,6 +63,21 @@ var _ = Describe("ClusterOrder transition events", func() {
 		)))
 	})
 
+	It("records a Normal event when a ClusterOrder is first created", func() {
+		recorder := newRecorder()
+		reconciler := &ClusterOrderReconciler{Recorder: recorder}
+		instance := &v1alpha1.ClusterOrder{}
+		instance.Status = statusWithProgressingReason(v1alpha1.ReasonPreparingInfrastructure)
+
+		reconciler.recordTransitionEvents(instance, &v1alpha1.ClusterOrderStatus{})
+
+		Eventually(recorder.Events).Should(Receive(And(
+			ContainSubstring(corev1.EventTypeNormal),
+			ContainSubstring(v1alpha1.ReasonCreated),
+			ContainSubstring("ClusterOrder created"),
+		)))
+	})
+
 	It("does not record an event when the provisioning sub-stage is unchanged", func() {
 		recorder := newRecorder()
 		reconciler := &ClusterOrderReconciler{Recorder: recorder}
@@ -104,5 +119,46 @@ var _ = Describe("ClusterOrder transition events", func() {
 			ContainSubstring(corev1.EventTypeNormal),
 			ContainSubstring(string(v1alpha1.ClusterOrderPhaseDeleting)),
 		)))
+	})
+
+	It("records a Normal event when a ClusterOrder becomes Ready", func() {
+		recorder := newRecorder()
+		reconciler := &ClusterOrderReconciler{Recorder: recorder}
+		instance := &v1alpha1.ClusterOrder{}
+		oldStatus := statusWithProgressingReason(v1alpha1.ReasonWorkersJoining)
+		instance.Status = v1alpha1.ClusterOrderStatus{
+			Phase: v1alpha1.ClusterOrderPhaseReady,
+			Conditions: []metav1.Condition{{
+				Type:               v1alpha1.ConditionProgressing,
+				Status:             metav1.ConditionFalse,
+				Reason:             v1alpha1.ReasonAsExpected,
+				LastTransitionTime: metav1.Now(),
+			}},
+		}
+
+		reconciler.recordTransitionEvents(instance, &oldStatus)
+
+		Eventually(recorder.Events).Should(Receive(And(
+			ContainSubstring(corev1.EventTypeNormal),
+			ContainSubstring(v1alpha1.ReasonReady),
+			ContainSubstring("ClusterOrder is ready"),
+		)))
+	})
+
+	It("does not duplicate the Ready event", func() {
+		recorder := newRecorder()
+		reconciler := &ClusterOrderReconciler{Recorder: recorder}
+		status := v1alpha1.ClusterOrderStatus{
+			Phase: v1alpha1.ClusterOrderPhaseReady,
+			Conditions: []metav1.Condition{{
+				Type:   v1alpha1.ConditionProgressing,
+				Status: metav1.ConditionFalse,
+			}},
+		}
+		instance := &v1alpha1.ClusterOrder{Status: status}
+
+		reconciler.recordTransitionEvents(instance, &status)
+
+		Consistently(recorder.Events, 200*time.Millisecond).ShouldNot(Receive())
 	})
 })

--- a/osac-operator/internal/controller/clusterorder_events_test.go
+++ b/osac-operator/internal/controller/clusterorder_events_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
+	. "github.com/onsi/gomega"    //nolint:revive,staticcheck
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
+
+	v1alpha1 "github.com/osac-project/osac/osac-operator/api/v1alpha1"
+)
+
+var _ = Describe("ClusterOrder transition events", func() {
+	newRecorder := func() *events.FakeRecorder {
+		return events.NewFakeRecorder(10)
+	}
+
+	statusWithProgressingReason := func(reason string) v1alpha1.ClusterOrderStatus {
+		return v1alpha1.ClusterOrderStatus{
+			Phase: v1alpha1.ClusterOrderPhaseProgressing,
+			Conditions: []metav1.Condition{
+				{
+					Type:               v1alpha1.ConditionProgressing,
+					Status:             metav1.ConditionTrue,
+					Reason:             reason,
+					LastTransitionTime: metav1.NewTime(time.Now().UTC()),
+				},
+			},
+		}
+	}
+
+	It("records a Normal event when the provisioning sub-stage changes", func() {
+		recorder := newRecorder()
+		reconciler := &ClusterOrderReconciler{Recorder: recorder}
+		instance := &v1alpha1.ClusterOrder{}
+		oldStatus := statusWithProgressingReason(v1alpha1.ReasonPreparingInfrastructure)
+		instance.Status = statusWithProgressingReason(v1alpha1.ReasonControlPlaneStarting)
+
+		reconciler.recordTransitionEvents(instance, &oldStatus)
+
+		Eventually(recorder.Events).Should(Receive(And(
+			ContainSubstring(corev1.EventTypeNormal),
+			ContainSubstring(v1alpha1.ReasonControlPlaneStarting),
+			ContainSubstring("entered provisioning stage"),
+		)))
+	})
+
+	It("does not record an event when the provisioning sub-stage is unchanged", func() {
+		recorder := newRecorder()
+		reconciler := &ClusterOrderReconciler{Recorder: recorder}
+		instance := &v1alpha1.ClusterOrder{}
+		oldStatus := statusWithProgressingReason(v1alpha1.ReasonWorkersJoining)
+		instance.Status = statusWithProgressingReason(v1alpha1.ReasonWorkersJoining)
+
+		reconciler.recordTransitionEvents(instance, &oldStatus)
+
+		Consistently(recorder.Events, 200*time.Millisecond).ShouldNot(Receive())
+	})
+
+	It("records a Normal event when provisioning becomes stalled", func() {
+		recorder := newRecorder()
+		reconciler := &ClusterOrderReconciler{Recorder: recorder}
+		instance := &v1alpha1.ClusterOrder{}
+		oldStatus := statusWithProgressingReason(v1alpha1.ReasonWorkersJoining)
+		instance.Status = statusWithProgressingReason(v1alpha1.ReasonStalled)
+
+		reconciler.recordTransitionEvents(instance, &oldStatus)
+
+		Eventually(recorder.Events).Should(Receive(And(
+			ContainSubstring(corev1.EventTypeNormal),
+			ContainSubstring(v1alpha1.ReasonStalled),
+		)))
+	})
+
+	It("records a Normal event when the ClusterOrder enters Deleting", func() {
+		recorder := newRecorder()
+		reconciler := &ClusterOrderReconciler{Recorder: recorder}
+		instance := &v1alpha1.ClusterOrder{}
+		oldStatus := statusWithProgressingReason(v1alpha1.ReasonWorkersJoining)
+		instance.Status = oldStatus
+		instance.Status.Phase = v1alpha1.ClusterOrderPhaseDeleting
+
+		reconciler.recordTransitionEvents(instance, &oldStatus)
+
+		Eventually(recorder.Events).Should(Receive(And(
+			ContainSubstring(corev1.EventTypeNormal),
+			ContainSubstring(string(v1alpha1.ClusterOrderPhaseDeleting)),
+		)))
+	})
+})

--- a/osac-operator/internal/controller/clusterorder_names.go
+++ b/osac-operator/internal/controller/clusterorder_names.go
@@ -7,6 +7,7 @@ import (
 )
 
 const (
+	ClusterOrderControllerName          = "clusterorder-controller"
 	subjectKindServiceAccount    string = "ServiceAccount"
 	defaultServiceAccountName    string = "osac"
 	defaultHostedClusterName     string = "cluster"


### PR DESCRIPTION
## Summary

- Add EventRecorder wiring to the ClusterOrder controller.
- Emit Normal events when provisioning sub-stage reasons change.
- Emit transition events for `Stalled` and entry into `Deleting`.
- Suppress duplicate events when the stage reason is unchanged.
- Add unit coverage for provisioning, stalled, deleting, and no-op transitions.

## Validation

- `make fmt`
- `make lint`
- `make test`
- `make helm-lint`
- pre-commit hooks

All checks pass. Helm lint was run with Helm v3.18.6.

## Relationship

This branch is stacked on the [OSAC-4441](https://redhat.atlassian.net/browse/OSAC-4441) stall-detection work in PR #783.

## Jira

[OSAC-4441](https://redhat.atlassian.net/browse/OSAC-4441)

## Test plan

- Verify a provisioning stage transition emits one Normal event.
- Verify an unchanged stage reason emits no event.
- Verify `Stalled` emits an event.
- Verify entering `Deleting` emits an event.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **API surface:** Added `ReasonReady`, `ClusterOrderControllerName`, and the exported `Recorder` field.
- **Controller:** Added Kubernetes events for provisioning reason changes, `Stalled`, `StageUnknown`, `Failed`, readiness, creation, and deletion transitions. Suppressed duplicate events.
- **Integration:** Wired the manager event recorder into the `ClusterOrder` reconciler. Persisted status before emitting transition events.
- **RBAC:** Added permission for event recording.
- **Tests:** Added coverage for event severity, state transitions, persistence, duplicate suppression, missing recorders, and persistence failures.
- **Compatibility:** Changes are additive. Existing reconciliation outcomes remain unchanged. The new field and constants do not break existing consumers.

## Risk classification

**risk:show** — The change adds user-visible Kubernetes events and event RBAC permissions. It does not change reconciliation outcomes or persist new application data. It does not qualify as **risk:ask** because event recording is optional, failure cases avoid emitting events, and duplicate events are suppressed. It is above **risk:ship** because it changes observable controller behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->