### PR TITLE
OSAC-1148: sign fulfillment-service release binaries with cosign

### DIFF
--- a/.github/workflows/publish-binaries.yaml
+++ b/.github/workflows/publish-binaries.yaml
@@ -40,6 +40,12 @@ jobs:
         working-directory: fulfillment-service
     - name: Install cosign
       uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+      with:
+        # Pinned explicitly (rather than relying on the installer action's
+        # own default) because goreleaser.yaml's `signs:` config depends on
+        # v3's --bundle-based sign-blob output -- an installer default that
+        # silently moved to a pre-v3 cosign would break that config.
+        cosign-release: 'v3.0.6'
     - name: Compute release version
       # Strip this component's tag prefix (see the `tags:` trigger above) --
       # goreleaser expects a bare vX.Y.Z, not the scoped git tag.

--- a/.github/workflows/publish-binaries.yaml
+++ b/.github/workflows/publish-binaries.yaml
@@ -26,6 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # cosign's keyless binary signing below (via goreleaser's `signs:`) --
+      # safe directly on this job, no pull_request exposure: this workflow
+      # only ever runs on push of a fulfillment-service/vX.Y.Z tag.
+      id-token: write
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       with:
@@ -34,6 +38,8 @@ jobs:
     - uses: ./.github/actions/setup-go
       with:
         working-directory: fulfillment-service
+    - name: Install cosign
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
     - name: Compute release version
       # Strip this component's tag prefix (see the `tags:` trigger above) --
       # goreleaser expects a bare vX.Y.Z, not the scoped git tag.

--- a/README.md
+++ b/README.md
@@ -134,11 +134,11 @@ see that pipeline's documentation for verifying those instead.
 The `osac` CLI and `fulfillment-service` binaries are released to GitHub
 Releases by `publish-binaries.yaml`, triggered on `fulfillment-service/vX.Y.Z`
 tags. Each release binary is signed the same keyless way as the images and
-charts above; goreleaser's `signs` step produces a detached signature
-(`<binary>.sig`) and Fulcio certificate (`<binary>.pem`) alongside every
-binary in the release.
+charts above; goreleaser's `signs` step produces a single Sigstore bundle
+(`<binary>.sigstore.json`, containing both the certificate and signature)
+alongside every binary in the release.
 
