### PR TITLE
OSAC-5006: exclude CaaS/BMaaS refs from nightly VMaaS e2e

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -525,6 +525,10 @@ jobs:
     uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main
     with:
       test-suite: vmaas
+      # The references module contains CaaS and BMaaS tests too. Those
+      # services are disabled in the VMaaS profile, so exclude tests marked
+      # with either dependency. Matches osac-project/osac#805.
+      test-marker: 'not requires_caas and not requires_bmaas'
       installer-repo: ${{ github.repository }}
       installer-ref: ${{ needs.prepare.outputs.temp-branch }}
       test-infra-repository: osac-project/osac-test-infra


### PR DESCRIPTION
## Summary
- Pass `test-marker: not requires_caas and not requires_bmaas` to nightly `e2e-vmaas-test`
- Aligns nightly with the PR caller default from #805

## Test plan
- [ ] Trigger fresh nightly (workflow_dispatch) after merge
- [ ] Confirm VMaaS e2e no longer runs `test_cluster_baremetal_references.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

- **CI:** Updated the nightly `e2e-vmaas-test` workflow to pass `test-marker: not requires_caas and not requires_bmaas`.
- **Tests:** Nightly VMaaS E2E runs now exclude tests that require CaaS or BMaaS, including `test_cluster_baremetal_references.py`.
- **Compatibility:** No API, runtime, database, or deployment changes. The change only reduces the test scope for nightly VMaaS validation.

## Risk classification

**risk:ship** — The change affects only CI test selection. It uses the existing PR caller marker behavior and has low operational impact.

This is not `risk:show` because it does not change user-visible or production behavior. It is not `risk:ask` because it does not introduce high-risk code, infrastructure, security, or data changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->