### PR TITLE
NO-ISSUE: Cover shared tests/e2e/core infra in the suite selection filter

### DIFF
--- a/.github/workflows/e2e-suite-selection-poc.yml
+++ b/.github/workflows/e2e-suite-selection-poc.yml
@@ -86,8 +86,23 @@ jobs:
             # substring (no "cluster_order"), so this bucket exists
             # specifically to catch what the -clear filters miss, not as a
             # rare edge case.
+            #
+            # tests/e2e/core/** (client/helper wrappers), tests/e2e/conftest.py
+            # (session fixtures), and tests/e2e/*.sh (run/setup scripts) are
+            # ALSO in this bucket, not just osac-operator/fulfillment-service --
+            # confirmed real via live production data: PR #688 changed 4
+            # tests/e2e/core/*.py files (grpc_client.py, helpers.py,
+            # k8s_client.py, osac_cli.py -- imported by every suite's test
+            # files per this repo's own AGENTS.md) plus tests/e2e/run-test.sh/
+            # setup-env.sh, and NONE of them matched any filter before this
+            # fix -- it only got a correct-looking verdict because that same
+            # PR also happened to touch a vmaas-specific test file. A PR
+            # touching ONLY shared test infra would previously have silently
+            # resolved every suite to "skip" with no AI judgment at all --
+            # exactly the "test that needed to run doesn't run" failure mode
+            # this whole feature exists to prevent.
             ambiguous-shared:
-              - '{osac-operator,fulfillment-service}/**'
+              - '{osac-operator/**,fulfillment-service/**,tests/e2e/core/**,tests/e2e/conftest.py,tests/e2e/*.sh}'
               - '!osac-operator/**/*computeinstance*'
               - '!fulfillment-service/**/*compute_instance*'
               - '!osac-operator/**/*clusterorder*'


### PR DESCRIPTION
## Summary
Reviewing the first 10 real PR runs of the E2E suite selection POC (OSAC-4741, since #789/#515 merged): PR #688 (still open) changes 4 shared \`tests/e2e/core/*.py\` client wrapper files (used across ALL THREE suites per this repo's own AGENTS.md) plus 2 shell scripts -- none of which matched any existing filter. That PR's comment still looked correct only because it happened to also touch a VMaaS-specific test file; a PR touching *only* shared test infra would have silently resolved every suite to "skip" with no AI judgment at all.

**Fix**: folded \`tests/e2e/core/**\`, \`tests/e2e/conftest.py\`, and \`tests/e2e/*.sh\` into the existing \`ambiguous-shared\` bucket (routes to Gemini judgment, not a deterministic skip -- these genuinely can't be attributed to one suite by path alone). Combined into the same brace-alternation pattern as the existing entries, preserving the \`predicate-quantifier: 'every'\` semantics already verified earlier in this feature.

## Test plan
- [x] Local glob simulation (gitwildmatch + proper brace-expansion) against 26 real paths, including PR #688's exact 6-file gap -- all now correctly classified
- [x] Sanity checks confirm genuinely unrelated files (\`tests/e2e/projects/**\`, \`tests/e2e/__init__.py\`) stay unmatched
- [x] \`actionlint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzMWXNMZSHdSXNdYj3owPC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## CI

Updated `.github/workflows/e2e-suite-selection-poc.yml` to classify shared E2E infrastructure as `ambiguous-shared`:

- `tests/e2e/core/**`
- `tests/e2e/conftest.py`
- `tests/e2e/*.sh`

These paths now use Gemini judgment instead of deterministic skipping. Existing exclusions and `predicate-quantifier: 'every'` semantics remain unchanged.

Validation covered 26 paths, including the six-file gap from PR `#688`. Unrelated paths remained unmatched. `actionlint` passed.

## Compatibility

No API, controller, database, authentication, deployment, or documentation changes are included. No production runtime behavior changes. The change only affects E2E suite selection.

## Risk classification

`risk:ship` applies because this is a scoped CI configuration change with no production code impact, preserved existing filter semantics, successful path simulations, and a clean `actionlint` run. It is close to `risk:show` because it changes automated test selection, but it does not qualify because the change routes shared tests to additional judgment rather than suppressing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->