### PR TITLE
OSAC-4922: Default networking resources enter PENDING instead of rejecting deletion

### DIFF
--- a/fulfillment-service/internal/servers/default_networking_provisioner.go
+++ b/fulfillment-service/internal/servers/default_networking_provisioner.go
@@ -23,6 +23,7 @@ import (
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	privatev1 "github.com/osac-project/osac/fulfillment-service/internal/api/osac/private/v1"
 	"github.com/osac-project/osac/fulfillment-service/internal/auth"
@@ -40,6 +41,21 @@ func validateNotDefault(labels map[string]string, resourceType string) error {
 			"cannot delete default %s: default networking resources are system-managed", resourceType)
 	}
 	return nil
+}
+
+func validateDefaultLabelUpdate(
+	existingLabels, updatedLabels map[string]string,
+	updateMask *fieldmaskpb.FieldMask,
+	resourceType string,
+) error {
+	if existingLabels[defaultLabel] != "true" || !updateIncludesField(updateMask, "metadata.labels") {
+		return nil
+	}
+	if updatedLabels[defaultLabel] == "true" {
+		return nil
+	}
+	return grpcstatus.Errorf(grpccodes.FailedPrecondition,
+		"cannot modify default %s: default networking resources are system-managed", resourceType)
 }
 
 type DefaultNetworkingProvisionerBuilder struct {

--- a/fulfillment-service/internal/servers/private_nat_gateways_server.go
+++ b/fulfillment-service/internal/servers/private_nat_gateways_server.go
@@ -208,15 +208,25 @@ func (s *PrivateNATGatewaysServer) Update(ctx context.Context,
 		return
 	}
 
+	getRequest := &privatev1.NATGatewaysGetRequest{}
+	getRequest.SetId(id)
+	var getResponse *privatev1.NATGatewaysGetResponse
+	err = s.generic.Get(ctx, getRequest, &getResponse)
+	if err != nil {
+		return
+	}
+
+	if err = validateDefaultLabelUpdate(
+		getResponse.GetObject().GetMetadata().GetLabels(),
+		request.GetObject().GetMetadata().GetLabels(),
+		request.GetUpdateMask(),
+		"NAT gateway",
+	); err != nil {
+		return
+	}
+
 	mask := request.GetUpdateMask()
 	if updateIncludesField(mask, "spec.virtual_network", "spec.external_ip") {
-		getRequest := &privatev1.NATGatewaysGetRequest{}
-		getRequest.SetId(id)
-		var getResponse *privatev1.NATGatewaysGetResponse
-		err = s.generic.Get(ctx, getRequest, &getResponse)
-		if err != nil {
-			return
-		}
 		err = validateImmutableFieldsNATGateway(request.GetObject(), getResponse.GetObject())
 		if err != nil {
 			return

--- a/fulfillment-service/internal/servers/private_nat_gateways_server_test.go
+++ b/fulfillment-service/internal/servers/private_nat_gateways_server_test.go
@@ -690,6 +690,7 @@ var _ = Describe("Private NAT gateways server", func() {
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
+			stateBeforeDelete := createResponse.GetObject().GetStatus().GetState()
 
 			_, err = natGatewaysServer.Delete(ctx, privatev1.NATGatewaysDeleteRequest_builder{
 				Id: createResponse.GetObject().GetId(),
@@ -700,6 +701,12 @@ var _ = Describe("Private NAT gateways server", func() {
 			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
 			Expect(err.Error()).To(ContainSubstring("default"))
 			Expect(err.Error()).To(ContainSubstring("system-managed"))
+			getResponse, err := natGatewaysServer.Get(ctx, privatev1.NATGatewaysGetRequest_builder{
+				Id: createResponse.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetMetadata().GetDeletionTimestamp()).To(BeNil())
+			Expect(getResponse.GetObject().GetStatus().GetState()).To(Equal(stateBeforeDelete))
 		})
 	})
 })

--- a/fulfillment-service/internal/servers/private_nat_gateways_server_test.go
+++ b/fulfillment-service/internal/servers/private_nat_gateways_server_test.go
@@ -708,5 +708,42 @@ var _ = Describe("Private NAT gateways server", func() {
 			Expect(getResponse.GetObject().GetMetadata().GetDeletionTimestamp()).To(BeNil())
 			Expect(getResponse.GetObject().GetStatus().GetState()).To(Equal(stateBeforeDelete))
 		})
+
+		It("blocks deletion after an update omits the default label", func() {
+			vnID := createVirtualNetwork()
+			eip := createAllocatedExternalIP()
+			createResp, err := natGatewaysServer.Create(ctx, privatev1.NATGatewaysCreateRequest_builder{
+				Object: privatev1.NATGateway_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:   "default-nat-gateway-update",
+						Tenant: testTenant,
+						Labels: map[string]string{"osac.openshift.io/default": "true"},
+					}.Build(),
+					Spec: privatev1.NATGatewaySpec_builder{
+						VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vnID}.Build(),
+						ExternalIp:     privatev1.ExternalIPLocalReference_builder{Id: eip.GetId()}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			object := createResp.GetObject()
+			object.GetMetadata().SetLabels(map[string]string{"env": "test"})
+			_, err = natGatewaysServer.Update(ctx, privatev1.NATGatewaysUpdateRequest_builder{Object: object}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+
+			_, err = natGatewaysServer.Delete(ctx, privatev1.NATGatewaysDeleteRequest_builder{Id: object.GetId()}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok = grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+
+			getResp, err := natGatewaysServer.Get(ctx, privatev1.NATGatewaysGetRequest_builder{Id: object.GetId()}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResp.GetObject().GetMetadata().GetLabels()).To(HaveKeyWithValue("osac.openshift.io/default", "true"))
+		})
 	})
 })

--- a/fulfillment-service/internal/servers/private_projects_server_test.go
+++ b/fulfillment-service/internal/servers/private_projects_server_test.go
@@ -378,6 +378,18 @@ var _ = Describe("Private projects server", func() {
 				Do(ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vnList.GetItems()).To(BeEmpty())
+
+			subnetList, err := provisioner.subnetDao.List().
+				SetFilter("this.metadata.tenant == 'my-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(subnetList.GetItems()).To(BeEmpty())
+
+			sgList, err := provisioner.securityGroupDao.List().
+				SetFilter("this.metadata.tenant == 'my-tenant'").
+				Do(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sgList.GetItems()).To(BeEmpty())
 		})
 
 		It("still deletes the root project when there is no default networking to deprovision", func() {

--- a/fulfillment-service/internal/servers/private_security_groups_server.go
+++ b/fulfillment-service/internal/servers/private_security_groups_server.go
@@ -187,6 +187,14 @@ func (s *PrivateSecurityGroupsServer) Update(ctx context.Context,
 	}
 
 	existingSecurityGroup := getResponse.GetObject()
+	if err = validateDefaultLabelUpdate(
+		existingSecurityGroup.GetMetadata().GetLabels(),
+		request.GetObject().GetMetadata().GetLabels(),
+		request.GetUpdateMask(),
+		"security group",
+	); err != nil {
+		return
+	}
 
 	// Validate with existing object context:
 	err = s.validateSecurityGroup(ctx, request.GetObject(), existingSecurityGroup)

--- a/fulfillment-service/internal/servers/private_subnets_server.go
+++ b/fulfillment-service/internal/servers/private_subnets_server.go
@@ -187,6 +187,14 @@ func (s *PrivateSubnetsServer) Update(ctx context.Context,
 	}
 
 	existingSubnet := getResponse.GetObject()
+	if err = validateDefaultLabelUpdate(
+		existingSubnet.GetMetadata().GetLabels(),
+		request.GetObject().GetMetadata().GetLabels(),
+		request.GetUpdateMask(),
+		"subnet",
+	); err != nil {
+		return
+	}
 
 	// Validate with existing object context:
 	err = s.validateSubnet(ctx, request.GetObject(), existingSubnet)

--- a/fulfillment-service/internal/servers/private_subnets_server_test.go
+++ b/fulfillment-service/internal/servers/private_subnets_server_test.go
@@ -1503,6 +1503,42 @@ var _ = Describe("Private subnets server", func() {
 				Expect(getResponse.GetObject().GetMetadata().GetDeletionTimestamp()).To(BeNil())
 				Expect(getResponse.GetObject().GetStatus().GetState()).To(Equal(stateBeforeDelete))
 			})
+
+			It("blocks deletion after an update omits the default label", func() {
+				vn := createVirtualNetwork(ctx, "10.20.0.0/16", "")
+				createResp, err := server.Create(ctx, privatev1.SubnetsCreateRequest_builder{
+					Object: privatev1.Subnet_builder{
+						Metadata: privatev1.Metadata_builder{
+							Name:   "default-subnet-update",
+							Tenant: testTenant,
+							Labels: map[string]string{"osac.openshift.io/default": "true"},
+						}.Build(),
+						Spec: privatev1.SubnetSpec_builder{
+							Ipv4Cidr:       new("10.20.1.0/24"),
+							VirtualNetwork: privatev1.VirtualNetworkLocalReference_builder{Id: vn.GetId()}.Build(),
+						}.Build(),
+					}.Build(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+
+				object := createResp.GetObject()
+				object.GetMetadata().SetLabels(map[string]string{"env": "test"})
+				_, err = server.Update(ctx, privatev1.SubnetsUpdateRequest_builder{Object: object}.Build())
+				Expect(err).To(HaveOccurred())
+				status, ok := grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+
+				_, err = server.Delete(ctx, privatev1.SubnetsDeleteRequest_builder{Id: object.GetId()}.Build())
+				Expect(err).To(HaveOccurred())
+				status, ok = grpcstatus.FromError(err)
+				Expect(ok).To(BeTrue())
+				Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+
+				getResp, err := server.Get(ctx, privatev1.SubnetsGetRequest_builder{Id: object.GetId()}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getResp.GetObject().GetMetadata().GetLabels()).To(HaveKeyWithValue("osac.openshift.io/default", "true"))
+			})
 		})
 	})
 

--- a/fulfillment-service/internal/servers/private_subnets_server_test.go
+++ b/fulfillment-service/internal/servers/private_subnets_server_test.go
@@ -1484,6 +1484,7 @@ var _ = Describe("Private subnets server", func() {
 					}.Build(),
 				}.Build())
 				Expect(err).ToNot(HaveOccurred())
+				stateBeforeDelete := createResponse.GetObject().GetStatus().GetState()
 
 				_, err = server.Delete(ctx, privatev1.SubnetsDeleteRequest_builder{
 					Id: createResponse.GetObject().GetId(),
@@ -1494,6 +1495,13 @@ var _ = Describe("Private subnets server", func() {
 				Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
 				Expect(err.Error()).To(ContainSubstring("default"))
 				Expect(err.Error()).To(ContainSubstring("system-managed"))
+
+				getResponse, err := server.Get(ctx, privatev1.SubnetsGetRequest_builder{
+					Id: createResponse.GetObject().GetId(),
+				}.Build())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getResponse.GetObject().GetMetadata().GetDeletionTimestamp()).To(BeNil())
+				Expect(getResponse.GetObject().GetStatus().GetState()).To(Equal(stateBeforeDelete))
 			})
 		})
 	})

--- a/fulfillment-service/internal/servers/private_virtual_networks_server.go
+++ b/fulfillment-service/internal/servers/private_virtual_networks_server.go
@@ -173,6 +173,14 @@ func (s *PrivateVirtualNetworksServer) Update(ctx context.Context,
 	}
 
 	existingVN := getResponse.GetObject()
+	if err = validateDefaultLabelUpdate(
+		existingVN.GetMetadata().GetLabels(),
+		request.GetObject().GetMetadata().GetLabels(),
+		request.GetUpdateMask(),
+		"virtual network",
+	); err != nil {
+		return
+	}
 
 	// Validate with existing object context:
 	err = s.validateVirtualNetwork(ctx, request.GetObject(), existingVN)

--- a/fulfillment-service/internal/servers/private_virtual_networks_server_test.go
+++ b/fulfillment-service/internal/servers/private_virtual_networks_server_test.go
@@ -1925,5 +1925,42 @@ var _ = Describe("Private virtual networks server", func() {
 			Expect(getResp.GetObject().GetMetadata().GetDeletionTimestamp()).To(BeNil())
 			Expect(getResp.GetObject().GetStatus().GetState()).To(Equal(stateBeforeDelete))
 		})
+
+		It("blocks deletion after an update omits the default label", func() {
+			nc := createNetworkClass(ctx, privatev1.NetworkClassState_NETWORK_CLASS_STATE_READY)
+			createResp, err := vnServer.Create(ctx, privatev1.VirtualNetworksCreateRequest_builder{
+				Object: privatev1.VirtualNetwork_builder{
+					Metadata: privatev1.Metadata_builder{
+						Name:   "default-virtual-network-update",
+						Tenant: testTenant,
+						Labels: map[string]string{"osac.openshift.io/default": "true"},
+					}.Build(),
+					Spec: privatev1.VirtualNetworkSpec_builder{
+						Ipv4Cidr:     proto.String("10.10.0.0/16"),
+						NetworkClass: privatev1.NetworkClassReference_builder{Id: nc.GetId()}.Build(),
+						Region:       "us-west-1",
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			object := createResp.GetObject()
+			object.GetMetadata().SetLabels(map[string]string{"env": "test"})
+			_, err = vnServer.Update(ctx, privatev1.VirtualNetworksUpdateRequest_builder{Object: object}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+
+			_, err = vnServer.Delete(ctx, privatev1.VirtualNetworksDeleteRequest_builder{Id: object.GetId()}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok = grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+
+			getResp, err := vnServer.Get(ctx, privatev1.VirtualNetworksGetRequest_builder{Id: object.GetId()}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResp.GetObject().GetMetadata().GetLabels()).To(HaveKeyWithValue("osac.openshift.io/default", "true"))
+		})
 	})
 })

--- a/fulfillment-service/internal/servers/private_virtual_networks_server_test.go
+++ b/fulfillment-service/internal/servers/private_virtual_networks_server_test.go
@@ -1906,6 +1906,7 @@ var _ = Describe("Private virtual networks server", func() {
 				}.Build(),
 			}.Build())
 			Expect(err).ToNot(HaveOccurred())
+			stateBeforeDelete := createResp.GetObject().GetStatus().GetState()
 
 			_, err = vnServer.Delete(ctx, privatev1.VirtualNetworksDeleteRequest_builder{
 				Id: createResp.GetObject().GetId(),
@@ -1916,6 +1917,13 @@ var _ = Describe("Private virtual networks server", func() {
 			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
 			Expect(err.Error()).To(ContainSubstring("default"))
 			Expect(err.Error()).To(ContainSubstring("system-managed"))
+
+			getResp, err := vnServer.Get(ctx, privatev1.VirtualNetworksGetRequest_builder{
+				Id: createResp.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResp.GetObject().GetMetadata().GetDeletionTimestamp()).To(BeNil())
+			Expect(getResp.GetObject().GetStatus().GetState()).To(Equal(stateBeforeDelete))
 		})
 	})
 })

--- a/fulfillment-service/internal/servers/security_groups_server_test.go
+++ b/fulfillment-service/internal/servers/security_groups_server_test.go
@@ -511,6 +511,12 @@ var _ = Describe("SecurityGroups server", func() {
 			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
 			Expect(err.Error()).To(ContainSubstring("default"))
 			Expect(err.Error()).To(ContainSubstring("system-managed"))
+
+			getResponse, err := server.Get(ctx, publicv1.SecurityGroupsGetRequest_builder{
+				Id: createResponse.GetObject().GetId(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetMetadata().GetDeletionTimestamp()).To(BeNil())
 		})
 	})
 })

