### PR TITLE
NO-ISSUE: dev-full: Allow pushing locally build images to kind

### DIFF
--- a/bare-metal-fulfillment-operator/Makefile
+++ b/bare-metal-fulfillment-operator/Makefile
@@ -130,6 +130,10 @@ image-build: ## Build docker image with the manager.
 image-push: ## Push docker image with the manager.
 	$(CONTAINER_TOOL) push ${IMG}
 
+.PHONY: kind-load-image
+kind-load-image: ## Load the built image into the dev-full Kind cluster.
+	$(call kind-load-image,$(IMG))
+
 # PLATFORMS defines the target platforms for the manager image be built to provide support to multiple
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
 # - be able to use docker buildx. More info: https://docs.docker.com/build/buildx/
@@ -197,6 +201,7 @@ ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
 
 include $(shell git rev-parse --show-toplevel)/tools/golangci-lint.mk
+include $(shell git rev-parse --show-toplevel)/osac-installer/scripts/dev-full/kind-load-image.mk
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.

--- a/fulfillment-service/Makefile
+++ b/fulfillment-service/Makefile
@@ -19,3 +19,9 @@ image-build: ## Build container image.
 .PHONY: image-push
 image-push: ## Push container image.
 	$(CONTAINER_TOOL) push ${IMG}
+
+.PHONY: kind-load-image
+kind-load-image: ## Load the built image into the dev-full Kind cluster.
+	$(call kind-load-image,$(IMG))
+
+include $(shell git rev-parse --show-toplevel)/osac-installer/scripts/dev-full/kind-load-image.mk

--- a/osac-csi-driver/Makefile
+++ b/osac-csi-driver/Makefile
@@ -79,6 +79,11 @@ image-build: ## Build the container image.
 image-push: ## Push the container image.
 	$(CONTAINER_TOOL) push $(IMG)
 
+.PHONY: kind-load-image
+kind-load-image: ## Load the built image into the dev-full Kind cluster.
+	$(call kind-load-image,$(IMG))
+
 ##@ Dependencies
 
 include $(shell git rev-parse --show-toplevel)/tools/golangci-lint.mk
+include $(shell git rev-parse --show-toplevel)/osac-installer/scripts/dev-full/kind-load-image.mk

--- a/osac-installer/Makefile
+++ b/osac-installer/Makefile
@@ -11,6 +11,7 @@
 #   make install-osac    PLATFORM=kind|openshift  PROFILE=dev|dev-full|vmaas-ci|bmaas-ci|caas-ci|full-ci  NS=osac
 #   make uninstall-osac  PLATFORM=kind|openshift  PROFILE=dev|dev-full|vmaas-ci|bmaas-ci|caas-ci|full-ci  NS=osac
 #   make uninstall-infra PLATFORM=kind|openshift  PROFILE=dev|dev-full|vmaas-ci|bmaas-ci|caas-ci|full-ci  NS=osac
+#   make kind-load-images  PLATFORM=kind PROFILE=dev-full NS=osac
 #   make test            PLATFORM=kind|openshift  PROFILE=dev|dev-full|vmaas-ci|bmaas-ci|caas-ci|full-ci  NS=osac  SUITE=all|fulfillment|operator|bmf
 #
 # PROFILE=dev-full (kind only) is a superset of dev: it runs the same chart-based
@@ -32,7 +33,7 @@ EXTRA_HELM_ARGS ?=
 # -- Fail-fast parameter validation ------------------------------------
 # Guards fire at parse time, gated by MAKECMDGOALS so `make help` works.
 
-ALL_TARGETS := install uninstall install-infra uninstall-infra install-osac uninstall-osac install-devstack test
+ALL_TARGETS := install uninstall install-infra uninstall-infra install-osac uninstall-osac install-devstack kind-load-images test
 
 ifneq ($(filter $(ALL_TARGETS),$(MAKECMDGOALS)),)
 ifndef PLATFORM
@@ -120,15 +121,25 @@ endif
 # it empty and helm/kubectl would fall back to localhost:8080. `$(or ...)` skips empty.
 export KUBECONFIG := $(or $(KUBECONFIG),$(KIND_KUBECONFIG))
 
