### PR TITLE
OSAC-1148: Sign GHCR container images with cosign

### DIFF
--- a/.github/actions/cosign-sign-image/action.yaml
+++ b/.github/actions/cosign-sign-image/action.yaml
@@ -1,0 +1,23 @@
+name: Sign image with cosign
+description: >-
+  Keylessly sign a container image already pushed to a registry, using
+  cosign and the calling job's GitHub Actions OIDC token (Fulcio/Rekor) --
+  no private key material to generate, store, or rotate. The calling job
+  must grant `permissions: id-token: write` for the OIDC token exchange to
+  succeed.
+inputs:
+  image:
+    description: >-
+      Fully-qualified image reference to sign, pinned to its digest (e.g.
+      ghcr.io/osac-project/osac-operator@sha256:...) rather than a mutable
+      tag -- the signature then verifies against every tag that resolves to
+      that digest.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Install cosign
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+    - name: Sign image
+      shell: bash
+      run: cosign sign --yes "${{ inputs.image }}"

--- a/.github/workflows/build-bmf-image.yaml
+++ b/.github/workflows/build-bmf-image.yaml
@@ -102,6 +102,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      operator-digest: ${{ steps.build-operator.outputs.digest }}
+      manifest-digest: ${{ steps.build-manifests.outputs.digest }}
 
     steps:
       - name: Checkout repository
@@ -236,6 +239,7 @@ jobs:
 
       # Build and push manifest container
       - name: Build and push manifest container
+        id: build-manifests
         if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
@@ -244,3 +248,38 @@ jobs:
           push: true
           tags: ${{ steps.meta-manifests.outputs.tags }}
           labels: ${{ steps.meta-manifests.outputs.labels }}
+
+  # Signing gets its own job, granted id-token: write only here, rather than
+  # on `build` -- `build` also runs (build-only, no push) on pull_request and
+  # merge_group with PR-controlled Containerfile/build context, so it must
+  # never hold the OIDC permission that mints Fulcio signing certs.
+  sign:
+    needs: build
+    if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign image with cosign
+        uses: ./.github/actions/cosign-sign-image
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build.outputs.operator-digest }}
+
+      - name: Sign manifest container with cosign
+        uses: ./.github/actions/cosign-sign-image
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build.outputs.manifest-digest }}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -106,6 +106,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      operator-digest: ${{ steps.build-operator.outputs.digest }}
+      manifest-digest: ${{ steps.build-manifests.outputs.digest }}
 
     steps:
       - name: Checkout repository
@@ -240,6 +243,7 @@ jobs:
 
       # Build and push manifest container
       - name: Build and push manifest container
+        id: build-manifests
         if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
@@ -248,3 +252,38 @@ jobs:
           push: true
           tags: ${{ steps.meta-manifests.outputs.tags }}
           labels: ${{ steps.meta-manifests.outputs.labels }}
+
+  # Signing gets its own job, granted id-token: write only here, rather than
+  # on `build` -- `build` also runs (build-only, no push) on pull_request and
+  # merge_group with PR-controlled Containerfile/build context, so it must
+  # never hold the OIDC permission that mints Fulcio signing certs.
+  sign:
+    needs: build
+    if: github.event_name != 'pull_request' && github.event_name != 'merge_group'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign image with cosign
+        uses: ./.github/actions/cosign-sign-image
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build.outputs.operator-digest }}
+
+      - name: Sign manifest container with cosign
+        uses: ./.github/actions/cosign-sign-image
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build.outputs.manifest-digest }}

--- a/.github/workflows/build-metering-echo-adapter-image.yaml
+++ b/.github/workflows/build-metering-echo-adapter-image.yaml
@@ -28,14 +28,16 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -57,7 +59,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -70,10 +72,41 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: osac-metering
           file: osac-metering/adapters/Containerfile.echo-adapter
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  # Signing gets its own job, granted id-token: write only here, rather than
+  # on `build` -- `build` also runs (build-only, no push) on pull_request
+  # with PR-controlled Containerfile/build context, so it must never hold
+  # the OIDC permission that mints Fulcio signing certs.
+  sign:
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign image with cosign
+        uses: ./.github/actions/cosign-sign-image
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build.outputs.digest }}

--- a/.github/workflows/build-metering-m360-adapter-image.yaml
+++ b/.github/workflows/build-metering-m360-adapter-image.yaml
@@ -28,14 +28,16 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -57,7 +59,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -70,10 +72,41 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: osac-metering
           file: osac-metering/adapters/Containerfile.m360-adapter
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  # Signing gets its own job, granted id-token: write only here, rather than
+  # on `build` -- `build` also runs (build-only, no push) on pull_request
+  # with PR-controlled Containerfile/build context, so it must never hold
+  # the OIDC permission that mints Fulcio signing certs.
+  sign:
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign image with cosign
+        uses: ./.github/actions/cosign-sign-image
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build.outputs.digest }}

