### PR TITLE
OSAC-1148: Sign artifacts published by the nightly build

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -619,6 +619,10 @@ jobs:
       contents: read
       # Push/pull chart OCI artifacts to GHCR
       packages: write
+      # cosign's keyless chart signing (see push_and_sign_chart in
+      # nightly-charts.sh) -- safe directly on this job, no pull_request
+      # exposure: nightly-build.yaml only ever runs on schedule/workflow_dispatch.
+      id-token: write
     outputs:
       version: ${{ steps.version.outputs.version }}
       base-version: ${{ steps.version.outputs.base-version }}
@@ -648,6 +652,9 @@ jobs:
       uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
       with:
         version: v3.21.4
+
+    - name: Install cosign
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
 
     - name: Set up chart-testing
       uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f  # v2.8.0
@@ -809,7 +816,7 @@ jobs:
 
           echo "Packaging ${CHART_NAME} ${SUB_VERSION}..."
           helm package "${CHART_DIR}" --destination ./packaged-charts
-          helm push "./packaged-charts/${CHART_NAME}-${SUB_VERSION}.tgz" "oci://${REGISTRY}/${CHARTS_REPO}"
+          push_and_sign_chart "./packaged-charts/${CHART_NAME}-${SUB_VERSION}.tgz" "${CHART_NAME}" "${REGISTRY}/${CHARTS_REPO}"
           append_chart_source chart-sources.txt "${CHART_NAME}" "${SUB_VERSION}"
         done
 
@@ -825,7 +832,7 @@ jobs:
           UI_IMAGE_REF="ghcr.io/osac-project/osac-ui:${UI_SUB_VERSION}"
           stamp_osac_ui_chart "${UI_CHART_DIR}" "${UI_SUB_VERSION}" "${UI_IMAGE_REF}"
           helm package "${UI_CHART_DIR}" --destination ./packaged-charts
-          helm push "./packaged-charts/${UI_CHART_NAME}-${UI_SUB_VERSION}.tgz" "oci://${REGISTRY}/${CHARTS_REPO}"
+          push_and_sign_chart "./packaged-charts/${UI_CHART_NAME}-${UI_SUB_VERSION}.tgz" "${UI_CHART_NAME}" "${REGISTRY}/${CHARTS_REPO}"
           append_chart_source chart-sources.txt "${UI_CHART_NAME}" "${UI_SUB_VERSION}" "${{ needs.prepare.outputs.ui-short-sha }}" "${{ needs.prepare.outputs.ui-sha }}"
           echo "${UI_SUB_VERSION}" > osac-ui-nightly-version.txt
         else
@@ -887,13 +894,14 @@ jobs:
           --version "${VERSION}" \
           --app-version "${VERSION}"
 
-    - name: Push umbrella chart to GHCR
+    - name: Push and sign umbrella chart
       working-directory: osac-installer
       env:
         VERSION: ${{ steps.version.outputs.version }}
-        OCI_REPO: oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
       run: |
-        helm push "osac-${VERSION}.tgz" "${OCI_REPO}"
+        set -euo pipefail
+        source ./scripts/nightly-charts.sh
+        push_and_sign_chart "osac-${VERSION}.tgz" "osac" "${REGISTRY}/${CHARTS_REPO}"
 
     - name: Verify umbrella chart publication
       working-directory: osac-installer

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -328,6 +328,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # cosign's keyless image signing below -- safe directly on this job,
+      # no pull_request exposure: nightly-build.yaml only ever runs on
+      # schedule/workflow_dispatch.
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -399,6 +403,14 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Install skopeo
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq skopeo
+
+    - name: Install cosign
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+
     # osac-aap's execution-environment-build target shells out to `uv`
     # (ansible-builder is invoked via `uv tool run`) -- not present on
     # ubuntu-latest by default. Mirrors execution-environment.yml's own setup.
@@ -440,6 +452,7 @@ jobs:
     # real, release-looking nightly version tag never appears in GHCR for a
     # build that never actually shipped.
     - name: Build and push image
