### PR TITLE
NO-ISSUE: reject stale metering Watch snapshots

### DIFF
--- a/osac-metering/metering-service/internal/watch/consumer.go
+++ b/osac-metering/metering-service/internal/watch/consumer.go
@@ -172,6 +172,13 @@ func (c *Consumer) handleEvent(ctx context.Context, event *privatev1.Event) erro
 		}
 		return err
 	}
+	if projectionIsAhead(existing, version, currentState, dims) {
+		c.logger.Info("skipping stale Watch event before publication",
+			"resource_id", resourceID,
+			"event_version", version,
+			"projection_version", existing.FulfillmentVersion)
+		return nil
+	}
 
 	if c.shouldSkipUpdate(ctx, event, existing, currentState, dims, version, transitionTime, resourceID) {
 		return nil
@@ -209,6 +216,17 @@ func (c *Consumer) handleEvent(ctx context.Context, event *privatev1.Event) erro
 	projState := c.buildProjectionState(mapper, existing, transitionTime, version, currentState, isBillable, dims)
 
 	if event.GetType() == privatev1.EventType_EVENT_TYPE_OBJECT_DELETED {
+		latest, err := c.store.Get(ctx, resourceID)
+		if err != nil {
+			return fmt.Errorf("rechecking projection for %s: %w", resourceID, err)
+		}
+		if projectionIsAhead(latest, version, currentState, dims) {
+			c.logger.Info("skipping stale delete event before publication",
+				"resource_id", resourceID,
+				"event_version", version,
+				"projection_version", latest.FulfillmentVersion)
+			return nil
+		}
 		if err := c.publishLifecycleEvents(ctx, ce, mapper, event.GetId()); err != nil {
 			return err
 		}
@@ -231,6 +249,18 @@ func (c *Consumer) handleEvent(ctx context.Context, event *privatev1.Event) erro
 // successful publish, replay produces duplicate events (handled by adapter
 // dedup via deterministic CloudEvent IDs).
 func (c *Consumer) publishAndUpsert(ctx context.Context, publish func() error, state projection.ResourceState, resourceID string) error {
+	latest, err := c.store.Get(ctx, resourceID)
+	if err != nil {
+		return fmt.Errorf("rechecking projection for %s: %w", resourceID, err)
+	}
+	if projectionIsAhead(latest, state.FulfillmentVersion, state.CurrentState, state.BillingDimensions) {
+		c.logger.Info("skipping stale Watch event before publication",
+			"resource_id", resourceID,
+			"event_version", state.FulfillmentVersion,
+			"projection_version", latest.FulfillmentVersion)
+		return nil
+	}
+
 	if err := publish(); err != nil {
 		return err
 	}
@@ -244,6 +274,20 @@ func (c *Consumer) publishAndUpsert(ctx context.Context, publish func() error, s
 		return fmt.Errorf("upserting projection for %s: %w", resourceID, err)
 	}
 	return nil
+}
+
+// projectionIsAhead rejects an older snapshot and a conflicting snapshot with
+// the same fulfillment version. A missing projection is always accepted because
+// no ordering information exists until the resource is first observed.
+func projectionIsAhead(existing *projection.ResourceState, version int32, currentState string, dims map[string]any) bool {
+	if existing == nil {
+		return false
+	}
+	if existing.FulfillmentVersion > version {
+		return true
+	}
+	return existing.FulfillmentVersion == version &&
+		(existing.CurrentState != currentState || !events.DimensionsEqual(existing.BillingDimensions, dims))
 }
 
 // handleTransientState updates only FulfillmentVersion and TransitionTime

--- a/osac-metering/metering-service/internal/watch/consumer_test.go
+++ b/osac-metering/metering-service/internal/watch/consumer_test.go
@@ -707,6 +707,7 @@ var _ = Describe("Consumer", func() {
 			}
 
 			ci := makeComputeInstance("vm-del", "tenant-1")
+			ci.Metadata.Version = 2
 			ci.Metadata.DeletionTimestamp = timestamppb.Now()
 			event := &privatev1.Event{
 				Id:      "vm-del",
@@ -735,7 +736,7 @@ var _ = Describe("Consumer", func() {
 			Expect(store.states).ToNot(HaveKey("vm-del"))
 		})
 
-		It("publishes event but skips projection update on stale version", func() {
+		It("does not publish a stale Watch snapshot after a newer snapshot advanced the projection", func() {
 			store := newMockStore()
 			now := time.Now().UTC().Truncate(time.Microsecond)
 			store.states["vm-stale"] = projection.ResourceState{
@@ -744,21 +745,34 @@ var _ = Describe("Consumer", func() {
 				TenantID:           "tenant-1",
 				CurrentState:       "STOPPED",
 				IsBillable:         false,
-				FulfillmentVersion: 10,
+				FulfillmentVersion: 1,
 				BillingDimensions:  map[string]any{},
 				TransitionTime:     now,
 			}
 
-			ci := makeComputeInstance("vm-stale", "tenant-1")
-			ci.Metadata.Version = 5
-			event := &privatev1.Event{
+			newerCI := makeComputeInstance("vm-stale", "tenant-1")
+			newerCI.Metadata.Version = 10
+			newerCI.Status.State = privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_RUNNING
+			newerEvent := &privatev1.Event{
+				Id:      "evt-newer",
+				Type:    privatev1.EventType_EVENT_TYPE_OBJECT_UPDATED,
+				Payload: &privatev1.Event_ComputeInstance{ComputeInstance: newerCI},
+			}
+
+			staleCI := makeComputeInstance("vm-stale", "tenant-1")
+			staleCI.Metadata.Version = 5
+			staleCI.Status.State = privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_STOPPED
+			staleEvent := &privatev1.Event{
 				Id:      "evt-stale",
 				Type:    privatev1.EventType_EVENT_TYPE_OBJECT_UPDATED,
-				Payload: &privatev1.Event_ComputeInstance{ComputeInstance: ci},
+				Payload: &privatev1.Event_ComputeInstance{ComputeInstance: staleCI},
 			}
 
 			stream := &mockWatchStream{
-				responses: []*privatev1.EventsWatchResponse{makeResponse(event)},
+				responses: []*privatev1.EventsWatchResponse{
+					makeResponse(newerEvent),
+					makeResponse(staleEvent),
+				},
 			}
 			client.results = []mockStreamResult{{stream: stream}}
 
@@ -770,11 +784,59 @@ var _ = Describe("Consumer", func() {
 
 			pub.mu.Lock()
 			defer pub.mu.Unlock()
-			Expect(pub.published).To(HaveLen(1), "event published even when projection is stale")
+			Expect(pub.published).To(HaveLen(1))
+			Expect(pub.published[0].ID()).To(Equal("evt-newer"))
 
 			store.mu.Lock()
 			defer store.mu.Unlock()
 			Expect(store.states["vm-stale"].FulfillmentVersion).To(Equal(int32(10)))
+			Expect(store.states["vm-stale"].CurrentState).To(Equal("RUNNING"))
+		})
+
+		It("does not publish a conflicting snapshot with the same fulfillment version", func() {
+			store := newMockStore()
+			now := time.Now().UTC().Truncate(time.Microsecond)
+			store.states["vm-conflict"] = projection.ResourceState{
+				ResourceID:         "vm-conflict",
+				ResourceType:       events.ResourceTypeComputeInstance,
+				TenantID:           "tenant-1",
+				CurrentState:       "RUNNING",
+				IsBillable:         true,
+				FulfillmentVersion: 10,
+				BillingDimensions:  map[string]any{},
+				TransitionTime:     now,
+			}
+
+			ci := makeComputeInstance("vm-conflict", "tenant-1")
+			ci.Metadata.Version = 10
+			ci.Status.State = privatev1.ComputeInstanceState_COMPUTE_INSTANCE_STATE_STOPPED
+			event := &privatev1.Event{
+				Id:      "evt-conflict",
+				Type:    privatev1.EventType_EVENT_TYPE_OBJECT_UPDATED,
+				Payload: &privatev1.Event_ComputeInstance{ComputeInstance: ci},
+			}
+
+			stream := &mockWatchStream{
+				responses: []*privatev1.EventsWatchResponse{makeResponse(event)},
+			}
+			client.results = []mockStreamResult{{stream: stream}}
+
+			pub := &mockPublisher{}
+			consumer := newConsumerWithStore(pub, store)
+
+			done := make(chan error, 1)
+			go func() { done <- consumer.Run(ctx) }()
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+			Eventually(done, time.Second).Should(Receive(BeNil()))
+
+			pub.mu.Lock()
+			defer pub.mu.Unlock()
+			Expect(pub.published).To(BeEmpty())
+
+			store.mu.Lock()
+			defer store.mu.Unlock()
+			Expect(store.states["vm-conflict"].CurrentState).To(Equal("RUNNING"))
 		})
 
 		It("publishes updated.v1 and updates projection on dimension change while billable (RUNNING->RUNNING)", func() {
@@ -1665,6 +1727,7 @@ var _ = Describe("Consumer", func() {
 				"cpu-workers": {HostType: &privatev1.HostTypeReference{Name: "cpu-only"}, Size: proto.Int32(5)},
 				"gpu-workers": {HostType: &privatev1.HostTypeReference{Name: "gpu-h100"}, Size: proto.Int32(4)},
 			})
+			clAtT2.Metadata.Version = 3
 			clAtT2.Status.StateTransitionTime = timestamppb.New(t2)
 			eventT2 := &privatev1.Event{
 				Id:      "evt-t2",


### PR DESCRIPTION
## Summary

- Reject Watch snapshots older than the metering projection before mapping or publishing billing events.
- Reject equal-version snapshots that conflict on state or billing dimensions.
- Recheck the projection immediately before publish to cover reconciliation races.

## Concrete Failure Example

1. Fulfillment emits version 5 with state `RUNNING`.
2. Reconciliation observes version 10 with state `STOPPED` and advances the metering projection.
3. The delayed version-5 Watch event is processed afterward.
4. Before this fix, metering published a new billable `RUNNING` event, then rejected version 5 during projection upsert.

The projection remained `STOPPED`, but Kafka and the billing adapter had already received the stale billable event.

## Validation

- Focused regression and equal-version tests
- `go test -race ./internal/watch -run TestWatch -ginkgo.focus="stale Watch snapshot|conflicting snapshot"`
- `make test` from `osac-metering/`
- `make lint` from `osac-metering/`
- `make build` from `osac-metering/metering-service/`
- `make helm-lint` from `osac-metering/`
