### PR TITLE
OSAC-4799: Migrate grpcserver tests from stdlib testing to Ginkgo

### DIFF
--- a/fulfillment-service/internal/cmd/service/start/grpcserver/no_inline_resource_registration_test.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/no_inline_resource_registration_test.go
@@ -14,11 +14,14 @@ language governing permissions and limitations under the License.
 package grpcserver
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
 	"strings"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 // registerServerExemptMarker must appear in a comment on the line immediately above any publicv1/privatev1
@@ -30,67 +33,71 @@ import (
 // registration logic independently. This test exists to catch that at review time instead.
 const registerServerExemptMarker = "filterable-resource-exempt:"
 
-// TestNoInlineResourceServerRegistration parses start_grpc_server_cmd.go's source and fails if it finds a
-// publicv1/privatev1 Register*Server call registering directly on grpcServer without an explicit
-// registerServerExemptMarker comment on the preceding line explaining why it isn't part of RegisterResourceServers.
-func TestNoInlineResourceServerRegistration(t *testing.T) {
-	const fileName = "start_grpc_server_cmd.go"
+var _ = Describe("NoInlineResourceServerRegistration", func() {
+	// This test parses start_grpc_server_cmd.go's source and fails if it finds a publicv1/privatev1
+	// Register*Server call registering directly on grpcServer without an explicit
+	// registerServerExemptMarker comment on the preceding line explaining why it isn't part of
+	// RegisterResourceServers.
+	It("should not have publicv1/privatev1 Register*Server calls without an exempt marker", func() {
+		const fileName = "start_grpc_server_cmd.go"
 
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, fileName, nil, parser.ParseComments)
-	if err != nil {
-		t.Fatalf("failed to parse %s: %v", fileName, err)
-	}
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, fileName, nil, parser.ParseComments)
+		Expect(err).ToNot(HaveOccurred())
 
-	// Map the line immediately after each comment group to that group's full text, so a marker anywhere in a
-	// multi-line comment block is found regardless of which line it's on.
-	textByLineAfter := map[int]string{}
-	for _, group := range file.Comments {
-		lineAfter := fset.Position(group.End()).Line + 1
-		textByLineAfter[lineAfter] = group.Text()
-	}
-
-	ast.Inspect(file, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
-			return true
-		}
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok {
-			return true
-		}
-		pkgIdent, ok := sel.X.(*ast.Ident)
-		if !ok {
-			return true
-		}
-		if pkgIdent.Name != "publicv1" && pkgIdent.Name != "privatev1" {
-			return true
-		}
-		if !strings.HasPrefix(sel.Sel.Name, "Register") || !strings.HasSuffix(sel.Sel.Name, "Server") {
-			return true
-		}
-		if len(call.Args) == 0 {
-			return true
-		}
-		firstArg, ok := call.Args[0].(*ast.Ident)
-		if !ok || firstArg.Name != "grpcServer" {
-			return true
+		// Map the line immediately after each comment group to that group's full text, so a marker anywhere in a
+		// multi-line comment block is found regardless of which line it's on.
+		textByLineAfter := map[int]string{}
+		for _, group := range file.Comments {
+			lineAfter := fset.Position(group.End()).Line + 1
+			textByLineAfter[lineAfter] = group.Text()
 		}
 
-		line := fset.Position(call.Pos()).Line
-		if comment, ok := textByLineAfter[line]; ok && strings.Contains(comment, registerServerExemptMarker) {
-			return true
-		}
+		var violations []string
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			pkgIdent, ok := sel.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if pkgIdent.Name != "publicv1" && pkgIdent.Name != "privatev1" {
+				return true
+			}
+			if !strings.HasPrefix(sel.Sel.Name, "Register") || !strings.HasSuffix(sel.Sel.Name, "Server") {
+				return true
+			}
+			if len(call.Args) == 0 {
+				return true
+			}
+			firstArg, ok := call.Args[0].(*ast.Ident)
+			if !ok || firstArg.Name != "grpcServer" {
+				return true
+			}
 
-		t.Errorf(
-			"%s:%d: %s.%s is registered directly on grpcServer without a preceding %q comment.\n"+
-				"Filterable resources (anything with a List RPC and a CEL filter field) must be registered "+
-				"through RegisterResourceServers in register_servers.go instead, so they get covered by its "+
-				"single, testable registration path.\n"+
-				"If this server is genuinely not a filterable resource, add a comment directly above this "+
-				"line explaining why, containing %q.",
-			fileName, line, pkgIdent.Name, sel.Sel.Name, registerServerExemptMarker, registerServerExemptMarker,
-		)
-		return true
+			line := fset.Position(call.Pos()).Line
+			if comment, ok := textByLineAfter[line]; ok && strings.Contains(comment, registerServerExemptMarker) {
+				return true
+			}
+
+			violations = append(violations, fmt.Sprintf(
+				"%s:%d: %s.%s is registered directly on grpcServer without a preceding %q comment.\n"+
+					"Filterable resources (anything with a List RPC and a CEL filter field) must be registered "+
+					"through RegisterResourceServers in register_servers.go instead, so they get covered by its "+
+					"single, testable registration path.\n"+
+					"If this server is genuinely not a filterable resource, add a comment directly above this "+
+					"line explaining why, containing %q.",
+				fileName, line, pkgIdent.Name, sel.Sel.Name, registerServerExemptMarker, registerServerExemptMarker,
+			))
+			return true
+		})
+
+		Expect(violations).To(BeEmpty(), strings.Join(violations, "\n"))
 	})
-}
+})