--- a/.github/workflows/build-metering-service-image.yaml
+++ b/.github/workflows/build-metering-service-image.yaml
@@ -28,14 +28,16 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -57,7 +59,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -70,10 +72,41 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: osac-metering
           file: osac-metering/metering-service/Containerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  # Signing gets its own job, granted id-token: write only here, rather than
+  # on `build` -- `build` also runs (build-only, no push) on pull_request
+  # with PR-controlled Containerfile/build context, so it must never hold
+  # the OIDC permission that mints Fulcio signing certs.
+  sign:
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign image with cosign
+        uses: ./.github/actions/cosign-sign-image
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build.outputs.digest }}

--- a/.github/workflows/execution-environment.yml
+++ b/.github/workflows/execution-environment.yml
@@ -26,15 +26,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
 
       - name: "Set up Python"
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version-file: "osac-aap/pyproject.toml"
 
@@ -76,7 +78,7 @@ jobs:
       - name: Extract metadata (tags, labels)
         if: github.event_name != 'pull_request'
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6
         with:
           # Hardcoded rather than ghcr.io/${{ github.repository }}: that now
           # resolves to ghcr.io/osac-project/osac for every component's build
@@ -101,9 +103,45 @@ jobs:
           echo ${{ secrets.GITHUB_TOKEN }} | podman login --username ${{ github.actor }} --password-stdin ghcr.io
 
       - name: Push execution environment image
+        id: push
         if: github.event_name != 'pull_request'
         run: |
+          # Every tag below points at the one locally-built "osac-ee" image, so
+          # they all resolve to the same digest -- pushing captures it once
+          # (from the last tag pushed) for the cosign step to sign by digest.
           for tag in $(echo "${{ steps.meta.outputs.tags }}" | tr '\n' ' '); do
             podman tag "osac-ee" "${tag}"
-            podman push "${tag}"
+            podman push --digestfile=digest.txt "${tag}"
           done
+          echo "digest=$(cat digest.txt)" >> "$GITHUB_OUTPUT"
+
+  # Signing gets its own job, granted id-token: write only here, rather than
+  # on build-execution-environment -- that job also runs (build-only, no
+  # push) on pull_request with PR-controlled execution-environment.yaml
+  # content, so it must never hold the OIDC permission that mints Fulcio
+  # signing certs.
+  sign-execution-environment:
+    needs: build-execution-environment
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Log into registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign image with cosign
+        uses: ./.github/actions/cosign-sign-image
+        with:
+          image: ghcr.io/osac-project/osac-aap@${{ needs.build-execution-environment.outputs.digest }}

--- a/.github/workflows/publish-csi-driver-image.yaml
+++ b/.github/workflows/publish-csi-driver-image.yaml
@@ -35,6 +35,8 @@ env:
 jobs:
   image:
     runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -101,6 +103,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
@@ -111,3 +114,33 @@ jobs:
           build-args: |
             VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
             GIT_COMMIT=${{ github.sha }}
+
+  # Signing gets its own job, granted id-token: write only here, rather than
+  # on `image` -- `image` also runs (build-only, no push) on pull_request
+  # with PR-controlled Containerfile/build context, so it must never hold
+  # the OIDC permission that mints Fulcio signing certs.
+  sign:
+    needs: image
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign image with cosign
+        uses: ./.github/actions/cosign-sign-image
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.image.outputs.digest }}

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -35,6 +35,8 @@ env:
 jobs:
   image:
     runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -99,6 +101,7 @@ jobs:
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
         with:
           context: .
