### PR TITLE
NO-ISSUE: Add E2E suite selection POC (deterministic layer + AI wrapper)

### DIFF
--- a/.github/workflows/e2e-suite-selection-ai.yml
+++ b/.github/workflows/e2e-suite-selection-ai.yml
@@ -1,0 +1,33 @@
+---
+# Tiny native wrapper -- workflow_run only fires for runs that happened in
+# the repo that OWNS the listener file, so this has to live here even
+# though all the real logic lives in osac-test-infra's own copy of this
+# file, invoked via workflow_call. That indirection matters for two
+# reasons, both already established by ai-diagnostic-e2e.yml's identical
+# pattern: every real PR here is fork-originated, and a pull_request-
+# triggered job's own GITHUB_TOKEN is read-only (posting the comment could
+# never work directly from e2e-suite-selection-poc.yml's own job) and
+# Vertex AI's WIF trust only covers main-branch runs, never a fork PR's own
+# job. A workflow_call'd job inherits ITS CALLER's own token/context (this
+# wrapper's, i.e. osac's, native workflow_run-triggered one) regardless of
+# what originally triggered the upstream run -- see
+# osac-test-infra/.github/workflows/e2e-suite-selection-ai.yml's own header
+# for the rest of the reasoning.
+name: E2E Suite Selection AI Judgment
+
+on:
+  workflow_run:
+    workflows:
+      - E2E Suite Selection POC
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  judge:
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-suite-selection-ai.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      actions: read

