### PR TITLE
NO-ISSUE: Bind pending e2e gate checks to workflow suite

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -286,10 +286,10 @@ jobs:
             echo "e2e passed"
           fi
 
-  # Latest check named e2e-bmaas-gate after the skipped gate job. Bind the
-  # pending check to this workflow's check suite so PR UI does not group it
-  # under unrelated pull_request_target workflows. Forks may lack checks:write;
-  # unreported check is still Expected/Waiting.
+  # Latest check named e2e-bmaas-gate after the skipped gate job. Resolve this
+  # workflow run's check_suite_id and attach the pending check so PR UI does not
+  # group it under unrelated pull_request_target workflows. Forks may lack
+  # checks:write; unreported check is still Expected/Waiting.
   e2e-bmaas-pending:
     if: >-
       always()
@@ -307,7 +307,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          CHECK_SUITE_ID: ${{ github.check_suite_id }}
+          RUN_ID: ${{ github.run_id }}
           CHECK_NAME: e2e-bmaas-gate
           DETAILS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REASON: ${{ needs.e2e-readiness.outputs.reason }}
@@ -317,10 +317,12 @@ jobs:
           summary=$(printf '%s\n\n%s\n\n%s' "${title}" \
             "Need coderabbitai[bot] APPROVED on this HEAD, lgtm, or /e2e-ready." \
             "See .github/e2e-readiness.md")
+          check_suite_id=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" \
+            --jq '.check_suite_id // empty' 2>/dev/null || true)
           payload=$(jq -n \
             --arg name "${CHECK_NAME}" \
             --arg sha "${HEAD_SHA}" \
-            --argjson check_suite_id "${CHECK_SUITE_ID}" \
+            --arg check_suite_id "${check_suite_id}" \
             --arg started "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --arg title "${title}" \
             --arg details "${DETAILS_URL}" \
@@ -328,7 +330,6 @@ jobs:
             '{
               name: $name,
               head_sha: $sha,
-              check_suite_id: $check_suite_id,
               status: "in_progress",
               details_url: $details,
               started_at: $started,
@@ -336,7 +337,11 @@ jobs:
                 title: $title,
                 summary: $summary
               }
-            }')
+            }
+            | if ($check_suite_id | length) > 0
+              then . + {check_suite_id: ($check_suite_id | tonumber)}
+              else .
+              end')
           if ! gh api "repos/${REPO}/check-runs" --input - <<<"${payload}"; then
             echo "Could not post in_progress check ${CHECK_NAME} (fork PRs may lack checks:write)."
             echo "Required check stays unreported until unlock rerun."

--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -286,8 +286,10 @@ jobs:
             echo "e2e passed"
           fi
 
-  # Latest check named e2e-bmaas-gate after the skipped gate job. Forks may
-  # lack checks:write; unreported check is still Expected/Waiting.
+  # Latest check named e2e-bmaas-gate after the skipped gate job. Bind the
+  # pending check to this workflow's check suite so PR UI does not group it
+  # under unrelated pull_request_target workflows. Forks may lack checks:write;
+  # unreported check is still Expected/Waiting.
   e2e-bmaas-pending:
     if: >-
       always()
@@ -305,6 +307,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CHECK_SUITE_ID: ${{ github.check_suite_id }}
           CHECK_NAME: e2e-bmaas-gate
           DETAILS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REASON: ${{ needs.e2e-readiness.outputs.reason }}
