### PR TITLE
NO-ISSUE: Restore pre-910 complete-stale cleanup

### DIFF
--- a/.github/scripts/complete-stale-e2e-gate-checks.sh
+++ b/.github/scripts/complete-stale-e2e-gate-checks.sh
@@ -1,20 +1,15 @@
 #!/usr/bin/env bash
-# Manual cleanup for orphaned in_progress e2e-*-gate API checks on HEAD_SHA.
-# MODE=complete: mark orphans success when native gate job already succeeded.
-# MODE=dismiss: mark unlock-time orphans cancelled (mislabeled /runs/<id> checks).
+# One-off cleanup: complete orphaned in_progress e2e-*-gate API checks when
+# native gate jobs already succeeded on HEAD_SHA. Run via workflow_dispatch.
 
 set -euo pipefail
 
 readonly GATES=(e2e-vmaas-gate e2e-bmaas-gate e2e-caas-gate)
+# Matches external_id set by invalidate-e2e-gates when present on newer checks.
 readonly INVALIDATE_EXTERNAL_ID_PREFIX="osac-invalidate-e2e-gate"
-MODE="${MODE:-complete}"
 
 if [[ -z "${HEAD_SHA:-}" || -z "${REPO:-}" ]]; then
   echo "HEAD_SHA and REPO are required" >&2
-  exit 1
-fi
-if [[ "${MODE}" != "complete" && "${MODE}" != "dismiss" ]]; then
-  echo "MODE must be complete or dismiss" >&2
   exit 1
 fi
 
@@ -33,60 +28,27 @@ check_runs=$(jq -s 'add' "${tmpdir}"/page-*.json)
 rm -rf "${tmpdir}"
 
 completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+title="Superseded by native e2e gate job"
+summary="Manual cleanup of stale invalidate-e2e-gates check; gate already success on this SHA."
 failed=0
 
