### PR TITLE
OSAC-4964: Integrate optional BMaaS Netris job in OSAC CI

### DIFF
--- a/.github/optional-workflows.yml
+++ b/.github/optional-workflows.yml
@@ -3,6 +3,8 @@ version: 1
 workflows:
   - command: e2e-bmaas-netris-full-install
     workflow: e2e-bmaas-netris-full-install-caller.yml
-    name: E2E BMaaS Netris
+    name: E2E BMaaS Netris Full Install
     description: BMaaS networking tests on the Netris infrastructure
+    trigger: label
+    label: e2e-bmaas-netris
     retestable: true

--- a/.github/optional-workflows.yml
+++ b/.github/optional-workflows.yml
@@ -1,0 +1,8 @@
+version: 1
+
+workflows:
+  - command: e2e-bmaas-netris-full-install
+    workflow: e2e-bmaas-netris-full-install-caller.yml
+    name: E2E BMaaS Netris
+    description: BMaaS networking tests on the Netris infrastructure
+    retestable: true

--- a/.github/workflows/e2e-bmaas-netris-full-install-caller.yml
+++ b/.github/workflows/e2e-bmaas-netris-full-install-caller.yml
@@ -1,11 +1,16 @@
 ---
 name: E2E BMaaS Netris Full Install
-run-name: "E2E BMaaS Netris Full Install${{ inputs.pr-number != '' && format(' / PR #{0} @ {1}', inputs.pr-number, inputs.pr-sha) || '' }}"
+run-name: "E2E BMaaS Netris Full Install${{ (inputs.pr-number || github.event.pull_request.number) != '' && format(' / PR #{0} @ {1}', inputs.pr-number || github.event.pull_request.number, inputs.pr-sha || github.event.pull_request.head.sha) || '' }}"
 
 permissions:
   contents: read
+  checks: write
+  pull-requests: read
 
 on:
+  pull_request_target:
+    types: [labeled]
+    branches: [main]
   workflow_dispatch:
     inputs:
       test-infra-repository:
@@ -46,25 +51,30 @@ on:
         default: ""
 
 concurrency:
-  group: e2e-bmaas-netris-full-install-${{ inputs.pr-repository || github.repository }}-${{ inputs.pr-number || github.run_id }}-${{ inputs.pr-sha || github.sha }}
-  cancel-in-progress: false
+  group: e2e-bmaas-netris-full-install-${{ inputs.pr-repository || github.event.pull_request.head.repo.full_name || github.repository }}-${{ inputs.pr-number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ inputs.pr-number != '' || github.event_name == 'pull_request_target' }}
 
 jobs:
   e2e-bmaas-netris:
+    if: >-
+      github.event_name != 'pull_request_target'
+      || github.event.label.name == 'e2e-bmaas-netris'
     permissions:
       contents: read
       id-token: write
+      checks: write
+      pull-requests: read
     uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-netris-full-install.yml@main
     with:
-      osac-repo: ${{ inputs.pr-repository || github.repository }}
-      osac-branch: ${{ inputs.pr-ref || github.ref_name }}
-      components: '[{"repo":"${{ inputs.pr-repository || github.repository }}","ref":"${{ inputs.pr-ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","context":".","imageKey":"service.images.service"},{"repo":"${{ inputs.pr-repository || github.repository }}","ref":"${{ inputs.pr-ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","context":".","imageKey":"operator.image.repository"},{"repo":"${{ inputs.pr-repository || github.repository }}","ref":"${{ inputs.pr-ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","context":".","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},{"repo":"${{ inputs.pr-repository || github.repository }}","ref":"${{ inputs.pr-ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","context":".","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"},{"repo":"${{ inputs.pr-repository || github.repository }}","ref":"${{ inputs.pr-ref || github.ref_name }}","containerfile":"bare-metal-fulfillment-operator/Containerfile","context":".","imageKey":"bmf.image.repository"}]'
+      osac-repo: ${{ inputs.pr-repository || github.event.pull_request.head.repo.full_name || github.repository }}
+      osac-branch: ${{ inputs.pr-ref || github.event.pull_request.head.ref || github.ref_name }}
+      components: '[{"repo":"${{ inputs.pr-repository || github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ inputs.pr-ref || github.event.pull_request.head.ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","context":".","imageKey":"service.images.service"},{"repo":"${{ inputs.pr-repository || github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ inputs.pr-ref || github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","context":".","imageKey":"operator.image.repository"},{"repo":"${{ inputs.pr-repository || github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ inputs.pr-ref || github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","context":".","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},{"repo":"${{ inputs.pr-repository || github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ inputs.pr-ref || github.event.pull_request.head.ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","context":".","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"},{"repo":"${{ inputs.pr-repository || github.event.pull_request.head.repo.full_name || github.repository }}","ref":"${{ inputs.pr-ref || github.event.pull_request.head.ref || github.ref_name }}","containerfile":"bare-metal-fulfillment-operator/Containerfile","context":".","imageKey":"bmf.image.repository"}]'
       test-infra-repository: ${{ inputs.test-infra-repository || 'osac-project/osac-test-infra' }}
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
       test-infra-sha: ${{ inputs.test-infra-sha || '' }}