@@ -317,6 +320,7 @@ jobs:
           payload=$(jq -n \
             --arg name "${CHECK_NAME}" \
             --arg sha "${HEAD_SHA}" \
+            --argjson check_suite_id "${CHECK_SUITE_ID}" \
             --arg started "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --arg title "${title}" \
             --arg details "${DETAILS_URL}" \
@@ -324,6 +328,7 @@ jobs:
             '{
               name: $name,
               head_sha: $sha,
+              check_suite_id: $check_suite_id,
               status: "in_progress",
               details_url: $details,
               started_at: $started,

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -303,8 +303,10 @@ jobs:
             echo "e2e passed"
           fi
 
-  # Latest check named e2e-caas-gate after the skipped gate job. Forks may
-  # lack checks:write; unreported check is still Expected/Waiting.
+  # Latest check named e2e-caas-gate after the skipped gate job. Bind the
+  # pending check to this workflow's check suite so PR UI does not group it
+  # under unrelated pull_request_target workflows. Forks may lack checks:write;
+  # unreported check is still Expected/Waiting.
   e2e-caas-pending:
     if: >-
       always()
@@ -322,6 +324,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CHECK_SUITE_ID: ${{ github.check_suite_id }}
           CHECK_NAME: e2e-caas-gate
           DETAILS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REASON: ${{ needs.e2e-readiness.outputs.reason }}
@@ -334,6 +337,7 @@ jobs:
           payload=$(jq -n \
             --arg name "${CHECK_NAME}" \
             --arg sha "${HEAD_SHA}" \
+            --argjson check_suite_id "${CHECK_SUITE_ID}" \
             --arg started "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --arg title "${title}" \
             --arg details "${DETAILS_URL}" \
@@ -341,6 +345,7 @@ jobs:
             '{
               name: $name,
               head_sha: $sha,
+              check_suite_id: $check_suite_id,
               status: "in_progress",
               details_url: $details,
               started_at: $started,

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -303,10 +303,10 @@ jobs:
             echo "e2e passed"
           fi
 
-  # Latest check named e2e-caas-gate after the skipped gate job. Bind the
-  # pending check to this workflow's check suite so PR UI does not group it
-  # under unrelated pull_request_target workflows. Forks may lack checks:write;
-  # unreported check is still Expected/Waiting.
+  # Latest check named e2e-caas-gate after the skipped gate job. Resolve this
+  # workflow run's check_suite_id and attach the pending check so PR UI does not
+  # group it under unrelated pull_request_target workflows. Forks may lack
+  # checks:write; unreported check is still Expected/Waiting.
   e2e-caas-pending:
     if: >-
       always()
@@ -324,7 +324,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          CHECK_SUITE_ID: ${{ github.check_suite_id }}
+          RUN_ID: ${{ github.run_id }}
           CHECK_NAME: e2e-caas-gate
           DETAILS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REASON: ${{ needs.e2e-readiness.outputs.reason }}
@@ -334,10 +334,12 @@ jobs:
           summary=$(printf '%s\n\n%s\n\n%s' "${title}" \
             "Need coderabbitai[bot] APPROVED on this HEAD, lgtm, or /e2e-ready." \
             "See .github/e2e-readiness.md")
+          check_suite_id=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" \
+            --jq '.check_suite_id // empty' 2>/dev/null || true)
           payload=$(jq -n \
             --arg name "${CHECK_NAME}" \
             --arg sha "${HEAD_SHA}" \
-            --argjson check_suite_id "${CHECK_SUITE_ID}" \
+            --arg check_suite_id "${check_suite_id}" \
             --arg started "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --arg title "${title}" \
             --arg details "${DETAILS_URL}" \
@@ -345,7 +347,6 @@ jobs:
             '{
               name: $name,
               head_sha: $sha,
-              check_suite_id: $check_suite_id,
               status: "in_progress",
               details_url: $details,
               started_at: $started,
@@ -353,7 +354,11 @@ jobs:
                 title: $title,
                 summary: $summary
               }
-            }')
+            }
+            | if ($check_suite_id | length) > 0
+              then . + {check_suite_id: ($check_suite_id | tonumber)}
+              else .
+              end')
           if ! gh api "repos/${REPO}/check-runs" --input - <<<"${payload}"; then
             echo "Could not post in_progress check ${CHECK_NAME} (fork PRs may lack checks:write)."
             echo "Required check stays unreported until unlock rerun."

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -302,10 +302,10 @@ jobs:
             echo "e2e passed"
           fi
 
-  # Latest check named e2e-vmaas-gate after the skipped gate job. Bind the
-  # pending check to this workflow's check suite so PR UI does not group it
-  # under unrelated pull_request_target workflows. Forks may lack checks:write;
-  # unreported check is still Expected/Waiting.
+  # Latest check named e2e-vmaas-gate after the skipped gate job. Resolve this
+  # workflow run's check_suite_id and attach the pending check so PR UI does not
+  # group it under unrelated pull_request_target workflows. Forks may lack
+  # checks:write; unreported check is still Expected/Waiting.
   e2e-vmaas-pending:
     if: >-
       always()
@@ -323,7 +323,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          CHECK_SUITE_ID: ${{ github.check_suite_id }}
+          RUN_ID: ${{ github.run_id }}
           CHECK_NAME: e2e-vmaas-gate
           DETAILS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REASON: ${{ needs.e2e-readiness.outputs.reason }}
@@ -333,10 +333,12 @@ jobs:
           summary=$(printf '%s\n\n%s\n\n%s' "${title}" \
             "Need coderabbitai[bot] APPROVED on this HEAD, lgtm, or /e2e-ready." \
             "See .github/e2e-readiness.md")