+      id: build
       if: steps.resolve.outputs.skip != 'true'
       env:
         VERSION: ${{ steps.resolve.outputs.version }}
@@ -454,6 +467,18 @@ jobs:
         fi
         make -C "${{ matrix.dir }}" "${{ matrix.target }}" "${BUILD_ARGS[@]}"
         make -C "${{ matrix.dir }}" "${{ matrix.push_target }}" "${BUILD_ARGS[@]}"
+        echo "image-ref=${IMG_REF}" >> "$GITHUB_OUTPUT"
+
+    # make image-push (plain `podman push`) doesn't report a digest, so
+    # resolve what's actually in the registry via skopeo -- inspecting the
+    # local image instead could sign a different digest than what a
+    # consumer actually pulls (e.g. under multi-arch/manifest-list builds).
+    - name: Sign image with cosign
+      if: steps.resolve.outputs.skip != 'true'
+      run: |
+        set -euo pipefail
+        digest=$(skopeo inspect "docker://${{ steps.build.outputs.image-ref }}" | jq -r '.Digest')
+        cosign sign --yes "${{ matrix.image }}@${digest}"
 
   # -------------------------------------------------------------------
   # Job 3: Code quality — unit tests, integration tests, and CodeQL SAST

--- a/osac-installer/scripts/nightly-charts.sh
+++ b/osac-installer/scripts/nightly-charts.sh
@@ -328,6 +328,29 @@ read_validated_chart_name() {
     echo "${chart_name}"
 }
 
+# Usage: push_and_sign_chart <chart_tgz_path> <chart_name> <oci_repo>
+# Pushes a packaged chart to <oci_repo> (no oci:// prefix) and signs the
+# resulting OCI artifact keylessly with cosign, using the calling workflow's
+# GitHub Actions OIDC identity (Fulcio/Rekor). Requires cosign already
+# installed on PATH and the calling job to grant permissions: id-token: write.
+# Digest is parsed straight from `helm push`'s own stdout ("Digest:
+# sha256:...") -- skopeo/crane-style inspection doesn't support Helm's OCI
+# artifact media type, so there's no simpler way to resolve it.
+push_and_sign_chart() {
+    local chart_tgz="$1" chart_name="$2" oci_repo="$3"
+    local output digest
+
+    output=$(helm push "${chart_tgz}" "oci://${oci_repo}" 2>&1)
+    echo "${output}"
+    digest=$(grep -oE '^Digest: sha256:[0-9a-f]+' <<<"${output}" | cut -d' ' -f2)
+    if [[ -z "${digest}" ]]; then
+        echo "::error::Could not parse digest from helm push output for ${chart_name}" >&2
+        return 1
+    fi
+
+    cosign sign --yes "${oci_repo}/${chart_name}@${digest}"
+}
+
 # Usage: compute_nightly_chart_version <base_tag> <nightly_suffix>
 compute_nightly_chart_version() {
     local base_tag="$1" nightly_suffix="$2"


### PR DESCRIPTION
## Summary

Follow-up to #901 (container images) and #902 (Helm charts). Both of those PRs only covered the tag-triggered release path (per-component `<component>/vX.Y.Z` tags → `build-image.yaml`/`publish-image.yaml`/etc. → `publish-charts.yaml`). It turns out that's **not** the commonly exercised path in this repo — nightly builds are — and `nightly-build.yaml` does its own **fully independent** packaging/pushing of both images and charts, entirely bypassing everything signed in #901/#902. This PR closes that gap.

## What I got wrong in #901 and am correcting here

I'd assumed nightly-build.yaml's "Promote images to nightly version" step (a `skopeo copy` retag) was retagging an already-signed digest from the regular per-component build workflows, so no additional signing was needed there. That's true for what the retag step itself does, but I hadn't traced far enough back: nightly-build.yaml's own `build` job (Job 2, matrix over osac-operator, bare-metal-fulfillment-operator, fulfillment-service, osac-aap, the three osac-metering images, and osac-csi-driver) does a **completely separate build+push** via generic `make image-build`/`image-push` targets (plain `podman build`/`podman push`, confirmed in each component's Makefile) — it doesn't reuse or depend on build-image.yaml/publish-image.yaml/etc. at all. The retag step later promotes *this* job's own digest, not necessarily anything the regular pipeline built. None of it was signed until this PR.

