### PR TITLE
fix(e2e): handle resource-gone in wait_for_cluster_deleting

### DIFF
--- a/tests/e2e/core/helpers.py
+++ b/tests/e2e/core/helpers.py
@@ -442,7 +442,7 @@ def _force_cleanup_machine_preterminate_hooks(*, k8s: K8sClient, name: str) -> N
 def wait_for_cluster_deleting(*, k8s: K8sClient, name: str) -> None:
     poll_until(
         fn=lambda: k8s.get_cluster_order_phase(name=name, checked=False),
-        until=lambda v: v == "Deleting",
+        until=lambda v: v == "Deleting" or v == "",
         retries=30,
         delay=5,
         description=f"{name} ClusterOrder Deleting phase",


### PR DESCRIPTION
The wait_for_cluster_deleting helper polls for the ClusterOrder phase to become "Deleting", but if the resource is already fully deleted, get_cluster_order_phase returns "" (empty string). Since "" != "Deleting", the poll retries for ~150s and times out.

Accept empty phase as a valid completion state — it means the resource has already passed through "Deleting" and been removed entirely.

Ref: osac-project/osac-test-infra#470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Affected areas

- **Tests:** Updated `wait_for_cluster_deleting` to accept an empty `ClusterOrder` phase as completion.
- **API and production systems:** No changes.
- **Performance:** Avoids unnecessary polling and timeout delays when the resource is already removed.
- **Backward compatibility:** No breaking impact. The existing `Deleting` completion state remains valid.

## Risk classification

**risk:ship** — The change is limited to E2E test helper behavior, adds one valid completion state, and does not modify production code or public APIs. It does not qualify for **risk:show** or **risk:ask** because it introduces no user-facing behavior, deployment change, security impact, or data migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->