### PR TITLE
NO-ISSUE: Complete stale e2e gates after native jobs pass

### DIFF
--- a/.github/scripts/cancel-stale-e2e-runs.sh
+++ b/.github/scripts/cancel-stale-e2e-runs.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Cancel in-progress full-install runs on obsolete SHAs for this PR branch.
+# gh run rerun (unlock replay) can outlive concurrency cancel-in-progress on
+# newer pull_request runs; synchronize must force-cancel stale SHAs explicitly.
+# Cancels all three suite workflows (VMaaS/BMaaS/CaaS) regardless of which
+# caller invokes this script.
+#
+# Env: REPO, HEAD_SHA, HEAD_BRANCH, HEAD_REPO, PR_NUMBER
+
+set -euo pipefail
+
+if [[ -z "${REPO:-}" || -z "${HEAD_SHA:-}" || -z "${HEAD_BRANCH:-}" || -z "${HEAD_REPO:-}" ]]; then
+  echo "REPO, HEAD_SHA, HEAD_BRANCH, and HEAD_REPO are required" >&2
+  exit 1
+fi
+
+# Return 0 when PR head still matches HEAD_SHA; 1 when moved or lookup failed.
+pr_head_still_current() {
+  local current_head
+
+  if [[ -z "${PR_NUMBER:-}" ]]; then
+    return 0
+  fi
+  current_head=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha // empty')
+  if [[ -z "${current_head}" ]]; then
+    echo "Could not read PR #${PR_NUMBER} head; skipping stale-run cancel." >&2
+    return 1
+  fi
+  if [[ "${current_head}" != "${HEAD_SHA}" ]]; then
+    echo "PR #${PR_NUMBER} head moved (${HEAD_SHA:0:7} -> ${current_head:0:7}); stopping stale-run cancel."
+    return 1
+  fi
+  return 0
+}
+
+if ! pr_head_still_current; then
+  exit 0
+fi
+
+E2E_NAMES='["E2E VMaaS Full Install","E2E BMaaS Full Install","E2E CaaS Full Install"]'
+cancelled=0
+failed=0
+for status in in_progress queued waiting pending requested; do
+  if ! pr_head_still_current; then
+    break
+  fi
+  runs=$(gh api --method GET "repos/${REPO}/actions/runs" \
+    -f event=pull_request \
+    -f branch="${HEAD_BRANCH}" \
+    -f status="${status}" \
+    -F per_page=100 \
+    --jq '.workflow_runs')
+  while IFS=$'\t' read -r id name sha; do
+    [[ -z "${id}" ]] && continue
+    if ! pr_head_still_current; then
+      break 2
+    fi
+    if [[ "${sha}" == "${HEAD_SHA}" ]]; then
+      echo "Skipping ${name} #${id}: matches current PR head"
+      continue
+    fi
+    echo "Cancelling stale ${name} #${id} (${sha:0:7} != ${HEAD_SHA:0:7})"
+    if gh api -X POST "repos/${REPO}/actions/runs/${id}/force-cancel" 2>/dev/null \
+      || gh run cancel "${id}" -R "${REPO}"; then
+      cancelled=$((cancelled + 1))
+    else
+      echo "Could not cancel run #${id}" >&2
+      failed=1
+    fi
+  done < <(jq -r --arg head "${HEAD_SHA}" --arg repo "${HEAD_REPO}" --argjson names "${E2E_NAMES}" '
+    .[] | select(
+      .head_repository.full_name == $repo
+      and .head_sha != $head
+      and (.name as $n | $names | index($n))
+    ) | "\(.id)\t\(.name)\t\(.head_sha)"
+  ' <<<"${runs}")
+done
+echo "Cancelled ${cancelled} stale full-install run(s)."
+exit "${failed}"

--- a/.github/scripts/complete-stale-e2e-gate-checks.sh
+++ b/.github/scripts/complete-stale-e2e-gate-checks.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
-# One-off cleanup: complete orphaned in_progress e2e-*-gate API checks when
-# native gate jobs already succeeded on HEAD_SHA. Run via workflow_dispatch.
+# Manual cleanup for orphaned in_progress e2e-*-gate API checks on HEAD_SHA.
+# MODE=complete: mark orphans success when native gate job already succeeded.
+# MODE=dismiss: mark unlock-time orphans cancelled (mislabeled /runs/<id> checks).
 
 set -euo pipefail
 
 readonly GATES=(e2e-vmaas-gate e2e-bmaas-gate e2e-caas-gate)
-# Matches external_id set by invalidate-e2e-gates when present on newer checks.
 readonly INVALIDATE_EXTERNAL_ID_PREFIX="osac-invalidate-e2e-gate"
+MODE="${MODE:-complete}"
 
 if [[ -z "${HEAD_SHA:-}" || -z "${REPO:-}" ]]; then
   echo "HEAD_SHA and REPO are required" >&2
+  exit 1
+fi
+if [[ "${MODE}" != "complete" && "${MODE}" != "dismiss" ]]; then
+  echo "MODE must be complete or dismiss" >&2
   exit 1
 fi
 
@@ -28,27 +33,60 @@ check_runs=$(jq -s 'add' "${tmpdir}"/page-*.json)
 rm -rf "${tmpdir}"
 
 completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-title="Superseded by native e2e gate job"
-summary="Manual cleanup of stale invalidate-e2e-gates check; gate already success on this SHA."
 failed=0
 
-for gate in "${GATES[@]}"; do
-  if ! jq -e --arg g "${gate}" '
+native_gate_job_success() {
+  local gate="$1"
+  jq -e --arg g "${gate}" '
     [.[] | select(
       .name == $g
-      and .status == "completed"
-      and .conclusion == "success"
       and ((.details_url // "") | test("/actions/runs/[0-9]+/job/"))
-    )] | length > 0
-  ' <<<"${check_runs}" >/dev/null; then
-    echo "Skipping ${gate}: no native gate job success on this SHA"
-    continue
+    )]
+    | sort_by(.created_at)
+    | last
+    | .status == "completed" and .conclusion == "success"
+  ' <<<"${check_runs}" >/dev/null
+}
+
+orphan_ids_for_gate() {
+  local gate="$1"
+  jq -r --arg g "${gate}" --arg prefix "${INVALIDATE_EXTERNAL_ID_PREFIX}" '
+    [.[] | select(
+      .name == $g
+      and .status == "in_progress"
+      and (
+        ((.external_id // "") | startswith($prefix))
+        or ((.details_url // "") | test("^https://github.com/[^/]+/[^/]+/actions/runs/[0-9]+$"))
+        or ((.details_url // "") | test("^https://github.com/[^/]+/[^/]+/runs/[0-9]+$"))
+      )
+    ) | .id] | .[]
+  ' <<<"${check_runs}"
+}
+
+for gate in "${GATES[@]}"; do
+  if [[ "${MODE}" == "complete" ]]; then
+    if ! native_gate_job_success "${gate}"; then
+      echo "Skipping ${gate}: no native gate job success on ${HEAD_SHA:0:7}"
+      continue
+    fi
+    title="Superseded by native e2e gate job"
+    summary="Manual cleanup; merge-required gate already success on this SHA."
+    conclusion="success"
+  else
+    title="Superseded by full-install gate job"
+    summary="Manual dismiss of unlock orphan API check on this SHA."
+    conclusion="cancelled"
   fi
+
   while IFS= read -r id; do
     [[ -z "${id}" || "${id}" == "null" ]] && continue
+    if [[ "${MODE}" == "complete" ]] && ! native_gate_job_success "${gate}"; then
+      echo "Skipping stale ${gate} check ${id}: native gate no longer success"
+      continue
+    fi
     payload=$(jq -n \
       --arg status "completed" \
-      --arg conclusion "success" \
+      --arg conclusion "${conclusion}" \
       --arg completed_at "${completed_at}" \
       --arg title "${title}" \
       --arg summary "${summary}" \
@@ -59,21 +97,12 @@ for gate in "${GATES[@]}"; do
         output: {title: $title, summary: $summary}
       }')
     if gh api "repos/${REPO}/check-runs/${id}" -X PATCH --input - <<<"${payload}"; then
-      echo "Completed stale in_progress ${gate} check ${id}"
+      echo "${MODE} stale ${gate} check ${id} on ${HEAD_SHA:0:7}"
     else
-      echo "Failed to complete ${gate} check ${id}" >&2
+      echo "Could not patch ${gate} check ${id}" >&2
       failed=1
     fi
-  done < <(jq -r --arg g "${gate}" --arg prefix "${INVALIDATE_EXTERNAL_ID_PREFIX}" '
-    [.[] | select(
-      .name == $g
-      and .status == "in_progress"
-      and (
-        ((.external_id // "") | startswith($prefix))
-        or ((.details_url // "") | test("^https://github.com/[^/]+/[^/]+/runs/[0-9]+$"))
-      )
-    ) | .id] | .[]
-  ' <<<"${check_runs}")
+  done < <(orphan_ids_for_gate "${gate}")
 done
 
 exit "${failed}"

--- a/.github/workflows/complete-stale-e2e-gates.yml
+++ b/.github/workflows/complete-stale-e2e-gates.yml
@@ -1,8 +1,9 @@
 ---
 name: Complete stale e2e gate checks
 
-# Manual cleanup when invalidate-e2e-gates left in_progress orphans after native
-# e2e-*-gate jobs already passed. Does not re-run e2e.
+# Manual cleanup for mislabeled unlock API checks and other in_progress orphans on
+# HEAD_SHA. Does not re-run e2e. Uses repo-local script so ops can run before or
+# without waiting on osac-test-infra action updates.
 on:
   workflow_dispatch:
     inputs:
@@ -11,9 +12,17 @@ on:
         required: true
         type: string
       pr_number:
-        description: Optional PR number (logged only)
+        description: Optional PR number (removes stale e2e-ready when set)
         required: false
         type: string
+      mode:
+        description: complete = success after native gate; dismiss = cancel unlock orphans
+        required: false
+        default: complete
+        type: choice
+        options:
+          - complete
+          - dismiss
 
 permissions:
   contents: read
@@ -25,19 +34,32 @@ jobs:
     permissions:
       checks: write
       contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-      - name: Complete stale in_progress e2e gate checks
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts/complete-stale-e2e-gate-checks.sh
+      - name: Complete or dismiss stale e2e gate checks
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           HEAD_SHA: ${{ inputs.head_sha }}
           PR_NUMBER: ${{ inputs.pr_number }}
+          MODE: ${{ inputs.mode }}
+        run: bash .github/scripts/complete-stale-e2e-gate-checks.sh
+      - name: Remove stale e2e-ready label
+        if: inputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           set -euo pipefail
-          if [[ -n "${PR_NUMBER}" ]]; then
-            echo "Cleaning stale e2e gates for PR #${PR_NUMBER} at ${HEAD_SHA:0:7}"
+          if gh pr view "${PR_NUMBER}" -R "${REPO}" --json labels --jq '[.labels[].name]' \
+            | jq -e 'index("e2e-ready")' >/dev/null; then
+            gh pr edit "${PR_NUMBER}" -R "${REPO}" --remove-label "e2e-ready"
+            echo "Removed e2e-ready from PR #${PR_NUMBER}"
           else
-            echo "Cleaning stale e2e gates at ${HEAD_SHA:0:7}"
+            echo "PR #${PR_NUMBER} has no e2e-ready label"
           fi
-          bash .github/scripts/complete-stale-e2e-gate-checks.sh

--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -286,6 +286,27 @@ jobs:
             echo "e2e passed"
           fi
 
+  e2e-bmaas-complete-stale-gates:
+    if: >-
+      always()
+      && github.event_name == 'pull_request'
+      && needs.changes.outputs.should-run == 'true'
+      && needs.e2e-readiness.result == 'success'
+      && needs.e2e-readiness.outputs.ready == 'true'
+      && !contains(needs.e2e-bmaas-gate.result, 'failure')
+      && !contains(needs.e2e-bmaas-gate.result, 'cancelled')
+    needs: [changes, e2e-readiness, e2e-bmaas-full-install, e2e-bmaas-gate]
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+    steps:
+      - name: Complete stale in_progress gate checks
+        uses: osac-project/osac-test-infra/.github/actions/complete-stale-e2e-gates@main
+        with:
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          gate-name: e2e-bmaas-gate
+
   # Latest check named e2e-bmaas-gate after the skipped gate job. Resolve this
   # workflow run's check_suite_id and attach the pending check so PR UI does not
   # group it under unrelated pull_request_target workflows. Forks may lack

--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -299,7 +299,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
-      contents: read
     steps:
       - name: Complete stale in_progress gate checks
         uses: osac-project/osac-test-infra/.github/actions/complete-stale-e2e-gates@main

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -303,6 +303,27 @@ jobs:
             echo "e2e passed"
           fi
 
+  e2e-caas-complete-stale-gates:
+    if: >-
+      always()
+      && github.event_name == 'pull_request'
+      && needs.changes.outputs.should-run == 'true'
+      && needs.e2e-readiness.result == 'success'
+      && needs.e2e-readiness.outputs.ready == 'true'
+      && !contains(needs.e2e-caas-gate.result, 'failure')
+      && !contains(needs.e2e-caas-gate.result, 'cancelled')
+    needs: [changes, e2e-readiness, e2e-caas-full-install, e2e-caas-gate]
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+    steps:
+      - name: Complete stale in_progress gate checks
+        uses: osac-project/osac-test-infra/.github/actions/complete-stale-e2e-gates@main
+        with:
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          gate-name: e2e-caas-gate
+
   # Latest check named e2e-caas-gate after the skipped gate job. Resolve this
   # workflow run's check_suite_id and attach the pending check so PR UI does not
   # group it under unrelated pull_request_target workflows. Forks may lack

--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -316,7 +316,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
-      contents: read
     steps:
       - name: Complete stale in_progress gate checks
         uses: osac-project/osac-test-infra/.github/actions/complete-stale-e2e-gates@main

--- a/.github/workflows/e2e-cancel-stale-runs-on-push.yml
+++ b/.github/workflows/e2e-cancel-stale-runs-on-push.yml
@@ -1,0 +1,48 @@
+---
+# Cancel stale full-install runs on every synchronize. pull_request_target uses
+# default-branch workflow YAML and base-repo GITHUB_TOKEN (required to cancel
+# runs). Runs outside full-install concurrency so cleanup still runs when new
+# caller runs queue behind gh run rerun.
+name: Cancel stale e2e runs on push
+on:
+  pull_request_target:
+    types: [synchronize]
+    branches: [main]
+  workflow_call: {}
+
+jobs:
+  cancel-stale-e2e:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: cancel-stale-e2e-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts/cancel-stale-e2e-runs.sh
+      - name: Cancel full-install runs on obsolete SHAs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        run: bash .github/scripts/cancel-stale-e2e-runs.sh
+
+  dismiss-unlock-orphan-gates:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+    steps:
+      - name: Dismiss unlock orphan gate checks
+        uses: osac-project/osac-test-infra/.github/actions/complete-stale-e2e-gates@main
+        with:
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          after-native-success: false
+          github-token: ${{ secrets.MERGE_QUEUE_TOKEN }}

--- a/.github/workflows/e2e-cancel-stale-runs-on-push.yml
+++ b/.github/workflows/e2e-cancel-stale-runs-on-push.yml
@@ -38,7 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
-      contents: read
     steps:
       - name: Dismiss unlock orphan gate checks
         uses: osac-project/osac-test-infra/.github/actions/complete-stale-e2e-gates@main

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -302,6 +302,27 @@ jobs:
             echo "e2e passed"
           fi
 
+  e2e-vmaas-complete-stale-gates:
+    if: >-
+      always()
+      && github.event_name == 'pull_request'
+      && needs.changes.outputs.should-run == 'true'
+      && needs.e2e-readiness.result == 'success'
+      && needs.e2e-readiness.outputs.ready == 'true'
+      && !contains(needs.e2e-vmaas-gate.result, 'failure')
+      && !contains(needs.e2e-vmaas-gate.result, 'cancelled')
+    needs: [changes, e2e-readiness, e2e-vmaas-full-install, e2e-vmaas-gate]
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+    steps:
+      - name: Complete stale in_progress gate checks
+        uses: osac-project/osac-test-infra/.github/actions/complete-stale-e2e-gates@main
+        with:
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          gate-name: e2e-vmaas-gate
+
   # Latest check named e2e-vmaas-gate after the skipped gate job. Resolve this
   # workflow run's check_suite_id and attach the pending check so PR UI does not
   # group it under unrelated pull_request_target workflows. Forks may lack

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -315,7 +315,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
-      contents: read
     steps:
       - name: Complete stale in_progress gate checks
         uses: osac-project/osac-test-infra/.github/actions/complete-stale-e2e-gates@main


### PR DESCRIPTION
## Summary
- Add follow-up `e2e-*-complete-stale-gates` jobs after native gate jobs succeed (uses test-infra action `@main` after osac-test-infra#542)
- Keep manual **Complete stale e2e gate checks** workflow with local script (`complete` / `dismiss` modes, optional `e2e-ready` removal)
- Add `e2e-cancel-stale-runs-on-push.yml` + shared cancel script for stale full-install runs on push

## Test plan
- [ ] Merge osac-project/osac-test-infra#542 first
- [ ] Push to an osac PR with in-flight e2e; confirm old-SHA runs cancelled
- [ ] After native gates pass, confirm orphan `in_progress` API checks complete
- [ ] Manual workflow: run `dismiss` on a mislabeled HEAD if needed

Depends on osac-project/osac-test-infra#542.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## CI

- Add post-success jobs to complete stale BMAAS, CAAS, and VMAAS gate checks.
- Add `complete` and `dismiss` modes for manual cleanup.
- Cancel obsolete full-install E2E runs after pushes.
- Dismiss orphaned unlock checks.
- Validate cleanup modes, inputs, PR head state, workflow names, repositories, and run status.
- Scope `checks: write` to cleanup jobs.

## Documentation

- Document manual completion, dismissal, orphaned checks, and optional `e2e-ready` label removal.

## Backward compatibility

- No product API, database, controller, authentication, or runtime changes.
- Manual cleanup continues to default to `complete`.
- Only stale E2E runs and checks change.

## Risk classification

**risk:show** — The PR changes CI cleanup workflows, permissions, check conclusions, and cancellation behavior. It does not change runtime product behavior. It is not **risk:ship** because it changes repository automation. It is not **risk:ask** because the scripts validate inputs and confirm the PR head before cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->