### PR TITLE
OSAC-4925: Scope Netris SecurityGroup ACLs to attached subnets

### DIFF
--- a/osac-aap/collections/ansible_collections/osac/templates/roles/netris/tasks/create_security_group.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/netris/tasks/create_security_group.yaml
@@ -1,8 +1,9 @@
 ---
 # SecurityGroup maps to Netris ACL rules (v1 API)
 # Creates permit ACL rules for each ingress and egress rule in the SecurityGroup CR.
-# ACL rules are created per-subnet in the VN — each subnet maps to a Netris network
+# ACL rules are created per attached subnet — each subnet maps to a Netris network
 # segment, and Netris ACL rules must use subnet CIDRs (not the wider VN CIDR).
+# Attached subnet CIDRs are operator-computed in SecurityGroup.status.
 
 - name: Extract SecurityGroup configuration
   ansible.builtin.set_fact:
@@ -19,7 +20,7 @@
       - "Ingress rules count: {{ ingress_rules | length }}"
       - "Egress rules count: {{ egress_rules | length }}"
 
-- name: Resolve VirtualNetwork UUID to VPC ID and discover subnets
+- name: Resolve VirtualNetwork UUID to VPC ID
   when: sg_virtual_network | length > 0
   block:
     - name: Look up VirtualNetwork CR by UUID label
@@ -44,36 +45,16 @@
         _sg_vpc_id: "{{ (netris_vpc.id | default(1)) }}"
       when: _sg_vn_lookup.resources | length > 0
 
-    - name: Look up all Subnets in this VirtualNetwork
-      kubernetes.core.k8s_info:
-        api_version: osac.openshift.io/v1alpha1
-        kind: Subnet
-        namespace: "{{ security_group.metadata.namespace }}"
-      register: _sg_all_subnets
-      when: _sg_vn_lookup.resources | length > 0
-
-    - name: Filter subnets belonging to this VirtualNetwork
-      ansible.builtin.set_fact:
-        _sg_subnet_cidrs: >-
-          {{ _sg_all_subnets.resources | default([])
-             | selectattr('spec.virtualNetwork', 'defined')
-             | selectattr('spec.virtualNetwork', 'equalto', sg_virtual_network)
-             | map(attribute='spec.ipv4Cidr')
-             | select('defined')
-             | reject('equalto', '')
-             | list }}
-      when: _sg_vn_lookup.resources | length > 0
-
-- name: Default VPC ID and subnet CIDRs if not resolved
+- name: Set scoped subnet CIDRs from SecurityGroup status
   ansible.builtin.set_fact:
     _sg_vpc_id: "{{ _sg_vpc_id | default(1) }}"
-    _sg_subnet_cidrs: "{{ _sg_subnet_cidrs | default(['0.0.0.0/0']) }}"
+    _sg_subnet_cidrs: "{{ security_group.status.attachedSubnetCIDRs | default([]) }}"
 
 - name: Display resolved subnet CIDRs
   ansible.builtin.debug:
-    msg: "ACL rules will be created for subnet CIDRs: {{ _sg_subnet_cidrs }}"
+    msg: "ACL rules will be created for attached subnet CIDRs: {{ _sg_subnet_cidrs }}"
 
-- name: Create ACL rules for ingress (per subnet)
+- name: Create ACL rules for ingress (per attached subnet)
   ansible.builtin.include_role:
     name: netris.controller.acl
     tasks_from: create
@@ -92,9 +73,9 @@
   loop_control:
     index_var: idx
     label: "{{ item.0.protocol | default('all') }}:{{ item.1 }}"
-  when: ingress_rules | length > 0
+  when: ingress_rules | length > 0 and _sg_subnet_cidrs | length > 0
 
-- name: Create ACL rules for egress (per subnet)
+- name: Create ACL rules for egress (per attached subnet)
   ansible.builtin.include_role:
     name: netris.controller.acl
     tasks_from: create
@@ -113,11 +94,11 @@
   loop_control:
     index_var: idx
     label: "{{ item.0.protocol | default('all') }}:{{ item.1 }}"
-  when: egress_rules | length > 0
+  when: egress_rules | length > 0 and _sg_subnet_cidrs | length > 0
 
 - name: Display SecurityGroup creation result
   ansible.builtin.debug:
     msg: >-
       ACL rules created for SecurityGroup '{{ sg_name }}':
-      {{ ingress_rules | length }} ingress × {{ _sg_subnet_cidrs | length }} subnets,
-      {{ egress_rules | length }} egress × {{ _sg_subnet_cidrs | length }} subnets
+      {{ ingress_rules | length }} ingress × {{ _sg_subnet_cidrs | length }} attached subnets,
+      {{ egress_rules | length }} egress × {{ _sg_subnet_cidrs | length }} attached subnets

--- a/osac-aap/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_security_group.yaml
+++ b/osac-aap/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_security_group.yaml
@@ -2,6 +2,7 @@
 # SecurityGroup deletion - removes the corresponding Netris ACL rules.
 # Handles both old-style names (sg-ingress-N) and new per-subnet names
 # (sg-ingress-N-M) for backward compatibility during transition.
+# Uses operator-computed attachedSubnetCIDRs from SecurityGroup.status.
 
 - name: Extract SecurityGroup configuration
   ansible.builtin.set_fact:
@@ -17,27 +18,9 @@
       - "Ingress rules to delete: {{ ingress_rules | length }}"
       - "Egress rules to delete: {{ egress_rules | length }}"
 
-- name: Look up subnets in VirtualNetwork for per-subnet ACL cleanup
-  when: sg_virtual_network | length > 0
-  block:
-    - name: Look up all Subnets
-      kubernetes.core.k8s_info:
-        api_version: osac.openshift.io/v1alpha1
-        kind: Subnet
-        namespace: "{{ security_group.metadata.namespace }}"
-      register: _sg_del_subnets
-
-    - name: Count subnets in this VN
-      ansible.builtin.set_fact:
-        _sg_del_subnet_count: >-
-          {{ _sg_del_subnets.resources | default([])
-             | selectattr('spec.virtualNetwork', 'defined')
-             | selectattr('spec.virtualNetwork', 'equalto', sg_virtual_network)
-             | list | length }}
-
-- name: Default subnet count
+- name: Set scoped subnet CIDR count from SecurityGroup status
   ansible.builtin.set_fact:
-    _sg_del_subnet_count: "{{ _sg_del_subnet_count | default(1) | int }}"
+    _sg_del_subnet_count: "{{ security_group.status.attachedSubnetCIDRs | default([]) | length }}"
 
 - name: Delete per-subnet ACL rules for ingress
   ansible.builtin.include_role:
@@ -51,7 +34,7 @@
   loop: "{{ range(ingress_rules | length) | product(range(_sg_del_subnet_count | int)) | list }}"
   loop_control:
     label: "ingress-rule{{ item.0 }}-subnet{{ item.1 }}"
-  when: ingress_rules | length > 0
+  when: ingress_rules | length > 0 and (_sg_del_subnet_count | int) > 0
 
 - name: Delete legacy ACL rules for ingress
   ansible.builtin.include_role:
@@ -76,7 +59,7 @@
   loop: "{{ range(egress_rules | length) | product(range(_sg_del_subnet_count | int)) | list }}"
   loop_control:
     label: "egress-rule{{ item.0 }}-subnet{{ item.1 }}"
-  when: egress_rules | length > 0
+  when: egress_rules | length > 0 and (_sg_del_subnet_count | int) > 0
 
 - name: Delete legacy ACL rules for egress
   ansible.builtin.include_role:

--- a/osac-operator/api/v1alpha1/securitygroup_types.go
+++ b/osac-operator/api/v1alpha1/securitygroup_types.go
@@ -125,6 +125,16 @@ type SecurityGroupStatus struct {
 	// +kubebuilder:validation:Type=string
 	BackendSecurityGroupID string `json:"backendSecurityGroupId,omitempty"`
 
+	// AttachedSubnetRefs lists Subnet CR names where a workload network attachment
+	// references this SecurityGroup. Operator-computed; used to scope Netris ACL fan-out.
+	// +kubebuilder:validation:Optional
+	AttachedSubnetRefs []string `json:"attachedSubnetRefs,omitempty"`
+
+	// AttachedSubnetCIDRs lists IPv4 CIDRs for AttachedSubnetRefs in the same order.
+	// Consumed by the Netris Ansible role when creating ACL rules.
+	// +kubebuilder:validation:Optional
+	AttachedSubnetCIDRs []string `json:"attachedSubnetCIDRs,omitempty"`
+
 	// Conditions holds an array of metav1.Condition that describe the state of the SecurityGroup
 	// +kubebuilder:validation:Optional
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`

--- a/osac-operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/osac-operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -1059,6 +1059,16 @@ func (in *SecurityGroupStatus) DeepCopyInto(out *SecurityGroupStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.AttachedSubnetRefs != nil {
+		in, out := &in.AttachedSubnetRefs, &out.AttachedSubnetRefs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.AttachedSubnetCIDRs != nil {
+		in, out := &in.AttachedSubnetCIDRs, &out.AttachedSubnetCIDRs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]v1.Condition, len(*in))

--- a/osac-operator/charts/operator-crds/templates/osac.openshift.io_securitygroups.yaml
+++ b/osac-operator/charts/operator-crds/templates/osac.openshift.io_securitygroups.yaml
@@ -153,6 +153,20 @@ spec:
           status:
             description: status defines the observed state of SecurityGroup
             properties:
+              attachedSubnetCIDRs:
+                description: |-
+                  AttachedSubnetCIDRs lists IPv4 CIDRs for AttachedSubnetRefs in the same order.
+                  Consumed by the Netris Ansible role when creating ACL rules.
+                items:
+                  type: string
+                type: array
+              attachedSubnetRefs:
+                description: |-
+                  AttachedSubnetRefs lists Subnet CR names where a workload network attachment
+                  references this SecurityGroup. Operator-computed; used to scope Netris ACL fan-out.
+                items:
+                  type: string
+                type: array
               backendSecurityGroupId:
                 description: BackendSecurityGroupID stores provider-specific security
                   group identifier

--- a/osac-operator/cmd/main.go
+++ b/osac-operator/cmd/main.go
@@ -771,9 +771,10 @@ func setupNetworkingControllers(
 		return err
 	}
 	if err := setupSecurityGroupControllers(
-		mgr, localMgr, grpcConn, networkingNamespace,
+		mgr, localMgr, grpcConn,
+		networkingNamespace, computeInstanceNamespace, clusterOrderNamespace, bareMetalInstanceNamespace,
 		networkingProvider, statusPollInterval, maxJobHistory, targetCluster, resolver,
-		networkProvisioningEnabled,
+		networkProvisioningEnabled, enableBareMetalInstance,
 	); err != nil {
 		return err
 	}
@@ -888,9 +889,10 @@ func setupSubnetControllers(
 
 func setupSecurityGroupControllers(
 	mgr mcmanager.Manager, localMgr ctrl.Manager, grpcConn *grpc.ClientConn,
-	networkingNamespace string, provider provisioning.ProvisioningProvider,
+	networkingNamespace, computeInstanceNamespace, clusterOrderNamespace, baremetalInstanceNamespace string,
+	provider provisioning.ProvisioningProvider,
 	statusPollInterval time.Duration, maxJobHistory int, targetCluster multicluster.ClusterName,
-	resolver *dispatcher.Resolver, networkProvisioningEnabled bool,
+	resolver *dispatcher.Resolver, networkProvisioningEnabled bool, enableBareMetalInstance bool,
 ) error {
 	if grpcConn != nil {
 		if err := controller.NewSecurityGroupFeedbackReconciler(
@@ -900,9 +902,11 @@ func setupSecurityGroupControllers(
 		}
 	}
 	reconciler := controller.NewSecurityGroupReconciler(
-		mgr, networkingNamespace, provider, statusPollInterval, maxJobHistory, targetCluster, resolver,
+		mgr, networkingNamespace, computeInstanceNamespace, clusterOrderNamespace, baremetalInstanceNamespace,
+		provider, statusPollInterval, maxJobHistory, targetCluster, resolver,
 	)
 	reconciler.NetworkProvisioningEnabled = networkProvisioningEnabled
+	reconciler.BareMetalInstanceEnabled = enableBareMetalInstance
 	if err := reconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("securitygroup controller: %w", err)
 	}

--- a/osac-operator/config/crd/bases/osac.openshift.io_securitygroups.yaml
+++ b/osac-operator/config/crd/bases/osac.openshift.io_securitygroups.yaml
@@ -151,6 +151,20 @@ spec:
           status:
             description: status defines the observed state of SecurityGroup
             properties:
+              attachedSubnetCIDRs:
+                description: |-
+                  AttachedSubnetCIDRs lists IPv4 CIDRs for AttachedSubnetRefs in the same order.
+                  Consumed by the Netris Ansible role when creating ACL rules.
+                items:
+                  type: string
+                type: array
+              attachedSubnetRefs:
+                description: |-
+                  AttachedSubnetRefs lists Subnet CR names where a workload network attachment
+                  references this SecurityGroup. Operator-computed; used to scope Netris ACL fan-out.
+                items:
+                  type: string
+                type: array
               backendSecurityGroupId:
                 description: BackendSecurityGroupID stores provider-specific security
                   group identifier

--- a/osac-operator/internal/controller/securitygroup_attachment.go
+++ b/osac-operator/internal/controller/securitygroup_attachment.go
@@ -1,0 +1,266 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	bmfov1alpha1 "github.com/osac-project/osac/bare-metal-fulfillment-operator/api/v1alpha1"
+	"github.com/osac-project/osac/osac-operator/api/v1alpha1"
+)
+
+// attachedSubnetScope holds subnet CR names and IPv4 CIDRs derived from workload
+// network attachments that reference a SecurityGroup.
+type attachedSubnetScope struct {
+	Refs  []string
+	CIDRs []string
+}
+
+// deriveAttachedSubnetScope scans ComputeInstance, ClusterOrder, and BareMetalInstance
+// attachments in the configured namespaces and returns unique Ready subnet refs and
+// CIDRs for the given SecurityGroup. pending is true when an attached subnet exists
+// but is not yet Ready.
+func (r *SecurityGroupReconciler) deriveAttachedSubnetScope(
+	ctx context.Context,
+	sg *v1alpha1.SecurityGroup,
+) (attachedSubnetScope, bool, error) {
+	refSet := make(map[string]struct{})
+
+	if err := r.collectComputeInstanceSubnetRefs(ctx, sg, refSet); err != nil {
+		return attachedSubnetScope{}, false, err
+	}
+	if err := r.collectClusterOrderSubnetRefs(ctx, sg, refSet); err != nil {
+		return attachedSubnetScope{}, false, err
+	}
+	if r.BareMetalInstanceEnabled {
+		if err := r.collectBareMetalInstanceSubnetRefs(ctx, sg, refSet); err != nil {
+			return attachedSubnetScope{}, false, err
+		}
+	}
+
+	refs := sortedKeys(refSet)
+	if len(refs) == 0 {
+		return attachedSubnetScope{}, false, nil
+	}
+
+	scope := attachedSubnetScope{Refs: make([]string, 0, len(refs)), CIDRs: make([]string, 0, len(refs))}
+	for _, ref := range refs {
+		subnet, ready, err := r.resolveAttachedSubnet(ctx, sg.Namespace, sg.Spec.VirtualNetwork, ref)
+		if err != nil {
+			return attachedSubnetScope{}, false, err
+		}
+		if !ready {
+			return attachedSubnetScope{}, true, nil
+		}
+		scope.Refs = append(scope.Refs, subnet.Name)
+		scope.CIDRs = append(scope.CIDRs, subnet.Spec.IPv4CIDR)
+	}
+
+	return scope, false, nil
+}
+
+func (r *SecurityGroupReconciler) collectComputeInstanceSubnetRefs(
+	ctx context.Context,
+	sg *v1alpha1.SecurityGroup,
+	refSet map[string]struct{},
+) error {
+	list := &v1alpha1.ComputeInstanceList{}
+	if err := r.List(ctx, list, client.InNamespace(r.ComputeInstanceNamespace)); err != nil {
+		return fmt.Errorf("listing ComputeInstances: %w", err)
+	}
+	for i := range list.Items {
+		for _, att := range list.Items[i].Spec.NetworkAttachments {
+			if securityGroupRefsContains(att.SecurityGroupRefs, sg.Name) {
+				refSet[att.SubnetRef] = struct{}{}
+			}
+		}
+	}
+	return nil
+}
+
+func (r *SecurityGroupReconciler) collectClusterOrderSubnetRefs(
+	ctx context.Context,
+	sg *v1alpha1.SecurityGroup,
+	refSet map[string]struct{},
+) error {
+	list := &v1alpha1.ClusterOrderList{}
+	if err := r.List(ctx, list, client.InNamespace(r.ClusterOrderNamespace)); err != nil {
+		return fmt.Errorf("listing ClusterOrders: %w", err)
+	}
+	for i := range list.Items {
+		att := list.Items[i].Spec.NetworkAttachment
+		if att == nil {
+			continue
+		}
+		if securityGroupRefsContains(att.SecurityGroupRefs, sg.Name) {
+			refSet[att.SubnetRef] = struct{}{}
+		}
+	}
+	return nil
+}
+
+func (r *SecurityGroupReconciler) collectBareMetalInstanceSubnetRefs(
+	ctx context.Context,
+	sg *v1alpha1.SecurityGroup,
+	refSet map[string]struct{},
+) error {
+	sgUUID := sg.Labels[osacSecurityGroupIDLabel]
+	if sgUUID == "" {
+		return nil
+	}
+
+	list := &bmfov1alpha1.BareMetalInstanceList{}
+	if err := r.List(ctx, list, client.InNamespace(r.BaremetalInstanceNamespace)); err != nil {
+		return fmt.Errorf("listing BareMetalInstances: %w", err)
+	}
+	for i := range list.Items {
+		for _, att := range list.Items[i].Spec.NetworkAttachments {
+			if securityGroupRefsContains(att.SecurityGroupRefs, sgUUID) {
+				refSet[att.SubnetRef] = struct{}{}
+			}
+		}
+	}
+	return nil
+}
+
+func (r *SecurityGroupReconciler) resolveAttachedSubnet(
+	ctx context.Context,
+	namespace, virtualNetwork, ref string,
+) (*v1alpha1.Subnet, bool, error) {
+	subnet := &v1alpha1.Subnet{}
+	err := r.Get(ctx, client.ObjectKey{Namespace: namespace, Name: ref}, subnet)
+	if apierrors.IsNotFound(err) {
+		subnetList := &v1alpha1.SubnetList{}
+		if err := r.List(ctx, subnetList,
+			client.InNamespace(namespace),
+			client.MatchingLabels{osacSubnetIDLabel: ref},
+		); err != nil {
+			return nil, false, fmt.Errorf("listing Subnet by uuid label %q: %w", ref, err)
+		}
+		if len(subnetList.Items) == 0 {
+			return nil, false, fmt.Errorf("subnet %q not found in namespace %q", ref, namespace)
+		}
+		if len(subnetList.Items) > 1 {
+			return nil, false, fmt.Errorf("expected one Subnet with uuid %q, found %d", ref, len(subnetList.Items))
+		}
+		subnet = subnetList.Items[0].DeepCopy()
+	} else if err != nil {
+		return nil, false, fmt.Errorf("getting Subnet %q: %w", ref, err)
+	}
+
+	if subnet.Spec.VirtualNetwork != virtualNetwork {
+		return nil, false, fmt.Errorf(
+			"subnet %q belongs to VirtualNetwork %q, expected %q",
+			subnet.Name, subnet.Spec.VirtualNetwork, virtualNetwork,
+		)
+	}
+	if subnet.Spec.IPv4CIDR == "" {
+		return nil, false, fmt.Errorf("subnet %q has no ipv4Cidr", subnet.Name)
+	}
+	if subnet.Status.Phase != v1alpha1.SubnetPhaseReady {
+		return subnet, false, nil
+	}
+	return subnet, true, nil
+}
+
+func securityGroupRefsContains(refs []string, target string) bool {
+	for _, ref := range refs {
+		if ref == target {
+			return true
+		}
+	}
+	return false
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	keys := make([]string, 0, len(set))
+	for k := range set {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// mapAttachmentsToSecurityGroups enqueues SecurityGroup reconcile requests when a
+// workload network attachment references a SecurityGroup.
+func (r *SecurityGroupReconciler) mapAttachmentsToSecurityGroups(
+	ctx context.Context,
+	obj client.Object,
+) []reconcile.Request {
+	requests := make([]reconcile.Request, 0)
+
+	switch o := obj.(type) {
+	case *v1alpha1.ComputeInstance:
+		for _, att := range o.Spec.NetworkAttachments {
+			for _, sgRef := range att.SecurityGroupRefs {
+				requests = append(requests, reconcile.Request{
+					NamespacedName: client.ObjectKey{Namespace: r.NetworkingNamespace, Name: sgRef},
+				})
+			}
+		}
+	case *v1alpha1.ClusterOrder:
+		if o.Spec.NetworkAttachment != nil {
+			for _, sgRef := range o.Spec.NetworkAttachment.SecurityGroupRefs {
+				requests = append(requests, reconcile.Request{
+					NamespacedName: client.ObjectKey{Namespace: r.NetworkingNamespace, Name: sgRef},
+				})
+			}
+		}
+	case *bmfov1alpha1.BareMetalInstance:
+		for _, att := range o.Spec.NetworkAttachments {
+			for _, sgUUID := range att.SecurityGroupRefs {
+				sgList := &v1alpha1.SecurityGroupList{}
+				if err := r.List(ctx, sgList,
+					client.InNamespace(r.NetworkingNamespace),
+					client.MatchingLabels{osacSecurityGroupIDLabel: sgUUID},
+				); err != nil {
+					continue
+				}
+				for i := range sgList.Items {
+					requests = append(requests, reconcile.Request{
+						NamespacedName: client.ObjectKeyFromObject(&sgList.Items[i]),
+					})
+				}
+			}
+		}
+	}
+
+	return dedupeReconcileRequests(requests)
+}
+
+func dedupeReconcileRequests(requests []reconcile.Request) []reconcile.Request {
+	if len(requests) <= 1 {
+		return requests
+	}
+	seen := make(map[string]struct{}, len(requests))
+	unique := make([]reconcile.Request, 0, len(requests))
+	for _, req := range requests {
+		key := req.Namespace + "/" + req.Name
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		unique = append(unique, req)
+	}
+	return unique
+}

--- a/osac-operator/internal/controller/securitygroup_attachment_test.go
+++ b/osac-operator/internal/controller/securitygroup_attachment_test.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	osacv1alpha1 "github.com/osac-project/osac/osac-operator/api/v1alpha1"
+)
+
+var _ = Describe("deriveAttachedSubnetScope", func() {
+	const (
+		testNS      = "test-namespace"
+		testVNetUID = "test-vnet-uuid"
+	)
+
+	var (
+		ctx        context.Context
+		testScheme *runtime.Scheme
+		reconciler *SecurityGroupReconciler
+		sg         *osacv1alpha1.SecurityGroup
+		subnetA    *osacv1alpha1.Subnet
+		subnetB    *osacv1alpha1.Subnet
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		testScheme = runtime.NewScheme()
+		Expect(osacv1alpha1.AddToScheme(testScheme)).To(Succeed())
+		Expect(scheme.AddToScheme(testScheme)).To(Succeed())
+
+		sg = &osacv1alpha1.SecurityGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-sg",
+				Namespace: testNS,
+			},
+			Spec: osacv1alpha1.SecurityGroupSpec{
+				VirtualNetwork: testVNetUID,
+			},
+		}
+
+		subnetA = &osacv1alpha1.Subnet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "subnet-a",
+				Namespace: testNS,
+			},
+			Spec: osacv1alpha1.SubnetSpec{
+				VirtualNetwork: testVNetUID,
+				IPv4CIDR:       "10.0.1.0/24",
+			},
+		}
+		subnetB = &osacv1alpha1.Subnet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "subnet-b",
+				Namespace: testNS,
+			},
+			Spec: osacv1alpha1.SubnetSpec{
+				VirtualNetwork: testVNetUID,
+				IPv4CIDR:       "10.0.2.0/24",
+			},
+		}
+	})
+
+	setSubnetReady := func(c client.Client, subnet *osacv1alpha1.Subnet) {
+		subnet.Status.Phase = osacv1alpha1.SubnetPhaseReady
+		Expect(c.Status().Update(ctx, subnet)).To(Succeed())
+	}
+
+	It("returns empty scope when no workloads reference the SecurityGroup", func() {
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithObjects(sg, subnetA, subnetB).
+			WithStatusSubresource(&osacv1alpha1.Subnet{}).
+			Build()
+		setSubnetReady(fakeClient, subnetA)
+		setSubnetReady(fakeClient, subnetB)
+
+		reconciler = &SecurityGroupReconciler{
+			Client:                   fakeClient,
+			NetworkingNamespace:      testNS,
+			ComputeInstanceNamespace: testNS,
+			ClusterOrderNamespace:    testNS,
+		}
+
+		scope, pending, err := reconciler.deriveAttachedSubnetScope(ctx, sg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pending).To(BeFalse())
+		Expect(scope.Refs).To(BeEmpty())
+		Expect(scope.CIDRs).To(BeEmpty())
+	})
+
+	It("scopes to subnet-a only when ComputeInstance attaches SG on subnet-a", func() {
+		ci := &osacv1alpha1.ComputeInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-ci",
+				Namespace: testNS,
+			},
+			Spec: osacv1alpha1.ComputeInstanceSpec{
+				TemplateID: "default",
+				NetworkAttachments: []osacv1alpha1.ComputeNetworkAttachment{
+					{
+						SubnetRef:         "subnet-a",
+						SecurityGroupRefs: []string{"test-sg"},
+					},
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithObjects(sg, subnetA, subnetB, ci).
+			WithStatusSubresource(&osacv1alpha1.Subnet{}).
+			Build()
+		setSubnetReady(fakeClient, subnetA)
+		setSubnetReady(fakeClient, subnetB)
+
+		reconciler = &SecurityGroupReconciler{
+			Client:                   fakeClient,
+			NetworkingNamespace:      testNS,
+			ComputeInstanceNamespace: testNS,
+			ClusterOrderNamespace:    testNS,
+		}
+
+		scope, pending, err := reconciler.deriveAttachedSubnetScope(ctx, sg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pending).To(BeFalse())
+		Expect(scope.Refs).To(Equal([]string{"subnet-a"}))
+		Expect(scope.CIDRs).To(Equal([]string{"10.0.1.0/24"}))
+	})
+
+	It("includes subnet from ClusterOrder network attachment", func() {
+		co := &osacv1alpha1.ClusterOrder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cluster",
+				Namespace: testNS,
+			},
+			Spec: osacv1alpha1.ClusterOrderSpec{
+				TemplateID: "default",
+				NetworkAttachment: &osacv1alpha1.ClusterNetworkAttachment{
+					SubnetRef:         "subnet-a",
+					SecurityGroupRefs: []string{"test-sg"},
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithObjects(sg, subnetA, co).
+			WithStatusSubresource(&osacv1alpha1.Subnet{}).
+			Build()
+		setSubnetReady(fakeClient, subnetA)
+
+		reconciler = &SecurityGroupReconciler{
+			Client:                   fakeClient,
+			NetworkingNamespace:      testNS,
+			ComputeInstanceNamespace: testNS,
+			ClusterOrderNamespace:    testNS,
+		}
+
+		scope, pending, err := reconciler.deriveAttachedSubnetScope(ctx, sg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pending).To(BeFalse())
+		Expect(scope.Refs).To(Equal([]string{"subnet-a"}))
+		Expect(scope.CIDRs).To(Equal([]string{"10.0.1.0/24"}))
+	})
+
+	It("requeues when an attached subnet is not Ready", func() {
+		ci := &osacv1alpha1.ComputeInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-ci",
+				Namespace: testNS,
+			},
+			Spec: osacv1alpha1.ComputeInstanceSpec{
+				TemplateID: "default",
+				NetworkAttachments: []osacv1alpha1.ComputeNetworkAttachment{
+					{
+						SubnetRef:         "subnet-a",
+						SecurityGroupRefs: []string{"test-sg"},
+					},
+				},
+			},
+		}
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithObjects(sg, subnetA, ci).
+			WithStatusSubresource(&osacv1alpha1.Subnet{}).
+			Build()
+
+		reconciler = &SecurityGroupReconciler{
+			Client:                   fakeClient,
+			NetworkingNamespace:      testNS,
+			ComputeInstanceNamespace: testNS,
+			ClusterOrderNamespace:    testNS,
+		}
+
+		scope, pending, err := reconciler.deriveAttachedSubnetScope(ctx, sg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pending).To(BeTrue())
+		Expect(scope.Refs).To(BeEmpty())
+		Expect(scope.CIDRs).To(BeEmpty())
+	})
+})

--- a/osac-operator/internal/controller/securitygroup_controller.go
+++ b/osac-operator/internal/controller/securitygroup_controller.go
@@ -29,10 +29,12 @@ import (
 	controllerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	mcbuilder "sigs.k8s.io/multicluster-runtime/pkg/builder"
+	mchandler "sigs.k8s.io/multicluster-runtime/pkg/handler"
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 	mc "sigs.k8s.io/multicluster-runtime/pkg/multicluster"
 	mcreconcile "sigs.k8s.io/multicluster-runtime/pkg/reconcile"
 
+	bmfov1alpha1 "github.com/osac-project/osac/bare-metal-fulfillment-operator/api/v1alpha1"
 	"github.com/osac-project/osac/osac-operator/api/v1alpha1"
 	"github.com/osac-project/osac/osac-operator/pkg/dispatcher"
 	"github.com/osac-project/osac/osac-operator/pkg/provisioning"
@@ -48,12 +50,16 @@ type SecurityGroupReconciler struct {
 	APIReader client.Reader
 	Scheme    *runtime.Scheme
 	// mgr and targetCluster are stored for future multi-cluster target client resolution
-	mgr                  mcmanager.Manager
-	NetworkingNamespace  string
-	ProvisioningProvider provisioning.ProvisioningProvider
-	StatusPollInterval   time.Duration
-	MaxJobHistory        int
-	targetCluster        mc.ClusterName
+	mgr                        mcmanager.Manager
+	NetworkingNamespace        string
+	ComputeInstanceNamespace   string
+	ClusterOrderNamespace      string
+	BaremetalInstanceNamespace string
+	BareMetalInstanceEnabled   bool
+	ProvisioningProvider       provisioning.ProvisioningProvider
+	StatusPollInterval         time.Duration
+	MaxJobHistory              int
+	targetCluster              mc.ClusterName
 	// Resolver resolves a NetworkClass to its registered managers. Nil when the
 	// two-manager model isn't configured (no gRPC connection / networking namespace),
 	// in which case the controller always uses the legacy implementation-strategy path.
@@ -66,7 +72,7 @@ type SecurityGroupReconciler struct {
 // NewSecurityGroupReconciler creates a new reconciler for SecurityGroup resources.
 func NewSecurityGroupReconciler(
 	mgr mcmanager.Manager,
-	networkingNamespace string,
+	networkingNamespace, computeInstanceNamespace, clusterOrderNamespace, baremetalInstanceNamespace string,
 	provisioningProvider provisioning.ProvisioningProvider,
 	statusPollInterval time.Duration,
 	maxJobHistory int,
@@ -82,17 +88,29 @@ func NewSecurityGroupReconciler(
 	if maxJobHistory <= 0 {
 		maxJobHistory = provisioning.DefaultMaxJobHistory
 	}
+	if computeInstanceNamespace == "" {
+		computeInstanceNamespace = defaultComputeInstanceNamespace
+	}
+	if clusterOrderNamespace == "" {
+		clusterOrderNamespace = defaultClusterOrderNamespace
+	}
+	if baremetalInstanceNamespace == "" {
+		baremetalInstanceNamespace = DefaultBareMetalInstanceNamespace
+	}
 	return &SecurityGroupReconciler{
-		Client:               mgr.GetLocalManager().GetClient(),
-		APIReader:            mgr.GetLocalManager().GetAPIReader(),
-		Scheme:               mgr.GetLocalManager().GetScheme(),
-		mgr:                  mgr,
-		NetworkingNamespace:  networkingNamespace,
-		ProvisioningProvider: provisioningProvider,
-		StatusPollInterval:   statusPollInterval,
-		MaxJobHistory:        maxJobHistory,
-		targetCluster:        targetCluster,
-		Resolver:             resolver,
+		Client:                     mgr.GetLocalManager().GetClient(),
+		APIReader:                  mgr.GetLocalManager().GetAPIReader(),
+		Scheme:                     mgr.GetLocalManager().GetScheme(),
+		mgr:                        mgr,
+		NetworkingNamespace:        networkingNamespace,
+		ComputeInstanceNamespace:   computeInstanceNamespace,
+		ClusterOrderNamespace:      clusterOrderNamespace,
+		BaremetalInstanceNamespace: baremetalInstanceNamespace,
+		ProvisioningProvider:       provisioningProvider,
+		StatusPollInterval:         statusPollInterval,
+		MaxJobHistory:              maxJobHistory,
+		targetCluster:              targetCluster,
+		Resolver:                   resolver,
 	}
 }
 
@@ -100,6 +118,10 @@ func NewSecurityGroupReconciler(
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=securitygroups/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=securitygroups/finalizers,verbs=update
 // +kubebuilder:rbac:groups=osac.openshift.io,resources=virtualnetworks,verbs=get;list;watch
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=computeinstances,verbs=get;list;watch
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=clusterorders,verbs=get;list;watch
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=baremetalinstances,verbs=get;list;watch
+// +kubebuilder:rbac:groups=osac.openshift.io,resources=subnets,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -182,32 +204,20 @@ func (r *SecurityGroupReconciler) handleUpdate(ctx context.Context, sg *v1alpha1
 			sg.Spec.VirtualNetwork, len(vnetList.Items))
 	} else if len(vnetList.Items) == 1 {
 		networkClassID = vnetList.Items[0].Spec.NetworkClass
-
-		// Gate: at least one subnet must be Ready before creating SG ACL rules,
-		// because the ACL fan-out uses per-subnet CIDRs. Subnets don't carry
-		// the VN UUID label — filter by spec.VirtualNetwork instead.
-		subnetList := &v1alpha1.SubnetList{}
-		if err := r.List(ctx, subnetList,
-			client.InNamespace(sg.Namespace),
-		); err != nil {
-			return ctrl.Result{}, err
-		}
-		hasReadySubnet := false
-		for i := range subnetList.Items {
-			if subnetList.Items[i].Spec.VirtualNetwork == sg.Spec.VirtualNetwork &&
-				subnetList.Items[i].Status.Phase == v1alpha1.SubnetPhaseReady {
-				hasReadySubnet = true
-				break
-			}
-		}
-		if !hasReadySubnet {
-			log.Info("no Ready subnets in parent VirtualNetwork, requeueing",
-				"virtualNetwork", vnetList.Items[0].Name)
-			return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
-		}
 	} else {
 		log.Info("parent VirtualNetwork not found, using legacy implementation strategy", "uuid", sg.Spec.VirtualNetwork)
 	}
+
+	scope, pending, err := r.deriveAttachedSubnetScope(ctx, sg)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if pending {
+		log.Info("attached subnet not Ready, requeueing", "securityGroup", sg.Name)
+		return ctrl.Result{RequeueAfter: defaultPreconditionRequeueInterval}, nil
+	}
+	sg.Status.AttachedSubnetRefs = scope.Refs
+	sg.Status.AttachedSubnetCIDRs = scope.CIDRs
 
 	// resolveImplementationStrategy returns "" when the dispatcher path isn't available
 	// (resolver nil, networkClassID empty, or no manager configured). SecurityGroup
@@ -235,7 +245,8 @@ func (r *SecurityGroupReconciler) handleUpdate(ctx context.Context, sg *v1alpha1
 	desiredVersion, err := provisioning.ComputeDesiredConfigVersion(struct {
 		Spec                   v1alpha1.SecurityGroupSpec
 		ImplementationStrategy string
-	}{sg.Spec, implementationStrategy})
+		AttachedSubnetRefs     []string
+	}{sg.Spec, implementationStrategy, scope.Refs})
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to compute desired config version: %w", err)
 	}
@@ -343,10 +354,33 @@ func (r *SecurityGroupReconciler) updateStatusWithRetry(ctx context.Context, key
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SecurityGroupReconciler) SetupWithManager(mgr mcmanager.Manager) error {
-	return mcbuilder.ControllerManagedBy(mgr).
+	b := mcbuilder.ControllerManagedBy(mgr).
 		For(&v1alpha1.SecurityGroup{},
 			mcbuilder.WithPredicates(NetworkingNamespacePredicate(r.NetworkingNamespace)),
 			mcbuilder.WithEngageWithLocalCluster(true),
 			mcbuilder.WithEngageWithProviderClusters(false)).
-		Complete(r)
+		Watches(
+			&v1alpha1.ComputeInstance{},
+			mchandler.EnqueueRequestsFromMapFunc(r.mapAttachmentsToSecurityGroups),
+			mcbuilder.WithPredicates(ComputeInstanceNamespacePredicate(r.ComputeInstanceNamespace)),
+			mcbuilder.WithEngageWithLocalCluster(true),
+			mcbuilder.WithEngageWithProviderClusters(false),
+		).
+		Watches(
+			&v1alpha1.ClusterOrder{},
+			mchandler.EnqueueRequestsFromMapFunc(r.mapAttachmentsToSecurityGroups),
+			mcbuilder.WithPredicates(NamespacePredicate(r.ClusterOrderNamespace)),
+			mcbuilder.WithEngageWithLocalCluster(true),
+			mcbuilder.WithEngageWithProviderClusters(false),
+		)
+	if r.BareMetalInstanceEnabled {
+		b = b.Watches(
+			&bmfov1alpha1.BareMetalInstance{},
+			mchandler.EnqueueRequestsFromMapFunc(r.mapAttachmentsToSecurityGroups),
+			mcbuilder.WithPredicates(BareMetalInstanceNamespacePredicate(r.BaremetalInstanceNamespace)),
+			mcbuilder.WithEngageWithLocalCluster(true),
+			mcbuilder.WithEngageWithProviderClusters(false),
+		)
+	}
+	return b.Complete(r)
 }

--- a/osac-operator/internal/controller/securitygroup_controller_test.go
+++ b/osac-operator/internal/controller/securitygroup_controller_test.go
@@ -103,7 +103,7 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			},
 		}
 
-		// Create Ready subnet fixture so the subnet-readiness gate passes by default
+		// Ready subnet fixture used when tests attach the SG to a workload.
 		readySubnet = &osacv1alpha1.Subnet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-subnet",
@@ -114,6 +114,7 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			},
 			Spec: osacv1alpha1.SubnetSpec{
 				VirtualNetwork: "test-vnet-uuid",
+				IPv4CIDR:       "10.0.1.0/24",
 			},
 		}
 
@@ -139,11 +140,59 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			APIReader:                  fakeClient,
 			Scheme:                     testScheme,
 			NetworkingNamespace:        "test-namespace",
+			ComputeInstanceNamespace:   "test-namespace",
+			ClusterOrderNamespace:      "test-namespace",
 			ProvisioningProvider:       mockProvider,
 			StatusPollInterval:         1 * time.Second,
 			MaxJobHistory:              10,
 			NetworkProvisioningEnabled: true,
 		}
+	})
+
+	Context("attached subnet scope", func() {
+		It("populates status from ComputeInstance attachment and excludes other subnets", func() {
+			subnetB := &osacv1alpha1.Subnet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "subnet-b",
+					Namespace: "test-namespace",
+				},
+				Spec: osacv1alpha1.SubnetSpec{
+					VirtualNetwork: "test-vnet-uuid",
+					IPv4CIDR:       "10.0.2.0/24",
+				},
+			}
+			Expect(fakeClient.Create(ctx, subnetB)).To(Succeed())
+			subnetB.Status.Phase = osacv1alpha1.SubnetPhaseReady
+			Expect(fakeClient.Status().Update(ctx, subnetB)).To(Succeed())
+
+			ci := &osacv1alpha1.ComputeInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ci",
+					Namespace: "test-namespace",
+				},
+				Spec: osacv1alpha1.ComputeInstanceSpec{
+					TemplateID: "default",
+					NetworkAttachments: []osacv1alpha1.ComputeNetworkAttachment{
+						{
+							SubnetRef:         readySubnet.Name,
+							SecurityGroupRefs: []string{sg.Name},
+						},
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, ci)).To(Succeed())
+
+			key := types.NamespacedName{Name: sg.Name, Namespace: sg.Namespace}
+			_, err := reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &osacv1alpha1.SecurityGroup{}
+			Expect(fakeClient.Get(ctx, key, updated)).To(Succeed())
+			Expect(updated.Status.AttachedSubnetRefs).To(Equal([]string{readySubnet.Name}))
+			Expect(updated.Status.AttachedSubnetCIDRs).To(Equal([]string{"10.0.1.0/24"}))
+		})
 	})
 
 	Context("Reconcile", func() {
@@ -689,25 +738,24 @@ var _ = Describe("SecurityGroupReconciler", func() {
 		})
 	})
 
-	Context("subnet readiness gate", func() {
-		It("should requeue when parent VirtualNetwork has no Ready subnets", func() {
-			// Build a client WITHOUT any subnets
+	Context("attached subnet readiness gate", func() {
+		It("should provision with empty scope when no workloads reference the SecurityGroup", func() {
 			testScheme := runtime.NewScheme()
 			Expect(osacv1alpha1.AddToScheme(testScheme)).To(Succeed())
 			Expect(scheme.AddToScheme(testScheme)).To(Succeed())
 
-			noSubnetSG := &osacv1alpha1.SecurityGroup{
+			noAttachmentSG := &osacv1alpha1.SecurityGroup{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "sg-no-subnets",
+					Name:      "sg-no-attachments",
 					Namespace: "test-namespace",
 				},
 				Spec: osacv1alpha1.SecurityGroupSpec{
 					VirtualNetwork: "test-vnet-uuid",
 				},
 			}
-			noSubnetClient := fake.NewClientBuilder().
+			noAttachmentClient := fake.NewClientBuilder().
 				WithScheme(testScheme).
-				WithObjects(vnet, noSubnetSG).
+				WithObjects(vnet, noAttachmentSG).
 				WithStatusSubresource(&osacv1alpha1.SecurityGroup{}).
 				Build()
 
@@ -715,36 +763,40 @@ var _ = Describe("SecurityGroupReconciler", func() {
 			mockProvider.triggerProvisionFunc = func(ctx context.Context, resource client.Object) (*provisioning.ProvisionResult, error) {
 				provisionCalled = true
 				return &provisioning.ProvisionResult{
-					JobID:        "job-should-not-fire",
+					JobID:        "job-empty-scope",
 					InitialState: osacv1alpha1.JobStatePending,
 				}, nil
 			}
 
 			r := &SecurityGroupReconciler{
-				Client:                     noSubnetClient,
-				APIReader:                  noSubnetClient,
+				Client:                     noAttachmentClient,
+				APIReader:                  noAttachmentClient,
 				Scheme:                     testScheme,
 				NetworkingNamespace:        "test-namespace",
+				ComputeInstanceNamespace:   "test-namespace",
+				ClusterOrderNamespace:      "test-namespace",
 				ProvisioningProvider:       mockProvider,
 				StatusPollInterval:         1 * time.Second,
 				MaxJobHistory:              10,
 				NetworkProvisioningEnabled: true,
 			}
 
-			key := types.NamespacedName{Name: noSubnetSG.Name, Namespace: noSubnetSG.Namespace}
+			key := types.NamespacedName{Name: noAttachmentSG.Name, Namespace: noAttachmentSG.Namespace}
 
-			// First reconcile adds finalizer
 			_, err := r.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
-
-			// Second reconcile should requeue because no subnets exist
 			result, err := r.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.RequeueAfter).To(Equal(defaultPreconditionRequeueInterval))
-			Expect(provisionCalled).To(BeFalse())
+			Expect(result.RequeueAfter).To(BeZero())
+			Expect(provisionCalled).To(BeTrue())
+
+			updated := &osacv1alpha1.SecurityGroup{}
+			Expect(noAttachmentClient.Get(ctx, key, updated)).To(Succeed())
+			Expect(updated.Status.AttachedSubnetRefs).To(BeEmpty())
+			Expect(updated.Status.AttachedSubnetCIDRs).To(BeEmpty())
 		})
 
-		It("should requeue when subnets exist but none are Ready", func() {
+		It("should requeue when an attached subnet is not Ready", func() {
 			testScheme := runtime.NewScheme()
 			Expect(osacv1alpha1.AddToScheme(testScheme)).To(Succeed())
 			Expect(scheme.AddToScheme(testScheme)).To(Succeed())
@@ -753,12 +805,10 @@ var _ = Describe("SecurityGroupReconciler", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "progressing-subnet",
 					Namespace: "test-namespace",
-					Labels: map[string]string{
-						osacVirtualNetworkIDLabel: "test-vnet-uuid",
-					},
 				},
 				Spec: osacv1alpha1.SubnetSpec{
 					VirtualNetwork: "test-vnet-uuid",
+					IPv4CIDR:       "10.0.3.0/24",
 				},
 			}
 			progressingSG := &osacv1alpha1.SecurityGroup{
@@ -770,13 +820,27 @@ var _ = Describe("SecurityGroupReconciler", func() {
 					VirtualNetwork: "test-vnet-uuid",
 				},
 			}
+			ci := &osacv1alpha1.ComputeInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ci-progressing-subnet",
+					Namespace: "test-namespace",
+				},
+				Spec: osacv1alpha1.ComputeInstanceSpec{
+					TemplateID: "default",
+					NetworkAttachments: []osacv1alpha1.ComputeNetworkAttachment{
+						{
+							SubnetRef:         progressingSubnet.Name,
+							SecurityGroupRefs: []string{progressingSG.Name},
+						},
+					},
+				},
+			}
 			progressingClient := fake.NewClientBuilder().
 				WithScheme(testScheme).
-				WithObjects(vnet, progressingSG, progressingSubnet).
+				WithObjects(vnet, progressingSG, progressingSubnet, ci).
 				WithStatusSubresource(&osacv1alpha1.SecurityGroup{}, &osacv1alpha1.Subnet{}).
 				Build()
 
-			// Set subnet phase to Progressing
 			progressingSubnet.Status.Phase = osacv1alpha1.SubnetPhaseProgressing
 			Expect(progressingClient.Status().Update(ctx, progressingSubnet)).To(Succeed())
 
@@ -794,6 +858,8 @@ var _ = Describe("SecurityGroupReconciler", func() {
 				APIReader:                  progressingClient,
 				Scheme:                     testScheme,
 				NetworkingNamespace:        "test-namespace",
+				ComputeInstanceNamespace:   "test-namespace",
+				ClusterOrderNamespace:      "test-namespace",
 				ProvisioningProvider:       mockProvider,
 				StatusPollInterval:         1 * time.Second,
 				MaxJobHistory:              10,
@@ -802,18 +868,33 @@ var _ = Describe("SecurityGroupReconciler", func() {
 
 			key := types.NamespacedName{Name: progressingSG.Name, Namespace: progressingSG.Namespace}
 
-			// First reconcile adds finalizer
 			_, err := r.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Second reconcile should requeue because subnet is not Ready
 			result, err := r.Reconcile(ctx, mcreconcile.Request{Request: ctrl.Request{NamespacedName: key}})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RequeueAfter).To(Equal(defaultPreconditionRequeueInterval))
 			Expect(provisionCalled).To(BeFalse())
 		})
 
-		It("should proceed to provisioning when at least one subnet is Ready", func() {
+		It("should proceed to provisioning when a referenced subnet is Ready", func() {
+			ci := &osacv1alpha1.ComputeInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ci-ready-subnet",
+					Namespace: "test-namespace",
+				},
+				Spec: osacv1alpha1.ComputeInstanceSpec{
+					TemplateID: "default",
+					NetworkAttachments: []osacv1alpha1.ComputeNetworkAttachment{
+						{
+							SubnetRef:         readySubnet.Name,
+							SecurityGroupRefs: []string{sg.Name},
+						},
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, ci)).To(Succeed())
+
 			key := types.NamespacedName{Name: sg.Name, Namespace: sg.Namespace}
 
 			provisionCalled := false


### PR DESCRIPTION
Derive attached subnet scope from workload network attachments in the osac-operator, persist it on `SecurityGroup.status`, and teach the Netris Ansible role to fan ACL rules only across those CIDRs instead of every subnet in the parent VirtualNetwork.

## Summary

Fixes OSAC-4925: Netris SecurityGroup ACL fan-out was applying rules to every subnet CIDR in the parent VirtualNetwork. Scope is now derived from workload `network_attachments` on ComputeInstance, ClusterOrder, and (when `enableBareMetalInstance` is true) BareMetalInstance.

## Changes

### API / CRD
- Add `status.attachedSubnetRefs` and `status.attachedSubnetCIDRs` to SecurityGroup (Go types, deepcopy, CRD bases, operator-crds chart).
- No proto or fulfillment-service changes.

### osac-operator
- New `securitygroup_attachment.go`: `deriveAttachedSubnetScope()` scans CI/ClusterOrder/BMI attachments referencing the SG, validates subnet VN membership/readiness/IPv4 CIDR, and returns sorted refs/CIDRs.
- Replace the VN-wide "any Ready subnet" precondition with attachment-based scope: requeue when a referenced subnet is not Ready; empty scope when no workloads reference the SG.
- Persist scope on status before provisioning; include sorted `attachedSubnetRefs` in the config version hash so attachment changes trigger reprovision.
- Watch ComputeInstance, ClusterOrder, and BareMetalInstance (when enabled) for attachment changes via `mapAttachmentsToSecurityGroups`.
- Pass compute/cluster/BMI namespaces and the BMI feature flag from `main.go` into the SG reconciler.
- Add kubebuilder RBAC markers documenting list/watch on workloads and subnets (operator ClusterRole already grants these verbs; no manifest change in this PR).

### osac-aap (Netris)
- `create_security_group.yaml`: read `status.attachedSubnetCIDRs` instead of listing all VN subnets; remove the `0.0.0.0/0` fallback; skip ACL creates when scope is empty.
- `delete_security_group.yaml`: use attached CIDR count from status instead of VN subnet discovery; skip per-subnet deletes when scope is empty.

### Tests
- `securitygroup_attachment_test.go`: attachment discovery, unrelated subnet exclusion, not-Ready requeue.
- `securitygroup_controller_test.go`: status population from CI attachment, empty-scope provisioning, attached-subnet readiness gate.

## OSAC-4888 coordination

Related: OSAC-4888 (stale Netris ACL reconcile on rule updates).

- **In scope here:** Create/delete ACL fan-out limited to attached subnet CIDRs; config version bumps when the attachment set changes.
- **Out of scope:** Pruning stale ACL rows after ingress/egress rule edits, or after scope shrink without a full reprovision, may still need OSAC-4888 follow-up.

## Backward compatibility

- Existing SecurityGroup CRs remain valid (new status fields are optional).
- **Behavior change:** SGs with no workload attachments now provision with empty ACL scope and can reach Ready (previously blocked until any VN subnet was Ready, then ACLs fanned out to all VN subnets).
- SGs with attachments wait until referenced subnets are Ready; invalid or missing subnets fail reconciliation instead of falling back to broad scope.

## Test plan

- [x] `cd osac-operator && make test` (SecurityGroup controller + attachment unit tests)
- [ ] osac-aap lint (template-only Ansible changes)
- [ ] Manual/lab: VN with two subnets, SG attached on one CI → ACLs only on the attached CIDR

## Risk classification

**risk:show** — Changes SecurityGroup reconciliation, CRD status, workload watches, and Netris ACL enforcement scope. Narrows fabric policy to attached subnets and can change behavior for existing SGs that previously received VN-wide ACLs.

Not **risk:ask**: validation, requeue handling, CRD updates, and controller tests are included. Not **risk:ship**: security enforcement changes across multiple resource types.