--- a/.github/workflows/e2e-suite-selection-poc.yml
+++ b/.github/workflows/e2e-suite-selection-poc.yml
@@ -1,0 +1,159 @@
+---
+# POC (Phase 1 of diff-aware E2E suite selection, OSAC-4741): reports which
+# of the three E2E full-install suites (VMaaS/CaaS/BMaaS) this PR appears to
+# need, and at which tier (sanity/regression), WITHOUT gating anything --
+# purely informational, posted as a PR comment. No required check, no
+# effect on merge. This validates the selection logic (in particular,
+# whether feeding graphify's own query output to Gemini actually produces a
+# useful signal, which is unconfirmed) before Phase 2 wires it up for real.
+#
+# This file only ever prepares context and uploads it as an artifact -- it
+# NEVER posts the PR comment itself. Every real PR here is fork-originated,
+# and GitHub Actions gives a pull_request-triggered job from a fork a
+# read-only token unconditionally, regardless of any `permissions:` block
+# requesting write (same constraint ai-diagnostic-e2e.yml's own header
+# comment documents for Vertex AI auth) -- so posting/editing a PR comment
+# from here would silently fail for every real PR. osac-test-infra's
+# e2e-suite-selection-ai.yml listener (workflow_run-triggered, default-
+# branch YAML, a real write token) downloads this artifact and owns all
+# comment posting, whether or not it ends up needing Gemini at all.
+#
+# Two layers, both prepared here, judged there:
+# 1. A deterministic dorny/paths-filter pass (this file) that resolves the
+#    common, unambiguous cases outright (e.g. a bare-metal-fulfillment-
+#    operator/** change obviously means BMaaS) without ever needing Gemini.
+# 2. For anything left ambiguous (shared osac-operator/fulfillment-service
+#    code not clearly VMaaS- or CaaS-named, or YAML/JSON config files
+#    graphify can't model well), the listener makes a Gemini judgment call.
+name: E2E Suite Selection POC
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      # Booleans: true if ANY changed file matches that named filter's rules.
+      vmaas-clear: ${{ steps.filter.outputs.vmaas-clear }}
+      caas-clear: ${{ steps.filter.outputs.caas-clear }}
+      bmaas-clear: ${{ steps.filter.outputs.bmaas-clear }}
+      ambiguous-shared: ${{ steps.filter.outputs.ambiguous-shared }}
+      config-yaml-json: ${{ steps.filter.outputs.config-yaml-json }}
+      # JSON arrays of the actual matching paths, for the ambiguous buckets
+      # only -- the listener needs the real filenames, not just a boolean,
+      # to know what it's looking at (and to feed to graphify/Gemini).
+      ambiguous-shared-files: ${{ steps.filter.outputs.ambiguous-shared_files }}
+      config-yaml-json-files: ${{ steps.filter.outputs.config-yaml-json_files }}
+    steps:
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d  # v4.0.3
+        id: filter
+        with:
+          predicate-quantifier: 'every'
+          list-files: json
+          # Each of the three "-clear" filters is ONE brace-alternation
+          # pattern, not a flat list of separate alternatives -- with
+          # predicate-quantifier: 'every', multiple list ENTRIES all apply
+          # to the same candidate file as an AND (that's what lets
+          # ambiguous-shared/config-yaml-json below combine one broad match
+          # with several negations, exactly like this repo's own existing
+          # `code` filter in e2e-*-full-install.yml). Four disjoint full
+          # patterns as separate list entries would require a single file to
+          # satisfy ALL FOUR at once, which no real file ever does -- verified
+          # this distinction directly against real repo paths before landing
+          # this file (a flat-list version matched nothing at all).
+          filters: |
+            vmaas-clear:
+              - '{osac-operator/**/*computeinstance*,fulfillment-service/**/*compute_instance*,tests/e2e/vmaas/**,tests/e2e/references/**}'
+            caas-clear:
+              - '{osac-operator/**/*clusterorder*,fulfillment-service/**/*cluster*,tests/e2e/caas/**}'
+            bmaas-clear:
+              - '{bare-metal-fulfillment-operator/**,tests/e2e/bmaas/**}'
+            # osac-operator (all CRD controllers) and fulfillment-service
+            # (the gRPC/REST API) each back BOTH VMaaS and CaaS -- a change
+            # under either that ISN'T clearly computeinstance/cluster-named
+            # (per the *-clear filters above) can't be attributed by path
+            # alone. Confirmed on disk: osac-operator consistently names
+            # files computeinstance_*.go/clusterorder_*.go, but
+            # fulfillment-service's CaaS-facing files use a looser "cluster"
+            # substring (no "cluster_order"), so this bucket exists
+            # specifically to catch what the -clear filters miss, not as a
+            # rare edge case.
+            ambiguous-shared:
+              - '{osac-operator,fulfillment-service}/**'
+              - '!osac-operator/**/*computeinstance*'
+              - '!fulfillment-service/**/*compute_instance*'
+              - '!osac-operator/**/*clusterorder*'
+              - '!fulfillment-service/**/*cluster*'
+              - '!**/*.md'
+              - '!**/docs/**'
+            # graphify's own knowledge graph is built from source via
+            # tree-sitter and has known gaps modeling plain YAML/JSON config
+            # (per AGENTS.md's graphify section) -- these need a different
+            # fallback (a curated path table, or Gemini judging the diff
+            # alone) rather than a graphify-augmented judgment. Deliberately
+            # excludes tests/e2e/**'s own fixtures and the vmaas/caas/bmaas
+            # CRD manifests already caught by the *-clear filters above --
+            # this bucket is for config files NOT already resolved.
+            config-yaml-json:
+              - '{**/*.yaml,**/*.yml,**/*.json}'
+              - '!tests/e2e/**'
+              - '!osac-operator/**/*computeinstance*'
+              - '!osac-operator/**/*clusterorder*'
+              - '!fulfillment-service/**/*compute_instance*'
+              - '!fulfillment-service/**/*cluster*'
+              - '!bare-metal-fulfillment-operator/**'
+
+  # Always runs (whether or not anything is ambiguous) -- the listener needs
+  # this context either way, to build the reported decision even in the
+  # all-deterministic case. See the file header for why this can't just
+  # post the comment itself.
+  prepare-context:
+    name: Prepare context for suite-selection listener
+    needs: changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Build context payload
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          VMAAS_CLEAR: ${{ needs.changes.outputs.vmaas-clear }}
+          CAAS_CLEAR: ${{ needs.changes.outputs.caas-clear }}
+          BMAAS_CLEAR: ${{ needs.changes.outputs.bmaas-clear }}
+          AMBIGUOUS_FILES: ${{ needs.changes.outputs.ambiguous-shared-files }}
+          CONFIG_FILES: ${{ needs.changes.outputs.config-yaml-json-files }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/suite-selection-context"
+          jq -n \
+            --arg pr_number "${PR_NUMBER}" \
+            --arg head_sha "${HEAD_SHA}" \
+            --argjson vmaas_clear "${VMAAS_CLEAR:-false}" \
+            --argjson caas_clear "${CAAS_CLEAR:-false}" \
+            --argjson bmaas_clear "${BMAAS_CLEAR:-false}" \
+            --argjson ambiguous_files "${AMBIGUOUS_FILES:-[]}" \
+            --argjson config_files "${CONFIG_FILES:-[]}" \
+            '{
+              pr_number: ($pr_number | tonumber),
+              head_sha: $head_sha,
+              deterministic: {vmaas: $vmaas_clear, caas: $caas_clear, bmaas: $bmaas_clear},
+              ambiguous_files: $ambiguous_files,
+              config_files: $config_files
+            }' > "${RUNNER_TEMP}/suite-selection-context/context.json"
+          cat "${RUNNER_TEMP}/suite-selection-context/context.json"
+
+      - name: Upload context artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: suite-selection-context
+          path: ${{ runner.temp }}/suite-selection-context/context.json
+          retention-days: 1


