### PR TITLE
OSAC-1148: Sign GHCR container images with cosign

### DIFF
--- a/.github/actions/cosign-sign-image/action.yaml
+++ b/.github/actions/cosign-sign-image/action.yaml
@@ -1,0 +1,23 @@
+name: Sign image with cosign
+description: >-
+  Keylessly sign a container image already pushed to a registry, using
+  cosign and the calling job's GitHub Actions OIDC token (Fulcio/Rekor) --
+  no private key material to generate, store, or rotate. The calling job
+  must grant `permissions: id-token: write` for the OIDC token exchange to
+  succeed.
+inputs:
+  image:
+    description: >-
+      Fully-qualified image reference to sign, pinned to its digest (e.g.
+      ghcr.io/osac-project/osac-operator@sha256:...) rather than a mutable
+      tag -- the signature then verifies against every tag that resolves to
+      that digest.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Install cosign
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+    - name: Sign image
+      shell: bash
+      run: cosign sign --yes "${{ inputs.image }}"

--- a/.github/workflows/build-bmf-image.yaml
+++ b/.github/workflows/build-bmf-image.yaml
@@ -102,6 +102,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      operator-digest: ${{ steps.build-operator.outputs.digest }}
+      manifest-digest: ${{ steps.build-manifests.outputs.digest }}
 
     steps:
       - name: Checkout repository
@@ -236,6 +239,7 @@ jobs:
 
       # Build and push manifest container
       - name: Build and push manifest container
+        id: build-manifests
         if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
@@ -244,3 +248,38 @@ jobs:
           push: true
           tags: ${{ steps.meta-manifests.outputs.tags }}
           labels: ${{ steps.meta-manifests.outputs.labels }}
+
+  # Signing gets its own job, granted id-token: write only here, rather than
+  # on `build` -- `build` also runs (build-only, no push) on pull_request and
+  # merge_group with PR-controlled Containerfile/build context, so it must
+  # never hold the OIDC permission that mints Fulcio signing certs.
+  sign:
+    needs: build
+    if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign image with cosign
+        uses: ./.github/actions/cosign-sign-image
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build.outputs.operator-digest }}
+
+      - name: Sign manifest container with cosign
+        uses: ./.github/actions/cosign-sign-image
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build.outputs.manifest-digest }}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -106,6 +106,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      operator-digest: ${{ steps.build-operator.outputs.digest }}
+      manifest-digest: ${{ steps.build-manifests.outputs.digest }}
 
     steps:
       - name: Checkout repository
@@ -240,6 +243,7 @@ jobs:
 
       # Build and push manifest container
       - name: Build and push manifest container
+        id: build-manifests
         if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
@@ -248,3 +252,38 @@ jobs:
           push: true
           tags: ${{ steps.meta-manifests.outputs.tags }}
           labels: ${{ steps.meta-manifests.outputs.labels }}
+
+  # Signing gets its own job, granted id-token: write only here, rather than
+  # on `build` -- `build` also runs (build-only, no push) on pull_request and
+  # merge_group with PR-controlled Containerfile/build context, so it must
+  # never hold the OIDC permission that mints Fulcio signing certs.
+  sign:
+    needs: build
+    if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign image with cosign
+        uses: ./.github/actions/cosign-sign-image
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build.outputs.operator-digest }}
+
+      - name: Sign manifest container with cosign
+        uses: ./.github/actions/cosign-sign-image
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build.outputs.manifest-digest }}

--- a/.github/workflows/build-metering-echo-adapter-image.yaml
+++ b/.github/workflows/build-metering-echo-adapter-image.yaml
@@ -28,14 +28,16 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -57,7 +59,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -70,10 +72,41 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: osac-metering
           file: osac-metering/adapters/Containerfile.echo-adapter
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  # Signing gets its own job, granted id-token: write only here, rather than
+  # on `build` -- `build` also runs (build-only, no push) on pull_request
+  # with PR-controlled Containerfile/build context, so it must never hold
+  # the OIDC permission that mints Fulcio signing certs.
+  sign:
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign image with cosign
+        uses: ./.github/actions/cosign-sign-image
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build.outputs.digest }}

--- a/.github/workflows/build-metering-m360-adapter-image.yaml
+++ b/.github/workflows/build-metering-m360-adapter-image.yaml
@@ -28,14 +28,16 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -57,7 +59,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -70,10 +72,41 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: osac-metering
           file: osac-metering/adapters/Containerfile.m360-adapter
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  # Signing gets its own job, granted id-token: write only here, rather than
+  # on `build` -- `build` also runs (build-only, no push) on pull_request
+  # with PR-controlled Containerfile/build context, so it must never hold
+  # the OIDC permission that mints Fulcio signing certs.
+  sign:
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign image with cosign
+        uses: ./.github/actions/cosign-sign-image
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build.outputs.digest }}

