### PR TITLE
NO-ISSUE: canonicalize correction adjustment identity

### DIFF
--- a/osac-metering/metering-service/internal/events/cluster.go
+++ b/osac-metering/metering-service/internal/events/cluster.go
@@ -304,8 +304,30 @@ func DecomposeClusterComponents(billingDims map[string]any) ([]ComponentRecord, 
 			ReleaseImage:    releaseImage,
 		})
 	}
+	sort.Slice(records, func(i, j int) bool {
+		return componentRecordLess(records[i], records[j])
+	})
 
 	return records, nil
+}
+
+func componentRecordLess(a, b ComponentRecord) bool {
+	if a.NodeSet != b.NodeSet {
+		return a.NodeSet < b.NodeSet
+	}
+	if a.Component != b.Component {
+		return a.Component < b.Component
+	}
+	if a.HostType != b.HostType {
+		return a.HostType < b.HostType
+	}
+	if a.NodeCount != b.NodeCount {
+		return a.NodeCount < b.NodeCount
+	}
+	if a.ClusterTemplate != b.ClusterTemplate {
+		return a.ClusterTemplate < b.ClusterTemplate
+	}
+	return a.ReleaseImage < b.ReleaseImage
 }
 
 // ComponentEventID derives a deterministic CloudEvent ID for a decomposed

