### PR TITLE
NO-ISSUE: Add sanity/regression/serial pytest markers to all E2E suites

### DIFF
--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -28,6 +28,10 @@ on:
         description: "pytest -k filter"
         required: false
         default: ""
+      test-marker:
+        description: "pytest -m marker expression (e.g. sanity, regression). Empty runs all."
+        required: false
+        default: ""
       test-infra-ref:
         description: "Branch/ref of osac-test-infra"
         required: false
@@ -219,6 +223,7 @@ jobs:
           'caas/sanity'
         }}
       test-filter: ${{ inputs.test-filter || '' }}
+      test-marker: ${{ inputs.test-marker || '' }}
       # osac-installer now lives as a subdirectory of this same monorepo checkout
       # (its Chart.yaml deps resolve fulfillment-service/osac-operator/osac-aap/BMF
       # as ../../../<name> siblings within it), so a PR touching those components

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -28,6 +28,10 @@ on:
         description: "pytest -k filter"
         required: false
         default: ""
+      test-marker:
+        description: "pytest -m marker expression (e.g. sanity, regression). Empty runs all."
+        required: false
+        default: ""
       test-infra-ref:
         description: "Branch/ref of osac-test-infra"
         required: false
@@ -219,6 +223,7 @@ jobs:
           'vmaas/sanity'
         }}
       test-filter: ${{ inputs.test-filter || '' }}
+      test-marker: ${{ inputs.test-marker || '' }}
       # osac-installer now lives as a subdirectory of this same monorepo checkout
       # (its Chart.yaml deps resolve fulfillment-service/osac-operator/osac-aap/BMF
       # as ../../../<name> siblings within it), so a PR touching those components

--- a/tests/e2e/bmaas/regression/networking/test_bmaas_networking.py
+++ b/tests/e2e/bmaas/regression/networking/test_bmaas_networking.py
@@ -37,6 +37,8 @@ from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.osac_cli import OsacCLI
 from tests.e2e.core.runner import poll_until
 
+pytestmark = pytest.mark.regression
+
 _NETRIS_BMI_RUNNING_RETRIES = 240
 
 

--- a/tests/e2e/bmaas/sanity/test_baremetal_instance_lifecycle.py
+++ b/tests/e2e/bmaas/sanity/test_baremetal_instance_lifecycle.py
@@ -19,6 +19,8 @@ from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.osac_cli import OsacCLI
 from tests.e2e.core.runner import poll_until
 
+pytestmark = pytest.mark.sanity
+
 logger = logging.getLogger(__name__)
 
 _RESTART_IN_PROGRESS: str = "BARE_METAL_INSTANCE_CONDITION_TYPE_RESTART_IN_PROGRESS"

--- a/tests/e2e/bmaas/serial/test_baremetal_instance_inventory_exhausted.py
+++ b/tests/e2e/bmaas/serial/test_baremetal_instance_inventory_exhausted.py
@@ -19,6 +19,8 @@ from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.osac_cli import OsacCLI
 from tests.e2e.core.runner import poll_until
 
+pytestmark = pytest.mark.serial
+
 _AVAILABLE_BMH_STATES = {"available", "ready"}
 _NOT_FOUND_RE = re.compile(r"Code:\s*NotFound|baremetalinstance\b.*\bnot found", re.IGNORECASE)
 

