### PR TITLE
Add workflow to clear stale e2e gate checks

### DIFF
--- a/.github/scripts/complete-stale-e2e-gate-checks.sh
+++ b/.github/scripts/complete-stale-e2e-gate-checks.sh
@@ -5,6 +5,8 @@
 set -euo pipefail
 
 readonly GATES=(e2e-vmaas-gate e2e-bmaas-gate e2e-caas-gate)
+# Matches external_id set by invalidate-e2e-gates when present on newer checks.
+readonly INVALIDATE_EXTERNAL_ID_PREFIX="osac-invalidate-e2e-gate"
 
 if [[ -z "${HEAD_SHA:-}" || -z "${REPO:-}" ]]; then
   echo "HEAD_SHA and REPO are required" >&2
@@ -14,7 +16,7 @@ fi
 tmpdir=$(mktemp -d)
 page=1
 while true; do
-  resp=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100&page=${page}")
+  resp=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100&page=${page}&filter=all")
   jq -c '.check_runs' <<<"${resp}" > "${tmpdir}/page-${page}.json"
   count=$(jq '.check_runs | length' <<<"${resp}")
   if [[ "${count}" -lt 100 ]]; then
@@ -31,12 +33,15 @@ summary="Manual cleanup of stale invalidate-e2e-gates check; gate already succes
 failed=0
 
 for gate in "${GATES[@]}"; do