--- a/osac-metering/metering-service/internal/reconciliation/correction.go
+++ b/osac-metering/metering-service/internal/reconciliation/correction.go
@@ -76,8 +76,11 @@ func buildCorrectionEvents(
 	interval *AffectedInterval,
 	now time.Time,
 ) ([]cloudevents.Event, error) {
-	baseID := fmt.Sprintf("correction/%s/%s/%s/%s/%s", resourceID, reason, projectionState, sourceState,
-		correctionFingerprint(billingDimensions, interval))
+	fingerprint, err := correctionFingerprint(resourceType, billingDimensions, interval)
+	if err != nil {
+		return nil, fmt.Errorf("building correction identity: %w", err)
+	}
+	baseID := fmt.Sprintf("correction/%s/%s/%s/%s/%s", resourceID, reason, projectionState, sourceState, fingerprint)
 	buildFn := func(dims map[string]any, eventID string) (cloudevents.Event, error) {
 		ce, err := buildCorrectionEvent(resourceID, resourceType, tenantID, projectID,
 			reason, projectionState, sourceState, dims, interval, now)
@@ -99,14 +102,47 @@ func buildCorrectionEvents(
 // producing the SAME ID so it dedups as the design intends ("duplicate
 // corrections... are acceptable"), while a genuinely different discrepancy
 // must not collide with a prior one and get silently dropped.
-func correctionFingerprint(billingDimensions map[string]any, interval *AffectedInterval) string {
-	enc, _ := json.Marshal(struct {
+func correctionFingerprint(resourceType string, billingDimensions map[string]any, interval *AffectedInterval) (string, error) {
+	canonicalDimensions, err := canonicalCorrectionDimensions(resourceType, billingDimensions)
+	if err != nil {
+		return "", err
+	}
+	enc, err := json.Marshal(struct {
 		Dims     map[string]any    `json:"dims"`
 		Interval *AffectedInterval `json:"interval,omitempty"`
-	}{billingDimensions, interval})
+	}{canonicalDimensions, interval})
+	if err != nil {
+		return "", fmt.Errorf("marshalling canonical correction content: %w", err)
+	}
 	h := fnv.New64a()
-	_, _ = h.Write(enc)
-	return fmt.Sprintf("%x", h.Sum64())
+	if _, err := h.Write(enc); err != nil {
+		return "", fmt.Errorf("hashing canonical correction content: %w", err)
+	}
+	return fmt.Sprintf("%x", h.Sum64()), nil
+}
+
+func canonicalCorrectionDimensions(resourceType string, billingDimensions map[string]any) (map[string]any, error) {
+	if resourceType != events.ResourceTypeClusterOrder {
+		return billingDimensions, nil
+	}
+
+	components, err := events.DecomposeClusterComponents(billingDimensions)
+	if err != nil {
+		return nil, err
+	}
+
+	canonical := make(map[string]any, len(billingDimensions))
+	for key, value := range billingDimensions {
+		if key != "components" {
+			canonical[key] = value
+		}
+	}
+	canonicalComponents := make([]any, 0, len(components))
+	for _, component := range components {
+		canonicalComponents = append(canonicalComponents, component.FlatBillingDimensions())
+	}
+	canonical["components"] = canonicalComponents
+	return canonical, nil
 }
 
 func buildCorrectionEvent(

--- a/osac-metering/metering-service/internal/reconciliation/correction_internal_test.go
+++ b/osac-metering/metering-service/internal/reconciliation/correction_internal_test.go
@@ -153,6 +153,66 @@ func TestBuildCorrectionEventsSameDimensionsGetSameID(t *testing.T) {
 	}
 }
 
+func TestBuildCorrectionEventsCanonicalizesAdjustmentOrder(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	firstOrder := map[string]any{
+		"cluster_template": "ocp-ci-small",
+		"release_image":    "4.17.0",
+		"components": []any{
+			map[string]any{
+				"node_set":   "_control_plane",
+				"component":  "control_plane",
+				"host_type":  "_control_plane",
+				"node_count": int32(1),
+			},
+			map[string]any{
+				"node_set":   "gpu-workers",
+				"component":  "worker",
+				"host_type":  "gpu-h100",
+				"node_count": int32(2),
+			},
+		},
+	}
+	secondOrder := map[string]any{
+		"components": []any{
+			map[string]any{
+				"node_count": int32(2),
+				"host_type":  "gpu-h100",
+				"component":  "worker",
+				"node_set":   "gpu-workers",
+			},
+			map[string]any{
+				"node_count": int32(1),
+				"host_type":  "_control_plane",
+				"component":  "control_plane",
+				"node_set":   "_control_plane",
+			},
+		},
+		"release_image":    "4.17.0",
+		"cluster_template": "ocp-ci-small",
+	}
+
+	first, err := buildCorrectionEvents("cluster-1", events.ResourceTypeClusterOrder, "tenant-1", "",
+		BillingDimensionsDrift, "READY", "READY", firstOrder, nil, now)
+	if err != nil {
+		t.Fatalf("first correction: unexpected error: %v", err)
+	}
+	replay, err := buildCorrectionEvents("cluster-1", events.ResourceTypeClusterOrder, "tenant-1", "",
+		BillingDimensionsDrift, "READY", "READY", secondOrder, nil, now)
+	if err != nil {
+		t.Fatalf("replayed correction: unexpected error: %v", err)
+	}
+
+	if len(first) != 2 || len(replay) != 2 {
+		t.Fatalf("expected two adjustment events per correction, got %d and %d", len(first), len(replay))
+	}
+	for i := range first {
+		if first[i].ID() != replay[i].ID() {
+			t.Errorf("semantic correction adjustment %d changed provider identity across order-only replay: %q != %q", i, first[i].ID(), replay[i].ID())
+		}
+	}
+}
+
 func TestTransientCheckersCoversAllBillabilityCheckerKeys(t *testing.T) {
 	for resourceType := range billabilityCheckers {
 		if _, ok := transientCheckers[resourceType]; !ok {


### PR DESCRIPTION
## Summary
- Sort cluster correction adjustments by semantic content before decomposition.
- Fingerprint canonicalized correction dimensions so adjustment order and map construction order cannot change CloudEvent/provider IDs.
- Add a regression covering replay of the same two-adjustment correction.

## Validation
- `go test ./...` in `osac-metering/metering-service`
- `go test -race ./internal/reconciliation ./internal/events` in `osac-metering/metering-service`
- `go test -race ./...` in `osac-metering/adapters` and `osac-metering/schema`
- `make test`, `make lint`, and `make helm-lint` in `osac-metering`
- `make build` in `metering-service`; adapter builds for echo and M360
- targeted pre-commit hooks

NO-ISSUE: no matching Jira ticket was supplied or found.