### PR TITLE
Retry transient Go module downloads in image builds

### DIFF
--- a/bare-metal-fulfillment-operator/Containerfile
+++ b/bare-metal-fulfillment-operator/Containerfile
@@ -17,7 +17,22 @@ COPY --chown=1001:1001 osac-csi-driver/go.mod osac-csi-driver/go.sum osac-csi-dr
 COPY --chown=1001:1001 osac-metering/schema/go.mod osac-metering/schema/go.sum osac-metering/schema/
 COPY --chown=1001:1001 osac-metering/metering-service/go.mod osac-metering/metering-service/go.sum osac-metering/metering-service/
 COPY --chown=1001:1001 osac-metering/adapters/go.mod osac-metering/adapters/go.sum osac-metering/adapters/
-RUN cd bare-metal-fulfillment-operator && go mod download
+RUN \
+  set -eu; \
+  for attempt in 1 2 3 4 5; do \
+    if output=$(cd bare-metal-fulfillment-operator && go mod download 2>&1); then \
+      printf '%s\n' "$output"; \
+      exit 0; \
+    else \
+      status=$?; \
+    fi; \
+    printf '%s\n' "$output" >&2; \
+    if ! printf '%s\n' "$output" | grep -Eq 'stream error|unexpected EOF|connection (reset|refused|closed)|i/o timeout|TLS handshake timeout|proxyconnect|no such host|HTTP (408|429|5[0-9][0-9])'; then \
+      exit "$status"; \
+    fi; \
+    if [ "$attempt" -lt 5 ]; then sleep "$((attempt * 2))"; fi; \
+  done; \
+  exit 1
 
 COPY --chown=1001:1001 bare-metal-fulfillment-operator/ bare-metal-fulfillment-operator/
 COPY --chown=1001:1001 osac-operator/ osac-operator/

--- a/fulfillment-service/Containerfile
+++ b/fulfillment-service/Containerfile
@@ -19,8 +19,21 @@ COPY --chown=1001:1001 osac-metering/schema/go.mod osac-metering/schema/go.sum o
 COPY --chown=1001:1001 osac-metering/metering-service/go.mod osac-metering/metering-service/go.sum osac-metering/metering-service/
 COPY --chown=1001:1001 osac-metering/adapters/go.mod osac-metering/adapters/go.sum osac-metering/adapters/
 RUN \
-  set -e; \
-  cd fulfillment-service && go mod download
+  set -eu; \
+  for attempt in 1 2 3 4 5; do \
+    if output=$(cd fulfillment-service && go mod download 2>&1); then \
+      printf '%s\n' "$output"; \
+      exit 0; \
+    else \
+      status=$?; \
+    fi; \
+    printf '%s\n' "$output" >&2; \
+    if ! printf '%s\n' "$output" | grep -Eq 'stream error|unexpected EOF|connection (reset|refused|closed)|i/o timeout|TLS handshake timeout|proxyconnect|no such host|HTTP (408|429|5[0-9][0-9])'; then \
+      exit "$status"; \
+    fi; \
+    if [ "$attempt" -lt 5 ]; then sleep "$((attempt * 2))"; fi; \
+  done; \
+  exit 1
 
 ARG VERSION=""
 

--- a/osac-csi-driver/Containerfile
+++ b/osac-csi-driver/Containerfile
@@ -17,7 +17,22 @@ COPY --chown=1001:1001 osac-operator/api/go.mod osac-operator/api/go.sum osac-op
 COPY --chown=1001:1001 osac-metering/schema/go.mod osac-metering/schema/go.sum osac-metering/schema/
 COPY --chown=1001:1001 osac-metering/metering-service/go.mod osac-metering/metering-service/go.sum osac-metering/metering-service/
 COPY --chown=1001:1001 osac-metering/adapters/go.mod osac-metering/adapters/go.sum osac-metering/adapters/
