### PR TITLE
NO-ISSUE: surface nightly umbrella dependencies left on file:// in Slack and step summary

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -841,14 +841,18 @@ jobs:
         source osac-installer/scripts/nightly-charts.sh
 
         CHART_YAML="osac-installer/charts/osac/Chart.yaml"
+        SKIPPED_DEPS_FILE="skipped-umbrella-dependencies.txt"
+        : > "${SKIPPED_DEPS_FILE}"
 
         # Every mono-repo-resident sub-chart with a resolved version was
         # already packaged and pushed to GHCR above ("Package and push
         # sub-charts") -- point the umbrella at those real published
         # artifacts instead of the committed file:// dev paths. A component
         # with no resolved version this run has nothing published to point
-        # at, so it stays on file:// (see rewrite_umbrella_mono_repo_dependencies).
-        rewrite_umbrella_mono_repo_dependencies "${CHART_YAML}" "${OCI_REPO}" "${COMPONENT_VERSIONS}"
+        # at, so it stays on file:// (see rewrite_umbrella_mono_repo_dependencies)
+        # -- recorded to SKIPPED_DEPS_FILE so it's surfaced below and in the
+        # Slack summary, not just a raw log warning nobody reads on a green run.
+        rewrite_umbrella_mono_repo_dependencies "${CHART_YAML}" "${OCI_REPO}" "${COMPONENT_VERSIONS}" "${SKIPPED_DEPS_FILE}"
 
         if [[ -f osac-ui-nightly-version.txt ]]; then
           UI_SUB_VERSION=$(<osac-ui-nightly-version.txt)
@@ -857,6 +861,18 @@ jobs:
 
         rm -f osac-installer/charts/osac/Chart.lock
         helm dependency build osac-installer/charts/osac/
+
+        if [[ -s "${SKIPPED_DEPS_FILE}" ]]; then
+          {
+            echo "### :warning: Umbrella dependencies still on \`file://\` this run"
+            echo
+            echo "No resolved release tag yet for these components -- stayed on their committed dev path instead of a published OCI version:"
+            echo
+            while IFS= read -r line; do
+              echo "- ${line}"
+            done < "${SKIPPED_DEPS_FILE}"
+          } >> "$GITHUB_STEP_SUMMARY"
+        fi
 
     - name: Lint chart
       working-directory: osac-installer
@@ -938,6 +954,7 @@ jobs:
           osac-installer/osac-${{ steps.version.outputs.version }}.tgz
           images.txt
           chart-sources.txt
+          skipped-umbrella-dependencies.txt
         retention-days: 14
 
   # -------------------------------------------------------------------
@@ -1035,6 +1052,7 @@ jobs:
         WORKFLOW_URL="${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}"
         SUMMARY_TEXT=$(build_slack_charts_published_summary nightly-artifacts/chart-sources.txt "${REPO_OWNER}")
         IMAGES_TEXT=$(build_slack_images_published_summary nightly-artifacts/images.txt)
+        SKIPPED_DEPS_TEXT=$(build_slack_skipped_umbrella_dependencies_summary nightly-artifacts/skipped-umbrella-dependencies.txt)
 
         # Only ever true on a manual workflow_dispatch run (see the e2e
         # jobs' own `if:` guards) -- never silent: a release that skipped
@@ -1049,6 +1067,7 @@ jobs:
           --arg header "${HEADER_TEXT}" \
           --arg summary "${SUMMARY_TEXT}" \
           --arg images "${IMAGES_TEXT}" \