-define kind-load-image
-	@if [ "$$(basename $(CONTAINER_TOOL))" = "podman" ]; then \
-		tmpfile=$$(mktemp /tmp/kind-image-XXXXXX.tar); \
-		$(CONTAINER_TOOL) save $(1) -o "$$tmpfile"; \
-		kind load image-archive "$$tmpfile" --name $(KIND_CLUSTER_NAME); \
-		rm -f "$$tmpfile"; \
-	else \
-		kind load docker-image $(1) --name $(KIND_CLUSTER_NAME); \
-	fi
+# These names deliberately match the image URLs rendered by the dev-full values.
+KIND_FULFILLMENT_IMAGE := ghcr.io/osac-project/fulfillment-service:latest
+KIND_OPERATOR_IMAGE := ghcr.io/osac-project/osac-operator:latest
+KIND_CSI_IMAGE := ghcr.io/osac-project/osac-csi-driver:latest
+KIND_UI_IMAGE := ghcr.io/osac-project/osac-ui:latest
+
+include scripts/dev-full/kind-load-image.mk
+
+# Integration-test image loading also supports PROFILE=dev. Keep this helper
+# separate from the dev-full component targets, which use kind-load-image.sh.
+KIND_COMMAND := kind
+ifeq ($(PLATFORM)/$(PROFILE),kind/dev-full)
+KIND_COMMAND := $(KIND_RUNTIME)
+endif
+define kind-load-test-image
+	@tmpfile=$$(mktemp /tmp/kind-image-XXXXXX.tar); \
+	trap 'rm -f "$$tmpfile"' EXIT; \
+	$(CONTAINER_TOOL) save $(1) > "$$tmpfile"; \
+	$(KIND_COMMAND) load image-archive "$$tmpfile" --name "$(KIND_CLUSTER_NAME)"
 endef
 
 # -- Help --------------------------------------------------------------
@@ -137,6 +148,17 @@ endef
 help: ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
+##@ Entity: Local Kind Images
+
+.PHONY: kind-load-images
+kind-load-images: ## Load previously built dev-full images into Kind (PLATFORM=kind PROFILE=dev-full NS= required)
+	@if [ "$(PLATFORM)/$(PROFILE)" != "kind/dev-full" ]; then \
+		echo "ERROR: kind-load-images requires PLATFORM=kind PROFILE=dev-full" >&2; exit 1; \
+	fi
+	$(MAKE) -C ../fulfillment-service kind-load-image PLATFORM=$(PLATFORM) PROFILE=$(PROFILE) NS=$(NS) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) CONTAINER_TOOL=$(CONTAINER_TOOL)
+	$(MAKE) -C ../osac-operator kind-load-image PLATFORM=$(PLATFORM) PROFILE=$(PROFILE) NS=$(NS) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) CONTAINER_TOOL=$(CONTAINER_TOOL)
+	$(MAKE) -C ../osac-csi-driver kind-load-image PLATFORM=$(PLATFORM) PROFILE=$(PROFILE) NS=$(NS) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) CONTAINER_TOOL=$(CONTAINER_TOOL)
+	$(call kind-load-image,$(KIND_UI_IMAGE))
 ##@ Entity: Infra
 
 .PHONY: install-infra
@@ -293,7 +315,7 @@ ifeq ($(SUITE),all)
 endif
 ifeq ($(SUITE),fulfillment)
 	$(CONTAINER_TOOL) build -t localhost/fulfillment-service:it -f ../fulfillment-service/Containerfile ..