-RUN cd osac-csi-driver && go mod download
+RUN \
+  set -eu; \
+  for attempt in 1 2 3 4 5; do \
+    if output=$(cd osac-csi-driver && go mod download 2>&1); then \
+      printf '%s\n' "$output"; \
+      exit 0; \
+    else \
+      status=$?; \
+    fi; \
+    printf '%s\n' "$output" >&2; \
+    if ! printf '%s\n' "$output" | grep -Eq 'stream error|unexpected EOF|connection (reset|refused|closed)|i/o timeout|TLS handshake timeout|proxyconnect|no such host|HTTP (408|429|5[0-9][0-9])'; then \
+      exit "$status"; \
+    fi; \
+    if [ "$attempt" -lt 5 ]; then sleep "$((attempt * 2))"; fi; \
+  done; \
+  exit 1
 
 COPY --chown=1001:1001 osac-csi-driver/ osac-csi-driver/
 

--- a/osac-metering/adapters/Containerfile.echo-adapter
+++ b/osac-metering/adapters/Containerfile.echo-adapter
@@ -5,7 +5,22 @@ ARG TARGETARCH
 WORKDIR /opt/app-root/src
 COPY --chown=1001:0 schema/ schema/
 COPY --chown=1001:0 adapters/go.mod adapters/go.sum adapters/
-RUN cd adapters && go mod download
+RUN \
+  set -eu; \
+  for attempt in 1 2 3 4 5; do \
+    if output=$(cd adapters && go mod download 2>&1); then \
+      printf '%s\n' "$output"; \
+      exit 0; \
+    else \
+      status=$?; \
+    fi; \
+    printf '%s\n' "$output" >&2; \
+    if ! printf '%s\n' "$output" | grep -Eq 'stream error|unexpected EOF|connection (reset|refused|closed)|i/o timeout|TLS handshake timeout|proxyconnect|no such host|HTTP (408|429|5[0-9][0-9])'; then \
+      exit "$status"; \
+    fi; \
+    if [ "$attempt" -lt 5 ]; then sleep "$((attempt * 2))"; fi; \
+  done; \
+  exit 1
 
 COPY --chown=1001:0 adapters/ adapters/
 

--- a/osac-metering/adapters/Containerfile.m360-adapter
+++ b/osac-metering/adapters/Containerfile.m360-adapter
@@ -5,7 +5,22 @@ ARG TARGETARCH
 WORKDIR /opt/app-root/src
 COPY --chown=1001:0 schema/ schema/
 COPY --chown=1001:0 adapters/go.mod adapters/go.sum adapters/
-RUN cd adapters && go mod download
+RUN \
+  set -eu; \
+  for attempt in 1 2 3 4 5; do \
+    if output=$(cd adapters && go mod download 2>&1); then \
+      printf '%s\n' "$output"; \
+      exit 0; \
+    else \
+      status=$?; \
+    fi; \
+    printf '%s\n' "$output" >&2; \
+    if ! printf '%s\n' "$output" | grep -Eq 'stream error|unexpected EOF|connection (reset|refused|closed)|i/o timeout|TLS handshake timeout|proxyconnect|no such host|HTTP (408|429|5[0-9][0-9])'; then \
+      exit "$status"; \
+    fi; \
+    if [ "$attempt" -lt 5 ]; then sleep "$((attempt * 2))"; fi; \
+  done; \
+  exit 1
 
 COPY --chown=1001:0 adapters/ adapters/
 

--- a/osac-metering/metering-service/Containerfile
+++ b/osac-metering/metering-service/Containerfile
@@ -5,7 +5,22 @@ ARG TARGETARCH
 WORKDIR /opt/app-root/src
 COPY --chown=1001:0 schema/ schema/
 COPY --chown=1001:0 metering-service/go.mod metering-service/go.sum metering-service/