-      pr-repository: ${{ inputs.pr-repository || '' }}
-      pr-ref: ${{ inputs.pr-ref || '' }}
-      pr-sha: ${{ inputs.pr-sha || '' }}
-      fork-pr-author-association: ${{ inputs.fork-pr-author-association || '' }}
-      fork-pr-author: ${{ inputs.fork-pr-author || '' }}
-      pr-number: ${{ inputs.pr-number || '' }}
+      pr-repository: ${{ inputs.pr-repository || github.event.pull_request.head.repo.full_name || '' }}
+      pr-ref: ${{ inputs.pr-ref || github.event.pull_request.head.ref || '' }}
+      pr-sha: ${{ inputs.pr-sha || github.event.pull_request.head.sha || '' }}
+      fork-pr-author-association: ${{ inputs.fork-pr-author-association || (github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.author_association) || '' }}
+      fork-pr-author: ${{ inputs.fork-pr-author || (github.event.pull_request.head.repo.full_name != github.repository && github.event.pull_request.user.login) || '' }}
+      pr-number: ${{ inputs.pr-number || github.event.pull_request.number || '' }}

--- a/.github/workflows/e2e-bmaas-netris-full-install-caller.yml
+++ b/.github/workflows/e2e-bmaas-netris-full-install-caller.yml
@@ -1,0 +1,70 @@
+---
+name: E2E BMaaS Netris Full Install
+run-name: "E2E BMaaS Netris Full Install${{ inputs.pr-number != '' && format(' / PR #{0} @ {1}', inputs.pr-number, inputs.pr-sha) || '' }}"
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      test-infra-repository:
+        description: "Repository containing the test-infra reusable workflow"
+        required: false
+        default: "osac-project/osac-test-infra"
+      test-infra-ref:
+        description: "Branch or tag of test-infra; ignored when test-infra-sha is set"
+        required: false
+        default: "main"
+      test-infra-sha:
+        description: "Exact test-infra commit SHA; overrides test-infra-ref"
+        required: false
+        default: ""
+      pr-number:
+        description: "PR number being tested"
+        required: false
+        default: ""
+      pr-repository:
+        description: "Repository containing the PR head, including a fork"
+        required: false
+        default: ""
+      pr-ref:
+        description: "PR head branch/ref"
+        required: false
+        default: ""
+      pr-sha:
+        description: "Expected immutable PR head SHA"
+        required: false
+        default: ""
+      fork-pr-author-association:
+        description: "PR author association used by fork authorization"
+        required: false
+        default: ""
+      fork-pr-author:
+        description: "PR author login used by fork authorization"
+        required: false
+        default: ""
+
+concurrency:
+  group: e2e-bmaas-netris-full-install-${{ inputs.pr-repository || github.repository }}-${{ inputs.pr-number || github.run_id }}-${{ inputs.pr-sha || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  e2e-bmaas-netris:
+    permissions:
+      contents: read
+      id-token: write
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-netris-full-install.yml@main
+    with:
+      osac-repo: ${{ inputs.pr-repository || github.repository }}
+      osac-branch: ${{ inputs.pr-ref || github.ref_name }}
+      components: '[{"repo":"${{ inputs.pr-repository || github.repository }}","ref":"${{ inputs.pr-ref || github.ref_name }}","containerfile":"fulfillment-service/Containerfile","context":".","imageKey":"service.images.service"},{"repo":"${{ inputs.pr-repository || github.repository }}","ref":"${{ inputs.pr-ref || github.ref_name }}","containerfile":"osac-operator/Containerfile","context":".","imageKey":"operator.image.repository"},{"repo":"${{ inputs.pr-repository || github.repository }}","ref":"${{ inputs.pr-ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","context":".","imageKey":"aap.bootstrap.image","buildType":"ansible-builder"},{"repo":"${{ inputs.pr-repository || github.repository }}","ref":"${{ inputs.pr-ref || github.ref_name }}","containerfile":"osac-aap/execution-environment/execution-environment.yaml","context":".","imageKey":"aap.configAsCode.eeImage","buildType":"ansible-builder"},{"repo":"${{ inputs.pr-repository || github.repository }}","ref":"${{ inputs.pr-ref || github.ref_name }}","containerfile":"bare-metal-fulfillment-operator/Containerfile","context":".","imageKey":"bmf.image.repository"}]'
+      test-infra-repository: ${{ inputs.test-infra-repository || 'osac-project/osac-test-infra' }}
+      test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+      test-infra-sha: ${{ inputs.test-infra-sha || '' }}
+      pr-repository: ${{ inputs.pr-repository || '' }}
+      pr-ref: ${{ inputs.pr-ref || '' }}
+      pr-sha: ${{ inputs.pr-sha || '' }}
+      fork-pr-author-association: ${{ inputs.fork-pr-author-association || '' }}
+      fork-pr-author: ${{ inputs.fork-pr-author || '' }}
+      pr-number: ${{ inputs.pr-number || '' }}

--- a/.github/workflows/e2e-bmaas-netris-label-cleanup.yml
+++ b/.github/workflows/e2e-bmaas-netris-label-cleanup.yml
@@ -1,16 +1,25 @@
 ---
-name: Remove e2e-bmaas-netris on new push
+name: Remove BMaaS Netris trigger on new push
 
 on:
   pull_request_target:
     types: [synchronize]
 
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  # Match the PR-scoped group used by the label-triggered Netris workflow so
+  # a new commit cancels its older run immediately.
+  group: e2e-bmaas-netris-full-install-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
-  remove-label:
+  reset-trigger:
+    name: Reset BMaaS Netris trigger
     if: contains(github.event.pull_request.labels.*.name, 'e2e-bmaas-netris')
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - name: Remove stale e2e-bmaas-netris label
         env:

--- a/.github/workflows/e2e-bmaas-netris-label-cleanup.yml
+++ b/.github/workflows/e2e-bmaas-netris-label-cleanup.yml
@@ -1,0 +1,24 @@
+---
+name: Remove e2e-bmaas-netris on new push
+
+on:
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  remove-label:
+    if: contains(github.event.pull_request.labels.*.name, 'e2e-bmaas-netris')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove stale e2e-bmaas-netris label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh pr edit "${PR_NUMBER}" -R "${REPO}" --remove-label "e2e-bmaas-netris"
+          gh pr comment "${PR_NUMBER}" -R "${REPO}" \
+            --body "Removed \`e2e-bmaas-netris\` due to new commits. Re-add the label to run BMaaS Netris again."


### PR DESCRIPTION
## Summary

- Add the OSAC-side optional workflow registry entry for `e2e-bmaas-netris-full-install`.
- Add a manual-only caller that invokes the reusable BMaaS Netris workflow from `osac-test-infra@main`.
- Pass the OSAC PR repository/ref and immutable PR metadata so fork authorization and stale-SHA validation remain active.
- Build the OSAC PR component images used by the BMaaS Netris deployment.
- Support an exact test-infra repository/ref/SHA override for validation of a specific infrastructure revision.

The workflow is optional and has no `pull_request` or `schedule` trigger, so it is not required for merge and does not introduce automatic BMaaS Netris runs.

## Dependency

- `osac-project/osac-test-infra#511` (merged)
- Jira: [OSAC-4964](https://redhat.atlassian.net/browse/OSAC-4964)

## Validation

- `pre-commit run --files .github/optional-workflows.yml .github/workflows/e2e-bmaas-netris-full-install-caller.yml`
- `actionlint .github/workflows/e2e-bmaas-netris-full-install-caller.yml`
- Optional-workflow registry normalization against the active workflow path
- Optional dispatch-plan validation with PR metadata


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## CI

- Adds optional `e2e-bmaas-netris` label support for the BMaaS Netris full-install workflow.
- Supports manual dispatch and labeled `pull_request_target` runs on `main`.
- Passes pull request repository, ref, SHA, author, and authorization metadata.
- Builds required OSAC component images.
- Invokes the reusable workflow from `osac-test-infra@main`.
- Supports exact test-infra repository, ref, and SHA overrides.
- Adds workflow permissions and concurrency controls.
- Removes the label after pull request synchronization and comments on the pull request.
- Includes validation for formatting, actionlint, workflow registration, and dispatch planning.
- Depends on `osac-project/osac-test-infra#511`.

## Compatibility

This change does not modify runtime APIs, controllers, databases, authentication, or production behavior. It does not add automatic `pull_request` or `schedule` execution. CI execution requires manual dispatch or the `e2e-bmaas-netris` label and depends on the reusable test infrastructure and its required inputs.

## Risk classification

`risk:show` — The change modifies CI triggers, workflow permissions, concurrency, label handling, and integration with external test infrastructure. It can affect CI execution but does not change production runtime behavior. It does not qualify for `risk:ship` because it is not limited to documentation or non-functional metadata. It does not qualify for `risk:ask` because execution requires manual dispatch or an explicit label and has no automatic `pull_request` or `schedule` trigger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->