### PR TITLE
Fix jq syntax in stale gate cleanup

### DIFF
--- a/.github/scripts/complete-stale-e2e-gate-checks.sh
+++ b/.github/scripts/complete-stale-e2e-gate-checks.sh
@@ -72,7 +72,6 @@ for gate in "${GATES[@]}"; do
         ((.external_id // "") | startswith($prefix))
         or ((.details_url // "") | test("^https://github.com/[^/]+/[^/]+/runs/[0-9]+$"))
       )
-      and not ((.details_url // "") | test("/actions/runs/[0-9]+/job/"))
     ) | .id] | .[]
   ' <<<"${check_runs}")
 done


### PR DESCRIPTION
## Summary
- Fix invalid jq `not` syntax that caused the cleanup workflow to no-op silently

## Test plan
- [ ] Merge and re-run **Complete stale e2e gate checks** workflow_dispatch
- [ ] Confirm log shows `Completed stale in_progress` lines and PR gates clear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## CI

- Fixed jq syntax in `.github/scripts/complete-stale-e2e-gate-checks.sh`.
- The cleanup now completes matching stale checks.
- Matching uses the invalidate external ID prefix or workflow-run URL.
- The workflow still verifies a successful native gate job before cleanup.
- Rerun the workflow and confirm `Completed stale in_progress` logs and cleared PR gates.

## Compatibility

- No API, database, authentication, deployment, or public entity changes.
- No backward-compatibility impact is expected.

## Risk classification

- `risk:ship`: The change is limited to CI cleanup logic and fixes a jq compile error.
- The change does not affect application runtime behavior or public interfaces.
- It is close to `risk:show` because it changes PR gate cleanup, but it restores the intended workflow behavior and does not change application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->