### PR TITLE
NO-ISSUE: configure OpenCode context limits

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "openai": {
+      "models": {
+        "gpt-5.6-sol": {
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          }
+        },
+        "gpt-5.6-terra": {
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          }
+        },
+        "gpt-5.6-luna": {
+          "limit": {
+            "context": 272000,
+            "output": 128000
+          }
+        }
+      }
+    }
+  },
+  "compaction": {
+    "auto": true,
+    "prune": true,
+    "reserved": 20000
+  }
+}


### PR DESCRIPTION
## Summary
- Add repository-local OpenCode configuration for the GPT 5.6 Sol, Terra, and Luna models.
- Limit model context to 272K tokens and enable automatic compaction with tool-output pruning.


## Test plan
- [x] Validate `opencode.json` with `jq empty`
- [x] Confirm the PR branch contains only `opencode.json`
- [ ] Unit tests not applicable
- [ ] Lint not applicable

---

_This PR description was drafted with AI assistance (OpenAI Codex). Review for accuracy._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **Configuration:** Added repository-local `opencode.json`.
- **Model support:** Configured `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.
- **Context management:** Set a 272,000-token context limit for each model. Enabled automatic compaction, pruning, and a 20,000-token reserve.
- **API surface:** No exported or public entities changed.
- **Application areas:** No changes to controllers, database, authentication, deployment, CI, or documentation.
- **Tests:** The test plan validates `opencode.json` with `jq empty` and confirms that the branch contains only this file.
- **Backward compatibility:** No application or runtime behavior changes are expected. The change affects repository-local OpenCode configuration only.

## Risk classification

**risk:ship** — The change adds only a repository-local configuration file, changes no runtime code or API surface, and has a JSON validation test plan.

The change is not close to **risk:show** because it does not alter application behavior or user-facing runtime functionality. No separate labeling criteria were supplied beyond the requested risk labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->