### PR TITLE
fix(e2e): preserve ClusterOrder deletion errors

### DIFF
--- a/tests/e2e/core/helpers.py
+++ b/tests/e2e/core/helpers.py
@@ -346,7 +346,7 @@ def wait_for_cluster_deletion(*, k8s: K8sClient, name: str) -> None:
         _force_cleanup_agentcluster_finalizers(k8s=k8s, name=name)
         _force_cleanup_agent_labels(k8s=k8s, name=name)
         _force_cleanup_machine_preterminate_hooks(k8s=k8s, name=name)
-        return not k8s.is_present(resource="clusterorder", name=name)
+        return k8s.get_cluster_order_phase(name=name, checked=False) is None
 
     poll_until(
         fn=_check_deleted, until=lambda v: v is True, retries=120, delay=10, description=f"{name} ClusterOrder deletion"
@@ -442,7 +442,9 @@ def _force_cleanup_machine_preterminate_hooks(*, k8s: K8sClient, name: str) -> N
 def wait_for_cluster_deleting(*, k8s: K8sClient, name: str) -> None:
     poll_until(
         fn=lambda: k8s.get_cluster_order_phase(name=name, checked=False),
-        until=lambda v: v == "Deleting",
+        # get_cluster_order_phase returns None only for a missing ClusterOrder;
+        # an empty phase from an existing object is not a deletion signal.
+        until=lambda v: v == "Deleting" or v is None,
         retries=30,
         delay=5,
         description=f"{name} ClusterOrder Deleting phase",

--- a/tests/e2e/core/k8s_client.py
+++ b/tests/e2e/core/k8s_client.py
@@ -8,7 +8,8 @@ from typing import Any
 from tests.e2e.core.runner import run, run_unchecked
 
 _CLUSTER_ORDER_NOT_FOUND_RE = re.compile(
-    r"\bclusterorders?(?:\.[^\s\"']+)?\s+[\"']?([^\"'\s]+)[\"']?\s+not\s+found\b", re.IGNORECASE
+    r'Error from server \(NotFound\): clusterorders(?:\.osac\.openshift\.io)? "(?P<name>[^"]+)" not found',
+    re.IGNORECASE,
 )
 
 
@@ -310,8 +311,8 @@ class K8sClient:
         output, rc = self._get(*args, checked=checked)
         if rc == 0:
             return output
-        not_found = _CLUSTER_ORDER_NOT_FOUND_RE.search(output)
-        if not_found is not None and not_found.group(1) == name:
+        not_found = _CLUSTER_ORDER_NOT_FOUND_RE.fullmatch(output.strip())
+        if not_found is not None and not_found.group("name") == name:
             return None
         raise subprocess.CalledProcessError(rc, [*self._base(), *args], output=output, stderr=output)
 

--- a/tests/e2e/core/k8s_client.py
+++ b/tests/e2e/core/k8s_client.py
@@ -8,7 +8,7 @@ from typing import Any
 from tests.e2e.core.runner import run, run_unchecked
 
 _CLUSTER_ORDER_NOT_FOUND_RE = re.compile(
-    r"\bclusterorders?(?:[./\s\"']|$).*?\b(?:not\s+found|notfound)\b", re.IGNORECASE
+    r"\bclusterorders?(?:\.[^\s\"']+)?\s+[\"']?([^\"'\s]+)[\"']?\s+not\s+found\b", re.IGNORECASE
 )
 
 
@@ -310,7 +310,8 @@ class K8sClient:
         output, rc = self._get(*args, checked=checked)
         if rc == 0:
             return output
-        if _CLUSTER_ORDER_NOT_FOUND_RE.search(output):
+        not_found = _CLUSTER_ORDER_NOT_FOUND_RE.search(output)
+        if not_found is not None and not_found.group(1) == name:
             return None
         raise subprocess.CalledProcessError(rc, [*self._base(), *args], output=output, stderr=output)
 

--- a/tests/e2e/core/k8s_client.py
+++ b/tests/e2e/core/k8s_client.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from typing import Any
 
 from tests.e2e.core.runner import run, run_unchecked
+
+_CLUSTER_ORDER_NOT_FOUND_RE = re.compile(
+    r"\bclusterorders?(?:[./\s\"']|$).*?\b(?:not\s+found|notfound)\b", re.IGNORECASE
+)
 
 
 class K8sClient:
@@ -297,11 +302,17 @@ class K8sClient:
         )
         return output if rc == 0 else ""
 
-    def get_cluster_order_phase(self, *, name: str, checked: bool = True) -> str:
-        output, rc = self._get(
-            "get", "clusterorder", name, "-n", self.namespace, "-o", "jsonpath={.status.phase}", checked=checked
-        )
-        return output if rc == 0 else ""
+    def get_cluster_order_phase(self, *, name: str, checked: bool = True) -> str | None:
+        # In unchecked mode, None means that this ClusterOrder is gone. Keep a
+        # successful lookup with no status phase as "" so pollers do not treat
+        # an unrelated kubectl failure as deletion.
+        args = ("get", "clusterorder", name, "-n", self.namespace, "-o", "jsonpath={.status.phase}")
+        output, rc = self._get(*args, checked=checked)
+        if rc == 0:
+            return output
+        if _CLUSTER_ORDER_NOT_FOUND_RE.search(output):
+            return None
+        raise subprocess.CalledProcessError(rc, [*self._base(), *args], output=output, stderr=output)
 
     def get_cluster_order_latest_job_id(self, *, name: str, job_type: str, checked: bool = True) -> str:
         output, rc = self._get("get", "clusterorder", name, "-n", self.namespace, "-o", "json", checked=checked)

--- a/tests/unit/test_cluster_deletion_polling.py
+++ b/tests/unit/test_cluster_deletion_polling.py
@@ -38,6 +38,8 @@ def test_cluster_order_not_found_is_distinct_from_an_empty_phase() -> None:
         'Error from server (NotFound): namespaces "tenant-a" not found',
         'Error from server (NotFound): namespaces "clusterorders" not found',
         'Error from server (NotFound): clusterorders.osac.openshift.io "other-cluster" not found',
+        'Error from server (NotFound): clusterorders.osac.openshift.io "cluster-a" not found: extra text',
+        'prefix: Error from server (NotFound): clusterorders.osac.openshift.io "cluster-a" not found',
         "Unable to connect to the server: dial tcp: lookup api.example.test: no such host",
     ],
 )

