### PR TITLE
OSAC-5006: filter service-specific VMaaS references

### DIFF
--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -222,7 +222,11 @@ jobs:
           'vmaas/sanity'
         }}
       test-filter: ${{ inputs.test-filter || '' }}
-      test-marker: ${{ inputs.test-marker || '' }}
+      # The references module contains CaaS and BMaaS tests too. Those
+      # services are disabled in the VMaaS profile, so exclude tests marked
+      # with either dependency unless an explicit workflow-dispatch marker is
+      # supplied.
+      test-marker: ${{ inputs.test-marker || 'not requires_caas and not requires_bmaas' }}
       # osac-installer now lives as a subdirectory of this same monorepo checkout
       # (its Chart.yaml deps resolve fulfillment-service/osac-operator/osac-aap/BMF
       # as ../../../<name> siblings within it), so a PR touching those components

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -82,6 +82,8 @@ def pytest_configure(config: pytest.Config) -> None:
     e2e.log artifact.
     """
     config.addinivalue_line("markers", "metering: test verifies metering events via the test adapter HTTP API")
+    config.addinivalue_line("markers", "requires_caas: test requires the CaaS service to be enabled")
+    config.addinivalue_line("markers", "requires_bmaas: test requires the BMaaS service to be enabled")
     config.addinivalue_line("markers", "sanity: fast, low-risk smoke test suitable for every PR")
     config.addinivalue_line("markers", "regression: broader/slower coverage, run on a schedule or on demand")
     config.addinivalue_line("markers", "serial: must run alone, not in parallel with other tests (e.g. exhausts a shared resource)")

--- a/tests/e2e/references/test_cluster_baremetal_references.py
+++ b/tests/e2e/references/test_cluster_baremetal_references.py
@@ -105,6 +105,7 @@ def bmi_template(private_grpc: GRPCClient) -> str:
 class TestClusterBareMetalReferences:
     """OSAC-3110: Cluster and bare metal resource reference tests."""
 
+    @pytest.mark.requires_caas
     def test_cluster_provisioning_chain_by_name(
         self, private_grpc: GRPCClient, grpc: GRPCClient, cli: OsacCLI, cluster_template: str, cluster_version: str
     ):
@@ -138,6 +139,7 @@ class TestClusterBareMetalReferences:
             except subprocess.CalledProcessError:
                 logger.warning("Failed to cleanup cluster catalog item %s", cat_id)
 
+    @pytest.mark.requires_bmaas
     def test_baremetal_instance_chain_by_name(self, private_grpc: GRPCClient, grpc: GRPCClient, bmi_template: str):
         tag = uuid4().hex[:8]
         cat_name = f"ref-bmi-cat-{tag}"
@@ -179,6 +181,7 @@ class TestClusterBareMetalReferences:
             except subprocess.CalledProcessError:
                 logger.warning("Failed to cleanup BMI catalog item %s", cat_id)
 
+    @pytest.mark.requires_caas
     def test_cross_tenant_cluster_template_reference(
         self,
         private_grpc: GRPCClient,
@@ -212,6 +215,7 @@ class TestClusterBareMetalReferences:
             except subprocess.CalledProcessError:
                 logger.warning("Failed to cleanup cross-tenant catalog item %s", cat_id)
 
+    @pytest.mark.requires_caas
     def test_invalid_cluster_template_name_returns_error(self, private_grpc: GRPCClient):
         tag = uuid4().hex[:8]
         with pytest.raises(subprocess.CalledProcessError) as exc_info:


### PR DESCRIPTION
Exclude CaaS and BMaaS reference tests from the VMaaS profile while preserving per-test markers for reuse by the corresponding suites.

Assisted-by: Codex <noreply@openai.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Affected areas

- **CI:** The VMaaS full-install workflow now excludes tests marked `requires_caas` or `requires_bmaas` by default. A user-supplied `test-marker` still overrides this default.
- **Tests:** Pytest now registers `requires_caas` and `requires_bmaas`. Reference tests now identify their required service.
- **API, controllers, database, auth, deployment, and documentation:** No changes.

## Compatibility

This change does not alter production APIs or runtime behavior. It changes the default VMaaS E2E test selection. CaaS- and BMaaS-specific tests will not run in the VMaaS workflow unless a user supplies an overriding marker.

The CaaS and BMaaS workflows must include the reference test path to execute the excluded tests. This PR does not add that workflow coverage.

## Risk classification

`risk:show` applies because the change affects CI test selection and can hide service-specific E2E coverage from the VMaaS workflow.

It does not qualify as `risk:ask` because it does not change production code, APIs, authentication, data, or deployment behavior. It is close to `risk:ship` because the code change is limited and reversible, but the missing CaaS and BMaaS workflow coverage prevents classification as low-risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->