-Download a binary with its signature and certificate, then verify:
+Download a binary with its bundle, then verify:
 
 ```bash
 gh release download fulfillment-service/<version> \
@@ -146,8 +146,7 @@ gh release download fulfillment-service/<version> \
   --pattern 'osac_<os>_<arch>*'
 
 cosign verify-blob \
-  --certificate osac_<os>_<arch>.pem \
-  --signature osac_<os>_<arch>.sig \
+  --bundle osac_<os>_<arch>.sigstore.json \
   --certificate-identity-regexp '^https://github\.com/osac-project/osac/\.github/workflows/publish-binaries\.yaml@refs/tags/fulfillment-service/.+$' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   osac_<os>_<arch>

--- a/README.md
+++ b/README.md
@@ -129,6 +129,34 @@ if needed. Images pushed to `quay.io/redhat-user-workloads/osac-tenant/...` via
 Konflux are signed separately by Konflux's own Enterprise Contract pipeline;
 see that pipeline's documentation for verifying those instead.
 
+## Verifying binary signatures
+
+The `osac` CLI and `fulfillment-service` binaries are released to GitHub
+Releases by `publish-binaries.yaml`, triggered on `fulfillment-service/vX.Y.Z`
+tags. Each release binary is signed the same keyless way as the images and
+charts above; goreleaser's `signs` step produces a detached signature
+(`<binary>.sig`) and Fulcio certificate (`<binary>.pem`) alongside every
+binary in the release.
+
+Download a binary with its signature and certificate, then verify:
+
+```bash
+gh release download fulfillment-service/<version> \
+  --repo osac-project/osac \
+  --pattern 'osac_<os>_<arch>*'
+
+cosign verify-blob \
+  --certificate osac_<os>_<arch>.pem \
+  --signature osac_<os>_<arch>.sig \
+  --certificate-identity-regexp '^https://github\.com/osac-project/osac/\.github/workflows/publish-binaries\.yaml@refs/tags/fulfillment-service/.+$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  osac_<os>_<arch>
+```
+
+Substitute `fulfillment-service` for `osac` to verify that binary instead —
+both are built and signed from the same release. `<os>`/`<arch>` match the
+asset names on the release page (e.g. `osac_Linux_x86_64`).
+
 ## Local development with go.work
 
 The root [`go.work`](go.work) file wires all Go modules in the mono-repo —

--- a/fulfillment-service/.goreleaser.yaml
+++ b/fulfillment-service/.goreleaser.yaml
@@ -56,16 +56,18 @@ archives:
 
 # Keyless cosign signing of every release binary, same Fulcio/Rekor OIDC flow
 # already used for container images and Helm charts (see the repo README) --
-# no private key material here either. Produces a detached signature
-# (<artifact>.sig) and Fulcio certificate (<artifact>.pem) per binary,
+# no private key material here either. cosign v3 (installed by the pinned
+# cosign-installer in publish-binaries.yaml) requires --bundle for sign-blob;
+# the old --output-certificate/--output-signature pair is legacy v2 output
+# and doesn't satisfy that requirement on its own. Produces a single
+# <artifact>.sigstore.json bundle per binary (cert + signature together),
 # which goreleaser uploads to the GitHub release alongside it.
 signs:
 - cmd: cosign
-  certificate: '${artifact}.pem'
+  signature: "${artifact}.sigstore.json"
   args:
     - sign-blob
-    - "--output-certificate=${certificate}"
-    - "--output-signature=${signature}"
+    - "--bundle=${signature}"
     - "${artifact}"
     - --yes
   artifacts: all

--- a/fulfillment-service/.goreleaser.yaml
+++ b/fulfillment-service/.goreleaser.yaml
@@ -54,6 +54,23 @@ archives:
     {{- if eq .Arch "amd64" }}x86_64
     {{- else }}{{ .Arch }}{{ end }}
 
+# Keyless cosign signing of every release binary, same Fulcio/Rekor OIDC flow
+# already used for container images and Helm charts (see the repo README) --
+# no private key material here either. Produces a detached signature
+# (<artifact>.sig) and Fulcio certificate (<artifact>.pem) per binary,
+# which goreleaser uploads to the GitHub release alongside it.
+signs:
+- cmd: cosign
+  certificate: '${artifact}.pem'
+  args:
+    - sign-blob
+    - "--output-certificate=${certificate}"
+    - "--output-signature=${signature}"
+    - "${artifact}"
+    - --yes
+  artifacts: all
+  output: true
+
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
## Summary
- adds a goreleaser `signs` step to fulfillment-service/.goreleaser.yaml, keylessly signing both the `osac` CLI and `fulfillment-service` binaries via cosign's Fulcio/Rekor OIDC flow -- same approach already used for container images and Helm charts in this repo
- grants `id-token: write` on publish-binaries.yaml (tag-triggered only via `fulfillment-service/v*`, no pull_request exposure) and installs cosign before goreleaser runs
- documents binary verification in the README, matching the existing image/chart sections' style

## Test plan
- [x] Validated goreleaser.yaml and workflow YAML parse correctly
- [x] Confirmed PR-time `goreleaser build --snapshot --clean` (check-pull-request.yaml) is unaffected -- `signs:` only runs on `release`, not `build`
- [ ] Verify signing actually succeeds end-to-end on the next real `fulfillment-service/vX.Y.Z` tag push (can't be exercised without cutting a real release)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## CI and release security

- Added keyless Cosign signing for `osac` and `fulfillment-service` release binaries.
- Configured GoReleaser to publish `.sigstore.json` bundles.
- Granted `id-token: write` and pinned Cosign `v3.0.6`.
- PR snapshot builds remain unchanged.

## Documentation

- Added README instructions for `cosign verify-blob`.
- Documented Sigstore bundle downloads and GitHub Actions OIDC identity verification.

## Compatibility

- No API, controller, database, or runtime changes.
- Consumers must download the matching `.sigstore.json` bundle.
- Consumers that expect separate `.sig` and `.pem` files must update verification.

## Risk classification

- `risk:show`: The change modifies release CI permissions and artifact signing without changing runtime behavior or public APIs.
- It is not `risk:ship` because it changes release security configuration and artifact formats.
- It is not `risk:ask` because the scope is limited to trusted release tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->