Same gap existed for charts: `nightly-build.yaml`'s "Publish nightly chart" job packages and pushes every chart itself (`helm package` + `helm push`), completely independent of `publish-charts.yaml`/`publish-osac-installer-chart.yaml` (signed in #902).

## What this PR adds

- **Images**: `skopeo` + `sigstore/cosign-installer` added to the `build` job; after `make image-push`, resolve the actual registry digest via `skopeo inspect` (not local image inspection, which could differ from what a consumer pulls under a multi-arch build) and `cosign sign` it. `id-token: write` added directly to the job — like #901/#902's `workflow_run`/`workflow_dispatch`-only jobs, `nightly-build.yaml` only runs on `schedule`/`workflow_dispatch`, never `pull_request`, so no separate signing job is needed.
- **Charts**: added `push_and_sign_chart()` to `osac-installer/scripts/nightly-charts.sh` — the same push+digest-parse+cosign-sign logic as #902's `helm-push-and-sign` composite action, but as a bash function since these charts are pushed from inside bash loops within a single step (a composite action can't be invoked mid-loop). Wired into all three nightly chart-push sites: the mono-repo sub-charts loop, the osac-ui chart, and the umbrella chart.

## Explicitly out of scope

`osac-ui`'s image is built and signed (or not) by its own separate repository's CI, not by anything in this mono-repo — `nightly-build.yaml` only retags whatever osac-ui already published under its own pinned SHA. Not something this PR can address.

## Validation

- Confirmed via each component's Makefile (`grep image-push`) that `make image-push` is a plain `podman push`, no signing, and confirmed no `cosign` reference existed anywhere in `nightly-build.yaml` before this PR.
- Validated `push_and_sign_chart`'s digest-parsing and `cosign sign` invocation with a mocked `helm`/`cosign` harness — confirms the exact same regex and `cosign sign --yes <ref>@<digest>` construction already proven end-to-end against a real local OCI registry for #902's composite-action version.
- YAML-validated both changed files and ran this repo's full `pre-commit` hook set.

Cannot validate outside a real nightly run: the actual `skopeo inspect`/`cosign sign` execution against real freshly-built images, and the GitHub Actions OIDC exchange itself (same caveat as #901/#902).

## Test plan

- [ ] On the next nightly run (or a manual `workflow_dispatch`), confirm the new "Sign image with cosign" step succeeds for each matrix component, and the "Push and sign chart"/"Push and sign umbrella chart" steps succeed
- [ ] `cosign verify` the resulting nightly-tagged images and charts against their real GHCR digests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Affected areas

- **CI and deployment:** The nightly workflow now signs pushed container images with Cosign and GitHub OIDC authentication.
- **Helm publishing:** `push_and_sign_chart()` pushes and signs all nightly-published charts. It fails when Helm does not return an image digest.
- **Authentication:** Relevant jobs now have `id-token: write` permission.
- **Tests and validation:** Mocked signing tests, YAML validation, and pre-commit checks passed. Real nightly execution and OIDC exchange remain untested.
- **API surface:** No public API changes.
- **Backward compatibility:** No runtime compatibility impact. Nightly artifact publishing now requires successful signing. `osac-ui` images remain unchanged because another repository builds them.

## Risk classification

**risk:show** — The change affects nightly artifact publication and signing, and real OIDC execution remains untested. It does not qualify as **risk:ask** because it changes CI artifact handling only, includes validation coverage, and does not modify runtime APIs, controllers, databases, or production application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->