### PR TITLE
NO-ISSUE: Support arm64 in kind-dev

### DIFF
--- a/osac-installer/Makefile
+++ b/osac-installer/Makefile
@@ -95,6 +95,13 @@ endif
 # chowns /dev/kvm), so it goes through the cross-platform wrapper; plain dev uses
 # bare kind (unchanged integration-test path).
 KIND_RUNTIME := scripts/dev-full/kind-runtime.sh
+KIND_ARM64_CLI_IMAGE := quay.io/openshift/origin-cli:4.20.0
+
+# quay.io/openshift/origin-cli:4.20.0 has no arm64 manifest. On Apple Silicon,
+# build a compatible local image with the same tag so every chart can continue
+# using the shared cliImage value without platform-specific values files.
+HOST_IS_MAC_ARM := $(shell if [ "$$(uname -s)" = "Darwin" ] && { [ "$$(uname -m)" = "arm64" ] || [ "$$(sysctl -in hw.optional.arm64 2>/dev/null)" = "1" ]; }; then echo true; fi)
+KIND_ARM64_CLI_IMAGE_SCRIPT := scripts/dev-full/build-arm64-cli-image.sh
 
 # Container tool and Kind cluster config.
 CONTAINER_TOOL ?= $(or $(shell command -v podman 2>/dev/null),$(shell command -v docker 2>/dev/null),$(error neither podman nor docker found in PATH))
@@ -138,6 +145,9 @@ ifeq ($(PLATFORM),kind)
 ifeq ($(PROFILE),dev-full)
 	@$(KIND_RUNTIME) check
 	@$(KIND_RUNTIME) create-cluster $(KIND_CLUSTER_NAME) $(KIND_CONFIG) $(KIND_KUBECONFIG)
+ifeq ($(HOST_IS_MAC_ARM),true)
+	@$(KIND_ARM64_CLI_IMAGE_SCRIPT) $(KIND_CLUSTER_NAME) $(KIND_ARM64_CLI_IMAGE)
+endif
 else
 	@if kind get clusters | grep -q "^$(KIND_CLUSTER_NAME)$$"; then \
 		echo "Kind cluster '$(KIND_CLUSTER_NAME)' already exists"; \

--- a/osac-installer/README.md
+++ b/osac-installer/README.md
@@ -198,6 +198,11 @@ so networking resources reconcile to READY without a real fabric (kind has none)
   `kind`, `helm`, `kubectl`, `jq`, `curl`, `openssl`, `python3` on `PATH`
 - Override runtime detection with `KIND_EXPERIMENTAL_PROVIDER=docker|podman`
 
+On an Apple Silicon Mac, the install target automatically builds an arm64
+replacement for `quay.io/openshift/origin-cli:4.20.0` with Docker and loads it
+into the kind cluster before installing Helm charts. Docker Desktop must be
+running; no manual image setup is required.
+
 **Endpoints** (via the kind port mappings; every `*.localhost` name resolves to
 127.0.0.1 automatically, so no `/etc/hosts` editing is needed):
 

--- a/osac-installer/scripts/dev-full/build-arm64-cli-image.sh
+++ b/osac-installer/scripts/dev-full/build-arm64-cli-image.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Build and load the arm64 replacement for the OpenShift CLI image used by the
+# installer hooks. The image keeps the upstream tag so no chart values change
+# is needed.
+
+set -euo pipefail
+
+cluster_name=${1:?usage: $0 <kind-cluster-name> [image]}
+image=${2:-quay.io/openshift/origin-cli:4.20.0}
+
+command -v docker >/dev/null 2>&1 || {
+  echo "docker is required to build the Apple Silicon CLI image" >&2
+  exit 1
+}
+command -v kind >/dev/null 2>&1 || {
+  echo "kind is required to load the Apple Silicon CLI image" >&2
+  exit 1
+}
+
+echo "Building ${image} for linux/arm64..."
+docker build --platform linux/arm64 -t "${image}" - <<'EOF'
+FROM registry.fedoraproject.org/fedora:latest
+RUN dnf install -y tar gzip jq curl openssl python3 && \
+    curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux-arm64.tar.gz | tar -xz -C /usr/local/bin/ oc kubectl && \
+    chmod +x /usr/local/bin/oc /usr/local/bin/kubectl
+EOF
+
+echo "Loading ${image} into kind cluster ${cluster_name}..."
+kind load docker-image "${image}" --name "${cluster_name}"


### PR DESCRIPTION
## Summary
- Build and load an arm64 `origin-cli` image on Apple Silicon Macs.
- Automatically load the image into the dev-full kind cluster.
- Document the Apple Silicon setup behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **Deployment:** Added Apple Silicon support for `dev-full` kind installations.
- The Makefile detects Apple Silicon macOS hosts.
- The `install-infra` target builds and loads a local `linux/arm64` `origin-cli:4.20.0` image before Helm installation.
- The build script validates Docker and kind, builds the image, and loads it into the selected kind cluster.
- **Documentation:** Added setup guidance for Apple Silicon users. Docker Desktop is required. Manual image setup is not required.
- **API surface, controllers, database, auth, CI, and tests:** No changes.

## Compatibility

Existing non-Apple-Silicon installations keep their current behavior. Apple Silicon installations now use a locally built ARM64 CLI image. The workflow requires Docker and kind to be available.

## Risk classification

**risk:show** — The change affects local deployment behavior and introduces a new image-build and kind-load step. It does not change application APIs, controllers, databases, authentication, or production deployment paths.

This is not **risk:ship** because the change adds platform-specific installation logic and external tool requirements. It does not qualify for **risk:ask** because the behavior is limited to Apple Silicon `dev-full` installations and includes validation for required tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->