--- a/fulfillment-service/internal/cmd/service/start/grpcserver/reference_lookups_test.go
+++ b/fulfillment-service/internal/cmd/service/start/grpcserver/reference_lookups_test.go
@@ -19,8 +19,9 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
-	"testing"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 	grpcstatus "google.golang.org/grpc/status"
@@ -32,35 +33,36 @@ import (
 	"github.com/osac-project/osac/fulfillment-service/internal/references"
 )
 
-func TestRegisterReferenceLookups(t *testing.T) {
-	validator := newTestReferenceValidator(t)
+var _ = Describe("RegisterReferenceLookups", func() {
+	var validator *references.ReferenceValidator
 
-	t.Run("registers SecretLocalReference for private and public APIs", func(t *testing.T) {
+	BeforeEach(func() {
+		validator = newTestReferenceValidator()
+	})
+
+	It("registers SecretLocalReference for private and public APIs", func() {
 		for _, name := range []protoreflect.FullName{
 			"osac.private.v1.SecretLocalReference",
 			"osac.public.v1.SecretLocalReference",
 		} {
-			if !validator.HasLookup(name) {
-				t.Errorf("missing lookup for %s", name)
-			}
+			Expect(validator.HasLookup(name)).To(BeTrue(), "missing lookup for %s", name)
 		}
 	})
 
-	t.Run("registers every reference type used in Create or Update requests", func(t *testing.T) {
+	It("registers every reference type used in Create or Update requests", func() {
 		var missing []string
-		for _, name := range createOrUpdateReferenceTypes(t) {
+		for _, name := range createOrUpdateReferenceTypes() {
 			if !validator.HasLookup(name) {
 				missing = append(missing, string(name))
 			}
 		}
 		slices.Sort(missing)
-		if len(missing) > 0 {
-			t.Errorf("no lookup registered for Create/Update reference types:\n  %s",
-				strings.Join(missing, "\n  "))
-		}
+		Expect(missing).To(BeEmpty(),
+			"no lookup registered for Create/Update reference types:\n  %s",
+			strings.Join(missing, "\n  "))
 	})
 
-	t.Run("interceptor does not reject identity provider client_secret_secret as unregistered", func(t *testing.T) {
+	It("does not reject identity provider client_secret_secret as unregistered", func() {
 		request := privatev1.IdentityProvidersCreateRequest_builder{
 			Object: privatev1.IdentityProvider_builder{
 				Spec: privatev1.IdentityProviderSpec_builder{
@@ -79,35 +81,26 @@ func TestRegisterReferenceLookups(t *testing.T) {
 			&grpc.UnaryServerInfo{FullMethod: "/osac.private.v1.IdentityProviders/Create"},
 			func(context.Context, any) (any, error) { return "ok", nil },
 		)
-		if err == nil {
-			return
-		}
-		st, _ := grpcstatus.FromError(err)
-		if strings.Contains(st.Message(), "no lookup registered") {
-			t.Fatalf("SecretLocalReference is not registered with the interceptor: %v", err)
+		if err != nil {
+			st, _ := grpcstatus.FromError(err)
+			Expect(st.Message()).ToNot(ContainSubstring("no lookup registered"),
+				"SecretLocalReference is not registered with the interceptor: %v", err)
 		}
 	})
-}
+})
 
-func newTestReferenceValidator(t *testing.T) *references.ReferenceValidator {
-	t.Helper()
+func newTestReferenceValidator() *references.ReferenceValidator {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	tenancy, err := auth.NewGuestTenancyLogic().SetLogger(logger).Build()
-	if err != nil {
-		t.Fatalf("failed to create guest tenancy logic: %v", err)
-	}
+	Expect(err).ToNot(HaveOccurred())
 	validator, err := references.NewReferenceValidator().SetLogger(logger).Build()
-	if err != nil {
-		t.Fatalf("failed to create reference validator: %v", err)
-	}
-	if err := registerReferenceLookups(validator, logger, tenancy, prometheus.NewRegistry()); err != nil {
-		t.Fatalf("failed to register reference lookups: %v", err)
-	}
+	Expect(err).ToNot(HaveOccurred())
+	err = registerReferenceLookups(validator, logger, tenancy, prometheus.NewRegistry())
+	Expect(err).ToNot(HaveOccurred())
 	return validator
 }
 
-func createOrUpdateReferenceTypes(t *testing.T) []protoreflect.FullName {
-	t.Helper()
+func createOrUpdateReferenceTypes() []protoreflect.FullName {
 	seen := map[protoreflect.FullName]struct{}{}
 	refs := map[protoreflect.FullName]struct{}{}
 	protoregistry.GlobalFiles.RangeFiles(func(fd protoreflect.FileDescriptor) bool {


### PR DESCRIPTION
Convert no_inline_resource_registration_test.go and reference_lookups_test.go from stdlib testing.T to Ginkgo v2 Describe/It blocks with Gomega assertions. Helper functions no longer accept *testing.T — they use Gomega's Expect directly, which works through the registered fail handler from the existing Ginkgo suite bootstrap.

Assisted-by: Claude Code claude-code-agent@anthropic.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

- **Tests:** Migrated two `grpcserver` tests to Ginkgo v2 and Gomega.
- Replaced `testing.T` methods with Ginkgo/Gomega assertions.
- Shared validator setup with `BeforeEach`.
- Preserved AST scanning and exemption-marker behavior.
- Removed `*testing.T` parameters from helper functions.

## Compatibility

- No production code or public API changes.
- No backward-compatibility impact.

## Risk classification

**risk:ship** — The PR changes test implementations only. It does not change runtime behavior, APIs, controllers, databases, authentication, deployment, or CI behavior. It is close to **risk:show** because it changes test execution and failure handling, but it does not modify production functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->