### PR TITLE
OSAC-5178: Restore OCI dependency rewrite for all umbrella chart dependencies at publish time

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -835,16 +835,28 @@ jobs:
     - name: Build umbrella chart dependencies
       env:
         OCI_REPO: oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
+        COMPONENT_VERSIONS: ${{ needs.prepare.outputs.component-versions }}
       run: |
         set -euo pipefail
         source osac-installer/scripts/nightly-charts.sh
+
+        CHART_YAML="osac-installer/charts/osac/Chart.yaml"
+
+        # Every mono-repo-resident sub-chart with a resolved version was
+        # already packaged and pushed to GHCR above ("Package and push
+        # sub-charts") -- point the umbrella at those real published
+        # artifacts instead of the committed file:// dev paths. A component
+        # with no resolved version this run has nothing published to point
+        # at, so it stays on file:// (see rewrite_umbrella_mono_repo_dependencies).
+        rewrite_umbrella_mono_repo_dependencies "${CHART_YAML}" "${OCI_REPO}" "${COMPONENT_VERSIONS}"
+
         if [[ -f osac-ui-nightly-version.txt ]]; then
           UI_SUB_VERSION=$(<osac-ui-nightly-version.txt)
-          rewrite_umbrella_osac_ui_dependency_and_rebuild \
-            osac-installer/charts/osac/Chart.yaml "${UI_SUB_VERSION}" "${OCI_REPO}"
-        else
-          helm dependency build osac-installer/charts/osac/
+          rewrite_umbrella_osac_ui_dependency "${CHART_YAML}" "${UI_SUB_VERSION}" "${OCI_REPO}"
         fi
+
+        rm -f osac-installer/charts/osac/Chart.lock
+        helm dependency build osac-installer/charts/osac/
 
     - name: Lint chart
       working-directory: osac-installer

--- a/.github/workflows/publish-osac-installer-chart.yaml
+++ b/.github/workflows/publish-osac-installer-chart.yaml
@@ -96,6 +96,46 @@ jobs:
         echo "Umbrella (and osac-operator/fulfillment-service/osac-aap/bare-metal-fulfillment-operator): ${version}"
         echo "osac-ui: ${ui_ver}"
 
+    - name: Verify mono-repo chart dependencies are published
+      env:
+        VERSION: ${{ steps.versions.outputs.version }}
+      run: |
+        set -euo pipefail
+        source osac-installer/scripts/nightly-charts.sh
+
+        # osac-operator(-crds), fulfillment-service, osac-aap,
+        # bare-metal-fulfillment-operator(-crds), osac-metering, and
+        # csi-driver/csi-backends are mono-repo-resident and share this
+        # release's single VERSION (see the "Component versions" table in
+        # the release-notes step below) -- but nothing before this step
+        # ever confirmed publish-charts.yaml actually published each of
+        # them at that version yet. Fail loudly here rather than let the
+        # rewrite below silently pin a version that isn't in GHCR.
+        check_umbrella_mono_repo_charts_published "${VERSION}" "${{ github.repository_owner }}"
+
+    - name: Rewrite mono-repo chart dependencies to published OCI versions
+      env:
+        VERSION: ${{ steps.versions.outputs.version }}
+      run: |
+        set -euo pipefail
+        source osac-installer/scripts/nightly-charts.sh
+
+        OCI_REPO="oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}"
+        COMPONENT_VERSIONS=$(jq -n --arg v "${VERSION}" '{
+          "osac-operator": $v,
+          "fulfillment-service": $v,
+          "osac-aap": $v,
+          "bare-metal-fulfillment-operator": $v,
+          "osac-metering": $v,
+          "osac-csi-driver": $v
+        }')
+
+        rewrite_umbrella_mono_repo_dependencies \
+          osac-installer/charts/osac/Chart.yaml "${OCI_REPO}" "${COMPONENT_VERSIONS}"
+
+        echo "--- Updated Chart.yaml (mono-repo dependencies) ---"
+        cat osac-installer/charts/osac/Chart.yaml
+
     - name: Rewrite osac-ui dependency to the requested OCI version
       env:
         UI_VER: ${{ steps.versions.outputs.ui_ver }}
@@ -103,19 +143,16 @@ jobs:
         cd osac-installer/charts/osac
         OCI_REPO="oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}"
 
