### PR TITLE
[WIP] NO-ISSUE: Add aggregate gate jobs to consolidate required PR checks

### DIFF
--- a/.github/workflows/check-generated-code.yaml
+++ b/.github/workflows/check-generated-code.yaml
@@ -61,7 +61,10 @@ jobs:
               - '!osac-metering/metering-service/.claude/**'
               - 'fulfillment-service/proto/private/**'
 
-  check-generated-code:
+  # Job id renamed from `check-generated-code` (its `name:` below, which is
+  # what shows on PRs, is unchanged) to free that bare id up for the
+  # aggregate gate job below.
+  check-generated-code-matrix:
     name: Check generated code (${{ matrix.component }})
     needs: changes
     # Run even if `changes` failed: a skipped job reports success, which would
@@ -127,3 +130,24 @@ jobs:
           fi
           exit 1
         fi
+
+  # Single required check aggregating the matrix above, so PRs see one
+  # "check-generated-code" line instead of one per component. `skipped`
+  # counts as pass, same as a real success -- only an actual failure or
+  # cancellation fails this job. Mirrors the e2e-*-gate jobs' pattern in
+  # e2e-vmaas-full-install.yml et al.
+  check-generated-code:
+    if: always()
+    needs: [changes, check-generated-code-matrix]
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "Upstream job results:"
+          echo "  changes: ${{ needs.changes.result }}"
+          echo "  check-generated-code-matrix: ${{ needs.check-generated-code-matrix.result }}"
+          echo ""
+          echo "One or more upstream jobs failed or were cancelled."
+          exit 1
+      - if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+        run: echo "All components' generated code is up to date (or were skipped)."

--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -142,3 +142,26 @@ jobs:
       with:
         workdir: fulfillment-service
         args: build --snapshot --clean
+
+  # Single required check aggregating the 3 jobs above, so PRs see one
+  # "check-pull-request" line instead of 3. `skipped` counts as pass, same
+  # as a real success -- only an actual failure or cancellation fails this
+  # job. Mirrors the e2e-*-gate jobs' pattern in
+  # e2e-vmaas-full-install.yml et al.
+  check-pull-request:
+    if: always()
+    needs: [changes, check-python-code, check-go-code, build-binaries]
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "Upstream job results:"
+          echo "  changes: ${{ needs.changes.result }}"
+          echo "  check-python-code: ${{ needs.check-python-code.result }}"
+          echo "  check-go-code: ${{ needs.check-go-code.result }}"
+          echo "  build-binaries: ${{ needs.build-binaries.result }}"
+          echo ""
+          echo "One or more upstream jobs failed or were cancelled."
+          exit 1
+      - if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+        run: echo "All checks passed (or were skipped)."

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -72,3 +72,21 @@ jobs:
       - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
         with:
           category: "/language:${{ matrix.language }}"
+
+  # Cosmetic-only aggregate: CodeQL isn't a required check today, this just
+  # collapses the 2 per-language matrix lines into one on the PR checks
+  # list. `skipped` counts as pass, same as a real success -- only an
+  # actual failure or cancellation fails this job. Mirrors the e2e-*-gate
+  # jobs' pattern in e2e-vmaas-full-install.yml et al.
+  codeql:
+    if: always()
+    needs: analyze
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "analyze: ${{ needs.analyze.result }}"
+          echo "One or more CodeQL analyze jobs failed or were cancelled."
+          exit 1
+      - if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+        run: echo "All CodeQL analyze jobs passed (or were skipped)."

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -108,7 +108,10 @@ jobs:
   # (auth/certs/idp config), so it needs its CI-only charts/service/ci-values.yaml
   # passed via -f to lint/template cleanly -- osac-operator's and osac-aap's
   # charts have no such guards and lint fine bare.
-  helm-lint:
+  # Job id renamed from `helm-lint` (its `name:` below, which is what shows
+  # on PRs, is unchanged) to free that bare id up for the aggregate gate
+  # job below.
+  helm-lint-matrix:
     name: Lint Helm chart (${{ matrix.component }}/${{ matrix.chart }})
     needs: changes
     if: always()
@@ -263,3 +266,30 @@ jobs:
               --set service.internalHostname=fulfillment-internal-api.example.com
           fi
         done
+
+  # Single required check aggregating all 3 jobs above (including
+  # helm-lint-matrix's 9 legs), so PRs see one "helm-lint" line instead of
+  # 12. `skipped` counts as pass, same as a real success -- only an actual
+  # failure or cancellation fails this job. Mirrors the e2e-*-gate jobs'
+  # pattern in e2e-vmaas-full-install.yml et al.
+  #
+  # NOTE: helm-lint-matrix's 9 legs are not individually required today, so
+  # folding them in here makes them newly merge-blocking -- confirmed
+  # intentional (they should probably have been blocking already).
+  helm-lint:
+    if: always()
+    needs: [changes, helm-crds-sync, helm-lint-matrix, helm-lint-installer]
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "Upstream job results:"
+          echo "  changes: ${{ needs.changes.result }}"
+          echo "  helm-crds-sync: ${{ needs.helm-crds-sync.result }}"
+          echo "  helm-lint-matrix: ${{ needs.helm-lint-matrix.result }}"
+          echo "  helm-lint-installer: ${{ needs.helm-lint-installer.result }}"
+          echo ""
+          echo "One or more upstream jobs failed or were cancelled."
+          exit 1
+      - if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+        run: echo "All Helm lint jobs passed (or were skipped)."

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -394,3 +394,29 @@ jobs:
       run: >-
         make -C osac-installer install-osac PLATFORM=kind PROFILE=dev NS=osac
         EXTRA_HELM_ARGS="--set service.images.service=localhost/fulfillment-service:it"