-  latest=$(jq -r --arg g "${gate}" '
-    [.[] | select(.name == $g)]
-    | sort_by(.started_at) | last | .conclusion // "missing"
-  ' <<<"${check_runs}")
-  if [[ "${latest}" != "success" ]]; then
-    echo "Skipping ${gate}: latest conclusion is ${latest}"
+  if ! jq -e --arg g "${gate}" '
+    [.[] | select(
+      .name == $g
+      and .status == "completed"
+      and .conclusion == "success"
+      and ((.details_url // "") | test("/actions/runs/[0-9]+/job/"))
+    )] | length > 0
+  ' <<<"${check_runs}" >/dev/null; then
+    echo "Skipping ${gate}: no native gate job success on this SHA"
     continue
   fi
   while IFS= read -r id; do
@@ -59,8 +64,16 @@ for gate in "${GATES[@]}"; do
       echo "Failed to complete ${gate} check ${id}" >&2
       failed=1
     fi
-  done < <(jq -r --arg g "${gate}" '
-    [.[] | select(.name == $g and .status == "in_progress") | .id] | .[]
+  done < <(jq -r --arg g "${gate}" --arg prefix "${INVALIDATE_EXTERNAL_ID_PREFIX}" '
+    [.[] | select(
+      .name == $g
+      and .status == "in_progress"
+      and (
+        ((.external_id // "") | startswith($prefix))
+        or ((.details_url // "") | test("^https://github.com/[^/]+/[^/]+/runs/[0-9]+$"))
+      )
+      and not ((.details_url // "") | test("/actions/runs/[0-9]+/job/"))
+    ) | .id] | .[]
   ' <<<"${check_runs}")
 done
 

--- a/.github/scripts/complete-stale-e2e-gate-checks.sh
+++ b/.github/scripts/complete-stale-e2e-gate-checks.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# One-off cleanup: complete orphaned in_progress e2e-*-gate API checks when
+# native gate jobs already succeeded on HEAD_SHA. Run via workflow_dispatch.
+
+set -euo pipefail
+
+readonly GATES=(e2e-vmaas-gate e2e-bmaas-gate e2e-caas-gate)
+
+if [[ -z "${HEAD_SHA:-}" || -z "${REPO:-}" ]]; then
+  echo "HEAD_SHA and REPO are required" >&2
+  exit 1
+fi
+
+tmpdir=$(mktemp -d)
+page=1
+while true; do
+  resp=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100&page=${page}")
+  jq -c '.check_runs' <<<"${resp}" > "${tmpdir}/page-${page}.json"
+  count=$(jq '.check_runs | length' <<<"${resp}")
+  if [[ "${count}" -lt 100 ]]; then
+    break
+  fi
+  page=$((page + 1))
+done
+check_runs=$(jq -s 'add' "${tmpdir}"/page-*.json)
+rm -rf "${tmpdir}"
+
+completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+title="Superseded by native e2e gate job"
+summary="Manual cleanup of stale invalidate-e2e-gates check; gate already success on this SHA."
+failed=0
+
+for gate in "${GATES[@]}"; do
+  latest=$(jq -r --arg g "${gate}" '
+    [.[] | select(.name == $g)]
+    | sort_by(.started_at) | last | .conclusion // "missing"
+  ' <<<"${check_runs}")
+  if [[ "${latest}" != "success" ]]; then
+    echo "Skipping ${gate}: latest conclusion is ${latest}"
+    continue
+  fi
+  while IFS= read -r id; do
+    [[ -z "${id}" || "${id}" == "null" ]] && continue
+    payload=$(jq -n \
+      --arg status "completed" \
+      --arg conclusion "success" \
+      --arg completed_at "${completed_at}" \
+      --arg title "${title}" \
+      --arg summary "${summary}" \
+      '{
+        status: $status,
+        conclusion: $conclusion,
+        completed_at: $completed_at,
+        output: {title: $title, summary: $summary}
+      }')
+    if gh api "repos/${REPO}/check-runs/${id}" -X PATCH --input - <<<"${payload}"; then
+      echo "Completed stale in_progress ${gate} check ${id}"
+    else
+      echo "Failed to complete ${gate} check ${id}" >&2
+      failed=1
+    fi
+  done < <(jq -r --arg g "${gate}" '
+    [.[] | select(.name == $g and .status == "in_progress") | .id] | .[]
+  ' <<<"${check_runs}")
+done
+
+exit "${failed}"

--- a/.github/workflows/complete-stale-e2e-gates.yml
+++ b/.github/workflows/complete-stale-e2e-gates.yml
@@ -1,0 +1,43 @@
+---
+name: Complete stale e2e gate checks
+
+# Manual cleanup when invalidate-e2e-gates left in_progress orphans after native
+# e2e-*-gate jobs already passed. Does not re-run e2e.
+on:
+  workflow_dispatch:
+    inputs:
+      head_sha:
+        description: PR head commit SHA (40 characters)
+        required: true
+        type: string
+      pr_number:
+        description: Optional PR number (logged only)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  complete-stale-gates:
+    if: github.repository == 'osac-project/osac'
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: Complete stale in_progress e2e gate checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${PR_NUMBER}" ]]; then
+            echo "Cleaning stale e2e gates for PR #${PR_NUMBER} at ${HEAD_SHA:0:7}"
+          else
+            echo "Cleaning stale e2e gates at ${HEAD_SHA:0:7}"
+          fi
+          bash .github/scripts/complete-stale-e2e-gate-checks.sh


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` job to complete orphaned `in_progress` `e2e-*-gate` checks when native gate jobs already succeeded
- Unblocks stuck PRs without re-running full e2e or admin merge

## Test plan
- [ ] Merge PR
- [ ] Actions → **Complete stale e2e gate checks** → **Run workflow**
- [ ] Enter affected PR head SHA
- [ ] Confirm stale `in_progress` gate checks complete and PR becomes mergeable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## CI and API surface

- Adds a manually dispatched workflow to complete stale `in_progress` `e2e-*-gate` checks.
- Uses the GitHub Checks API to find successful native gate jobs and update matching orphan checks.
- Processes paginated check-run results.
- Excludes active native gate jobs.
- Requires check-write permission and limits execution to `osac-project/osac`.

## Tests

- The workflow is tested manually with an affected pull request head SHA.
- Verification confirms that stale checks complete and the pull request becomes mergeable.

## Backward compatibility

- No application API, database, controller, authentication, or deployment behavior changes.
- The workflow does not rerun the e2e suite.
- The workflow changes only matching stale checks after the corresponding native gate succeeds.

## Risk classification

- **risk:show** — The change modifies GitHub check state and uses write permission, but execution is manual, repository-scoped, SHA-targeted, and limited to orphan checks with successful native gate jobs.
- It does not qualify as **risk:ask** because it does not change production behavior, application data, authentication, or release automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->