### PR TITLE
OSAC-1148: Sign Helm chart OCI artifacts with cosign

### DIFF
--- a/.github/actions/helm-push-and-sign/action.yaml
+++ b/.github/actions/helm-push-and-sign/action.yaml
@@ -1,0 +1,36 @@
+name: Push and sign Helm chart
+description: >-
+  Push a packaged Helm chart to an OCI registry, then sign the resulting OCI
+  artifact keylessly with cosign (see .github/actions/cosign-sign-image) --
+  the calling job must grant `permissions: id-token: write`. Assumes `helm`
+  is already on PATH and already logged into the target registry.
+inputs:
+  chart-file:
+    description: Path to the packaged chart .tgz to push, relative to the repo root.
+    required: true
+  chart-name:
+    description: Chart name -- the artifact pushed to and signed is <oci-repo>/<chart-name>.
+    required: true
+  oci-repo:
+    description: OCI repo to push under, without the oci:// prefix (e.g. ghcr.io/osac-project/charts).
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Push chart to registry
+      id: push
+      shell: bash
+      run: |
+        output=$(helm push "${{ inputs.chart-file }}" "oci://${{ inputs.oci-repo }}" 2>&1)
+        echo "${output}"
+        digest=$(grep -oE '^Digest: sha256:[0-9a-f]+' <<<"${output}" | cut -d' ' -f2)
+        if [[ -z "${digest}" ]]; then
+          echo "::error::Could not parse digest from helm push output"
+          exit 1
+        fi
+        echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+    - name: Sign chart with cosign
+      uses: ./.github/actions/cosign-sign-image
+      with:
+        image: ${{ inputs.oci-repo }}/${{ inputs.chart-name }}@${{ steps.push.outputs.digest }}

--- a/.github/scripts/fulfillment-service-verify-tag-matches-sha.sh
+++ b/.github/scripts/fulfillment-service-verify-tag-matches-sha.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Verifies that a git tag still resolves to the guarded commit SHA that was
+# validated by this workflow's guard job, protecting against a force-push/
+# retag race between the image build and any subsequent chart-publish or
+# release step.
+#
+# Required env vars: GH_TOKEN, REPO, TAG, GUARDED_SHA
+set -euo pipefail
+
+ref_json="$(gh api "repos/${REPO}/git/ref/tags/${TAG}" --jq '[.object.type, .object.sha] | @tsv')"
+read -r current_type current_sha <<< "$ref_json"
+if [[ "$current_type" == "tag" ]]; then
+  # Annotated tag: the ref's object.sha is the tag object, not the commit - peel it.
+  current_sha="$(gh api "repos/${REPO}/git/tags/${current_sha}" --jq .object.sha)"
+fi
+
+if [[ "$current_sha" != "$GUARDED_SHA" ]]; then
+  echo "::error::Tag '${TAG}' now points at ${current_sha}, not the guarded commit ${GUARDED_SHA} (force-pushed?). Refusing to proceed."
+  exit 1
+fi
+
+echo "Tag '${TAG}' still points at the guarded commit ${GUARDED_SHA}."

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -94,16 +94,29 @@ jobs:
     needs: guard
     if: success() && github.event.workflow_run.name == 'Container image'
     runs-on: ubuntu-latest
-    # contents: read to checkout; packages: write to push the chart to GHCR.
+    # contents: read to checkout; packages: write to push the chart to GHCR;
+    # id-token: write for cosign's keyless signing (this job only ever runs
+    # via workflow_run after a tag-triggered image build already succeeded,
+    # never on pull_request-controlled content).
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
         ref: ${{ needs.guard.outputs.sha }}
         fetch-depth: 0
         persist-credentials: false
+
+    - name: Verify tag still points at the guarded commit
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ needs.guard.outputs.tag }}
+        GUARDED_SHA: ${{ needs.guard.outputs.sha }}
+        REPO: ${{ github.repository }}
+      run: .github/scripts/fulfillment-service-verify-tag-matches-sha.sh
+
     - id: run
       working-directory: fulfillment-service
       env:
@@ -136,10 +149,16 @@ jobs:
         export chart_version="${git_version#v}"
         helm package charts/service --version "${chart_version}" --app-version "${app_version}"
 