--- a/.github/workflows/build-metering-service-image.yaml
+++ b/.github/workflows/build-metering-service-image.yaml
@@ -28,14 +28,16 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -57,7 +59,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -70,10 +72,41 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: osac-metering
           file: osac-metering/metering-service/Containerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  # Signing gets its own job, granted id-token: write only here, rather than
+  # on `build` -- `build` also runs (build-only, no push) on pull_request
+  # with PR-controlled Containerfile/build context, so it must never hold
+  # the OIDC permission that mints Fulcio signing certs.
+  sign:
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign image with cosign
+        uses: ./.github/actions/cosign-sign-image
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build.outputs.digest }}

--- a/.github/workflows/execution-environment.yml
+++ b/.github/workflows/execution-environment.yml
@@ -26,15 +26,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
 
       - name: "Set up Python"
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version-file: "osac-aap/pyproject.toml"
 
@@ -76,7 +78,7 @@ jobs:
       - name: Extract metadata (tags, labels)
         if: github.event_name != 'pull_request'
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6
         with:
           # Hardcoded rather than ghcr.io/${{ github.repository }}: that now
           # resolves to ghcr.io/osac-project/osac for every component's build
@@ -101,9 +103,45 @@ jobs:
           echo ${{ secrets.GITHUB_TOKEN }} | podman login --username ${{ github.actor }} --password-stdin ghcr.io
 
       - name: Push execution environment image
+        id: push
         if: github.event_name != 'pull_request'
         run: |
+          # Every tag below points at the one locally-built "osac-ee" image, so
+          # they all resolve to the same digest -- pushing captures it once
+          # (from the last tag pushed) for the cosign step to sign by digest.
           for tag in $(echo "${{ steps.meta.outputs.tags }}" | tr '\n' ' '); do
             podman tag "osac-ee" "${tag}"
-            podman push "${tag}"
+            podman push --digestfile=digest.txt "${tag}"
           done
+          echo "digest=$(cat digest.txt)" >> "$GITHUB_OUTPUT"
+
+  # Signing gets its own job, granted id-token: write only here, rather than
+  # on build-execution-environment -- that job also runs (build-only, no
+  # push) on pull_request with PR-controlled execution-environment.yaml
+  # content, so it must never hold the OIDC permission that mints Fulcio
+  # signing certs.
+  sign-execution-environment:
+    needs: build-execution-environment
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Log into registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign image with cosign
+        uses: ./.github/actions/cosign-sign-image
+        with:
+          image: ghcr.io/osac-project/osac-aap@${{ needs.build-execution-environment.outputs.digest }}

--- a/.github/workflows/publish-csi-driver-image.yaml
+++ b/.github/workflows/publish-csi-driver-image.yaml
@@ -35,6 +35,8 @@ env:
 jobs:
   image:
     runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -101,6 +103,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
@@ -111,3 +114,33 @@ jobs:
           build-args: |
             VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
             GIT_COMMIT=${{ github.sha }}
