### PR TITLE
NO-ISSUE: Block merge queue ahead of incomplete post-lgtm e2e

### DIFF
--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -122,14 +122,24 @@ jobs:
               blocked=true
             fi
           fi
+          eligible=true
+          for label in lgtm approved jira/valid-reference; do
+            if ! echo "$LABELS" | jq -e "index(\"$label\")" > /dev/null; then
+              echo "Missing required merge label: $label"
+              eligible=false
+            fi
+          done
           echo "blocked=$blocked"
           echo "blocked=$blocked" >> "$GITHUB_OUTPUT"
+          echo "eligible=$eligible"
+          echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
 
       - name: Enable auto-merge
         if: >-
           github.event.pull_request.draft == false
           && steps.org-check.outputs.org_member == 'true'
           && steps.label-check.outputs.blocked == 'false'
+          && steps.label-check.outputs.eligible == 'true'
         env:
           GH_TOKEN: ${{ secrets.MERGE_QUEUE_TOKEN }}
           PR: ${{ github.event.pull_request.number }}

--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -149,7 +149,10 @@ jobs:
       - name: Disable auto-merge
         if: >-
           steps.org-check.outputs.org_member == 'true'
-          && steps.label-check.outputs.blocked == 'true'
+          && (
+            steps.label-check.outputs.blocked == 'true' ||
+            steps.label-check.outputs.eligible == 'false'
+          )
         env:
           GH_TOKEN: ${{ secrets.MERGE_QUEUE_TOKEN }}
           PR: ${{ github.event.pull_request.number }}

--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -257,7 +257,8 @@ jobs:
       enable-ai-diagnostic: ${{ github.ref == 'refs/heads/main' }}
 
   # Skip this required check on unreadiness so it stays pending (not red).
-  # Docs-only / non-PR / unlocked still report here.
+  # workflow_dispatch may green this gate on a PR SHA. Merge requires all
+  # three suite gates on HEAD; unlock accepts them when already success.
   e2e-bmaas-gate:
     if: >-
       always()

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -274,7 +274,8 @@ jobs:
       enable-ai-diagnostic: ${{ github.ref == 'refs/heads/main' }}
 
   # Skip this required check on unreadiness so it stays pending (not red).
-  # Docs-only / non-PR / unlocked still report here.
+  # workflow_dispatch may green this gate on a PR SHA. Merge requires all
+  # three suite gates on HEAD; unlock accepts them when already success.
   e2e-caas-gate:
     if: >-
       always()

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -273,7 +273,8 @@ jobs:
       enable-ai-diagnostic: ${{ github.ref == 'refs/heads/main' }}
 
   # Skip this required check on unreadiness so it stays pending (not red).
-  # Docs-only / non-PR / unlocked still report here.
+  # workflow_dispatch may green this gate on a PR SHA. Merge requires all
+  # three suite gates on HEAD; unlock accepts them when already success.
   e2e-vmaas-gate:
     if: >-
       always()

--- a/.github/workflows/label-gate.yml
+++ b/.github/workflows/label-gate.yml
@@ -13,10 +13,27 @@ on:
 jobs:
   check-labels:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: read
     steps:
       - name: Auto-pass for merge queue
         if: github.event_name == 'merge_group'
         run: echo "Labels already validated on PR"
+      - name: Prepare e2e merge gates on unlock
+        if: >-
+          github.event_name == 'pull_request'
+          && github.event.action == 'labeled'
+          && contains(fromJSON('["lgtm","e2e-ready"]'), github.event.label.name)
+        uses: osac-project/osac-test-infra/.github/actions/invalidate-e2e-gates@main
+        with:
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          reason: >-
+            ${{ format('{0} unlock - waiting for fresh full-install run',
+            github.event.label.name) }}
+          skip-if-all-green: "true"
+        continue-on-error: true
       - name: Check required Prow labels
         if: github.event_name == 'pull_request'
         env:


### PR DESCRIPTION
## Summary
- Run `invalidate-e2e-gates` from `label-gate.yml` on `/lgtm` and `/e2e-ready` unless all three merge e2e gates are already green on HEAD
- Require `lgtm`, `approved`, and `jira/valid-reference` before auto-merge (align auto-queue with Prow gates)
- Clarify gate job comments: manual `workflow_dispatch` can green merge gates; merge still needs all three on current SHA

Fixes merge-queue race seen in osac-project/osac#791.

Depends on osac-project/osac-test-infra#521 (merge `invalidate-e2e-gates@main` first).

## Jira
N/A

## Test plan
- [ ] Merge osac-test-infra#521 first, then rebase if needed
- [ ] On a test PR, apply `/lgtm` with incomplete e2e gates and confirm merge queue does not enter until all three gates pass
- [ ] On a test PR with all three gates green on HEAD via manual dispatch, confirm `/lgtm` does not invalidate or replay e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **CI:** Auto-merge now requires `lgtm`, `approved`, and `jira/valid-reference`. It is disabled when the PR is no longer eligible.
- **CI:** Adding `lgtm` or `e2e-ready` invalidates E2E gates unless all three gates pass on the current PR HEAD.
- **CI:** E2E workflows now document manual `workflow_dispatch` behavior and current-HEAD merge requirements.
- **Tests:** The change covers incomplete and manually completed E2E gate scenarios.
- **Backward compatibility:** No application API or runtime behavior changes. PRs may need updated labels or rerun E2E gates before auto-merge.

## Risk classification

**risk:show** — The change modifies CI merge and E2E gate behavior. It does not modify application runtime code. It can delay or block merges when required labels or current-HEAD E2E gates are missing. It does not qualify for **risk:ship** because it changes merge controls, and it does not qualify for **risk:ask** because it does not affect application runtime behavior, data, security, or production deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->