-        # Push the chart to the registry:
-        export chart_name="$(yq -r '.name' charts/service/Chart.yaml)"
-        export chart_file="${chart_name}-${chart_version}.tgz"
-        helm push "${chart_file}" "oci://${registry}/${{ github.repository_owner }}/charts"
+        chart_name="$(yq -r '.name' charts/service/Chart.yaml)"
+        echo "chart-name=${chart_name}" >> "$GITHUB_OUTPUT"
+        echo "chart-file=fulfillment-service/${chart_name}-${chart_version}.tgz" >> "$GITHUB_OUTPUT"
+
+    - name: Push and sign chart
+      uses: ./.github/actions/helm-push-and-sign
+      with:
+        chart-file: ${{ steps.run.outputs.chart-file }}
+        chart-name: ${{ steps.run.outputs.chart-name }}
+        oci-repo: ${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
 
   publish-operator-crds-chart:
     name: Publish osac-operator-crds chart
@@ -149,6 +168,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -188,11 +208,12 @@ jobs:
           --version "${{ steps.version.outputs.version }}" \
           --app-version "${{ steps.version.outputs.version }}"
 
-    - name: Push chart to GHCR
-      working-directory: osac-operator
-      run: |
-        helm push osac-operator-crds-${{ steps.version.outputs.version }}.tgz \
-          oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
+    - name: Push and sign chart
+      uses: ./.github/actions/helm-push-and-sign
+      with:
+        chart-file: osac-operator/osac-operator-crds-${{ steps.version.outputs.version }}.tgz
+        chart-name: osac-operator-crds
+        oci-repo: ${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
 
   publish-operator-chart:
     name: Publish osac-operator chart
@@ -202,6 +223,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -246,11 +268,12 @@ jobs:
           --version "${{ steps.version.outputs.version }}" \
           --app-version "${{ steps.version.outputs.version }}"
 
-    - name: Push chart to GHCR
-      working-directory: osac-operator
-      run: |
-        helm push osac-operator-${{ steps.version.outputs.version }}.tgz \
-          oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
+    - name: Push and sign chart
+      uses: ./.github/actions/helm-push-and-sign
+      with:
+        chart-file: osac-operator/osac-operator-${{ steps.version.outputs.version }}.tgz
+        chart-name: osac-operator
+        oci-repo: ${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
 
   create-operator-release:
     name: Create GitHub Release (osac-operator)
@@ -304,6 +327,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
     steps:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -369,11 +393,12 @@ jobs:
           --version "${{ steps.version.outputs.version }}" \
           --app-version "${{ steps.version.outputs.version }}"
 
-    - name: Push chart to GHCR
-      working-directory: osac-aap
-      run: |
-        helm push osac-aap-${{ steps.version.outputs.version }}.tgz \
-          oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
+    - name: Push and sign chart
+      uses: ./.github/actions/helm-push-and-sign
+      with:
+        chart-file: osac-aap/osac-aap-${{ steps.version.outputs.version }}.tgz
+        chart-name: osac-aap
+        oci-repo: ${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
 
     - name: Verify tag still points at the guarded commit
       env:
@@ -407,6 +432,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -446,11 +472,12 @@ jobs:
           --version "${{ steps.version.outputs.version }}" \
           --app-version "${{ steps.version.outputs.version }}"
 
-    - name: Push chart to GHCR
-      working-directory: bare-metal-fulfillment-operator
-      run: |
-        helm push bare-metal-fulfillment-operator-crds-${{ steps.version.outputs.version }}.tgz \
-          oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
+    - name: Push and sign chart
+      uses: ./.github/actions/helm-push-and-sign
+      with:
+        chart-file: bare-metal-fulfillment-operator/bare-metal-fulfillment-operator-crds-${{ steps.version.outputs.version }}.tgz
+        chart-name: bare-metal-fulfillment-operator-crds
+        oci-repo: ${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
 
   publish-bmf-chart:
     name: Publish bare-metal-fulfillment-operator chart
@@ -460,6 +487,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -504,11 +532,12 @@ jobs:
           --version "${{ steps.version.outputs.version }}" \
           --app-version "${{ steps.version.outputs.version }}"
 
-    - name: Push chart to GHCR
-      working-directory: bare-metal-fulfillment-operator
-      run: |
-        helm push bare-metal-fulfillment-operator-${{ steps.version.outputs.version }}.tgz \
-          oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
+    - name: Push and sign chart
+      uses: ./.github/actions/helm-push-and-sign
+      with:
+        chart-file: bare-metal-fulfillment-operator/bare-metal-fulfillment-operator-${{ steps.version.outputs.version }}.tgz
+        chart-name: bare-metal-fulfillment-operator
+        oci-repo: ${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
 
   create-bmf-release:
     name: Create GitHub Release (bare-metal-fulfillment-operator)
@@ -556,6 +585,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -612,11 +642,12 @@ jobs:
           --version "${{ steps.version.outputs.version }}" \
           --app-version "${{ steps.version.outputs.version }}"
 
-    - name: Push chart to GHCR
-      working-directory: osac-csi-driver
-      run: |
-        helm push csi-driver-${{ steps.version.outputs.version }}.tgz \
-          oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
+    - name: Push and sign chart
+      uses: ./.github/actions/helm-push-and-sign
+      with:
+        chart-file: osac-csi-driver/csi-driver-${{ steps.version.outputs.version }}.tgz
+        chart-name: csi-driver
+        oci-repo: ${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
 
   publish-csi-backends-chart:
     name: Publish csi-backends chart
@@ -626,6 +657,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -665,11 +697,12 @@ jobs:
           --version "${{ steps.version.outputs.version }}" \
           --app-version "${{ steps.version.outputs.version }}"
 
-    - name: Push chart to GHCR
-      working-directory: osac-csi-driver
-      run: |
-        helm push csi-backends-${{ steps.version.outputs.version }}.tgz \
-          oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
+    - name: Push and sign chart
+      uses: ./.github/actions/helm-push-and-sign
+      with:
+        chart-file: osac-csi-driver/csi-backends-${{ steps.version.outputs.version }}.tgz
+        chart-name: csi-backends
+        oci-repo: ${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
 
   create-osac-csi-driver-release:
     name: Create GitHub Release (osac-csi-driver)
@@ -737,6 +770,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -813,11 +847,12 @@ jobs:
           --version "${{ steps.version.outputs.version }}" \
           --app-version "${{ steps.version.outputs.version }}"
 
-    - name: Push chart to GHCR
-      working-directory: osac-metering
-      run: |
-        helm push osac-metering-${{ steps.version.outputs.version }}.tgz \
-          oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
+    - name: Push and sign chart
+      uses: ./.github/actions/helm-push-and-sign
+      with:
+        chart-file: osac-metering/osac-metering-${{ steps.version.outputs.version }}.tgz
+        chart-name: osac-metering
+        oci-repo: ${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
 
   create-metering-release:
     name: Create GitHub Release (osac-metering)

--- a/.github/workflows/publish-osac-installer-chart.yaml
+++ b/.github/workflows/publish-osac-installer-chart.yaml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
     steps:
     - name: Checkout repository
       uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
@@ -221,12 +222,12 @@ jobs:
           --version "${VERSION}" \
           --app-version "${VERSION}"
 
-    - name: Push chart to GHCR
-      env:
-        VERSION: ${{ steps.versions.outputs.version }}
-      run: |
-        helm push "osac-${VERSION}.tgz" \
-          oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
+    - name: Push and sign chart
+      uses: ./.github/actions/helm-push-and-sign
+      with:
+        chart-file: osac-${{ steps.versions.outputs.version }}.tgz
+        chart-name: osac
+        oci-repo: ${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
 
     - name: Create GitHub Release
       env:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,39 @@ cosign verify \
   ghcr.io/osac-project/osac-operator@sha256:<digest>
 ```
 
+## Verifying Helm chart signatures
+
+Helm charts published to `oci://ghcr.io/osac-project/charts/*` are signed the
+same way. All charts built from this mono-repo's own components (everything
+except `osac`, the umbrella chart) are published by `publish-charts.yaml`,
+which only ever runs via `workflow_run` off the repository's default branch
+(`main`) — never a tag ref, regardless of which component's tag triggered the
+originating image build. `publish-osac-installer-chart.yaml` (the umbrella
+chart) is `workflow_dispatch`-only and normally also runs from `main`, but can
+be dispatched against one of the umbrella chart's own `osac/v*` tags.
+
+`helm pull`/`helm push` print the artifact's digest directly, so no extra
+tooling is needed to resolve it:
+
+```bash
+helm pull oci://ghcr.io/osac-project/charts/<chart-name> --version <version>
+# Digest: sha256:<digest>
+
+cosign verify \
+  --certificate-identity-regexp '^https://github\.com/osac-project/osac/\.github/workflows/publish-charts\.yaml@refs/heads/main$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/osac-project/charts/<chart-name>@sha256:<digest>
+```
+
+For the umbrella chart, accept either ref:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp '^https://github\.com/osac-project/osac/\.github/workflows/publish-osac-installer-chart\.yaml@refs/(heads/main|tags/osac/.+)$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/osac-project/charts/osac@sha256:<digest>
+```
+
 Always verify by digest (`@sha256:...`), not by mutable tag — resolve a tag to
 its digest first with `skopeo inspect docker://ghcr.io/osac-project/<component>:<tag>`
 if needed. Images pushed to `quay.io/redhat-user-workloads/osac-tenant/...` via


### PR DESCRIPTION
## Summary

Second slice of [OSAC-1148](https://redhat.atlassian.net/browse/OSAC-1148) (container images landed in #901). Signs every Helm chart this repo publishes to `oci://ghcr.io/osac-project/charts`, using the same keyless cosign approach as the container-image work: GitHub Actions OIDC via Fulcio/Rekor, no private key material to manage.

- New shared composite action `.github/actions/helm-push-and-sign` wraps `helm push` + digest capture + cosign sign, instead of duplicating that sequence across 10 call sites.
- Applied to all 9 chart-publish jobs in `publish-charts.yaml` (fulfillment-service, osac-operator, osac-operator-crds, osac-aap, bare-metal-fulfillment-operator, bare-metal-fulfillment-operator-crds, csi-driver, csi-backends, osac-metering) plus the umbrella chart in `publish-osac-installer-chart.yaml`.

## Design notes

- **Digest extraction**: `helm push`'s own stdout prints `Digest: sha256:...` after a successful push. I use that directly rather than reaching for a container-image-specific tool — `skopeo inspect` explicitly refuses non-container OCI artifacts (`unsupported image-specific operation on artifact with type "application/vnd.cncf.helm.config.v1+json"`, confirmed by testing against a local registry).
- **`id-token: write` placement**: unlike the container-image workflows (which split build and sign into separate jobs so a job also running on `pull_request` never holds the OIDC permission), every chart-publish job here gets `id-token: write` added directly, no job split. These jobs only ever run via `workflow_run` after a tag-triggered image build already succeeded — never on `pull_request`-controlled content — so the least-privilege concern that justified the earlier split doesn't apply.

## What I validated locally vs. what needs a real release

- Downloaded the exact Helm version this repo pins (`v3.21.4`, via `azure/setup-helm`) and confirmed its `helm push` stdout format matches what the new composite action parses.
- Stood up a local OCI registry (`podman run registry:2`) and ran the full push → digest-parse → `cosign sign` → `cosign verify` cycle against a real Helm chart OCI artifact end-to-end, using a local cosign key pair (to avoid needing real GitHub Actions OIDC) — confirmed cosign works identically against Helm charts as it does against container images.
- YAML-validated every changed file and ran this repo's full `pre-commit` hook set (yamllint, gitleaks, etc.) — all pass.

Cannot validate outside a real release: the actual GitHub Actions OIDC token exchange, and an end-to-end run of any of these 10 jobs (they only trigger on a real tag push after their component's image build succeeds, or via `workflow_dispatch` for the umbrella chart).

## Test plan

- [ ] On the next tagged release of any covered component, confirm the corresponding `publish-*-chart` job's new "Push and sign chart" step succeeds
- [ ] `cosign verify` the resulting chart OCI artifact against `ghcr.io/osac-project/charts/<chart-name>@sha256:<digest>` and confirm it validates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **CI and deployment:** Added the shared `helm-push-and-sign` action. It pushes Helm charts, extracts the OCI digest, and signs the digest-pinned artifact with Cosign.
- **Authentication:** Added GitHub Actions OIDC permissions for chart publishing jobs.
- **Chart publishing:** Updated nine component chart jobs and the umbrella chart workflow to publish signed OCI artifacts.
- **Release validation:** Added tag-to-commit verification for the fulfillment service release workflow.
- **Documentation:** Added Cosign verification instructions for component and umbrella charts.
- **Tests and validation:** Covered Helm output parsing, local push/sign/verify behavior, YAML validation, and pre-commit checks. GitHub OIDC exchange and release-triggered workflow execution remain untested.
- **API and data:** No application API, controller, database, or runtime changes.

## Backward compatibility

Existing unsigned charts remain unchanged. New chart releases require Cosign signing and OIDC permissions. Consumers that verify signatures must use the documented workflow identity constraints.

## Risk classification

**risk:show** — The change affects CI authentication and release artifact publication. It adds signing, digest parsing, and tag validation without changing application runtime behavior or stored data. It does not qualify as **risk:ship** because GitHub OIDC exchange and release-triggered workflow execution were not tested end to end. It does not qualify as **risk:ask** because local end-to-end verification and configuration checks were completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->