--- a/fulfillment-service/internal/servers/security_groups_server_test.go
+++ b/fulfillment-service/internal/servers/security_groups_server_test.go
@@ -518,5 +518,38 @@ var _ = Describe("SecurityGroups server", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(getResponse.GetObject().GetMetadata().GetDeletionTimestamp()).To(BeNil())
 		})
+
+		It("blocks deletion after an update omits the default label", func() {
+			createResp, err := server.Create(ctx, publicv1.SecurityGroupsCreateRequest_builder{
+				Object: publicv1.SecurityGroup_builder{
+					Metadata: publicv1.Metadata_builder{
+						Name:   "default-security-group-update",
+						Labels: map[string]string{"osac.openshift.io/default": "true"},
+					}.Build(),
+					Spec: publicv1.SecurityGroupSpec_builder{
+						VirtualNetwork: publicv1.VirtualNetworkLocalReference_builder{Id: virtualNetworkID}.Build(),
+					}.Build(),
+				}.Build(),
+			}.Build())
+			Expect(err).ToNot(HaveOccurred())
+
+			object := createResp.GetObject()
+			object.GetMetadata().SetLabels(map[string]string{"env": "test"})
+			_, err = server.Update(ctx, publicv1.SecurityGroupsUpdateRequest_builder{Object: object}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok := grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+
+			_, err = server.Delete(ctx, publicv1.SecurityGroupsDeleteRequest_builder{Id: object.GetId()}.Build())
+			Expect(err).To(HaveOccurred())
+			status, ok = grpcstatus.FromError(err)
+			Expect(ok).To(BeTrue())
+			Expect(status.Code()).To(Equal(grpccodes.FailedPrecondition))
+
+			getResponse, err := server.Get(ctx, publicv1.SecurityGroupsGetRequest_builder{Id: object.GetId()}.Build())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(getResponse.GetObject().GetMetadata().GetLabels()).To(HaveKeyWithValue("osac.openshift.io/default", "true"))
+		})
 	})
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **API and resource lifecycle:** Protects the default label on default virtual networks, subnets, security groups, and NAT gateways. Updates that remove the label now fail. Deletion of default resources remains blocked.
- **Controllers and cleanup:** Verifies that root-project deletion removes tenant virtual networks, subnets, and security groups.
- **Tests:** Adds regression coverage for rejected deletions, rejected label removal, preserved resource state, and cleanup of system-owned networking resources.
- **Database and deployment:** No changes.
- **Auth and CI:** No changes.
- **Documentation:** No changes.

## Backward compatibility

Clients that attempt to remove the default label from an existing default resource will now receive an error. Other label updates and unchanged default labels remain allowed. No public declarations changed.

## Risk classification

**risk:show** — The change affects networking resource update and deletion behavior, but it is narrowly scoped and includes regression tests for each affected resource type.

The change does not qualify for **risk:ship** because it changes API behavior for existing update requests and affects resource lifecycle protection. It does not qualify for **risk:ask** because it does not change authentication, deployment, data schemas, or public API declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->