### PR TITLE
OSAC-1832: ClusterOrder CR missing nodeRequests when cluster created via catalog item

### DIFF
--- a/fulfillment-service/internal/controllers/cluster/cluster_reconciler_function_test.go
+++ b/fulfillment-service/internal/controllers/cluster/cluster_reconciler_function_test.go
@@ -161,6 +161,63 @@ var _ = Describe("update tenant annotation", func() {
 		Expect(createdCR.GetLabels()).To(HaveKeyWithValue(labels.ClusterOrderUuid, clusterID))
 	})
 
+	It("should serialize catalog-item template node sets into ClusterOrder node requests", func() {
+		scheme := runtime.NewScheme()
+		Expect(osacv1alpha1.AddToScheme(scheme)).To(Succeed())
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			Build()
+
+		hubCache := controllers.NewMockHubCache(ctrl)
+		hubCache.EXPECT().
+			Get(gomock.Any(), hubID).
+			Return(&controllers.HubEntry{
+				Namespace: hubNamespace,
+				Client:    fakeClient,
+			}, nil)
+
+		cluster := privatev1.Cluster_builder{
+			Id: clusterID,
+			Metadata: privatev1.Metadata_builder{
+				Finalizers: []string{finalizers.Controller},
+				Tenant:     tenantName,
+			}.Build(),
+			Spec: privatev1.ClusterSpec_builder{
+				Template: &privatev1.ClusterTemplateReference{Name: "osac.templates.ocp_ci_small"},
+				NodeSets: map[string]*privatev1.ClusterNodeSet{
+					"ci-worker": privatev1.ClusterNodeSet_builder{
+						HostType: &privatev1.HostTypeReference{Name: "ci-worker"},
+						Size:     proto.Int32(1),
+					}.Build(),
+				},
+			}.Build(),
+			Status: privatev1.ClusterStatus_builder{
+				State: privatev1.ClusterState_CLUSTER_STATE_PROGRESSING,
+				Hub:   hubID,
+			}.Build(),
+		}.Build()
+
+		t := &task{
+			r: &function{
+				logger:         logger,
+				hubCache:       hubCache,
+				maskCalculator: nil,
+			},
+			cluster: cluster,
+		}
+
+		err := t.update(ctx)
+		Expect(err).ToNot(HaveOccurred())
+
+		list := &osacv1alpha1.ClusterOrderList{}
+		Expect(fakeClient.List(ctx, list)).To(Succeed())
+		Expect(list.Items).To(HaveLen(1))
+		Expect(list.Items[0].Spec.NodeRequests).To(HaveLen(1))
+		Expect(list.Items[0].Spec.NodeRequests[0].ResourceClass).To(Equal("ci-worker"))
+		Expect(list.Items[0].Spec.NodeRequests[0].NumberOfNodes).To(Equal(1))
+	})
+
 	It("should update ClusterOrder when node set size changes on a ready cluster", func() {
 		// Create an existing ClusterOrder with size 3:
 		existingOrder := &osacv1alpha1.ClusterOrder{


### PR DESCRIPTION
## [OSAC-1832](https://redhat.atlassian.net/browse/OSAC-1832): ClusterOrder CR missing nodeRequests when cluster created via catalog item

**Jira:** https://redhat.atlassian.net/browse/OSAC-1832
**Story type:** Bug

### Summary

Add regression coverage for catalog-item cluster provisioning so template-derived node sets continue through reconciliation into `ClusterOrder.spec.nodeRequests`. The existing production fix is preserved and the new test locks down the expected `ci-worker` resource class and node count of `1`.

### Changes

- Added a cluster reconciler regression for catalog-transformed `ci-worker` node sets.
- Verified the existing catalog-item server test covers template node-set propagation.
- No production behavior changes.

### Testing

- **Unit tests:** Full `internal/servers` package passed with 1801 specs; full cluster controller package passed.
- **Lint and build:** Go/proto lint, Ruff, Go builds, and pre-commit hooks passed.
- **Integration tests:** No new integration test; the existing server test and controller fake-hub test cover both propagation boundaries.

### Acceptance Criteria

- [x] AC-1: Catalog-item template node sets reach the downstream node-request path.
- [x] AC-2: Resource class and node count are preserved as `ci-worker` and `1`.
- [x] AC-3: The catalog-item path does not produce a ClusterOrder with missing node requests.