-	$(call kind-load-image,localhost/fulfillment-service:it)
+	$(call kind-load-test-image,localhost/fulfillment-service:it)
 	$(MAKE) install-osac PLATFORM=$(PLATFORM) PROFILE=$(PROFILE) NS=$(NS) \
 		EXTRA_HELM_ARGS="--set service.images.service=localhost/fulfillment-service:it --set operator.enabled=false --set networkClass.enabled=false"
 	@for f in ../fulfillment-service/it/crds/*.yaml; do kubectl apply --server-side --force-conflicts -f "$$f"; done
@@ -301,14 +323,14 @@ ifeq ($(SUITE),fulfillment)
 endif
 ifeq ($(SUITE),operator)
 	$(CONTAINER_TOOL) build -t localhost/osac-operator:it -f ../osac-operator/Containerfile ..
-	$(call kind-load-image,localhost/osac-operator:it)
+	$(call kind-load-test-image,localhost/osac-operator:it)
 	$(MAKE) install-osac PLATFORM=$(PLATFORM) PROFILE=$(PROFILE) NS=$(NS) \
 		EXTRA_HELM_ARGS="--set operator.image.repository=localhost/osac-operator --set operator.image.tag=it --set operator.image.pullPolicy=Never --set service.enabled=false --set hubAccess.enabled=false --set validation.enabled=false --set networkClass.enabled=false"
 	cd ../osac-operator && ginkgo run --timeout 30m -v test/integration
 endif
 ifeq ($(SUITE),bmf)
 	$(CONTAINER_TOOL) build -t localhost/bmf-operator:it -f ../bare-metal-fulfillment-operator/Containerfile ..
-	$(call kind-load-image,localhost/bmf-operator:it)
+	$(call kind-load-test-image,localhost/bmf-operator:it)
 	kubectl apply --server-side --force-conflicts -f ../bare-metal-fulfillment-operator/test/crds/
 	$(MAKE) install-osac PLATFORM=$(PLATFORM) PROFILE=$(PROFILE) NS=$(NS) \
 		EXTRA_HELM_ARGS="--set global.services.bmaas.enabled=true --set bmf.replicaCount=1 --set bmf.image.repository=localhost/bmf-operator --set bmf.image.tag=it --set bmf.image.pullPolicy=Never --set operator.enabled=false --set service.enabled=false --set hubAccess.enabled=false --set validation.enabled=false --set networkClass.enabled=false"

--- a/osac-installer/README.md
+++ b/osac-installer/README.md
@@ -18,6 +18,7 @@ For detailed architecture, workflows, and design documentation, please refer to 
 [OSAC documentation repository](https://github.com/osac-project/docs).
 
 The OSAC platform provides:
+
 - **Self-service provisioning** for clusters and virtual machines through a governed API
 - **Template-based automation** using Red Hat Ansible Automation Platform
 - **Multi-hub support** allowing multiple infrastructure hubs to be managed by a single fulfillment service
@@ -60,10 +61,11 @@ The OSAC platform relies on five core components to deliver governed self-servic
 
 > **System Requirements** This solution requires the following platforms to be installed
 > and operational:
-> * Red Hat OpenShift Advanced Cluster Management (RHACM)
-> * Red Hat OpenShift Virtualization (OCP-Virt) - **Optional**: Only required for VM as a Service (VMaaS) support
-> * Red Hat Ansible Automation Platform (AAP)
-> * A network backend for bare metal provisioning: either **ESI** (Elastic System Infrastructure) or **Netris** (see [Network Backend Configuration](#network-backend-configuration-caas))
+>
+> - Red Hat OpenShift Advanced Cluster Management (RHACM)
+> - Red Hat OpenShift Virtualization (OCP-Virt) - **Optional**: Only required for VM as a Service (VMaaS) support
+> - Red Hat Ansible Automation Platform (AAP)
+> - A network backend for bare metal provisioning: either **ESI** (Elastic System Infrastructure) or **Netris** (see [Network Backend Configuration](#network-backend-configuration-caas))
 
 **Configuration Manifests**
 
@@ -75,11 +77,10 @@ target Hub cluster.
 > files modify cluster-wide settings. Please coordinate with the appropriate cluster
 > administrators before proceeding.
 
-
 ### Prerequisites Summary
 
 | **Category** | **Requirement** | **Notes / Details** |
-|---------------|-----------------|----------------------|
+| --------------- | ----------------- | ---------------------- |
 | **Platform** | Red Hat OpenShift Container Platform (OCP) 4.17 or later | Must have cluster admin access to the hub cluster. |
 | **Operators** | Red Hat Advanced Cluster Management (RHACM) 2.18+<br>Red Hat OpenShift Virtualization (OCP-Virt) 4.17+<br>Red Hat Ansible Automation Platform (AAP) 2.5+ | These must be installed and running prior to OSAC installation. |
 | **CLI Tools** | `oc` (OpenShift CLI) v4.17+<br>`helm` v3.x<br>`git` | Ensure all CLIs are available in your `PATH`. |
@@ -90,7 +91,6 @@ target Hub cluster.
 | **Permissions** | Cluster-admin access to deploy operators and create CRDs | Limited access users can only deploy into namespaces configured by the admin. |
 | **License Files** | `license.zip` (AAP subscription) | Must be placed in your values directory (e.g., `values/<env>/license.zip`). |
 | **Internet Access** | Outbound access to GitHub and `ghcr.io` (for fetching chart dependencies, OCI charts, and releases) | Required during installation and updates. |
-
 
 ## Installation
 
@@ -145,7 +145,7 @@ make install-osac  PLATFORM=openshift PROFILE=<profile> NS=<namespace>   # OSAC 
 ```
 
 | Variable | Description |
-|----------|-------------|
+| ---------- | ------------- |
 | `PLATFORM` | `kind` or `openshift` (required) |
 | `PROFILE` | `dev`, `dev-full`, `vmaas-ci`, `bmaas-ci`, `caas-ci`, or `full-ci` (required; `dev-full` is kind only) |
 | `NS` | Target namespace (required) |
@@ -162,6 +162,39 @@ the end-to-end "create a VM from the UI" experience:
 ```bash
 make install PLATFORM=kind PROFILE=dev-full NS=osac
 ```
+
+To use source-built images, use the existing component build targets and then
+load the resulting image tags into Kind. Use the same `CONTAINER_TOOL` value for
+building and loading; the image names must remain registry-qualified so they
+match the dev-full Helm values:
+
+```bash
+make install-infra PLATFORM=kind PROFILE=dev-full NS=osac
+
+export CONTAINER_TOOL=podman  # Use docker consistently instead if preferred.
+make -C ../fulfillment-service image-build \
+  IMG=ghcr.io/osac-project/fulfillment-service:latest \
+  CONTAINER_TOOL="$CONTAINER_TOOL"
+make -C ../osac-operator image-build \
+  IMG=ghcr.io/osac-project/osac-operator:latest \
+  CONTAINER_TOOL="$CONTAINER_TOOL"
+make -C ../osac-csi-driver image-build \
+  IMG=ghcr.io/osac-project/osac-csi-driver:latest \
+  CONTAINER_TOOL="$CONTAINER_TOOL"
+"$CONTAINER_TOOL" build -t ghcr.io/osac-project/osac-ui:latest \
+  -f ../../osac-ui/Containerfile ../../osac-ui
+
+make kind-load-images PLATFORM=kind PROFILE=dev-full NS=osac \
+  CONTAINER_TOOL="$CONTAINER_TOOL"
+make install-osac PLATFORM=kind PROFILE=dev-full NS=osac
+make install-devstack PLATFORM=kind PROFILE=dev-full NS=osac
+```
+
+`kind-load-images` only loads already-built images; it does not rebuild them.
+After changing source code, rerun the relevant component `image-build` target
+and then `kind-load-images`. Loaded images are restarted only for workloads that
+use one of the local image references. Each Go component also exposes a
+single-image `kind-load-image` target when loading only that component is useful.
 
 On top of `dev`, `dev-full` adds (via `scripts/dev-full/`, orchestrated by the
 `install-devstack` target):
@@ -195,13 +228,19 @@ so networking resources reconcile to READY without a real fabric (kind has none)
     install the drop-in at `scripts/dev-full/manifests/podman-socket-rootful.conf`
   - **macOS** — Docker Desktop (auto-detected)
 - **`/dev/kvm`** present (Linux), **`fs.inotify.max_user_instances >= 256`**, and
-  `kind`, `helm`, `kubectl`, `jq`, `curl`, `openssl`, `python3` on `PATH`
+  `kind`, `helm`, `kubectl`, `jq`, `curl`, `openssl`, and `python3` on `PATH`
 - Override runtime detection with `KIND_EXPERIMENTAL_PROVIDER=docker|podman`
 
 On an Apple Silicon Mac, the install target automatically builds an arm64
 replacement for `quay.io/openshift/origin-cli:4.20.0` with Docker and loads it
 into the kind cluster before installing Helm charts. Docker Desktop must be
 running; no manual image setup is required.
+
+`dev-full` uses the normal `ghcr.io/osac-project/...:latest` image references, so
+the rendered deployment does not need a development-only registry name. The
+profile uses `IfNotPresent`: Kubernetes uses an image loaded in the node and does
+not pull it again, while still allowing a partial deployment to pull an image
+that has not been built locally.
 
 **Endpoints** (via the kind port mappings; every `*.localhost` name resolves to
 127.0.0.1 automatically, so no `/etc/hosts` editing is needed):
@@ -300,6 +339,7 @@ make uninstall
 make install       PLATFORM=... PROFILE=... NS=...  # Full install (infra + osac)
 make install-infra PLATFORM=... PROFILE=... NS=...  # Infrastructure only
 make install-osac  PLATFORM=... PROFILE=... NS=...  # OSAC application only
+make kind-load-images PLATFORM=kind PROFILE=dev-full NS=... # Load existing images
 make uninstall     PLATFORM=... PROFILE=... NS=...  # Full uninstall
 make test          PLATFORM=... PROFILE=... NS=... SUITE=...  # Integration tests
 make helm-lint                                       # Lint all charts
@@ -383,7 +423,7 @@ After deployment, you can access the AAP web interface to monitor jobs and manag
 ### Get the AAP URL
 
 ```bash
-$ oc get route -n <project-name> | grep osac-aap
+oc get route -n <project-name> | grep osac-aap
 ```
 
 > **Note:** The main AAP URL will be something like: `https://osac-aap-<project-name>.apps.your-cluster.com`
@@ -423,6 +463,7 @@ $ EXTRA_SERVICES=true INSTALLER_NAMESPACE=<project-name> ./scripts/teardown.sh
 ```
 
 The script removes resources in reverse order:
+
 1. OSAC CRs (while operator is running for finalizer processing)
 2. Helm release and project namespace
 3. Keycloak
@@ -437,9 +478,10 @@ The script removes resources in reverse order:
 > **Warning:** This removes **all** prerequisite operators and their namespaces. If other
 > workloads on the cluster depend on these operators (e.g., cert-manager, MetalLB), do not
 > run this script. Instead, manually uninstall:
+>
 > ```bash
-> $ helm uninstall osac -n <project-name>
-> $ oc delete namespace <project-name>
+> helm uninstall osac -n <project-name>
+> oc delete namespace <project-name>
 > ```
 
 ## Troubleshooting
@@ -479,6 +521,7 @@ $ oc get events -n <project-name> --sort-by=.metadata.creationTimestamp
 ## Support
 
 For issues and questions:
+
 - Check the troubleshooting section above
 - Review component logs for error messages
 - Verify prerequisites are properly installed

--- a/osac-installer/charts/osac-devstack/files/seed-catalog-simple.sh
+++ b/osac-installer/charts/osac-devstack/files/seed-catalog-simple.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Seed the OSAC catalog via the private gRPC API
+# Seed the OSAC catalog via the private REST API.
 #
 # Creates disk images, instance types, templates, and catalog items for dev-full.
 # Values are hardcoded from catalog-seed.yaml for simplicity.
@@ -11,24 +11,58 @@ set -euo pipefail
 SERVICE="${1:-fulfillment-internal-api}"
 PORT="${2:-8001}"
 NS="${NS:-osac}"
+ADMIN_TOKEN="${ADMIN_TOKEN:-$(kubectl -n "${NS}" create token admin)}"
 
 log() { echo "[+] $*"; }
 
-# Helper: gRPC call via grpcurl
-grpc_call() {
-  local method="$1"
-  local data="$2"
-  grpcurl -plaintext -d "${data}" "${SERVICE}.${NS}.svc.cluster.local:${PORT}" "${method}"
+# The internal API is TLS-enabled. The certificate is signed by the dev CA, so
+# curl skips verification while still using TLS for the connection.
+API="https://${SERVICE}.${NS}.svc.cluster.local:${PORT}/api/private/v1"
+CURL=(curl -skS \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "Content-Type: application/json")
+
+# Create a resource, treating only a 409 response as an idempotent success.
+# Validation, authentication, and transport errors must fail the hook instead
+# of being reported as successful seeding.
+create_or_skip() {
+  local label="$1"
+  local path="$2"
+  local data="$3"
+  local response
+  local status
+  local body
+
+  if ! response=$("${CURL[@]}" -X POST "${API}/${path}" -d "${data}" -w $'\n%{http_code}' 2>&1); then
+    printf '%s\n' "${response}" >&2
+    return 1
+  fi
+
+  status="${response##*$'\n'}"
+  body="${response%$'\n'*}"
+  case "${status}" in
+    2??)
+      log "  ${label}"
+      return 0
+      ;;
+    409)
+    log "  ${label} (already exists)"
+    return 0
+      ;;
+    *)
+      printf 'HTTP %s: %s\n' "${status}" "${body}" >&2
+      return 1
+      ;;
+  esac
 }
 
 log "Seeding catalog into '${NS}'..."
 
 # Disk images
 log "Creating disk images..."
-grpc_call "osac.private.v1.DiskImages/Create" \
-  '{"object":{"metadata":{"name":"fedora"},"spec":{"sourceType":"SOURCE_TYPE_REGISTRY","sourceRef":"quay.io/containerdisks/fedora:latest","architecture":["amd64","arm64"]}}}' \
-  >/dev/null 2>&1 || log "  disk-image: fedora (already exists)"
-log "  disk-image: fedora"
+create_or_skip "disk-image: fedora" \
+  "disk_images" \
+  '{"metadata":{"name":"fedora","tenant":"shared"},"spec":{"source_type":"SOURCE_TYPE_REGISTRY","source_ref":"quay.io/containerdisks/fedora:latest","guest_os_family":"GUEST_OS_FAMILY_LINUX","architecture":["ARCHITECTURE_AMD64"],"lifecycle":"DISK_IMAGE_LIFECYCLE_AVAILABLE"}}'
 
 # Instance types
 log "Creating instance types..."
@@ -37,24 +71,21 @@ for it in \
   "u1-medium:4:8:4 cores, 8 GiB RAM" \
   "u1-large:8:16:8 cores, 16 GiB RAM"; do
   IFS=: read -r name cores memGib desc <<<"$it"
-  grpc_call "osac.private.v1.ComputeInstanceTypes/Create" \
-    "{\"object\":{\"metadata\":{\"name\":\"${name}\"},\"spec\":{\"cores\":${cores},\"memoryGib\":${memGib},\"description\":\"${desc}\"}}}" \
-    >/dev/null 2>&1 || log "  instance-type: ${name} (already exists)"
-  log "  instance-type: ${name} (${cores} cores, ${memGib} GiB RAM)"
+  create_or_skip "instance-type: ${name} (${cores} cores, ${memGib} GiB RAM)" \
+    "instance_types" \
+    "{\"metadata\":{\"name\":\"${name}\"},\"spec\":{\"cores\":${cores},\"memory_gib\":${memGib},\"description\":\"${desc}\",\"state\":\"INSTANCE_TYPE_STATE_ACTIVE\"}}"
 done
 
 # Templates
 log "Creating templates..."
-grpc_call "osac.private.v1.ComputeInstanceTemplates/Create" \
-  '{"object":{"metadata":{"name":"osac.templates.ocp_virt_vm"},"spec":{"title":"Virtual Machine Template (Linux and Windows)"}}}' \
-  >/dev/null 2>&1 || log "  template: osac.templates.ocp_virt_vm (already exists)"
-log "  template: osac.templates.ocp_virt_vm"
+create_or_skip "template: osac.templates.ocp_virt_vm" \
+  "compute_instance_templates" \
+  '{"id":"osac.templates.ocp_virt_vm","title":"Virtual Machine Template (Linux and Windows)","description":"VM template for OpenShift Virtualization supporting Linux and Windows guests.","spec_defaults":{"boot_disk":{"size_gib":10},"run_strategy":"Always","instance_type":{"name":"u1-medium"},"disk_image":{"name":"fedora"}},"parameters":[{"name":"exposed_ports","title":"Exposed Ports","description":"Ports to expose (e.g. 22/tcp,80/tcp)","type":"string","required":false}]}'
 
 # Catalog items
 log "Creating catalog items..."
-grpc_call "osac.private.v1.CatalogItems/Create" \
-  '{"object":{"metadata":{"name":"linux-vm"},"spec":{"title":"Linux Virtual Machine","description":"Fedora-based VM with KVM acceleration","templateId":"osac.templates.ocp_virt_vm","published":true}}}' \
-  >/dev/null 2>&1 || log "  catalog-item: linux-vm (already exists)"
-log "  catalog-item: linux-vm"
+create_or_skip "catalog-item: linux-vm" \
+  "compute_instance_catalog_items" \
+  '{"metadata":{"name":"linux-vm"},"title":"Linux Virtual Machine","description":"Fedora-based VM with KVM acceleration. Default: 4 cores, 8 GiB RAM, 10 GiB disk.","template":{"id":"osac.templates.ocp_virt_vm"},"published":true}'
 
 log "Catalog seeded — ready to create compute instances"

--- a/osac-installer/charts/osac-devstack/templates/hooks/seed-catalog.yaml
+++ b/osac-installer/charts/osac-devstack/templates/hooks/seed-catalog.yaml
@@ -44,7 +44,7 @@ spec:
       - name: seed-catalog
         image: {{ .Values.cliImage }}
         command: ["/bin/bash", "/scripts/seed-catalog-simple.sh"]
-        args: ["{{ .Values.osacNamespace }}"]
+        args: ["{{ .Values.catalog.internalApiService }}", "{{ .Values.catalog.internalApiPort }}"]
         env:
         - name: NS
           value: {{ .Values.osacNamespace | quote }}

--- a/osac-installer/charts/osac-devstack/values.yaml
+++ b/osac-installer/charts/osac-devstack/values.yaml
@@ -45,7 +45,7 @@ ui:
   image:
     repository: ghcr.io/osac-project/osac-ui
     tag: latest  # DEV_FLOATING -- intentionally unpinned for local dev
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   replicas: 1
   resources:
     requests: {cpu: 100m, memory: 128Mi}

--- a/osac-installer/scripts/dev-full/kind-load-image.mk
+++ b/osac-installer/scripts/dev-full/kind-load-image.mk
@@ -1,0 +1,15 @@
+# Shared Make helper for loading a component image into the dev-full Kind cluster.
+# The implementation remains in kind-load-image.sh so it is independent of each
+# component's shell and Make settings.
+
+KIND_INSTALLER_DIR ?= $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../..)
+KIND_LOAD_IMAGE_SCRIPT ?= $(KIND_INSTALLER_DIR)/scripts/dev-full/kind-load-image.sh
+KIND_CLUSTER_NAME ?= osac-dev
+
+PROFILE=dev-full
+NS=osac
+define kind-load-image
+	PLATFORM="kind" PROFILE="$(PROFILE)" NS="$(NS)" \
+	KIND_CLUSTER_NAME="$(KIND_CLUSTER_NAME)" KUBECONFIG="$(KUBECONFIG)" \
+	CONTAINER_TOOL="$(CONTAINER_TOOL)" "$(KIND_LOAD_IMAGE_SCRIPT)" "$(1)"
+endef

--- a/osac-installer/scripts/dev-full/kind-load-image.sh
+++ b/osac-installer/scripts/dev-full/kind-load-image.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Load one locally built image into the PROFILE=dev-full Kind cluster.
+# Component Makefiles call this script so the runtime and kubeconfig details stay
+# owned by the installer rather than being duplicated in each component.
+
+set -euo pipefail
+
+IMAGE="${1:?usage: kind-load-image.sh IMAGE}"
+PLATFORM="${PLATFORM:?PLATFORM is required}"
+PROFILE="${PROFILE:?PROFILE is required}"
+NS="${NS:?NS is required}"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-osac-dev}"
+CONTAINER_TOOL="${CONTAINER_TOOL:-podman}"
+INSTALLER_DIR="$(CDPATH= cd -- "$(dirname "${BASH_SOURCE[0]}")/../.." >/dev/null && pwd)"
+KIND_RUNTIME="${INSTALLER_DIR}/scripts/dev-full/kind-runtime.sh"
+
+if [[ "${PLATFORM}/${PROFILE}" != "kind/dev-full" ]]; then
+  echo "ERROR: image loading requires PLATFORM=kind PROFILE=dev-full" >&2
+  exit 1
+fi
+
+if [[ -z "${KUBECONFIG:-}" ]]; then
+  KUBECONFIG="${HOME}/.kube/${KIND_CLUSTER_NAME}-kind-root.kubeconfig"
+  export KUBECONFIG
+fi
+
+"${KIND_RUNTIME}" check
+"${KIND_RUNTIME}" get clusters | grep -q "^${KIND_CLUSTER_NAME}$" || {
+  echo "ERROR: Kind cluster '${KIND_CLUSTER_NAME}' does not exist; run make install-infra first" >&2
+  exit 1
+}
+
+tmpfile="$(mktemp /tmp/kind-image-XXXXXX.tar)"
+trap 'rm -f "${tmpfile}"' EXIT
+echo "Loading ${IMAGE} into Kind cluster ${KIND_CLUSTER_NAME}..."
+"${CONTAINER_TOOL}" save "${IMAGE}" > "${tmpfile}"
+"${KIND_RUNTIME}" load image-archive "${tmpfile}" --name "${KIND_CLUSTER_NAME}"
+
+if kubectl get namespace "${NS}" >/dev/null 2>&1; then
+  for resource in deployment daemonset; do
+    names="$(kubectl -n "${NS}" get "${resource}" -o json 2>/dev/null |
+      jq -r --arg image "${IMAGE}" \
+        '.items[] | select(any(.spec.template.spec.containers[]?; .image == $image)) | .metadata.name' || true)"
+    while IFS= read -r name; do
+      [[ -n "${name}" ]] || continue
+      echo "Restarting ${resource}/${name} after loading ${IMAGE}..."
+      kubectl -n "${NS}" rollout restart "${resource}/${name}"
+    done <<< "${names}"
+  done
+else
+  echo "Namespace ${NS} does not exist yet; the image is loaded for the next install."
+fi

--- a/osac-installer/values/dev/kind-instance-devfull.yaml
+++ b/osac-installer/values/dev/kind-instance-devfull.yaml
@@ -10,6 +10,8 @@
 # controller itself stays enabled (kind-instance.yaml: operator.controllers.networking=true)
 # so it still runs and marks resources Ready.
 operator:
+  image:
+    pullPolicy: IfNotPresent
   controllers:
     networkingProvisioning: false
     storage: true
@@ -25,6 +27,8 @@ operator:
 # local PVs) which doesn't require external storage array controllers.
 csiDriver:
   enabled: true
+  image:
+    pullPolicy: IfNotPresent
 
 # csiBackends chart is deployed (same condition as csiDriver), but all vendor
 # backends are disabled. To enable a backend for testing, set csiBackends.<vendor>.enabled: true
@@ -45,6 +49,8 @@ csiBackends: {}
 # left as-is — only in-cluster controllers use it, never the browser.
 service:
   externalHostname: fulfillment-api.osac.localhost
+  images:
+    pullPolicy: IfNotPresent
   auth:
     issuerUrl: https://keycloak.osac.localhost:8443/realms/osac
   idp:

--- a/osac-operator/Makefile
+++ b/osac-operator/Makefile
@@ -163,6 +163,10 @@ image-build: ## Build container image with manager and console-proxy.
 image-push: ## Push container image.
 	$(CONTAINER_TOOL) push ${IMG}
 
+.PHONY: kind-load-image
+kind-load-image: ## Load the built image into the dev-full Kind cluster.
+	$(call kind-load-image,$(IMG))
+
 .PHONY: image-run
 image-run: ## Run container image locally.
 	$(CONTAINER_TOOL) run --rm --userns keep-id --name osac-controller \
@@ -238,6 +242,7 @@ CONTROLLER_TOOLS_VERSION ?= v0.20.0
 ENVTEST_VERSION ?= release-0.19
 
 include $(shell git rev-parse --show-toplevel)/tools/golangci-lint.mk
+include $(shell git rev-parse --show-toplevel)/osac-installer/scripts/dev-full/kind-load-image.mk
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.


### PR DESCRIPTION
Additional fixes:
- move the seed catalog to REST from grpc, to not rely on grpcurl binary

Signed-off-by: Roy Golan <rgolan@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

### Deployment and development workflow
- Adds shared support for loading locally built images into the `kind/dev-full` cluster.
- Adds `kind-load-image` targets to component Makefiles.
- Adds the `kind-load-images` installer target and integration-test image loading.
- Validates the Kind runtime, cluster, namespace, and image before loading.
- Restarts matching workloads after an image load.
- Sets `dev-full` image pull policies to `IfNotPresent`.
- Adds Apple Silicon CLI-image handling during cluster creation.

### API and security
- Replaces seed-catalog gRPC calls and the `grpcurl` dependency with REST calls over TLS.
- Uses a Kubernetes-generated admin bearer token.
- Treats 2xx responses and HTTP 409 conflicts as successful create-or-skip operations.
- Fails on transport errors and other HTTP errors.

### Documentation
- Documents image builds, image loading, rebuilds, registry-qualified `latest` images, `IfNotPresent` behavior, and Apple Silicon handling.

### Backward compatibility
- No production API or persistent data model change is indicated.
- Seed-catalog transport changes from gRPC to REST and require updated service, port, and authentication parameters.
- `dev-full` no longer always pulls images, so locally loaded images must use matching image references and `IfNotPresent`.
- The new image-loading workflow is limited to Kind development and integration-test environments.

## Risk classification

**risk:show** — The change modifies deployment behavior, Kind image loading, workload restarts, image pull policies, and authenticated catalog seeding. The scope is limited to development and installer workflows, but failures can affect local cluster setup and seed-catalog execution.

The change does not qualify for **risk:ship** because it changes deployment and authentication flows. It does not qualify for **risk:ask** because the change has a limited scope, validates inputs and cluster state, cleans up temporary image archives, and does not indicate a production runtime change or database migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->