+
+  # Single required check aggregating every component's integration test job
+  # above, so PRs see one "integration-tests" line instead of one per
+  # component. `skipped` (docs-only PRs, via `changes`) counts as pass, same
+  # as a real success -- only an actual failure or cancellation fails this
+  # job. Mirrors the e2e-*-gate jobs' pattern in
+  # e2e-vmaas-full-install.yml et al.
+  integration-tests:
+    if: always()
+    needs: [changes, fulfillment-service, osac-operator, bare-metal-fulfillment-operator, osac-aap, osac-installer]
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "Upstream job results:"
+          echo "  changes: ${{ needs.changes.result }}"
+          echo "  fulfillment-service: ${{ needs.fulfillment-service.result }}"
+          echo "  osac-operator: ${{ needs.osac-operator.result }}"
+          echo "  bare-metal-fulfillment-operator: ${{ needs.bare-metal-fulfillment-operator.result }}"
+          echo "  osac-aap: ${{ needs.osac-aap.result }}"
+          echo "  osac-installer: ${{ needs.osac-installer.result }}"
+          echo ""
+          echo "One or more upstream jobs failed or were cancelled."
+          exit 1
+      - if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+        run: echo "All integration test jobs passed (or were skipped)."

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -136,3 +136,27 @@ jobs:
     - working-directory: osac-metering/schema
       run: |
         ginkgo run -r .
+
+  # Single required check aggregating every job above, so PRs see one
+  # "unit-tests" line instead of one per component. `skipped` (docs-only
+  # PRs, via `changes`) counts as pass, same as a real success -- only an
+  # actual failure or cancellation fails this job. Mirrors the e2e-*-gate
+  # jobs' pattern in e2e-vmaas-full-install.yml et al.
+  unit-tests:
+    if: always()
+    needs: [changes, run-unit-tests, run-osac-metering-tests, run-osac-metering-adapters-tests, run-osac-metering-schema-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "Upstream job results:"
+          echo "  changes: ${{ needs.changes.result }}"
+          echo "  run-unit-tests: ${{ needs.run-unit-tests.result }}"
+          echo "  run-osac-metering-tests: ${{ needs.run-osac-metering-tests.result }}"
+          echo "  run-osac-metering-adapters-tests: ${{ needs.run-osac-metering-adapters-tests.result }}"
+          echo "  run-osac-metering-schema-tests: ${{ needs.run-osac-metering-schema-tests.result }}"
+          echo ""
+          echo "One or more upstream jobs failed or were cancelled."
+          exit 1
+      - if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+        run: echo "All unit test jobs passed (or were skipped)."


### PR DESCRIPTION
## What

Adds one aggregate "gate" job to each of `unit-tests.yml`,
`integration-tests.yml`, `check-pull-request.yaml`,
`check-generated-code.yaml`, and `helm-lint.yaml`, plus a cosmetic one to
`codeql.yml` — following the exact pattern `e2e-vmaas-gate`/
`e2e-bmaas-gate`/`e2e-caas-gate` already use in this repo.

Each new gate job:
- `needs: [...]` every real job already in that file
- `if: always()`, fails only if any upstream job `failure`d or was
  `cancelled` (a `skipped` job — e.g. docs-only PRs via the `changes`
  path-filter — still counts as pass)
- Has no explicit `name:`, so its job id is the check's display name,
  same as `check-labels`/`pre-commit` today

`check-generated-code.yaml`'s and `helm-lint.yaml`'s existing matrixed job
ids (`check-generated-code`, `helm-lint`) are renamed to
`check-generated-code-matrix`/`helm-lint-matrix` to free the bare name up
for the new gate job — their `name:` display strings (what actually shows
on PRs, e.g. "Check generated code (osac-operator)") are untouched.

## Why

Per-component/matrix jobs in these files are each individually listed in
`github-config`'s `required_status_checks` for this repo, so the
required-checks list has grown to ~27 entries. This is purely additive —
nothing that runs today changes; it just gives `github-config` one
context per file to require instead of many, mirroring what the e2e
suites already do. A follow-up `github-config` change (held until this
merges and the new jobs are confirmed reporting) will collapse those ~27
required contexts down to ~15.

Note: this does **not** shrink the full checks list on a PR — every
per-component job still posts its own check run, same as
`e2e-vmaas-full-install`/`e2e-readiness (vmaas)`/etc. still show up
alongside `e2e-vmaas-gate` today. Only the *required* (merge-blocking) set
shrinks.

## helm-lint.yaml behavior note

9 of the 12 jobs in `helm-lint.yaml` (the `helm-lint-matrix` legs) are not
individually required today. Folding them into the new required
`helm-lint` gate makes those 9 newly merge-blocking — confirmed
intentional.