### PR TITLE
NO-ISSUE: fix duplicate workflow inputs

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -247,7 +247,6 @@ jobs:
       # is fork-originated and gets no OIDC/WIF access at all by GitHub
       # Actions policy. merge_group is excluded the same way (its
       # github.ref is the readonly-queue ref).
-      notify-on-failure: ${{ github.event_name == 'schedule' }}
       enable-ai-diagnostic: ${{ github.ref == 'refs/heads/main' }}
 
   # Skip this required check on unreadiness so it stays pending (not red).

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -264,7 +264,6 @@ jobs:
       # is fork-originated and gets no OIDC/WIF access at all by GitHub
       # Actions policy. merge_group is excluded the same way (its
       # github.ref is the readonly-queue ref).
-      notify-on-failure: ${{ github.event_name == 'schedule' }}
       enable-ai-diagnostic: ${{ github.ref == 'refs/heads/main' }}
 
   # Skip this required check on unreadiness so it stays pending (not red).

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -263,7 +263,6 @@ jobs:
       # is fork-originated and gets no OIDC/WIF access at all by GitHub
       # Actions policy. merge_group is excluded the same way (its
       # github.ref is the readonly-queue ref).
-      notify-on-failure: ${{ github.event_name == 'schedule' }}
       enable-ai-diagnostic: ${{ github.ref == 'refs/heads/main' }}
 
   # Skip this required check on unreadiness so it stays pending (not red).


### PR DESCRIPTION
## Summary

- Remove duplicate `notify-on-failure` inputs from the CaaS, VMaaS, and BMaaS full-install workflow callers.
- Restore the `pre-commit` yamllint check by keeping one input mapping per reusable workflow call.

## Testing

- Targeted `yamllint` passed.
- `git diff --check` passed.
- Full pre-commit reached the YAML checks successfully; Go hooks were blocked locally by read-only cache paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

- **CI:** Removed duplicate `notify-on-failure` mappings from the CaaS, VMaaS, and BMaaS full-install workflow callers.
- **CI:** Preserved `enable-ai-diagnostic` for runs on `refs/heads/main`.
- **Validation:** Targeted `yamllint` and `git diff --check` passed. Go hooks were blocked by read-only cache paths.
- **Backward compatibility:** No runtime or API changes.

## Risk classification

**risk:ship** — The change is limited to CI configuration, removes duplicate inputs, preserves behavior, and passes targeted validation.

It does not qualify for `risk:show` because it does not change runtime, deployment, security, or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->