### PR TITLE
OSAC-4945: Complete OSAC-4694 storage_tier migration (catalog defaults + e2e assertions)

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -247,7 +247,6 @@ jobs:
       # is fork-originated and gets no OIDC/WIF access at all by GitHub
       # Actions policy. merge_group is excluded the same way (its
       # github.ref is the readonly-queue ref).
-      notify-on-failure: ${{ github.event_name == 'schedule' }}
       enable-ai-diagnostic: ${{ github.ref == 'refs/heads/main' }}
 
   # Skip this required check on unreadiness so it stays pending (not red).

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -264,7 +264,6 @@ jobs:
       # is fork-originated and gets no OIDC/WIF access at all by GitHub
       # Actions policy. merge_group is excluded the same way (its
       # github.ref is the readonly-queue ref).
-      notify-on-failure: ${{ github.event_name == 'schedule' }}
       enable-ai-diagnostic: ${{ github.ref == 'refs/heads/main' }}
 
   # Skip this required check on unreadiness so it stays pending (not red).

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -263,7 +263,6 @@ jobs:
       # is fork-originated and gets no OIDC/WIF access at all by GitHub
       # Actions policy. merge_group is excluded the same way (its
       # github.ref is the readonly-queue ref).
-      notify-on-failure: ${{ github.event_name == 'schedule' }}
       enable-ai-diagnostic: ${{ github.ref == 'refs/heads/main' }}
 
   # Skip this required check on unreadiness so it stays pending (not red).

--- a/fulfillment-service/internal/servers/catalog_item_validation.go
+++ b/fulfillment-service/internal/servers/catalog_item_validation.go
@@ -191,6 +191,29 @@ func validateCatalogItemAccess(item catalogItem, ref string) error {
 	return nil
 }
 
