### PR TITLE
NO-ISSUE: Run full E2E suites on pull requests

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -197,13 +197,13 @@ jobs:
       id-token: write
     uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-full-install.yml@main
     with:
-      # PR/merge_group: sanity (-n 4).
-      # Schedule: serial (-n 0, inventory exhaust). workflow_dispatch: honor
-      # input, else sanity (bmaas/regression for networking, bmaas for all).
+      # PR/merge_group: full bmaas suite. Schedule: serial (-n 0, inventory
+      # exhaust). workflow_dispatch: honor input, else sanity (bmaas/regression
+      # for networking, bmaas for all).
       test-suite: >-
         ${{
           inputs.test-suite != '' && inputs.test-suite ||
-          (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'bmaas/sanity' ||
+          (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'bmaas' ||
           github.event_name == 'schedule' && 'bmaas/serial' ||
           'bmaas/sanity'
         }}

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -212,13 +212,13 @@ jobs:
       id-token: write
     uses: osac-project/osac-test-infra/.github/workflows/e2e-caas-full-install.yml@main
     with:
-      # test-source=osac prefixes tests/e2e/. PR/merge_group: sanity.
-      # Schedule: regression. workflow_dispatch: honor input, else sanity
-      # (caas for the full suite).
+      # test-source=osac prefixes tests/e2e/. PR/merge_group: full caas suite
+      # (sanity + regression). Schedule: regression. workflow_dispatch: honor
+      # input, else sanity (caas for the full suite).
       test-suite: >-
         ${{
           inputs.test-suite != '' && inputs.test-suite ||
-          (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'caas/sanity' ||
+          (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'caas' ||
           github.event_name == 'schedule' && 'caas/regression' ||
           'caas/sanity'
         }}

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -212,13 +212,12 @@ jobs:
       id-token: write
     uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main
     with:
-      # PR/merge_group: sanity (fast smoke). Schedule: full vmaas suite
-      # (sanity + regression + serial). workflow_dispatch: honor input,
-      # else sanity.
+      # PR/merge_group and schedule: full vmaas suite (sanity + regression +
+      # serial). workflow_dispatch: honor the selected input, else sanity.
       test-suite: >-
         ${{
           inputs.test-suite != '' && inputs.test-suite ||
-          (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'vmaas/sanity' ||
+          (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'vmaas' ||
           github.event_name == 'schedule' && 'vmaas' ||
           'vmaas/sanity'
         }}


### PR DESCRIPTION
## Summary

- Run the full VMaaS suite on pull requests and merge-queue entries.
- Run the full BMaaS suite on pull requests and merge-queue entries.
- Run the full CaaS suite on pull requests and merge-queue entries.
- Preserve scheduled suite selection and workflow-dispatch overrides.

This keeps sanity and regression coverage together until the suite separation is ready to return.

## Validation

- `git diff --check`
- Reviewed the three caller workflow diffs
- `actionlint` and `yamllint` are not installed in the local environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **CI:** Pull requests and merge-queue entries now run the full VMaaS, BMaaS, and CaaS E2E suites.
- **CI:** Scheduled runs and workflow-dispatch suite selection remain unchanged.
- **Tests:** Broader E2E coverage runs before merge.
- **Compatibility:** No production API, controller, database, authentication, deployment, or documentation changes. No backward-compatibility impact is expected.
- **Validation:** `git diff --check` passed. The three caller workflow diffs were reviewed. `actionlint` and `yamllint` were unavailable locally.

## Risk classification

**risk:show** — The change affects CI execution scope and increases E2E runtime, but it does not change production behavior or interfaces. It does not qualify as **risk:ship** because the workflow behavior changes for pull requests and merge-queue entries. It does not qualify as **risk:ask** because the change does not introduce production, security, data, or compatibility risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->