-native_gate_job_success() {
-  local gate="$1"
-  jq -e --arg g "${gate}" '
-    [.[] | select(
-      .name == $g
-      and ((.details_url // "") | test("/actions/runs/[0-9]+/job/"))
-    )]
-    | sort_by(.created_at)
-    | last
-    | .status == "completed" and .conclusion == "success"
-  ' <<<"${check_runs}" >/dev/null
-}
-
-orphan_ids_for_gate() {
-  local gate="$1"
-  jq -r --arg g "${gate}" --arg prefix "${INVALIDATE_EXTERNAL_ID_PREFIX}" '
-    [.[] | select(
-      .name == $g
-      and .status == "in_progress"
-      and (
-        ((.external_id // "") | startswith($prefix))
-        or ((.details_url // "") | test("^https://github.com/[^/]+/[^/]+/actions/runs/[0-9]+$"))
-        or ((.details_url // "") | test("^https://github.com/[^/]+/[^/]+/runs/[0-9]+$"))
-      )
-    ) | .id] | .[]
-  ' <<<"${check_runs}"
-}
-
 for gate in "${GATES[@]}"; do
-  if [[ "${MODE}" == "complete" ]]; then
-    if ! native_gate_job_success "${gate}"; then
-      echo "Skipping ${gate}: no native gate job success on ${HEAD_SHA:0:7}"
-      continue
-    fi
-    title="Superseded by native e2e gate job"
-    summary="Manual cleanup; merge-required gate already success on this SHA."
-    conclusion="success"
-  else
-    title="Superseded by full-install gate job"
-    summary="Manual dismiss of unlock orphan API check on this SHA."
-    conclusion="cancelled"
+  if ! jq -e --arg g "${gate}" '
+    [.[] | select(
+      .name == $g
+      and .status == "completed"
+      and .conclusion == "success"
+      and ((.details_url // "") | test("/actions/runs/[0-9]+/job/"))
+    )] | length > 0
+  ' <<<"${check_runs}" >/dev/null; then
+    echo "Skipping ${gate}: no native gate job success on this SHA"
+    continue
   fi
-
   while IFS= read -r id; do
     [[ -z "${id}" || "${id}" == "null" ]] && continue
-    if [[ "${MODE}" == "complete" ]] && ! native_gate_job_success "${gate}"; then
-      echo "Skipping stale ${gate} check ${id}: native gate no longer success"
-      continue
-    fi
     payload=$(jq -n \
       --arg status "completed" \
-      --arg conclusion "${conclusion}" \
+      --arg conclusion "success" \
       --arg completed_at "${completed_at}" \
       --arg title "${title}" \
       --arg summary "${summary}" \
@@ -97,12 +59,21 @@ for gate in "${GATES[@]}"; do
         output: {title: $title, summary: $summary}
       }')
     if gh api "repos/${REPO}/check-runs/${id}" -X PATCH --input - <<<"${payload}"; then
-      echo "${MODE} stale ${gate} check ${id} on ${HEAD_SHA:0:7}"
+      echo "Completed stale in_progress ${gate} check ${id}"
     else
-      echo "Could not patch ${gate} check ${id}" >&2
+      echo "Failed to complete ${gate} check ${id}" >&2
       failed=1
     fi
-  done < <(orphan_ids_for_gate "${gate}")
+  done < <(jq -r --arg g "${gate}" --arg prefix "${INVALIDATE_EXTERNAL_ID_PREFIX}" '
+    [.[] | select(
+      .name == $g
+      and .status == "in_progress"
+      and (
+        ((.external_id // "") | startswith($prefix))
+        or ((.details_url // "") | test("^https://github.com/[^/]+/[^/]+/runs/[0-9]+$"))
+      )
+    ) | .id] | .[]
+  ' <<<"${check_runs}")
 done
 
 exit "${failed}"

--- a/.github/workflows/complete-stale-e2e-gates.yml
+++ b/.github/workflows/complete-stale-e2e-gates.yml
@@ -1,9 +1,8 @@
 ---
 name: Complete stale e2e gate checks
 
-# Manual cleanup for mislabeled unlock API checks and other in_progress orphans on
-# HEAD_SHA. Does not re-run e2e. Uses repo-local script so ops can run before or
-# without waiting on osac-test-infra action updates.
+# Manual cleanup when invalidate-e2e-gates left in_progress orphans after native
+# e2e-*-gate jobs already passed. Does not re-run e2e.
 on:
   workflow_dispatch:
     inputs:
@@ -12,17 +11,9 @@ on:
         required: true
         type: string
       pr_number:
-        description: Optional PR number (removes stale e2e-ready when set)
+        description: Optional PR number (logged only)
         required: false
         type: string
-      mode:
-        description: complete = success after native gate; dismiss = cancel unlock orphans
-        required: false
-        default: complete
-        type: choice
-        options:
-          - complete
-          - dismiss
 
 permissions:
   contents: read
@@ -34,32 +25,19 @@ jobs:
     permissions:
       checks: write
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-        with:
-          persist-credentials: false
-          sparse-checkout: .github/scripts/complete-stale-e2e-gate-checks.sh
-      - name: Complete or dismiss stale e2e gate checks
+      - name: Complete stale in_progress e2e gate checks
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           HEAD_SHA: ${{ inputs.head_sha }}
           PR_NUMBER: ${{ inputs.pr_number }}
-          MODE: ${{ inputs.mode }}
-        run: bash .github/scripts/complete-stale-e2e-gate-checks.sh
-      - name: Remove stale e2e-ready label
-        if: inputs.pr_number != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           set -euo pipefail
-          if gh pr view "${PR_NUMBER}" -R "${REPO}" --json labels --jq '[.labels[].name]' \
-            | jq -e 'index("e2e-ready")' >/dev/null; then
-            gh pr edit "${PR_NUMBER}" -R "${REPO}" --remove-label "e2e-ready"
-            echo "Removed e2e-ready from PR #${PR_NUMBER}"
+          if [[ -n "${PR_NUMBER}" ]]; then
+            echo "Cleaning stale e2e gates for PR #${PR_NUMBER} at ${HEAD_SHA:0:7}"
           else
-            echo "PR #${PR_NUMBER} has no e2e-ready label"
+            echo "Cleaning stale e2e gates at ${HEAD_SHA:0:7}"
           fi
+          bash .github/scripts/complete-stale-e2e-gate-checks.sh


### PR DESCRIPTION
## Summary
- Restore `.github/scripts/complete-stale-e2e-gate-checks.sh` and `.github/workflows/complete-stale-e2e-gates.yml` to the pre-#910 `main` versions (parent `54884ae`).
- Leave #910 auto mop-up in place: full-install `complete-stale` jobs and `e2e-cancel-stale-runs-on-push.yml`.

## Test plan
- [ ] Actions → Complete stale e2e gate checks matches the old dispatch inputs (`head_sha`, optional `pr_number`, no `mode`).
- [ ] Full-install workflows still have the post-gate complete-stale jobs from #910.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **CI:** Restores the stale e2e gate cleanup script and workflow to the pre-#910 behavior.
- **CI:** Limits cleanup to stale `in_progress` e2e gate checks with a successful native gate job on the target SHA.
- **CI:** Removes dismiss mode and `e2e-ready` label removal.
- **CI:** Keeps `#910`’s full-install `complete-stale` jobs and `e2e-cancel-stale-runs-on-push.yml`.
- **Tests:** The test plan verifies workflow dispatch inputs and confirms that post-gate cleanup jobs remain in full-install workflows.

## Backward compatibility

- Manual workflow dispatch no longer accepts the `mode` input.
- `pr_number` is logging-only and no longer removes the `e2e-ready` label.
- Existing automation that uses dismiss mode or expects label removal must be updated.

## Risk classification

- **risk:show:** The change affects CI workflow behavior and manual dispatch inputs, but it does not change product runtime behavior, APIs, data, authentication, or deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->