-        # osac-operator(-crds), fulfillment-service, osac-aap,
-        # bare-metal-fulfillment-operator(-crds), and csi-driver/csi-backends
-        # stay on their committed file:// dependencies -- they're
-        # mono-repo-resident (or a submodule checked out alongside this
-        # chart), so `helm dependency build` resolves them straight from
-        # this checkout with no rewrite needed. Only osac-ui is a real
-        # external OCI chart dependency this workflow re-pins per release.
+        # osac-ui is the one umbrella dependency with its own independent
+        # release cadence (see the ui_version workflow input above) -- every
+        # other dependency was already re-pinned to its published OCI
+        # version by the "Rewrite mono-repo chart dependencies" step above.
         yq -i "
           (.dependencies[] | select(.name == \"osac-ui\")) .repository = \"${OCI_REPO}\" |
           (.dependencies[] | select(.name == \"osac-ui\")) .version = \"${UI_VER}\"
         " Chart.yaml
 
-        # Remove stale Chart.lock so helm pulls the newly-pinned osac-ui version
+        # Remove stale Chart.lock so helm pulls every newly-pinned dependency version
         rm -f Chart.lock
 
         echo "--- Updated Chart.yaml ---"

--- a/.github/workflows/publish-osac-installer-chart.yaml
+++ b/.github/workflows/publish-osac-installer-chart.yaml
@@ -186,7 +186,7 @@ jobs:
       run: |
         set -euo pipefail
         # Mirrors helm-lint.yaml's own two loops (ci/*-values.yaml need no
-        # extra overrides, they're self-contained; values/*/values.yaml
+        # extra overrides, they're self-contained; values/*/instance.yaml
         # leave hostnames blank for a real cluster to fill in) -- this step
         # is checking the just-rewritten Chart.yaml/values.yaml render
         # cleanly across every overlay this chart actually ships, not just
@@ -196,8 +196,14 @@ jobs:
           helm lint charts/osac/ --values "$f"
           helm template osac charts/osac/ --values "$f" > /dev/null
         done
-        for f in values/*/values.yaml; do
-          echo "--- helm lint/template with $(dirname "$f" | xargs basename) ---"
+        # Per-environment overlays under values/*/ mix instance.yaml (this
+        # chart) with infra.yaml (osac-deps/osac-infra, a different chart --
+        # not packaged/validated here). Only pick up instance.yaml, and only
+        # where present -- not every profile directory has one.
+        for d in values/*/; do
+          f="${d}instance.yaml"
+          [ -f "$f" ] || continue
+          echo "--- helm lint/template with $(basename "$d") ---"
           helm lint charts/osac/ --values "$f" \
             --set service.externalHostname=fulfillment-api.example.com \
             --set service.internalHostname=fulfillment-internal-api.example.com

--- a/osac-installer/scripts/nightly-charts.sh
+++ b/osac-installer/scripts/nightly-charts.sh
@@ -22,6 +22,24 @@ readonly NIGHTLY_CHART_SLACK_ORDER=(
     osac
 )
 
+# Every umbrella dependency other than osac-ui, mapped "<Chart.yaml
+# dependency name>:<owning component>" -- the owning component is what
+# COMPONENT_VERSIONS (nightly-build.yaml's per-release-cut version map) is
+# keyed by. osac-operator-crds/bare-metal-fulfillment-operator-crds/
+# csi-backends share their owning component's version with their non-crds
+# sibling chart; they have no independent release cadence of their own.
+readonly MONO_REPO_UMBRELLA_DEPENDENCIES=(
+    "osac-operator-crds:osac-operator"
+    "osac-operator:osac-operator"
+    "fulfillment-service:fulfillment-service"
+    "osac-aap:osac-aap"
+    "bare-metal-fulfillment-operator-crds:bare-metal-fulfillment-operator"
+    "bare-metal-fulfillment-operator:bare-metal-fulfillment-operator"
+    "osac-metering:osac-metering"
+    "csi-driver:osac-csi-driver"
+    "csi-backends:osac-csi-driver"
+)
+
 # CI overlay values files with their own separate floating image tag
 # overrides for mono-repo components (operator/aap/bmf/metering/csiDriver),
 # on top of the umbrella chart's own values.yaml. Not every file overrides
@@ -98,6 +116,74 @@ check_osac_ui_image() {
     fi
 
     echo "${sha}"
+}
+
+# Usage: check_chart_published <chart_name> <version> [repo_owner]
+# Verify oci://ghcr.io/<repo_owner>/charts/<chart_name>:<version> exists.
+# Same anonymous-GHCR-token-then-manifest-HEAD-check technique as
+# check_osac_ui_image above, applied to a chart OCI artifact (helm push)
+# rather than a container image -- GHCR serves both under the same
+# manifests API, just under the "charts/<name>" package path helm push uses.
+check_chart_published() {
+    local chart_name="$1" version="$2" repo_owner="${3:-osac-project}"
+    local token safe_name safe_version
+
+    if [[ ! "${chart_name}" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+        safe_name=$(_gha_sanitize_for_message "${chart_name}")
+        echo "::error::Invalid chart name '${safe_name}' — must match [a-zA-Z0-9._-]+" >&2
+        return 1
+    fi
+    if [[ ! "${version}" =~ ^[a-zA-Z0-9._+-]+$ ]]; then
+        safe_version=$(_gha_sanitize_for_message "${version}")
+        echo "::error::Invalid version '${safe_version}' for chart ${chart_name}" >&2
+        return 1
+    fi
+
+    safe_name=$(_gha_sanitize_for_message "${chart_name}")
+    if ! token=$(http_json "Could not obtain GHCR token to verify chart ${safe_name}:${version}" 3 5 '.token' \
+        "https://ghcr.io/token?scope=repository:${repo_owner}/charts/${chart_name}:pull"); then
+        echo "::error::Could not obtain GHCR token to verify chart ${safe_name}:${version}" >&2
+        return 1
+    fi
+    if [[ -z "${token}" || "${token}" == "null" ]]; then
+        echo "::error::GHCR token is empty or null for chart ${safe_name}:${version}" >&2
+        return 1
+    fi
+
+    if ! http_retry "Chart ${safe_name}:${version} not found in GHCR" 3 5 \
+        -s -o /dev/null \
+        -H "Authorization: Bearer ${token}" \
+        -H "Accept: application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json" \
+        "https://ghcr.io/v2/${repo_owner}/charts/${chart_name}/manifests/${version}"; then
+        echo "::error::Chart ${safe_name}:${version} not found in GHCR — has publish-charts.yaml published it yet for this release?" >&2
+        return 1
+    fi
+}
+
+# Usage: check_umbrella_mono_repo_charts_published <version> [repo_owner]
+# Verify every mono-repo-resident umbrella dependency (see
+# MONO_REPO_UMBRELLA_DEPENDENCIES) is already published to GHCR at
+# <version> -- one shared version across all of them per release cut (see
+# publish-osac-installer-chart.yaml's "Component versions" release-notes
+# table). Closes the ordering gap between publish-charts.yaml's per-component
+# publishes and the umbrella publish, which has no explicit dependency on
+# them completing first: checks every dependency (not just the first
+# failure) so a caller sees the full list of what's missing at once, and
+# fails loudly rather than letting the umbrella rewrite proceed and silently
+# ship a stale file:// path for whatever isn't published yet.
+check_umbrella_mono_repo_charts_published() {
+    local version="$1" repo_owner="${2:-osac-project}"
+    local entry dep_name failed=0
+
+    for entry in "${MONO_REPO_UMBRELLA_DEPENDENCIES[@]}"; do
+        dep_name="${entry%%:*}"
+        check_chart_published "${dep_name}" "${version}" "${repo_owner}" || failed=1
+    done
+
+    if (( failed )); then
+        echo "::error::One or more mono-repo-resident chart dependencies are not yet published at version ${version} — aborting rather than shipping a file:// dependency path in the published umbrella chart" >&2
+        return 1
+    fi
 }
 
 # Usage: retag_component_image <image_repo> <source_short_sha> <target_version>
@@ -483,33 +569,55 @@ _build_slack_charts_table() {
     printf '%s' "${table}"
 }
 
-# Usage: rewrite_umbrella_osac_ui_dependency <chart_yaml> <ui_version> <oci_repo>
+# Usage: rewrite_umbrella_dependency <chart_yaml> <dep_name> <version> <oci_repo>
 # yamllint is not performed on Chart.yaml. Hence, use of yq is safe here.
-rewrite_umbrella_osac_ui_dependency() {
-    local chart_yaml="$1" ui_version="$2" oci_repo="$3"
+rewrite_umbrella_dependency() {
+    local chart_yaml="$1" dep_name="$2" version="$3" oci_repo="$4"
     local safe_chart_yaml
     if [[ ! -f "${chart_yaml}" ]]; then
         safe_chart_yaml=$(_gha_sanitize_for_message "${chart_yaml}")
         echo "::error::Chart manifest not found: ${safe_chart_yaml}" >&2
         return 1
     fi
-    UI_VERSION="${ui_version}" yq -i \
-        '(.dependencies[] | select(.name == "osac-ui")).version = strenv(UI_VERSION)' \
+    DEP_NAME="${dep_name}" DEP_VERSION="${version}" yq -i \
+        '(.dependencies[] | select(.name == strenv(DEP_NAME))).version = strenv(DEP_VERSION)' \
         "${chart_yaml}"
-    UI_REPO="${oci_repo}" yq -i \
-        '(.dependencies[] | select(.name == "osac-ui")).repository = strenv(UI_REPO)' \
+    DEP_NAME="${dep_name}" DEP_REPO="${oci_repo}" yq -i \
+        '(.dependencies[] | select(.name == strenv(DEP_NAME))).repository = strenv(DEP_REPO)' \
         "${chart_yaml}"
 }
 
-# Usage: rewrite_umbrella_osac_ui_dependency_and_rebuild <chart_yaml> <ui_version> <oci_repo>
-rewrite_umbrella_osac_ui_dependency_and_rebuild() {
+# Usage: rewrite_umbrella_osac_ui_dependency <chart_yaml> <ui_version> <oci_repo>
+rewrite_umbrella_osac_ui_dependency() {
     local chart_yaml="$1" ui_version="$2" oci_repo="$3"
-    local chart_dir
-    chart_dir=$(dirname "${chart_yaml}")
+    rewrite_umbrella_dependency "${chart_yaml}" osac-ui "${ui_version}" "${oci_repo}"
+}
 
-    rewrite_umbrella_osac_ui_dependency "${chart_yaml}" "${ui_version}" "${oci_repo}"
-    rm -f "${chart_dir}/Chart.lock"
-    helm dependency build "${chart_dir}/"
+# Usage: rewrite_umbrella_mono_repo_dependencies <chart_yaml> <oci_repo> <component_versions_json>
+# Rewrite every mono-repo-resident umbrella dependency (everything but
+# osac-ui -- see MONO_REPO_UMBRELLA_DEPENDENCIES) from its committed file://
+# path to a pinned oci:// reference, for every dependency whose owning
+# component has a resolved version in component_versions_json (a JSON map
+# of component name -> version, same shape as nightly-build.yaml's
+# COMPONENT_VERSIONS output). A dependency whose owning component has no
+# resolved version is left on its committed file:// path -- mirrors how the
+# nightly build already skips packaging/publishing that component's
+# sub-chart entirely when it has no release tag yet, so there is nothing to
+# point the umbrella at.
+rewrite_umbrella_mono_repo_dependencies() {
+    local chart_yaml="$1" oci_repo="$2" component_versions_json="$3"
+    local entry dep_name component version
+
+    for entry in "${MONO_REPO_UMBRELLA_DEPENDENCIES[@]}"; do
+        dep_name="${entry%%:*}"
+        component="${entry#*:}"
+        version=$(jq -r --arg k "${component}" '.[$k] // empty' <<<"${component_versions_json}")
+        if [[ -z "${version}" ]]; then
+            echo "::warning::Skipping OCI rewrite for ${dep_name} — no resolved version for ${component} this run (stays on its committed file:// path)" >&2
+            continue
+        fi
+        rewrite_umbrella_dependency "${chart_yaml}" "${dep_name}" "${version}" "${oci_repo}"
+    done
 }
 
 # Usage: stamp_osac_ui_chart <chart_dir> <sub_version> <image_ref>


### PR DESCRIPTION
## Summary

The umbrella chart (`osac-installer/charts/osac/Chart.yaml`) declares 9 mono-repo-resident dependencies via committed `file://../../../<component>/...` paths. That's correct and intentional for local development and PR/CI
validation (`helm lint`/`helm template`, nightly cross-component testing) — it lets those flows resolve in-progress, not-yet-published sibling changes without a publish step. This PR does **not** touch that.

It's wrong for the actual **published release artifact**: pulling the current chart from `oci://ghcr.io/osac-project/charts/osac` shows the `file://` strings shipped verbatim in the packaged `Chart.yaml`/`Chart.lock` — unresolvable outside the original mono-repo checkout. The `charts/` subdirectory is still fully vendored with real content, so `helm install`/`helm template` work fine for consumers today, but the dependency-provenance metadata is wrong, which matters more than usual here since this exact umbrella chart is the subject of [OSAC-4224](https://redhat.atlassian.net/browse/OSAC-4224) (shipping it to `registry.redhat.io` via Konflux, where dependency provenance is scrutinized).

`OSAC-4035` restored this "rewrite `file://` to a real pinned `oci://` ref at publish time, then rebuild dependencies for real" behavior — but only for `osac-ui`. The other 9 dependencies (osac-operator(-crds), fulfillment-service, osac-aap, bare-metal-fulfillment-operator(-crds), osac-metering, csi-driver, csi-backends) were never covered. This PR closes
that gap by generalizing the existing `osac-ui` pattern in `osac-installer/scripts/nightly-charts.sh` to all 9, and wiring it into both places that actually package/push the umbrella chart:

- **`nightly-build.yaml`**: its "Package and push sub-charts" step already  packages and pushes all 9 sub-charts to GHCR before building the umbrella's dependencies — it just never pointed the umbrella at them afterward. It now does, via the new shared `rewrite_umbrella_mono_repo_dependencies` helper. A component with no resolved nightly version this run (no release tag yet) is left on its committed `file://` path, same as today — there's nothing published to point it at.
- **`publish-osac-installer-chart.yaml`**: this is `workflow_dispatch`-only with no ordering guarantee against `publish-charts.yaml`'s per-component publishes at all — a caller manually enters a version and trusts the matching sub-chart publishes already happened. This PR adds a real pre-flight check (`check_umbrella_mono_repo_charts_published`, mirroring the existing `check_osac_ui_image` pattern) that verifies every dependency is actually published to GHCR at the release version *before* rewriting `Chart.yaml`. It fails loudly (checking and reporting every missing dependency, not just the first) rather than silently shipping a stale `file://` path.

No changes to `Chart.yaml` itself (dev/CI `file://` resolution is untouched), and `osac-ui`'s own logic/behavior is unchanged — only refactored so it shares the same underlying `rewrite_umbrella_dependency`
primitive as the newly-generalized code.

Also fixed, in the same "Validate chart" step: a pre-existing dead glob (`values/*/values.yaml`) that never matched anything, since the real files are named `instance.yaml`/`infra.yaml`. It now mirrors `helm-lint.yaml`'s
own working pattern (iterate `values/*/`, pick up `instance.yaml` where present). Found while validating this PR's own changes; unrelated to the OCI-rewrite fix itself but small enough to include here rather than file a separate ticket for a one-line loop fix in the same step.

## What I validated

- **Function-level, against real GHCR data**: copied `Chart.yaml` into a   scratch dir, looked up real already-published nightly chart versions for   all 9 components + osac-ui via `skopeo list-tags`, ran the new
  `rewrite_umbrella_mono_repo_dependencies` + `rewrite_umbrella_osac_ui_dependency`
  against them, then ran `helm dependency build` for real over the network.
  All 10 dependencies resolved from `oci://ghcr.io/osac-project/charts` —
  confirmed via the pulled digests in the command output.
- **Rendering**: ran `helm lint` + `helm template` against every
  `charts/osac/ci/*-values.yaml` and `values/*/instance.yaml` overlay with
  the OCI-resolved dependencies in place — all pass.
- **Pre-flight check, both paths**: exercised `check_chart_published`
  directly against real GHCR — a known-published version succeeds, a
  nonexistent version fails loudly with `::error::` after retries. Also
  exercised `check_umbrella_mono_repo_charts_published`'s aggregate
  behavior with a deliberately mismatched version, confirming it reports
  every missing dependency (not just the first) and fails the run.
- **Glob fix**: confirmed the corrected loop now matches all 5 real
  `values/*/instance.yaml` files (previously matched none), and re-ran
  `helm lint`/`helm template` against each.
- **Static checks**: `bash -n` on the changed shell; `pre-commit run`
  (yamllint --strict + the other repo-wide hooks) on all changed files —
  all pass.

## What still needs a real CI run to confirm

- The actual `workflow_dispatch` / `workflow_run` behavior of both
  workflows end-to-end (GITHUB_OUTPUT wiring, job-level env passing, the
  full nightly pipeline's job graph) — I could not trigger a real Actions
  run from here.
- `ct lint` (nightly-build.yaml's "Lint chart" step) against the
  fully-rewritten umbrella chart — I validated with `helm lint`/`helm
  template` directly instead, since `ct` isn't available in this
  environment.

## Test plan

- [ ] CI: yamllint / pre-commit
- [ ] Manually dispatch `publish-osac-installer-chart.yaml` against a
      version where not all sub-charts are published yet, and confirm it
      fails loudly at the new pre-flight step instead of proceeding
- [ ] Manually dispatch it again against a version where everything is
      published, and confirm the umbrella chart's published `Chart.yaml`
      now shows `oci://` for all 10 dependencies, and that the "Validate
      chart" step actually runs against the `values/*/instance.yaml`
      overlays
- [ ] Let a real nightly run confirm the same for `nightly-build.yaml`