+          check_suite_id=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" \
+            --jq '.check_suite_id // empty' 2>/dev/null || true)
           payload=$(jq -n \
             --arg name "${CHECK_NAME}" \
             --arg sha "${HEAD_SHA}" \
-            --argjson check_suite_id "${CHECK_SUITE_ID}" \
+            --arg check_suite_id "${check_suite_id}" \
             --arg started "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --arg title "${title}" \
             --arg details "${DETAILS_URL}" \
@@ -344,7 +346,6 @@ jobs:
             '{
               name: $name,
               head_sha: $sha,
-              check_suite_id: $check_suite_id,
               status: "in_progress",
               details_url: $details,
               started_at: $started,
@@ -352,7 +353,11 @@ jobs:
                 title: $title,
                 summary: $summary
               }
-            }')
+            }
+            | if ($check_suite_id | length) > 0
+              then . + {check_suite_id: ($check_suite_id | tonumber)}
+              else .
+              end')
           if ! gh api "repos/${REPO}/check-runs" --input - <<<"${payload}"; then
             echo "Could not post in_progress check ${CHECK_NAME} (fork PRs may lack checks:write)."
             echo "Required check stays unreported until unlock rerun."

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -302,8 +302,10 @@ jobs:
             echo "e2e passed"
           fi
 
-  # Latest check named e2e-vmaas-gate after the skipped gate job. Forks may
-  # lack checks:write; unreported check is still Expected/Waiting.
+  # Latest check named e2e-vmaas-gate after the skipped gate job. Bind the
+  # pending check to this workflow's check suite so PR UI does not group it
+  # under unrelated pull_request_target workflows. Forks may lack checks:write;
+  # unreported check is still Expected/Waiting.
   e2e-vmaas-pending:
     if: >-
       always()
@@ -321,6 +323,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CHECK_SUITE_ID: ${{ github.check_suite_id }}
           CHECK_NAME: e2e-vmaas-gate
           DETAILS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REASON: ${{ needs.e2e-readiness.outputs.reason }}
@@ -333,6 +336,7 @@ jobs:
           payload=$(jq -n \
             --arg name "${CHECK_NAME}" \
             --arg sha "${HEAD_SHA}" \
+            --argjson check_suite_id "${CHECK_SUITE_ID}" \
             --arg started "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --arg title "${title}" \
             --arg details "${DETAILS_URL}" \
@@ -340,6 +344,7 @@ jobs:
             '{
               name: $name,
               head_sha: $sha,
+              check_suite_id: $check_suite_id,
               status: "in_progress",
               details_url: $details,
               started_at: $started,


### PR DESCRIPTION
## Summary
- Resolve the current workflow run's `check_suite_id` via the Actions API when `e2e-*-pending` posts in-progress required gate checks
- Attach pending `e2e-bmaas/caas/vmaas-gate` checks to the correct full-install workflow suite so PR UI no longer groups them under unrelated `pull_request_target` workflows (e.g. "Remove BMaaS Netris trigger on new push")
- Omit `check_suite_id` when lookup fails, preserving the previous fallback behavior

## Background
`e2e-*-pending` posts required gate checks through the Checks API. Without a suite binding, GitHub grouped them under whichever `pull_request_target` workflow ran on the same push. The first attempt used `github.check_suite_id`, but that context is empty in these jobs and caused `e2e-*-pending` to fail before posting any check.

## Test plan
- [ ] Open a code PR and confirm pending `e2e-*-gate` checks show under `E2E * Full Install` (not Netris cleanup)
- [ ] Confirm `e2e-*-pending` succeeds when e2e is not yet unlocked
- [ ] After unlock, confirm gate checks still flip green/red when full-install completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

- Updated the BMAAS, CAAS, and VMaaS full-install workflows.
- Resolved `check_suite_id` through the Actions API for pending E2E gate checks.
- Added `check_suite_id` only when the lookup succeeds.
- Preserved fallback behavior when the lookup fails.

## Affected areas

- **CI:** Corrects check-suite association for `e2e-*-pending` checks.
- **API integration:** Uses the workflow run API and passes the result to `jq`.
- **Tests:** Covers check grouping, pending-job success before unlock, and gate status transitions after full-install completion.
- **Backward compatibility:** Preserved. Failed lookups omit `check_suite_id`.

## Risk classification

**risk:ship** — The change is limited to CI workflow logic, has a safe fallback, and includes coverage for the affected gate transitions.

It does not qualify for **risk:show** because it does not change user-facing product behavior or require staged rollout. It does not qualify for **risk:ask** because it does not modify production code, data, authentication, or security controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->