### PR TITLE
OSAC-4529: Remove Friday-only schedule restriction from Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,3 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "schedule": ["* 22-23 * * 5"],
-  "timezone": "America/Los_Angeles"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
 }


### PR DESCRIPTION
## Summary

- #657 (merged 2026-09-01) restricted Renovate to a single weekly window (Friday 22:00-23:59 Pacific) to throttle dependency-PR volume, which had been running at dozens of PRs/day.
- Since that landed, Renovate has opened **zero** "Update dependency X" PRs across the two Friday windows that have since passed (2026-09-04/05 and 2026-09-11/12) — this isn't the intended quieter cadence, it looks like Renovate isn't running at all under this schedule.
- Removing the schedule restriction to restore default scheduling. (Separately: the "Update Konflux references" PRs and Konflux component-reference PRs are a different automation, not governed by this file, and have continued on their own healthy ~weekly cadence throughout.)

## Test plan

- [x] JSON validated
- [ ] Confirm Renovate resumes opening dependency PRs after this merges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

- **Dependency automation:** Removed Renovate’s Friday-only schedule and Pacific timezone from `renovate.json`.
- Renovate now uses its default schedule.
- No changes affect the API surface, controllers, database, authentication, CI, tests, or documentation.

## Compatibility

- Renovate can create dependency update PRs outside the previous Friday window.
- No application runtime or public API changes are expected.
- JSON validation passed.
- Renovate activity after this change is not yet confirmed.

## Risk classification

- **risk:show:** The change alters automated dependency-update timing and may increase PR volume.
- It does not qualify as **risk:ship** because it changes repository automation behavior.
- It does not qualify as **risk:ask** because it does not change application behavior, security controls, data, or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->