+          --arg skipped_deps "${SKIPPED_DEPS_TEXT}" \
           --arg workflow_url "${WORKFLOW_URL}" \
           '{
             "blocks": (
@@ -1065,6 +1084,11 @@ jobs:
               # Slack rejects a section with empty text -- omit it entirely
               # rather than send one if images.txt was somehow unavailable.
               + (if $images != "" then [{"type": "section", "text": {"type": "mrkdwn", "text": $images}}] else [] end)
+              # Same omit-if-empty rule -- empty is the expected common case
+              # (every mono-repo component already has a release tag most
+              # nights), only non-empty when rewrite_umbrella_mono_repo_dependencies
+              # actually skipped something this run.
+              + (if $skipped_deps != "" then [{"type": "section", "text": {"type": "mrkdwn", "text": $skipped_deps}}] else [] end)
               + [
                 {
                   "type": "actions",

--- a/osac-installer/scripts/nightly-charts.sh
+++ b/osac-installer/scripts/nightly-charts.sh
@@ -593,7 +593,7 @@ rewrite_umbrella_osac_ui_dependency() {
     rewrite_umbrella_dependency "${chart_yaml}" osac-ui "${ui_version}" "${oci_repo}"
 }
 
-# Usage: rewrite_umbrella_mono_repo_dependencies <chart_yaml> <oci_repo> <component_versions_json>
+# Usage: rewrite_umbrella_mono_repo_dependencies <chart_yaml> <oci_repo> <component_versions_json> [skipped_file]
 # Rewrite every mono-repo-resident umbrella dependency (everything but
 # osac-ui -- see MONO_REPO_UMBRELLA_DEPENDENCIES) from its committed file://
 # path to a pinned oci:// reference, for every dependency whose owning
@@ -603,9 +603,15 @@ rewrite_umbrella_osac_ui_dependency() {
 # resolved version is left on its committed file:// path -- mirrors how the
 # nightly build already skips packaging/publishing that component's
 # sub-chart entirely when it has no release tag yet, so there is nothing to
-# point the umbrella at.
+# point the umbrella at. That's an expected, non-error state (e.g. a
+# brand-new component with no release cut yet), so it's still a ::warning::
+# here, not a failure -- but a raw log warning is easy to miss on an
+# otherwise-green nightly run, so also record it (one "<dep_name> (<component>:
+# no resolved version this run)" line per skip) to skipped_file when given,
+# so a caller can surface it somewhere a human actually looks (see
+# build_slack_skipped_umbrella_dependencies_summary).
 rewrite_umbrella_mono_repo_dependencies() {
-    local chart_yaml="$1" oci_repo="$2" component_versions_json="$3"
+    local chart_yaml="$1" oci_repo="$2" component_versions_json="$3" skipped_file="${4:-}"
     local entry dep_name component version
 
     for entry in "${MONO_REPO_UMBRELLA_DEPENDENCIES[@]}"; do
@@ -614,6 +620,9 @@ rewrite_umbrella_mono_repo_dependencies() {
         version=$(jq -r --arg k "${component}" '.[$k] // empty' <<<"${component_versions_json}")
         if [[ -z "${version}" ]]; then
             echo "::warning::Skipping OCI rewrite for ${dep_name} — no resolved version for ${component} this run (stays on its committed file:// path)" >&2
+            if [[ -n "${skipped_file}" ]]; then
+                printf '%s (%s: no resolved version this run)\n' "${dep_name}" "${component}" >> "${skipped_file}"
+            fi
             continue
         fi
         rewrite_umbrella_dependency "${chart_yaml}" "${dep_name}" "${version}" "${oci_repo}"
@@ -726,6 +735,28 @@ build_slack_images_published_summary() {
     fi
 
     printf '*Images published:*\n```\n%s\n```' "${content}"
+}
+
+# Usage: build_slack_skipped_umbrella_dependencies_summary <skipped_file>
+# Surface any umbrella dependency that stayed on its committed file:// path
+# this run (no resolved release tag yet for its owning component -- see
+# rewrite_umbrella_mono_repo_dependencies) in the same Slack message every
+# other nightly success is already posted to, since nothing about a green
+# nightly run otherwise prompts anyone to go looking for this in the raw
+# job logs. Unlike build_slack_images_published_summary, a missing or empty
+# skipped_file is the expected common case (every mono-repo component
+# already has a release tag most nights) -- not a warning, just an empty
+# string so the caller omits this Slack block entirely.
+build_slack_skipped_umbrella_dependencies_summary() {
+    local skipped_file="$1"
+    local content
+
+    if [[ ! -s "${skipped_file}" ]]; then
+        return 0
+    fi
+
+    content=$(<"${skipped_file}")
+    printf ':warning: *Umbrella dependencies still on `file://` this run (no release tag yet):*\n```\n%s\n```' "${content}"
 }
 
 # Usage: build_slack_charts_published_summary <manifest_file> <repo_owner>


### PR DESCRIPTION
## Summary

Follow-up to [OSAC-5178](https://redhat.atlassian.net/browse/OSAC-5178) (PR #895, merged as 4725c2394), raised by CodeRabbit
on that PR and scoped down from its literal suggestion.

`rewrite_umbrella_mono_repo_dependencies` (in
`osac-installer/scripts/nightly-charts.sh`) skips rewriting a dependency to
its published OCI version when the owning component has no resolved
release tag yet this nightly run, leaving that dependency on its committed
`file://` path. That's the correct behavior, not a bug: a component with no
release tag ever (e.g. one just added to the umbrella chart) is an expected
state, and nightly isn't the customer-facing release artifact --
`publish-osac-installer-chart.yaml` already hard-fails on this via
`check_umbrella_mono_repo_charts_published`, and that's unchanged here.

The actual problem is visibility: the only trace of a skip today is a raw
`::warning::` in the job log, which nobody reads line-by-line on an
otherwise-green nightly run. If it ever fires, someone could pull that
night's chart, find an unexplained `file://` dependency, and have no way to
tell why.

## What changed

Reused the existing chart-sources.txt / Slack-notification infrastructure
instead of adding a new mechanism:

- `rewrite_umbrella_mono_repo_dependencies` takes a new optional 4th arg,
  `skipped_file` -- when given, each skip is also recorded there as
  `<dep_name> (<component>: no resolved version this run)`. Fully
  backward-compatible: the existing 3-arg call in
  `publish-osac-installer-chart.yaml` is untouched and unaffected.
- `nightly-build.yaml`'s "Build umbrella chart dependencies" step creates
  `skipped-umbrella-dependencies.txt`, passes it through, and -- only if
  non-empty -- echoes a formatted list to `$GITHUB_STEP_SUMMARY` right
  there, visible in the Actions run UI for anyone not watching Slack.
- The file is uploaded alongside the existing `chart-sources.txt`/
  `images.txt` artifacts.
- A new `build_slack_skipped_umbrella_dependencies_summary` helper
  (parallel to the existing `build_slack_images_published_summary`) turns
  it into an extra Slack block in "Notify Slack on success", omitted
  entirely when there's nothing to report (the common case today).

No change to when or why a skip happens, no change to
`publish-osac-installer-chart.yaml` (already correct, no equivalent skip
path there), and no change to local dev / PR-validation `file://` usage.

## What I validated

Confirmed via `skopeo list-tags` that all 6 mono-repo components already
have real release tags today, so this path isn't currently reachable in
practice -- no urgency, and no real nightly run to test end-to-end. Instead,
exercised the actual shell logic in a scratch environment:

- `rewrite_umbrella_mono_repo_dependencies` with the new 4th arg: full skip
  (0 of 9 resolved), partial skip (1 of 9), and no skip -- confirmed
  `skipped-umbrella-dependencies.txt` gets exactly the right lines in each
  case, and that a genuinely-skipped dependency's `Chart.yaml` entry stays
  on `file://` while resolved ones correctly rewrite to `oci://`.
- Backward compatibility: called the function with only 3 args (matching
  `publish-osac-installer-chart.yaml`'s existing call site) and confirmed
  it still runs cleanly with no missing-arg error.
- `build_slack_skipped_umbrella_dependencies_summary` against a missing
  file, an empty file, and a populated file -- confirmed it returns an
  empty string for the first two (no `::warning::`, since empty/missing is
  the expected common case) and correctly formats the fenced Slack block
  for the third.
- Assembled the actual `jq` payload from the "Notify Slack on success"
  step by hand with both an empty and a populated `SKIPPED_DEPS_TEXT`,
  confirming the block is correctly included (5 blocks, right position) or
  omitted (4 blocks) and the JSON is valid either way.
- Rendered the `$GITHUB_STEP_SUMMARY` block-writing logic directly against
  both a populated and an empty skip file, confirming it appends the
  formatted list in the first case and appends nothing in the second.
- `bash -n` on the changed shell; `pre-commit run` (yamllint --strict +
  the other repo-wide hooks) on both changed files -- all pass.

## What I could not exercise

A real nightly Actions run end-to-end (the actual `$GITHUB_STEP_SUMMARY`
API behavior, the artifact upload/download round-trip between the
`publish` and `tag-and-notify` jobs, and the live Slack post). Since this
path isn't currently reachable (every component has a release tag today),
there's no way to trigger it for real without deliberately breaking a
component's tag history, which isn't worth doing just to test this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

- **CI and deployment:** Nightly chart builds now record umbrella dependencies that remain on `file://` because no release tag resolved.
- The nightly workflow writes the report to the step summary.
- The workflow uploads the report with existing artifacts.
- Slack success notifications include the report when skipped dependencies exist.
- **API surface:** `rewrite_umbrella_mono_repo_dependencies` accepts an optional skipped-dependencies output file.
- **Backward compatibility:** Existing three-argument calls remain valid. Publish workflows and local or pull-request validation behavior remain unchanged.
- **Tests and validation:** Full, partial, and empty skip cases were validated. Slack and step-summary formatting, shell syntax, and pre-commit checks were validated. A nightly end-to-end run was not performed because the skip path is currently unreachable.

## Risk classification

**risk:show** was applied because the change adds user-visible CI summaries, artifacts, and Slack notification content without changing dependency publishing behavior.

The change was close to **risk:ship** because it modifies nightly workflow execution and shell logic. It did not qualify because the rewrite remains backward compatible and preserves existing behavior when no skipped-dependencies file is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->