+// normalizeDiskField wraps bare-string disk field values (disk_image, storage_tier)
+// as typed reference objects for backward compatibility with legacy catalog item defaults.
+func normalizeDiskField(v any, fieldName string) any {
+	switch val := v.(type) {
+	case string:
+		return map[string]any{"name": val}
+	case map[string]any:
+		if fieldVal, ok := val[fieldName]; ok {
+			if s, ok := fieldVal.(string); ok {
+				val[fieldName] = map[string]any{"name": s}
+			}
+		}
+		return val
+	case []any:
+		for i, elem := range val {
+			val[i] = normalizeDiskField(elem, fieldName)
+		}
+		return val
+	default:
+		return v
+	}
+}
+
 func applyDefault(specMap map[string]any, path string, defaultVal *structpb.Value) error {
 	if defaultVal == nil {
 		return nil
@@ -208,15 +231,13 @@ func applyDefault(specMap map[string]any, path string, defaultVal *structpb.Valu
 	if strings.HasPrefix(path, "template_parameters.") {
 		parsed = wrapValueAsAny(parsed)
 	}
-	// The disk_image default is normally already a DiskImageReference object
-	// ({"id": ..., "name": ...}), normalized on catalog-item create/update (see
-	// validateFieldDefinitionsDiskImage), so its id resolves the ComputeInstance reference
-	// unambiguously. This wrap is a defensive fallback: a bare-string default is converted to the
-	// {"name": ...} object the proto DiskImageReference field expects.
-	if path == "disk_image" {
-		if s, ok := parsed.(string); ok {
-			parsed = map[string]any{"name": s}
-		}
+	// Backward compatibility: normalize bare-string disk_image and storage_tier defaults.
+	if path == "disk_image" || path == "boot_disk" || strings.HasPrefix(path, "additional_disks") {
+		parsed = normalizeDiskField(parsed, "disk_image")
+	}
+	if path == "boot_disk" || path == "boot_disk.storage_tier" ||
+		strings.HasPrefix(path, "additional_disks") {
+		parsed = normalizeDiskField(parsed, "storage_tier")
 	}
 	maputil.SetNestedValue(specMap, path, parsed)
 	return nil

--- a/tests/e2e/vmaas/regression/test_compute_instance_storage_tier.py
+++ b/tests/e2e/vmaas/regression/test_compute_instance_storage_tier.py
@@ -264,7 +264,12 @@ def test_compute_instance_boot_disk_tier_required(
         )
 
     assert_grpc_rejected(exc_info, "InvalidArgument")
-    assert "storage_tier is required" in str(exc_info.value.stderr).lower()
+    # Param-aware: None → "storage_tier is required" (validateDisk);
+    # {"name": ""} → "storagetier reference must specify id or name" (reference interceptor).
+    if storage_tier is None:
+        assert "storage_tier is required" in str(exc_info.value.stderr).lower()
+    else:
+        assert "storagetier reference must specify id or name" in str(exc_info.value.stderr).lower()
 
 
 @pytest.mark.parametrize("storage_tier", [None, {"name": ""}])
@@ -302,7 +307,12 @@ def test_compute_instance_additional_disk_tier_required(
         )
 
     assert_grpc_rejected(exc_info, "InvalidArgument")
-    assert "additional_disks[0].storage_tier is required" in str(exc_info.value.stderr).lower()
+    # Param-aware: None → "additional_disks[0].storage_tier is required" (validateDisk);
+    # {"name": ""} → "storagetier reference must specify id or name" (reference interceptor).
+    if storage_tier is None:
+        assert "additional_disks[0].storage_tier is required" in str(exc_info.value.stderr).lower()
+    else:
+        assert "storagetier reference must specify id or name" in str(exc_info.value.stderr).lower()
 
 
 def test_compute_instance_boot_disk_tier_from_catalog_item_default(
@@ -322,7 +332,7 @@ def test_compute_instance_boot_disk_tier_from_catalog_item_default(
             "path": "boot_disk.storage_tier",
             "display_name": "Boot Disk Storage Tier",
             "editable": True,
-            "default": default_storage_tier,
+            "default": {"name": default_storage_tier},
         },
         {"path": "boot_disk.size_gib", "display_name": "Boot Disk Size", "editable": True},
         {"path": "network_attachments", "display_name": "Network Attachments", "editable": True},
@@ -499,7 +509,7 @@ def test_compute_instance_explicit_additional_disks_without_catalog_item_default
             "path": "boot_disk.storage_tier",
             "display_name": "Boot Disk Storage Tier",
             "editable": True,
-            "default": default_storage_tier,
+            "default": {"name": default_storage_tier},
         },
         {"path": "boot_disk.size_gib", "display_name": "Boot Disk Size", "editable": True},
         {"path": "additional_disks", "display_name": "Additional Disks", "editable": True},
@@ -636,6 +646,77 @@ def test_compute_instance_additional_disks_from_catalog_item_default(
             #     ci_name=ci_name,
             #     cr=cr,
             # )
+        finally:
+            grpc.delete_compute_instance(ci_id=uuid)
+            wait_for_deletion(k8s=k8s_hub_client, name=ci_name)
+    finally:
+        private_grpc.delete_compute_instance_catalog_item(catalog_item_id=catalog_item_id)
+
+
+def test_compute_instance_additional_disks_from_catalog_item_array_default_legacy_string(
+    private_grpc: GRPCClient,
+    grpc: GRPCClient,
+    k8s_hub_client: K8sClient,
+    k8s_virt_client: K8sClient,
+    vm_template: str,
+    default_subnet: str,
+    default_storage_tier: str,
+    additional_storage_tiers: dict[str, dict[str, str]],
+    default_instance_type: str,
+    default_disk_image: str,
+) -> None:
+    """Verify bare-string storage_tier in additional_disks array defaults are normalized."""
+    fast_tier = additional_storage_tiers["fast"]["name"]
+
+    # Legacy bare-string default inside the array
+    field_defs = [
+        {
+            "path": "additional_disks",
+            "display_name": "Additional Disks",
+            "editable": True,
+            "default": [{"size_gib": 10, "storage_tier": fast_tier}],  # Bare string (legacy)
+        },
+        {"path": "boot_disk.size_gib", "display_name": "Boot Disk Size", "editable": True},
+        {"path": "boot_disk.storage_tier", "display_name": "Boot Disk Storage Tier", "editable": True},
+        {"path": "network_attachments", "display_name": "Network Attachments", "editable": True},
+        {"path": "disk_image", "display_name": "Disk Image", "editable": True},
+        {"path": "instance_type", "display_name": "Instance Type", "editable": True},
+        {"path": "run_strategy", "display_name": "Run Strategy", "editable": True},
+    ]
+    catalog_item_id = private_grpc.create_compute_instance_catalog_item(
+        name=unique_name("e2e-cat-legacy-str"), template=vm_template, published=True, field_definitions=field_defs
+    )
+
+    try:
+        # Create CI without additional_disks to exercise the array default normalization
+        ci_obj = grpc.call(
+            service="osac.public.v1.ComputeInstances/Create",
+            data={
+                "object": {
+                    "metadata": {"name": unique_name("e2e-ci-legacy-def")},
+                    "spec": {
+                        "catalog_item": {"id": catalog_item_id},
+                        "instance_type": {"name": default_instance_type},
+                        "boot_disk": {"size_gib": 20, "storage_tier": {"name": default_storage_tier}},
+                        # No additional_disks specified
+                        "network_attachments": [{"subnet": {"id": default_subnet}}],
+                        "disk_image": {"name": default_disk_image},
+                        "run_strategy": "Always",
+                    },
+                }
+            },
+        )
+        uuid = ci_obj["object"]["id"]
+
+        ci_name = None
+        try:
+            ci_name = wait_for_cr(k8s=k8s_hub_client, uuid=uuid)
+            wait_for_provision(k8s=k8s_hub_client, name=ci_name)
+
+            cr = k8s_hub_client.get_json(resource="computeinstance", name=ci_name)
+            assert len(cr["spec"]["additionalDisks"]) == 1
+            assert cr["spec"]["additionalDisks"][0]["sizeGiB"] == 10
+            assert cr["spec"]["additionalDisks"][0]["storageTier"] == fast_tier
         finally:
             grpc.delete_compute_instance(ci_id=uuid)
             wait_for_deletion(k8s=k8s_hub_client, name=ci_name)


### PR DESCRIPTION
## Summary

Fixes the 8 VMaaS regression e2e failures introduced by [OSAC-4694](https://redhat.atlassian.net/browse/OSAC-4694) (#748, Sep 6), which retyped `ComputeInstanceDisk.storage_tier` from bare `string` to `StorageTierReference {id, name}`. That change migrated vmaas/sanity but left gaps in vmaas/regression (runs only on `schedule`), so PRs merged green while nightly broke.

## Changes

**Server normalization** (real product bug):
- `catalog_item_validation.go`: Added bare-string → `{"name": s}` normalization for `boot_disk.storage_tier` and `additional_disks[N].storage_tier` catalog-item field-definition defaults, mirroring the existing `disk_image` fallback. Before this, a string catalog default became an invalid typed reference → rejected. Real users with string storage-tier catalog defaults hit this.

**E2E test fixes**:
- `test_compute_instance_storage_tier.py`: Fixed catalog-default shape (2 tests) and made error-string assertions param-aware (2 tests):
  1. Catalog defaults → typed `{"name": tier}` (aligned with the server normalization and #748's documented format).
  2. Param-aware assertions: `None` → "storage_tier is required" (validateDisk); `{"name": ""}` → "storagetier reference must specify id or name" (reference interceptor).

## Testing

- Pre-commit hooks pass (Python ruff + Go golangci-lint).
- Scheduled VMaaS e2e will verify green nightly after merge.

## Related

- Jira: [OSAC-4945](https://redhat.atlassian.net/browse/OSAC-4945)
- Root cause: #748 / [OSAC-4694](https://redhat.atlassian.net/browse/OSAC-4694)
- osac-test-infra#478: separate issue (osac-test-infra's own e2e uses latest CLI release (0.0.95) → wire-format errors); not addressed here (osac-project/osac builds CLI from source, no such issue)

## ⚠️ Currently blocked

This PR's vmaas E2E gate is **blocked** by a pre-existing, unrelated failure in the references test suite: cluster/baremetal reference tests require CaaS/BMaaS, which are disabled in the vmaas-ci profile. Tracked in **[OSAC-5006](https://redhat.atlassian.net/browse/OSAC-5006)** (Blocker, OSAC-Infra).

This PR will be **rebased as soon as a fix for [OSAC-5006](https://redhat.atlassian.net/browse/OSAC-5006) is available**, at which point CI should go green.

_Note: a separate low-frequency metering flake ([OSAC-5001](https://redhat.atlassian.net/browse/OSAC-5001)) may also surface intermittently but is not a hard blocker._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Affected areas

- **Validation:** Normalize legacy string defaults for `disk_image` and `storage_tier`, including `additional_disks` arrays.
- **Tests:** Update VMaaS regression tests for typed references, parameter-aware errors, and legacy array defaults.
- **CI:** Remove duplicate workflow keys and enable AI diagnostics only on `main`.
- **Backward compatibility:** Legacy string catalog defaults remain supported through normalization. Empty references keep distinct validation errors.
- **API, database, auth, and deployment:** No changes.

## Risk classification

**risk:show** — The change affects provisioning validation and workflow behavior, but it is localized and includes regression coverage.

No repository risk-label criteria were found. The change is close to **risk:ship** because it has focused changes and reported green regression tests, but the VMaaS e2e gate remains blocked by [OSAC-5006](https://redhat.atlassian.net/browse/OSAC-5006).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