+
+  # Signing gets its own job, granted id-token: write only here, rather than
+  # on `image` -- `image` also runs (build-only, no push) on pull_request
+  # with PR-controlled Containerfile/build context, so it must never hold
+  # the OIDC permission that mints Fulcio signing certs.
+  sign:
+    needs: image
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign image with cosign
+        uses: ./.github/actions/cosign-sign-image
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.image.outputs.digest }}

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -35,6 +35,8 @@ env:
 jobs:
   image:
     runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -99,6 +101,7 @@ jobs:
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
@@ -108,3 +111,33 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             TARGETPLATFORM=${{ matrix.platform }}
+
+  # Signing gets its own job, granted id-token: write only here, rather than
+  # on `image` -- `image` also runs (build-only, no push) on pull_request
+  # with PR-controlled Containerfile/build context, so it must never hold
+  # the OIDC permission that mints Fulcio signing certs.
+  sign:
+    needs: image
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign image with cosign
+        uses: ./.github/actions/cosign-sign-image
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.image.outputs.digest }}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,51 @@ conventions content that doesn't belong in any single component's docs (not to b
 with the external [osac-project/docs](https://github.com/osac-project/docs) repo, which
 covers broader project-level architecture guides and diagrams).
 
+## Verifying container image signatures
+
+Container images published to `ghcr.io/osac-project/*` from this repo's GitHub
+Actions workflows are signed keylessly with [cosign](https://docs.sigstore.dev/),
+using each workflow run's GitHub Actions OIDC identity via Fulcio/Rekor — no
+long-lived private key is involved. Images are signed both from ordinary
+pushes to `main` and from component-scoped release tags; the certificate
+identity's workflow filename and ref reflect whichever build produced the
+image, so pin both rather than accepting any workflow or any tag in this repo:
+
+| Component (+ manifest image, where built) | Image                                 | Workflow file                             | Release tag prefix                |
+|--------------------------------------------|----------------------------------------|---------------------------------------------|------------------------------------|
+| osac-operator                               | `osac-project/osac-operator`           | `build-image.yaml`                          | `osac-operator`                    |
+| fulfillment-service                         | `osac-project/fulfillment-service`     | `publish-image.yaml`                        | `fulfillment-service`              |
+| bare-metal-fulfillment-operator             | `osac-project/bare-metal-fulfillment-operator` | `build-bmf-image.yaml`              | `bare-metal-fulfillment-operator`  |
+| osac-aap                                    | `osac-project/osac-aap`                | `execution-environment.yml`                 | `osac-aap`                         |
+| metering-service                            | `osac-project/metering-service`        | `build-metering-service-image.yaml`         | `osac-metering`                    |
+| metering-m360-adapter                       | `osac-project/metering-m360-adapter`   | `build-metering-m360-adapter-image.yaml`    | `osac-metering`                    |
+| metering-echo-adapter                       | `osac-project/metering-echo-adapter`   | `build-metering-echo-adapter-image.yaml`    | `osac-metering`                    |
+| osac-csi-driver                             | `osac-project/osac-csi-driver`         | `publish-csi-driver-image.yaml`             | `osac-csi-driver`                  |
+
+Verify an image, substituting the workflow file and tag prefix from the table above:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp '^https://github\.com/osac-project/osac/\.github/workflows/<workflow-file>@refs/(heads/main|tags/<tag-prefix>/.+)$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/<image>@sha256:<digest>
+```
+
+For example, to verify an osac-operator image:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp '^https://github\.com/osac-project/osac/\.github/workflows/build-image\.yaml@refs/(heads/main|tags/osac-operator/.+)$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/osac-project/osac-operator@sha256:<digest>
+```
+
+Always verify by digest (`@sha256:...`), not by mutable tag — resolve a tag to
+its digest first with `skopeo inspect docker://ghcr.io/osac-project/<component>:<tag>`
+if needed. Images pushed to `quay.io/redhat-user-workloads/osac-tenant/...` via
+Konflux are signed separately by Konflux's own Enterprise Contract pipeline;
+see that pipeline's documentation for verifying those instead.
+
 ## Local development with go.work
 
 The root [`go.work`](go.work) file wires all Go modules in the mono-repo —


### PR DESCRIPTION
## Summary

- Adds keyless cosign signing (GitHub Actions OIDC → Fulcio/Rekor, no private key material to manage) to every workflow that pushes a container image to `ghcr.io/osac-project/*`.
- DRYs the install+sign steps into one shared composite action, `.github/actions/cosign-sign-image` (same pattern as the existing `.github/actions/vault-slack-webhook`), rather than duplicating them across 8 workflow files.
- Documents `cosign verify` usage for downstream consumers in `README.md`.

This is a first pass on [OSAC-1148](https://redhat.atlassian.net/browse/OSAC-1148) ("Sign all distributed artifacts (container images, binaries, Helm charts, documentation) with cosign") — **container images only**. Binaries, Helm chart OCI artifacts, and documentation signing are explicitly deferred; tracked as a comment on the Jira ticket.

## Workflows covered

Verified the full set myself (grepped for every `docker/build-push-action`/`podman push` in `.github/workflows/`) rather than trusting any pre-existing list:

- `build-image.yaml` — osac-operator image **and** its generated manifest-container image (2 signs)
- `publish-image.yaml` — fulfillment-service
- `build-bmf-image.yaml` — bare-metal-fulfillment-operator image **and** its manifest-container image (2 signs)
- `execution-environment.yml` — osac-aap (uses `podman push`, not `docker/build-push-action`; captures the digest via `--digestfile`)
- `build-metering-service-image.yaml`, `build-metering-m360-adapter-image.yaml`, `build-metering-echo-adapter-image.yaml`
- `publish-csi-driver-image.yaml` — osac-csi-driver

Each build/push step now has an `id`, exposes `outputs.digest`, and a following step calls `./.github/actions/cosign-sign-image` with `<registry>/<image>@<digest>` — signing by digest so the signature covers every tag that resolves to it. Each job's `permissions` gained `id-token: write` (required for the OIDC token exchange); no other permission changes.

**`build-metering-echo-adapter-image.yaml`** wasn't in the previously-known `workflow_run` trigger list — found by doing my own grep pass instead of trusting that list as exhaustive.

## Deliberately not touched

- **`nightly-build.yaml`** — its "Promote images to nightly version" step is a server-side `skopeo copy` retag of an already-pushed image onto a release-looking tag, same digest, no rebuild (see `osac-installer/scripts/nightly-charts.sh`'s `retag_component_image`). Since cosign signatures are attached to the digest, not the tag, the original signature from the build workflow already covers the promoted tag. No changes needed.
- **Konflux-built images** (`quay.io/redhat-user-workloads/osac-tenant/...`) — out of scope per OSAC-1147's 2026-08-20 scope note; already signed by Konflux's own Enterprise Contract pipeline.
- **Binaries / Helm chart OCI artifacts / documentation** — deferred, named explicitly in a Jira comment on [OSAC-1148](https://redhat.atlassian.net/browse/OSAC-1148) rather than silently dropped.

## What I validated locally vs. what needs real CI

Validated locally:
- YAML syntax on every changed workflow + the new composite action (`python3 -c "import yaml..."`), and the full `pre-commit` file-scoped hook set (`trailing-whitespace`, `yamllint --strict`, `gitleaks`, etc.) — all pass.
- Downloaded a real `cosign` binary and confirmed `cosign sign --yes <image>@<digest>` and the `cosign verify --certificate-identity-regexp ... --certificate-oidc-issuer ...` flags documented in the README are accepted syntax, by running `cosign verify` against a real, currently-unsigned published image (`ghcr.io/osac-project/fulfillment-service@sha256:...`, via `skopeo inspect`) — it correctly failed with `no signatures found` rather than a flag-parsing error, confirming the digest/reference format and flag shapes are correct.
- Confirmed `docker/build-push-action`'s `outputs.digest` field exists (checked the action's own `action.yml`) and that `podman push --digestfile=<path>` is a real flag.
- Confirmed the pinned `sigstore/cosign-installer` SHA (`6f9f17788090df1f26f669e9d70d6ae9567deba6`) corresponds to release `v4.1.2`, the latest tag.

Cannot validate outside a real GitHub Actions run:
- The actual OIDC token exchange with GitHub's issuer and the Fulcio certificate issuance / Rekor transparency-log round-trip.
- That the composite action resolves correctly (`uses: ./.github/actions/cosign-sign-image`) when invoked from each of these 8 workflows in a real Actions runner.

## Test plan

- [ ] CI runs on this PR for the workflows with `pull_request` triggers (build/push steps stay skipped on PR per existing `if: github.event_name != 'pull_request'` gating, but confirms no YAML/job-graph regressions)
- [ ] After merge, watch the first `push`-to-`main` run of each affected workflow (or a manual `workflow_dispatch`) to confirm the sign step actually succeeds and `cosign verify` from the README works against the resulting image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **CI and deployment:** Added a shared composite action for keyless Cosign signing of digest-pinned GHCR images.
- **CI security:** Added dedicated signing jobs to eight image-publishing workflows. The jobs use GitHub Actions OIDC with Fulcio and Rekor. Build jobs do not receive `id-token: write`. Pull request and merge-group builds remain unsigned.
- **Supply-chain coverage:** Signed application images and generated manifest-container images. Pinned several mutable GitHub Actions references to commit SHAs.
- **Documentation:** Added digest-based verification instructions for branch- and tag-built `ghcr.io/osac-project` images. Documented separate signing for selected Konflux-built images.
- **Validation:** Local YAML, pre-commit, Cosign syntax, digest handling, and tool-version checks passed. GitHub Actions OIDC exchange, Fulcio/Rekor interaction, composite-action resolution, and successful CI signing remain unverified.
- **Other areas:** No API, controller, database, application-runtime, or test-code changes.
- **Backward compatibility:** Existing image build and publish behavior remains unchanged apart from the added signing jobs and OIDC permissions. Binary signing, Helm chart OCI signing, documentation signing, nightly retags, and separately managed Konflux artifacts are unchanged.

## Risk classification

**risk:show** — The change modifies CI authentication and image-publishing workflows and adds supply-chain signing. The scope is limited to GitHub Actions and does not change production runtime behavior. Local validation passed, but GitHub Actions signing integration remains unverified.

This is close to **risk:ask** because incorrect permissions or signing failures could affect image publication. It does not qualify because the change does not alter runtime code, production credentials, or deployment logic, and signing runs after image builds in separate jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->