### PR TITLE
OSAC-1148: document nightly-build.yaml as an alternate signer identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ image, so pin both rather than accepting any workflow or any tag in this repo:
 | metering-echo-adapter                       | `osac-project/metering-echo-adapter`   | `build-metering-echo-adapter-image.yaml`    | `osac-metering`                    |
 | osac-csi-driver                             | `osac-project/osac-csi-driver`         | `publish-csi-driver-image.yaml`             | `osac-csi-driver`                  |
 
+`nightly-build.yaml` independently rebuilds and republishes every image above
+on its own schedule (`schedule`/`workflow_dispatch`, always off `main`), so
+`nightly-build.yaml@refs/heads/main` is also a valid signer identity for any
+image in this table — not just the workflow listed. Which identity you
+actually see on a given digest depends on which workflow signed it first: if
+a night's rebuild is byte-identical to that day's regular build, the digest
+already carries the regular workflow's signature and nightly never re-signs
+it; a rebuild that differs gets its own `nightly-build.yaml` signature.
+
 Verify an image, substituting the workflow file and tag prefix from the table above:
 
 ```bash
@@ -78,6 +87,14 @@ which only ever runs via `workflow_run` off the repository's default branch
 originating image build. `publish-osac-installer-chart.yaml` (the umbrella
 chart) is `workflow_dispatch`-only and normally also runs from `main`, but can
 be dispatched against one of the umbrella chart's own `osac/v*` tags.
+
+`nightly-build.yaml` also independently packages and republishes every chart
+above (including the umbrella chart) as part of its nightly run, off `main`.
+The same rule as images applies: `nightly-build.yaml@refs/heads/main` is a
+valid alternate identity for any chart here, but you'll only see it on a
+digest whose nightly rebuild actually differed from the existing published
+chart — byte-identical rebuilds keep the earlier workflow's signature rather
+than being re-signed.
 
 `helm pull`/`helm push` print the artifact's digest directly, so no extra
 tooling is needed to resolve it:

--- a/README.md
+++ b/README.md
@@ -51,13 +51,17 @@ image, so pin both rather than accepting any workflow or any tag in this repo:
 | osac-csi-driver                             | `osac-project/osac-csi-driver`         | `publish-csi-driver-image.yaml`             | `osac-csi-driver`                  |
 
 `nightly-build.yaml` independently rebuilds and republishes every image above
-on its own schedule (`schedule`/`workflow_dispatch`, always off `main`), so
+on its own schedule (`schedule` or a manual `workflow_dispatch`), so
 `nightly-build.yaml@refs/heads/main` is also a valid signer identity for any
-image in this table — not just the workflow listed. Which identity you
-actually see on a given digest depends on which workflow signed it first: if
-a night's rebuild is byte-identical to that day's regular build, the digest
-already carries the regular workflow's signature and nightly never re-signs
-it; a rebuild that differs gets its own `nightly-build.yaml` signature.
+image in this table — not just the workflow listed. Signing isn't skipped for
+an already-signed digest: nightly signs whatever digest each run pushes, even
+when a rebuild is byte-identical to an already-published one, so that digest
+ends up with more than one valid signature from different identities rather
+than only the newest. `workflow_dispatch` has no restriction to `main` — it
+checks out `github.sha` for whichever ref is selected when the run is
+dispatched, so a manual run against a non-`main` ref signs under that ref's
+identity instead; match the regex to the ref actually used if you dispatched
+it yourself.
 
 Verify an image, substituting the workflow file and tag prefix from the table above:
 
@@ -89,12 +93,13 @@ chart) is `workflow_dispatch`-only and normally also runs from `main`, but can
 be dispatched against one of the umbrella chart's own `osac/v*` tags.
 
 `nightly-build.yaml` also independently packages and republishes every chart
-above (including the umbrella chart) as part of its nightly run, off `main`.
-The same rule as images applies: `nightly-build.yaml@refs/heads/main` is a
-valid alternate identity for any chart here, but you'll only see it on a
-digest whose nightly rebuild actually differed from the existing published
-chart — byte-identical rebuilds keep the earlier workflow's signature rather
-than being re-signed.
+above (including the umbrella chart) as part of its nightly run. The same
+rule as images applies: `nightly-build.yaml@refs/heads/main` is a valid
+alternate identity for any chart here, and it signs every chart it packages
+each run regardless of whether that run's digest is byte-identical to an
+already-published one — so a chart digest can legitimately carry signatures
+from more than one identity, not just the most recent signer. The same
+`workflow_dispatch`-ref caveat from the image section applies here too.
 
 `helm pull`/`helm push` print the artifact's digest directly, so no extra
 tooling is needed to resolve it:
@@ -104,7 +109,7 @@ helm pull oci://ghcr.io/osac-project/charts/<chart-name> --version <version>
 # Digest: sha256:<digest>
 
 cosign verify \
-  --certificate-identity-regexp '^https://github\.com/osac-project/osac/\.github/workflows/publish-charts\.yaml@refs/heads/main$' \
+  --certificate-identity-regexp '^https://github\.com/osac-project/osac/\.github/workflows/(publish-charts|nightly-build)\.yaml@refs/heads/main$' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   ghcr.io/osac-project/charts/<chart-name>@sha256:<digest>
 ```
@@ -113,7 +118,7 @@ For the umbrella chart, accept either ref:
 
 ```bash
 cosign verify \
-  --certificate-identity-regexp '^https://github\.com/osac-project/osac/\.github/workflows/publish-osac-installer-chart\.yaml@refs/(heads/main|tags/osac/.+)$' \
+  --certificate-identity-regexp '^https://github\.com/osac-project/osac/\.github/workflows/(publish-osac-installer-chart\.yaml@refs/(heads/main|tags/osac/.+)|nightly-build\.yaml@refs/heads/main)$' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   ghcr.io/osac-project/charts/osac@sha256:<digest>
 ```


### PR DESCRIPTION
## Summary
- nightly-build.yaml independently rebuilds and republishes every image and chart in the per-component tables, so its cosign identity is a valid alternate signer, not just an oversight
- documents the "first signer wins" behavior for byte-identical nightly rebuilds vs. genuinely different rebuilds, so the verification tables reflect what you'll actually see on a given digest

## Test plan
- [x] Reviewed rendered README diff for accuracy against nightly-build.yaml's actual triggers (schedule/workflow_dispatch, always off main)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Documentation and CI

- Documents `nightly-build.yaml` as an alternate Cosign signer for images and Helm charts.
- Documents signatures for every nightly push, including byte-identical rebuilds.
- Updates both chart verification regexes.
- Clarifies that manual `workflow_dispatch` runs are not restricted to `main`.
- No API, runtime, deployment, authentication, database, controller, or test changes.

## Backward compatibility

- No backward-compatibility impact.
- The PR changes documentation and verification examples only.

## Risk classification

- **risk:ship** — Documentation-only changes. No runtime behavior, interface, security control, or deployment logic changes.
- The PR is not **risk:show** because it introduces no product behavior.
- The PR is not **risk:ask** because it does not modify code or operational configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->