--- a/tests/unit/test_cluster_deletion_polling.py
+++ b/tests/unit/test_cluster_deletion_polling.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from tests.e2e.core import helpers
+from tests.e2e.core.k8s_client import K8sClient
+
+
+def _mock_get(k8s: K8sClient, *, output: str, returncode: int) -> None:
+    def get(*args: str, checked: bool = True) -> tuple[str, int]:
+        return output, returncode
+
+    k8s._get = get  # type: ignore[method-assign]
+
+
+def test_cluster_order_not_found_is_distinct_from_an_empty_phase() -> None:
+    k8s = K8sClient(namespace="tenant-a")
+
+    _mock_get(
+        k8s,
+        output='Error from server (NotFound): clusterorders.osac.openshift.io "cluster-a" not found',
+        returncode=1,
+    )
+    assert k8s.get_cluster_order_phase(name="cluster-a", checked=False) is None
+
+    _mock_get(k8s, output="", returncode=0)
+    assert k8s.get_cluster_order_phase(name="cluster-a", checked=False) == ""
+
+
+@pytest.mark.parametrize(
+    "kubectl_output",
+    [
+        "Error from server (Forbidden): clusterorders.osac.openshift.io is forbidden",
+        'Error from server (NotFound): namespaces "tenant-a" not found',
+        "Unable to connect to the server: dial tcp: lookup api.example.test: no such host",
+    ],
+)
+def test_cluster_order_phase_propagates_non_resource_not_found_errors(kubectl_output: str) -> None:
+    k8s = K8sClient(namespace="tenant-a")
+    _mock_get(k8s, output=kubectl_output, returncode=1)
+
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        k8s.get_cluster_order_phase(name="cluster-a", checked=False)
+
+    assert exc_info.value.returncode == 1
+    assert exc_info.value.stderr == kubectl_output
+
+
+def test_wait_for_cluster_deleting_accepts_only_not_found_as_already_gone(monkeypatch: pytest.MonkeyPatch) -> None:
+    k8s = Mock(spec=K8sClient)
+    captured: dict[str, Any] = {}
+
+    def capture_poll(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(helpers, "poll_until", capture_poll)
+    helpers.wait_for_cluster_deleting(k8s=k8s, name="cluster-a")
+
+    until = captured["until"]
+    assert until("Deleting") is True
+    assert until(None) is True
+    assert until("") is False
+
+
+@pytest.mark.parametrize(
+    "kubectl_output",
+    [
+        "Error from server (Forbidden): clusterorders.osac.openshift.io is forbidden",
+        'Error from server (NotFound): namespaces "tenant-a" not found',
+        "Unable to connect to the server: connection refused",
+    ],
+)
+def test_wait_for_cluster_deleting_propagates_kubectl_errors(
+    monkeypatch: pytest.MonkeyPatch, kubectl_output: str
+) -> None:
+    k8s = Mock(spec=K8sClient)
+    k8s.get_cluster_order_phase.side_effect = subprocess.CalledProcessError(
+        1, ["kubectl"], stderr=kubectl_output
+    )
+
+    def invoke_once(**kwargs: Any) -> None:
+        kwargs["fn"]()
+
+    monkeypatch.setattr(helpers, "poll_until", invoke_once)
+
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        helpers.wait_for_cluster_deleting(k8s=k8s, name="cluster-a")
+
+    assert exc_info.value.stderr == kubectl_output
+
+
+@pytest.mark.parametrize("phase, expected", [(None, True), ("", False), ("Deleting", False)])
+def test_wait_for_cluster_deletion_uses_not_found_as_the_deletion_signal(
+    monkeypatch: pytest.MonkeyPatch, phase: str | None, expected: bool
+) -> None:
+    k8s = Mock(spec=K8sClient)
+    k8s.get_cluster_order_phase.return_value = phase
+    captured: dict[str, Any] = {}
+
+    for cleanup in (
+        "_force_cleanup_agentcluster_finalizers",
+        "_force_cleanup_agent_labels",
+        "_force_cleanup_machine_preterminate_hooks",
+    ):
+        monkeypatch.setattr(helpers, cleanup, lambda **kwargs: None)
+
+    def capture_poll(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(helpers, "poll_until", capture_poll)
+    helpers.wait_for_cluster_deletion(k8s=k8s, name="cluster-a")
+
+    assert captured["fn"]() is expected
+
+
+def test_wait_for_cluster_deletion_propagates_kubectl_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    k8s = Mock(spec=K8sClient)
+    error = subprocess.CalledProcessError(1, ["kubectl"], stderr="Unable to connect to the server")
+    k8s.get_cluster_order_phase.side_effect = error
+
+    for cleanup in (
+        "_force_cleanup_agentcluster_finalizers",
+        "_force_cleanup_agent_labels",
+        "_force_cleanup_machine_preterminate_hooks",
+    ):
+        monkeypatch.setattr(helpers, cleanup, lambda **kwargs: None)
+
+    def invoke_once(**kwargs: Any) -> None:
+        kwargs["fn"]()
+
+    monkeypatch.setattr(helpers, "poll_until", invoke_once)
+
+    with pytest.raises(subprocess.CalledProcessError) as exc_info:
+        helpers.wait_for_cluster_deletion(k8s=k8s, name="cluster-a")
+
+    assert exc_info.value.stderr == "Unable to connect to the server"

--- a/tests/unit/test_cluster_deletion_polling.py
+++ b/tests/unit/test_cluster_deletion_polling.py
@@ -36,6 +36,8 @@ def test_cluster_order_not_found_is_distinct_from_an_empty_phase() -> None:
     [
         "Error from server (Forbidden): clusterorders.osac.openshift.io is forbidden",
         'Error from server (NotFound): namespaces "tenant-a" not found',
+        'Error from server (NotFound): namespaces "clusterorders" not found',
+        'Error from server (NotFound): clusterorders.osac.openshift.io "other-cluster" not found',
         "Unable to connect to the server: dial tcp: lookup api.example.test: no such host",
     ],
 )


### PR DESCRIPTION
## Summary
- Preserve ClusterOrder NotFound separately from empty phases during deletion polling.
- Propagate authentication, namespace, transport, and ambiguous kubectl failures.
- Add regression coverage for deletion polling and NotFound classification.

## Jira
N/A

## Test plan
- [x] 16 targeted regression tests pass
- [x] Syntax and whitespace checks pass
- [x] Performance, security, and over-engineering pre-flight reviews pass
- [ ] CI checks pass

---

_This PR description was drafted with AI assistance (OpenAI Codex). Review for accuracy_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Affected areas

- **API surface:** `get_cluster_order_phase` now returns `str | None`.
- **Deletion polling:** Confirmed `NotFound` means deletion complete. Empty phases and unrelated `kubectl` errors no longer mean success.
- **Error handling:** Authentication, namespace, transport, and ambiguous `kubectl` errors propagate.
- **Tests:** Added regression coverage for `NotFound` classification, empty phases, polling, and error propagation.
- **CI:** Targeted tests and checks passed. CI remains pending.
- **Database, deployment, and documentation:** No changes.

## Backward compatibility

Callers must handle the new `None` result and propagated exceptions. This prevents false deletion success.

## Risk classification

**risk:show** — The change affects deletion control flow and a public method return type, but the scope is narrow and regression coverage is included. It does not qualify for **risk:ship** because behavior and error propagation change. It does not qualify for **risk:ask** because the change does not affect data schemas, deployment, or broad system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->