### PR TITLE
NO-ISSUE: Grant checks:write to e2e unlock callers

### DIFF
--- a/.github/workflows/e2e-on-approval-fork.yml
+++ b/.github/workflows/e2e-on-approval-fork.yml
@@ -19,6 +19,7 @@ jobs:
   replay:
     permissions:
       actions: write
+      checks: write
       contents: read
       issues: read
       pull-requests: write

--- a/.github/workflows/e2e-on-approval.yml
+++ b/.github/workflows/e2e-on-approval.yml
@@ -22,6 +22,7 @@ jobs:
   start-e2e:
     permissions:
       actions: write
+      checks: write
       contents: read
       issues: read
       pull-requests: write

--- a/.github/workflows/e2e-on-label.yml
+++ b/.github/workflows/e2e-on-label.yml
@@ -32,6 +32,7 @@ jobs:
   start-e2e:
     permissions:
       actions: write
+      checks: write
       contents: read
       issues: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- Add `checks: write` to the three thin workflows that call `osac-test-infra/.github/workflows/e2e-on-label.yml@main`
- Fixes `startup_failure` on **E2E on unlock label** since osac-test-infra#521 added gate invalidation (requires `checks: write` in the reusable workflow)

## Context
All `lgtm` / `e2e-ready` / CodeRabbit unlock paths have been failing at workflow validation with zero jobs since ~Sept 10 18:39 UTC. Example: osac#896.

## Test plan
- [ ] Merge and apply `/e2e-ready` or `lgtm` on a PR — **E2E on unlock label** should start (not `startup_failure`)
- [ ] Confirm full-install workflows replay at HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **CI:** Added `checks: write` to the three thin E2E workflow jobs.
- This restores `lgtm`, `e2e-ready`, and CodeRabbit unlock workflows.
- No API, controller, database, authentication, deployment, test, or documentation changes.
- **Backward compatibility:** No application runtime changes. GitHub Actions jobs now request broader check permissions.

## Risk classification

**risk:ship** applies because the change only updates CI workflow permissions and has no production runtime impact. It does not qualify for **risk:show** because it does not change user-visible application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->