### PR DESCRIPTION
## Summary
- Phase 1 (POC) of diff-aware E2E suite selection (OSAC-4741, see the companion \`osac-test-infra\` PR): informational-only, posts a PR comment showing which E2E suites/tiers a PR appears to need. Nothing is gated yet -- this is exactly the verification step \`e2e-vmaas-full-install.yml\`'s own \`changes\` job comment already anticipates ("deferred to the future full path-based CI matrix, once its skip-logic pattern is verified").
- New \`changes\` job (dorny/paths-filter, modeled on this repo's own \`check-generated-code.yaml\`) resolves the common, unambiguous cases (e.g. \`bare-metal-fulfillment-operator/**\` obviously means BMaaS) without needing AI.
- New \`prepare-context\` job always uploads the verdict as an artifact for the companion \`osac-test-infra\` workflow to pick up and post the comment -- can't post it directly here, since every real PR is fork-originated and this job's own token is read-only.
- New \`e2e-suite-selection-ai.yml\` wrapper (~15 lines) mirrors \`ai-diagnostic-e2e.yml\`'s own \`workflow_run\`+\`workflow_call\` pattern exactly.

## Merge order
The companion \`osac-test-infra\` PR must merge **before** this one -- this wrapper's \`uses: .../e2e-suite-selection-ai.yml@main\` would otherwise reference a workflow that doesn't exist yet on main.

## Test plan
- [x] Verified the deterministic filter design (in particular, the brace-alternation fix for \`predicate-quantifier: 'every'\` semantics) against 15 real repo paths using a local glob simulation -- all correct
- [x] \`actionlint\` clean
- [ ] Real end-to-end validation needs a live PR once both halves are merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

### CI

- Added a non-gating workflow for diff-aware E2E suite selection.
- The workflow classifies VMaaS, CaaS, BMaaS, shared-code, and YAML/JSON configuration changes.
- The workflow excludes resolved `fulfillment-service` configuration paths from fallback classification.
- The workflow uploads validated, short-lived selection results for downstream processing.
- Added a `workflow_run` wrapper that delegates PR comment handling to the reusable `osac-test-infra` workflow.
- Added permissions for repository and action reads, PR comment writes, and OIDC authentication.

### Validation

- Tested deterministic filters against 15 repository paths.
- `actionlint` passed.
- Live end-to-end validation remains pending.

### Backward compatibility

- No API, database, controller, authentication, deployment, or runtime behavior changed.
- The workflow does not gate merges.
- The companion `osac-test-infra` workflow must merge first.

## Risk classification

**risk:show** — The change affects CI classification and PR comments, but it is informational-only and does not affect runtime behavior. It does not qualify as **risk:ask** because it does not change production behavior, security boundaries, or merge gating. It is above **risk:ship** because it adds new CI automation, artifact handling, workflow permissions, and PR comment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->