-RUN cd metering-service && go mod download
+RUN \
+  set -eu; \
+  for attempt in 1 2 3 4 5; do \
+    if output=$(cd metering-service && go mod download 2>&1); then \
+      printf '%s\n' "$output"; \
+      exit 0; \
+    else \
+      status=$?; \
+    fi; \
+    printf '%s\n' "$output" >&2; \
+    if ! printf '%s\n' "$output" | grep -Eq 'stream error|unexpected EOF|connection (reset|refused|closed)|i/o timeout|TLS handshake timeout|proxyconnect|no such host|HTTP (408|429|5[0-9][0-9])'; then \
+      exit "$status"; \
+    fi; \
+    if [ "$attempt" -lt 5 ]; then sleep "$((attempt * 2))"; fi; \
+  done; \
+  exit 1
 
 COPY --chown=1001:0 metering-service/ metering-service/
 

--- a/osac-operator/Containerfile
+++ b/osac-operator/Containerfile
@@ -17,7 +17,22 @@ COPY --chown=1001:1001 osac-csi-driver/go.mod osac-csi-driver/go.sum osac-csi-dr
 COPY --chown=1001:1001 osac-metering/schema/go.mod osac-metering/schema/go.sum osac-metering/schema/
 COPY --chown=1001:1001 osac-metering/metering-service/go.mod osac-metering/metering-service/go.sum osac-metering/metering-service/
 COPY --chown=1001:1001 osac-metering/adapters/go.mod osac-metering/adapters/go.sum osac-metering/adapters/
-RUN cd osac-operator && go mod download
+RUN \
+  set -eu; \
+  for attempt in 1 2 3 4 5; do \
+    if output=$(cd osac-operator && go mod download 2>&1); then \
+      printf '%s\n' "$output"; \
+      exit 0; \
+    else \
+      status=$?; \
+    fi; \
+    printf '%s\n' "$output" >&2; \
+    if ! printf '%s\n' "$output" | grep -Eq 'stream error|unexpected EOF|connection (reset|refused|closed)|i/o timeout|TLS handshake timeout|proxyconnect|no such host|HTTP (408|429|5[0-9][0-9])'; then \
+      exit "$status"; \
+    fi; \
+    if [ "$attempt" -lt 5 ]; then sleep "$((attempt * 2))"; fi; \
+  done; \
+  exit 1
 
 COPY --chown=1001:1001 osac-operator/ osac-operator/
 COPY --chown=1001:1001 bare-metal-fulfillment-operator/ bare-metal-fulfillment-operator/


### PR DESCRIPTION
## Problem
E2E image builds run `go mod download` inside Podman. The existing host-side Go retry action cannot affect those layers, and proxy.golang.org HTTP/2 stream errors have failed builds across multiple runners.

## Fix
Wrap each OSAC image build module download in five bounded attempts. Retry only transport signatures such as HTTP/2 stream errors, connection resets, timeouts, proxy connection failures, DNS failures, and 4xx/5xx transient responses. Non-transport failures preserve their original exit status immediately.

Checksum verification remains enabled; no dependency or module error is hidden.

## Validation
- `git diff --check`
- Shell simulation verifies transient errors retry and non-transient module errors fail immediately.
- `podman --version` verified on the build host; a full image build was not run because it requires the external registries and dependency downloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **Deployment:** Adds bounded retries for `go mod download` in seven OSAC `Containerfile` build stages.
- Retries cover transient transport, proxy, DNS, timeout, HTTP 408/429, and HTTP 5xx failures.
- Non-transport failures retain their original status and fail immediately.
- Checksum verification remains enabled.
- Validation covered formatting and shell simulations. Full image builds were not run because they require external registries and dependency downloads.
- No changes affect APIs, controllers, databases, authentication, runtime behavior, CI, or documentation.
- **Backward compatibility:** No runtime or API compatibility impact. The change improves build resilience.

## Risk classification

**risk:ship** — The change is limited to bounded dependency-download retries. It preserves checksum verification and fail-fast behavior for non-transport errors.

The change does not qualify as **risk:show** because it does not alter deployed runtime behavior. It does not qualify as **risk:ask** because retry count and backoff are bounded, and no unresolved data-integrity or security risk is evident.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->