@@ -108,3 +111,33 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             TARGETPLATFORM=${{ matrix.platform }}
+
+  # Signing gets its own job, granted id-token: write only here, rather than
+  # on `image` -- `image` also runs (build-only, no push) on pull_request
+  # with PR-controlled Containerfile/build context, so it must never hold
+  # the OIDC permission that mints Fulcio signing certs.
+  sign:
+    needs: image
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sign image with cosign
+        uses: ./.github/actions/cosign-sign-image
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.image.outputs.digest }}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,51 @@ conventions content that doesn't belong in any single component's docs (not to b
 with the external [osac-project/docs](https://github.com/osac-project/docs) repo, which
 covers broader project-level architecture guides and diagrams).
 
+## Verifying container image signatures
+
+Container images published to `ghcr.io/osac-project/*` from this repo's GitHub
+Actions workflows are signed keylessly with [cosign](https://docs.sigstore.dev/),
+using each workflow run's GitHub Actions OIDC identity via Fulcio/Rekor — no
+long-lived private key is involved. Images are signed both from ordinary
+pushes to `main` and from component-scoped release tags; the certificate
+identity's workflow filename and ref reflect whichever build produced the
+image, so pin both rather than accepting any workflow or any tag in this repo:
+
+| Component (+ manifest image, where built) | Image                                 | Workflow file                             | Release tag prefix                |
+|--------------------------------------------|----------------------------------------|---------------------------------------------|------------------------------------|
+| osac-operator                               | `osac-project/osac-operator`           | `build-image.yaml`                          | `osac-operator`                    |
+| fulfillment-service                         | `osac-project/fulfillment-service`     | `publish-image.yaml`                        | `fulfillment-service`              |
+| bare-metal-fulfillment-operator             | `osac-project/bare-metal-fulfillment-operator` | `build-bmf-image.yaml`              | `bare-metal-fulfillment-operator`  |
+| osac-aap                                    | `osac-project/osac-aap`                | `execution-environment.yml`                 | `osac-aap`                         |
+| metering-service                            | `osac-project/metering-service`        | `build-metering-service-image.yaml`         | `osac-metering`                    |
+| metering-m360-adapter                       | `osac-project/metering-m360-adapter`   | `build-metering-m360-adapter-image.yaml`    | `osac-metering`                    |
+| metering-echo-adapter                       | `osac-project/metering-echo-adapter`   | `build-metering-echo-adapter-image.yaml`    | `osac-metering`                    |
+| osac-csi-driver                             | `osac-project/osac-csi-driver`         | `publish-csi-driver-image.yaml`             | `osac-csi-driver`                  |
+
+Verify an image, substituting the workflow file and tag prefix from the table above:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp '^https://github\.com/osac-project/osac/\.github/workflows/<workflow-file>@refs/(heads/main|tags/<tag-prefix>/.+)$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/<image>@sha256:<digest>
+```
+
+For example, to verify an osac-operator image:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp '^https://github\.com/osac-project/osac/\.github/workflows/build-image\.yaml@refs/(heads/main|tags/osac-operator/.+)$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/osac-project/osac-operator@sha256:<digest>
+```
+
+Always verify by digest (`@sha256:...`), not by mutable tag — resolve a tag to
+its digest first with `skopeo inspect docker://ghcr.io/osac-project/<component>:<tag>`
+if needed. Images pushed to `quay.io/redhat-user-workloads/osac-tenant/...` via
+Konflux are signed separately by Konflux's own Enterprise Contract pipeline;
+see that pipeline's documentation for verifying those instead.
+
 ## Local development with go.work
 
 The root [`go.work`](go.work) file wires all Go modules in the mono-repo —


### PR DESCRIPTION
Duplicate of #900, opened to get a fresh PR number/concurrency group after #900's e2e-*-full-install runs got stuck behind stale runs tied to a superseded commit (see #900 for full discussion). Same commit, same content as #900.

## Summary

- Adds keyless cosign signing (GitHub Actions OIDC → Fulcio/Rekor, no private key material to manage) to every workflow that pushes a container image to `ghcr.io/osac-project/*`.
- DRYs the install+sign steps into one shared composite action, `.github/actions/cosign-sign-image`, rather than duplicating them across 8 workflow files.
- Documents `cosign verify` usage for downstream consumers in `README.md`, with a per-component table pinning each verify command's expected workflow filename and release-tag prefix.

See #900 for the full history, review discussion, and validation notes.

## Test plan

- [ ] Same as #900 — confirm e2e-vmaas/bmaas/caas-full-install actually start and complete on this PR without the concurrency issue seen on #900

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **CI and supply-chain security:** Added keyless Cosign signing for GHCR images. Signing runs in separate jobs with restricted OIDC permissions and digest-pinned images.
- **Deployment workflows:** Updated image-publishing workflows to expose image digests, authenticate to GHCR, and sign published images. Actions were also SHA-pinned in several workflows.
- **Documentation:** Added component-specific `cosign verify` commands and identity constraints to `README.md`.
- **Tests:** The test plan requires successful `e2e-vmaas`, `e2e-bmaas`, and `e2e-caas-full-install` workflow runs.
- **API, controllers, database, and application auth:** No changes.
- **Backward compatibility:** No runtime or image-consumption changes. Existing images remain usable. Only newly published images receive signatures. Konflux images, binary artifacts, Helm OCI artifacts, and documentation remain outside this scope.

## Risk classification

**risk:show** was applied because the change affects CI authentication, GHCR publishing, and supply-chain verification, but it does not change runtime application behavior or public APIs. It was close to **risk:ask** because it grants `id-token: write` and `packages: write` permissions to signing jobs; the permissions are isolated from pull-request build jobs and limited to signing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->