--- a/tests/e2e/caas/regression/test_cluster_version.py
+++ b/tests/e2e/caas/regression/test_cluster_version.py
@@ -4,6 +4,8 @@ import contextlib
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from tests.e2e.catalog.conftest import unique_name
 from tests.e2e.core.grpc_client import GRPCClient
 from tests.e2e.core.helpers import (
@@ -16,6 +18,8 @@ from tests.e2e.core.helpers import (
 from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.osac_cli import OsacCLI
 from tests.e2e.core.runner import poll_until
+
+pytestmark = pytest.mark.regression
 
 # Fixed so repeated runs reuse the same ClusterVersion on the shared cluster.
 TEST_RELEASE_IMAGE = "quay.io/openshift-release-dev/ocp-release:4.20.0-multi"

--- a/tests/e2e/caas/sanity/test_cluster_create.py
+++ b/tests/e2e/caas/sanity/test_cluster_create.py
@@ -22,6 +22,8 @@ from tests.e2e.core.metering import MeteringCollector
 from tests.e2e.core.osac_cli import OsacCLI
 from tests.e2e.core.runner import run
 
+pytestmark = pytest.mark.sanity
+
 
 @pytest.mark.metering
 def test_cluster_create(

--- a/tests/e2e/caas/sanity/test_cluster_delete_feedback_light.py
+++ b/tests/e2e/caas/sanity/test_cluster_delete_feedback_light.py
@@ -4,6 +4,8 @@ import contextlib
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from tests.e2e.catalog.conftest import unique_name
 from tests.e2e.core.grpc_client import GRPCClient
 from tests.e2e.core.helpers import (
@@ -16,6 +18,8 @@ from tests.e2e.core.helpers import (
 )
 from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.osac_cli import OsacCLI
+
+pytestmark = pytest.mark.sanity
 
 
 def test_cluster_delete_reports_deleting_state_without_provisioning(

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -82,6 +82,9 @@ def pytest_configure(config: pytest.Config) -> None:
     e2e.log artifact.
     """
     config.addinivalue_line("markers", "metering: test verifies metering events via the test adapter HTTP API")
+    config.addinivalue_line("markers", "sanity: fast, low-risk smoke test suitable for every PR")
+    config.addinivalue_line("markers", "regression: broader/slower coverage, run on a schedule or on demand")
+    config.addinivalue_line("markers", "serial: must run alone, not in parallel with other tests (e.g. exhausts a shared resource)")
     worker_id = os.environ.get("PYTEST_XDIST_WORKER")
     if worker_id is not None:
         log_dir = Path(config.getini("log_file")).parent

--- a/tests/e2e/vmaas/regression/external_ip/test_external_ip_pool_capacity.py
+++ b/tests/e2e/vmaas/regression/external_ip/test_external_ip_pool_capacity.py
@@ -11,6 +11,8 @@ from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.runner import poll_until
 from tests.e2e.vmaas.regression.external_ip.helpers import create_ip, delete_ip, pool_status
 
+pytestmark = pytest.mark.regression
+
 
 class TestPoolCapacity:
     """

--- a/tests/e2e/vmaas/regression/external_ip/test_external_ip_pool_lifecycle.py
+++ b/tests/e2e/vmaas/regression/external_ip/test_external_ip_pool_lifecycle.py
@@ -19,6 +19,8 @@ from tests.e2e.core.helpers import (
 from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.runner import poll_until
 
+pytestmark = pytest.mark.regression
+
 
 class TestExternalIPPoolLifecycle:
     def test_attach_detach_reattach(

--- a/tests/e2e/vmaas/regression/test_compute_instance_api_fields.py
+++ b/tests/e2e/vmaas/regression/test_compute_instance_api_fields.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import pytest
+
 from tests.e2e.catalog.conftest import unique_name
 from tests.e2e.core.grpc_client import GRPCClient
 from tests.e2e.core.helpers import wait_for_cr, wait_for_deletion, wait_for_provision, wait_for_running
 from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.osac_cli import OsacCLI
 from tests.e2e.core.runner import poll_until
+
+pytestmark = pytest.mark.regression
 
 TEST_BOOT_DISK_SIZE: int = 20
 TEST_RUN_STRATEGY: str = "Always"

--- a/tests/e2e/vmaas/regression/test_compute_instance_creation.py
+++ b/tests/e2e/vmaas/regression/test_compute_instance_creation.py
@@ -15,6 +15,8 @@ from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.metering import MeteringCollector
 from tests.e2e.core.osac_cli import OsacCLI
 
+pytestmark = pytest.mark.regression
+
 
 @pytest.mark.metering
 def test_compute_instance_lifecycle(

--- a/tests/e2e/vmaas/regression/test_compute_instance_delete_during_provision.py
+++ b/tests/e2e/vmaas/regression/test_compute_instance_delete_during_provision.py
@@ -12,6 +12,8 @@ from tests.e2e.core.metering import MeteringCollector
 from tests.e2e.core.osac_cli import OsacCLI
 from tests.e2e.core.runner import poll_until
 
+pytestmark = pytest.mark.regression
+
 TERMINAL_JOB_STATES: tuple[str, ...] = ("Canceled", "Failed", "Succeeded")
 
 

--- a/tests/e2e/vmaas/regression/test_compute_instance_disk_image.py
+++ b/tests/e2e/vmaas/regression/test_compute_instance_disk_image.py
@@ -16,6 +16,8 @@ from tests.e2e.core.helpers import (
 )
 from tests.e2e.core.k8s_client import K8sClient
 
+pytestmark = pytest.mark.regression
+
 SOURCE_REF = "quay.io/containerdisks/fedora:41"
 
 

--- a/tests/e2e/vmaas/regression/test_compute_instance_gpu.py
+++ b/tests/e2e/vmaas/regression/test_compute_instance_gpu.py
@@ -4,12 +4,16 @@ import json
 import subprocess
 from typing import Any
 
+import pytest
+
 from tests.e2e.catalog.conftest import unique_name
 from tests.e2e.core.grpc_client import GRPCClient
 from tests.e2e.core.helpers import wait_for_cr, wait_for_deletion, wait_for_grpc_removal
 from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.osac_cli import OsacCLI
 from tests.e2e.core.runner import poll_until
+
+pytestmark = pytest.mark.regression
 
 GPU_IT_CORES: int = 2
 GPU_IT_MEMORY_GIB: int = 4

--- a/tests/e2e/vmaas/regression/test_compute_instance_heartbeat.py
+++ b/tests/e2e/vmaas/regression/test_compute_instance_heartbeat.py
@@ -15,6 +15,8 @@ from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.metering import MeteringCollector
 from tests.e2e.core.osac_cli import OsacCLI
 
+pytestmark = pytest.mark.regression
+
 
 @pytest.mark.metering
 def test_compute_instance_heartbeat(

--- a/tests/e2e/vmaas/regression/test_compute_instance_instance_type.py
+++ b/tests/e2e/vmaas/regression/test_compute_instance_instance_type.py
@@ -15,6 +15,8 @@ from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.osac_cli import OsacCLI
 from tests.e2e.core.runner import run_unchecked
 
+pytestmark = pytest.mark.regression
+
 IT_CORES: int = 2
 IT_MEMORY_GIB: int = 4
 

--- a/tests/e2e/vmaas/regression/test_compute_instance_restart.py
+++ b/tests/e2e/vmaas/regression/test_compute_instance_restart.py
@@ -12,6 +12,8 @@ from tests.e2e.core.metering import MeteringCollector
 from tests.e2e.core.osac_cli import OsacCLI
 from tests.e2e.core.runner import poll_until
 
+pytestmark = pytest.mark.regression
+
 
 def _wait_for_new_vmi(k8s_virt: K8sClient, *, vmi_namespace: str, ci_name: str, original_ts: str) -> str:
     poll_until(

--- a/tests/e2e/vmaas/regression/test_compute_instance_restart_negative.py
+++ b/tests/e2e/vmaas/regression/test_compute_instance_restart_negative.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 import time
 from datetime import UTC, datetime
 
+import pytest
+
 from tests.e2e.catalog.conftest import unique_name
 from tests.e2e.core.grpc_client import GRPCClient
 from tests.e2e.core.helpers import wait_for_cr, wait_for_deletion, wait_for_restart, wait_for_running
 from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.osac_cli import OsacCLI
+
+pytestmark = pytest.mark.regression
 
 
 def test_compute_instance_restart_past_timestamp_ignored(

--- a/tests/e2e/vmaas/regression/test_compute_instance_short_lived_metering.py
+++ b/tests/e2e/vmaas/regression/test_compute_instance_short_lived_metering.py
@@ -9,6 +9,8 @@ from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.metering import MeteringCollector
 from tests.e2e.core.osac_cli import OsacCLI
 
+pytestmark = pytest.mark.regression
+
 
 @pytest.mark.metering
 def test_short_lived_vm_metering(

--- a/tests/e2e/vmaas/regression/test_compute_instance_stop_metering.py
+++ b/tests/e2e/vmaas/regression/test_compute_instance_stop_metering.py
@@ -19,6 +19,8 @@ from tests.e2e.core.metering import MeteringCollector
 from tests.e2e.core.osac_cli import OsacCLI
 from tests.e2e.core.runner import poll_until
 
+pytestmark = pytest.mark.regression
+
 
 @pytest.mark.metering
 def test_compute_instance_stop_metering(

--- a/tests/e2e/vmaas/regression/test_compute_instance_storage_tier.py
+++ b/tests/e2e/vmaas/regression/test_compute_instance_storage_tier.py
@@ -11,6 +11,8 @@ from tests.e2e.core.helpers import assert_grpc_rejected, wait_for_cr, wait_for_d
 from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.osac_cli import OsacCLI
 
+pytestmark = pytest.mark.regression
+
 
 def verify_datavolume_storage_classes(
     k8s_hub_client: K8sClient, k8s_virt_client: K8sClient, ci_name: str, cr: dict[str, Any]
@@ -290,9 +292,7 @@ def test_compute_instance_additional_disk_tier_required(
                         "template": {"name": vm_template},
                         "instance_type": {"name": default_instance_type},
                         "boot_disk": {"size_gib": 20, "storage_tier": {"name": default_storage_tier}},
-                        "additional_disks": [
-                            additional_disk,
-                        ],
+                        "additional_disks": [additional_disk],
                         "network_attachments": [{"subnet": {"id": default_subnet}}],
                         "disk_image": {"name": default_disk_image},
                         "run_strategy": "Always",

--- a/tests/e2e/vmaas/regression/test_console.py
+++ b/tests/e2e/vmaas/regression/test_console.py
@@ -28,6 +28,8 @@ from tests.e2e.core.helpers import (
 from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.osac_cli import OsacCLI
 
+pytestmark = pytest.mark.regression
+
 logger = logging.getLogger(__name__)
 
 CONSOLE_WS_PATH = "/api/fulfillment/v1/console_sessions/connect"

--- a/tests/e2e/vmaas/regression/test_metadata_name_validation.py
+++ b/tests/e2e/vmaas/regression/test_metadata_name_validation.py
@@ -16,6 +16,8 @@ from tests.e2e.core.helpers import (
 from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.runner import poll_until
 
+pytestmark = pytest.mark.regression
+
 
 def _grpc_error_message(exc: subprocess.CalledProcessError) -> str:
     combined = (exc.stderr or "") + (exc.stdout or "")

--- a/tests/e2e/vmaas/regression/test_name_immutability.py
+++ b/tests/e2e/vmaas/regression/test_name_immutability.py
@@ -8,6 +8,8 @@ import pytest
 from tests.e2e.core.grpc_client import PUBLIC_API, GRPCClient
 from tests.e2e.core.helpers import assert_grpc_rejected
 
+pytestmark = pytest.mark.regression
+
 
 def _grpc_error_output(exc: subprocess.CalledProcessError) -> str:
     return (exc.stderr or "") + (exc.stdout or "")

--- a/tests/e2e/vmaas/regression/test_name_uniqueness.py
+++ b/tests/e2e/vmaas/regression/test_name_uniqueness.py
@@ -15,6 +15,8 @@ from tests.e2e.core.helpers import (
 )
 from tests.e2e.core.k8s_client import K8sClient
 
+pytestmark = pytest.mark.regression
+
 
 def _grpc_error_message(exc: subprocess.CalledProcessError) -> str:
     combined = (exc.stderr or "") + (exc.stdout or "")

--- a/tests/e2e/vmaas/sanity/test_compute_instance_cli_fields.py
+++ b/tests/e2e/vmaas/sanity/test_compute_instance_cli_fields.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import base64
 from typing import Any
 
+import pytest
+
 from tests.e2e.catalog.conftest import unique_name
 from tests.e2e.core.grpc_client import GRPCClient
 from tests.e2e.core.helpers import wait_for_cr, wait_for_deletion, wait_for_provision, wait_for_running
 from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.osac_cli import OsacCLI
 from tests.e2e.vmaas.conftest import DEFAULT_IT_CORES, DEFAULT_IT_MEMORY_GIB
+
+pytestmark = pytest.mark.sanity
 
 TEST_BOOT_DISK_SIZE: int = 20
 TEST_RUN_STRATEGY: str = "Always"

--- a/tests/e2e/vmaas/sanity/test_disk_image_lifecycle.py
+++ b/tests/e2e/vmaas/sanity/test_disk_image_lifecycle.py
@@ -8,6 +8,8 @@ import pytest
 from tests.e2e.core.grpc_client import GRPCClient
 from tests.e2e.core.helpers import assert_grpc_rejected
 
+pytestmark = pytest.mark.sanity
+
 SOURCE_REF = "quay.io/containerdisks/fedora:41"
 
 

--- a/tests/e2e/vmaas/sanity/test_instance_type_lifecycle.py
+++ b/tests/e2e/vmaas/sanity/test_instance_type_lifecycle.py
@@ -4,8 +4,12 @@ import subprocess
 from typing import Any
 from uuid import uuid4
 
+import pytest
+
 from tests.e2e.core.grpc_client import PRIVATE_API, GRPCClient
 from tests.e2e.core.osac_cli import OsacCLI
+
+pytestmark = pytest.mark.sanity
 
 TEST_CORES: int = 4
 TEST_MEMORY_GIB: int = 8

--- a/tests/e2e/vmaas/sanity/test_jwt_auth_smoke.py
+++ b/tests/e2e/vmaas/sanity/test_jwt_auth_smoke.py
@@ -9,6 +9,8 @@ from tests.e2e.core.grpc_client import GRPCClient
 from tests.e2e.core.osac_cli import OsacCLI
 from tests.e2e.core.runner import run_unchecked
 
+pytestmark = pytest.mark.sanity
+
 CLIENT_LISTABLE_RESOURCES = [
     "computeinstancetemplates",
     "computeinstances",

--- a/tests/e2e/vmaas/sanity/test_security_group_lifecycle.py
+++ b/tests/e2e/vmaas/sanity/test_security_group_lifecycle.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from uuid import uuid4
 
+import pytest
+
 from tests.e2e.core.grpc_client import GRPCClient
 from tests.e2e.core.helpers import (
     wait_for_security_group_cr,
@@ -16,6 +18,8 @@ from tests.e2e.core.helpers import (
 )
 from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.runner import poll_until
+
+pytestmark = pytest.mark.sanity
 
 
 def test_security_group_lifecycle(grpc: GRPCClient, k8s_hub_client: K8sClient) -> None:

--- a/tests/e2e/vmaas/sanity/test_subnet_lifecycle.py
+++ b/tests/e2e/vmaas/sanity/test_subnet_lifecycle.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from uuid import uuid4
 
+import pytest
+
 from tests.e2e.core.grpc_client import GRPCClient
 from tests.e2e.core.helpers import (
     wait_for_subnet_cr,
@@ -13,6 +15,8 @@ from tests.e2e.core.helpers import (
 )
 from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.runner import poll_until
+
+pytestmark = pytest.mark.sanity
 
 
 def test_subnet_lifecycle(grpc: GRPCClient, k8s_hub_client: K8sClient) -> None:

--- a/tests/e2e/vmaas/sanity/test_virtual_network_lifecycle.py
+++ b/tests/e2e/vmaas/sanity/test_virtual_network_lifecycle.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from uuid import uuid4
 
+import pytest
+
 from tests.e2e.core.grpc_client import GRPCClient
 from tests.e2e.core.helpers import (
     wait_for_virtual_network_cr,
@@ -10,6 +12,8 @@ from tests.e2e.core.helpers import (
 )
 from tests.e2e.core.k8s_client import K8sClient
 from tests.e2e.core.runner import poll_until
+
+pytestmark = pytest.mark.sanity
 
 
 def test_virtual_network_lifecycle(grpc: GRPCClient, k8s_hub_client: K8sClient) -> None:


### PR DESCRIPTION
## Summary
- Phase 0 of diff-aware E2E suite selection (see companion `osac-test-infra` PR): today, sanity/regression tier selection is 100% directory-path-based -- confirmed no `@pytest.mark.sanity`/`@pytest.mark.regression` decorators exist anywhere in `tests/e2e/`, meaning `e2e-bmaas-full-install.yml`'s existing `test-marker` input has been a no-op despite being fully wired.
- Adds a module-level `pytestmark = pytest.mark.<tier>` to all 31 E2E test files (25 vmaas, 3 caas, 3 bmaas) -- mechanical, one line per file, tier derived directly from each file's own existing directory location, no test logic changes.
- Registers `sanity`/`regression`/`serial` markers in `conftest.py`.
- Passes a new `test-marker` input through the vmaas/caas callers (paired with the companion `osac-test-infra` PR that adds the input to those reusable workflows) -- currently unused by any real invocation, same as bmaas's has been.

## Test plan
- [x] Static check: every one of the 31 files has exactly one `pytestmark` line matching its own directory tier
- [x] `ruff check` (all rules) and `ruff format` clean across all three suites
- [x] `actionlint` clean on the two changed workflow files
- [ ] **Please run in CI/a real 3.11+ environment before merging**: `pytest --collect-only -m sanity|regression|serial tests/e2e/<suite>/` for each suite, confirm it's byte-identical to today's directory-based `tests/e2e/<suite>/<tier>/` collection (this sandbox only has Python 3.8, couldn't run pytest directly here since `conftest.py` needs `datetime.UTC`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Affected areas

- **CI:** Added optional `test-marker` inputs to the VMaaS and CaaS E2E workflow callers. The inputs pass pytest marker expressions to reusable workflows.
- **Tests:** Added module-level `sanity`, `regression`, and `serial` markers to all 31 E2E test files across VMaaS, CaaS, and BMaaS.
- **Test configuration:** Registered the three markers in `tests/e2e/conftest.py`.
- **Other areas:** No API, controller, database, authentication, deployment-runtime, or documentation changes.

## Compatibility

- No production behavior changes are expected.
- Existing workflow dispatches remain compatible because `test-marker` defaults to an empty value.
- Test selection changes when a marker expression is provided.
- Python 3.11+ pytest collection comparison remains pending.

## Validation

- Ruff passed.
- actionlint passed.
- Full pytest collection validation was not completed.

## Risk classification

**risk:ship** — The changes are limited to test metadata, pytest configuration, and optional CI workflow inputs. They do not change production code or default workflow behavior.

The change does not qualify for **risk:show** or **risk:ask** because it has no expected user-facing or production-runtime impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->