### PR TITLE
NO-ISSUE: Cancel in-flight e2e work and dismiss orphan gates on PR close

### DIFF
--- a/.github/scripts/cancel-stale-e2e-runs.sh
+++ b/.github/scripts/cancel-stale-e2e-runs.sh
@@ -21,6 +21,15 @@ if [[ -z "${REPO:-}" || -z "${HEAD_SHA:-}" || -z "${HEAD_BRANCH:-}" || -z "${HEA
   exit 1
 fi
 
+# CANCEL_ALL drops the "differs from HEAD_SHA" scoping below, so it leans on
+# repo+branch alone to identify "this PR's runs" -- not enough on its own if a
+# branch name is ever reused across PRs (delete-and-recreate, or a stale run
+# from a previous close/reopen cycle). Require an exact PR_NUMBER match too.
+if [[ "${CANCEL_ALL}" == "true" && -z "${PR_NUMBER:-}" ]]; then
+  echo "PR_NUMBER is required when CANCEL_ALL=true" >&2
+  exit 1
+fi
+
 # Return 0 when PR head still matches HEAD_SHA; 1 when moved or lookup failed.
 # Always 0 in CANCEL_ALL mode: a closed PR's head won't move, and there's no
 # newer push for this cleanup to defer to.
@@ -76,10 +85,13 @@ for status in in_progress queued waiting pending requested; do
       echo "Could not cancel run #${id}" >&2
       failed=1
     fi
-  done < <(jq -r --arg head "${HEAD_SHA}" --arg repo "${HEAD_REPO}" --argjson names "${E2E_NAMES}" --argjson all "$([[ "${CANCEL_ALL}" == "true" ]] && echo true || echo false)" '
+  done < <(jq -r --arg head "${HEAD_SHA}" --arg repo "${HEAD_REPO}" --argjson names "${E2E_NAMES}" \
+    --argjson all "$([[ "${CANCEL_ALL}" == "true" ]] && echo true || echo false)" \
+    --argjson pr "${PR_NUMBER:-0}" '
     .[] | select(
       .head_repository.full_name == $repo
       and ($all or .head_sha != $head)
+      and (if $all then ((.pull_requests // []) | any(.number == $pr)) else true end)
       and (.name as $n | $names | index($n))
     ) | "\(.id)\t\(.name)\t\(.head_sha)"
   ' <<<"${runs}")

--- a/.github/scripts/cancel-stale-e2e-runs.sh
+++ b/.github/scripts/cancel-stale-e2e-runs.sh
@@ -5,9 +5,16 @@
 # Cancels all three suite workflows (VMaaS/BMaaS/CaaS) regardless of which
 # caller invokes this script.
 #
-# Env: REPO, HEAD_SHA, HEAD_BRANCH, HEAD_REPO, PR_NUMBER
+# CANCEL_ALL=true (PR closed/merged): cancel every in-flight run for this PR
+# branch, including ones matching HEAD_SHA, and skip the "did the PR head
+# move on" guard -- there's no newer push to defer to once the PR is closed,
+# and nothing further needs this SHA's e2e result.
+#
+# Env: REPO, HEAD_SHA, HEAD_BRANCH, HEAD_REPO, PR_NUMBER, CANCEL_ALL
 
 set -euo pipefail
+
+readonly CANCEL_ALL="${CANCEL_ALL:-false}"
 
 if [[ -z "${REPO:-}" || -z "${HEAD_SHA:-}" || -z "${HEAD_BRANCH:-}" || -z "${HEAD_REPO:-}" ]]; then
   echo "REPO, HEAD_SHA, HEAD_BRANCH, and HEAD_REPO are required" >&2
@@ -15,10 +22,12 @@ if [[ -z "${REPO:-}" || -z "${HEAD_SHA:-}" || -z "${HEAD_BRANCH:-}" || -z "${HEA
 fi
 
 # Return 0 when PR head still matches HEAD_SHA; 1 when moved or lookup failed.
+# Always 0 in CANCEL_ALL mode: a closed PR's head won't move, and there's no
+# newer push for this cleanup to defer to.
 pr_head_still_current() {
   local current_head
 
-  if [[ -z "${PR_NUMBER:-}" ]]; then
+  if [[ "${CANCEL_ALL}" == "true" || -z "${PR_NUMBER:-}" ]]; then
     return 0
   fi
   current_head=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha // empty')
@@ -55,11 +64,11 @@ for status in in_progress queued waiting pending requested; do
     if ! pr_head_still_current; then
       break 2
     fi
-    if [[ "${sha}" == "${HEAD_SHA}" ]]; then
+    if [[ "${CANCEL_ALL}" != "true" && "${sha}" == "${HEAD_SHA}" ]]; then
       echo "Skipping ${name} #${id}: matches current PR head"
       continue
     fi
-    echo "Cancelling stale ${name} #${id} (${sha:0:7} != ${HEAD_SHA:0:7})"
+    echo "Cancelling ${name} #${id} (${sha:0:7})"
     if gh api -X POST "repos/${REPO}/actions/runs/${id}/force-cancel" 2>/dev/null \
       || gh run cancel "${id}" -R "${REPO}"; then
       cancelled=$((cancelled + 1))
@@ -67,13 +76,13 @@ for status in in_progress queued waiting pending requested; do
       echo "Could not cancel run #${id}" >&2
       failed=1
     fi
-  done < <(jq -r --arg head "${HEAD_SHA}" --arg repo "${HEAD_REPO}" --argjson names "${E2E_NAMES}" '
+  done < <(jq -r --arg head "${HEAD_SHA}" --arg repo "${HEAD_REPO}" --argjson names "${E2E_NAMES}" --argjson all "$([[ "${CANCEL_ALL}" == "true" ]] && echo true || echo false)" '
     .[] | select(
       .head_repository.full_name == $repo
-      and .head_sha != $head
+      and ($all or .head_sha != $head)
       and (.name as $n | $names | index($n))
     ) | "\(.id)\t\(.name)\t\(.head_sha)"
   ' <<<"${runs}")
 done
-echo "Cancelled ${cancelled} stale full-install run(s)."
+echo "Cancelled ${cancelled} run(s)."
 exit "${failed}"

--- a/.github/workflows/e2e-cancel-on-pr-close.yml
+++ b/.github/workflows/e2e-cancel-on-pr-close.yml
@@ -1,0 +1,46 @@
+---
+# Stop e2e work the moment a PR closes -- merged or not -- instead of letting
+# in-flight full-install runs finish for no reason, or leaving invalidate-time
+# in_progress gate checks (see e2e-on-label's invalidate-e2e-gates) sitting
+# unresolved forever once nothing will ever complete them. pull_request_target
+# uses the base-branch workflow YAML and base-repo GITHUB_TOKEN (required to
+# cancel runs and patch checks on fork PRs).
+name: Cancel e2e on PR close
+on:
+  pull_request_target:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  cancel-in-flight-runs:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts/cancel-stale-e2e-runs.sh
+      - name: Cancel all in-flight full-install runs for this PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          CANCEL_ALL: "true"
+        run: bash .github/scripts/cancel-stale-e2e-runs.sh
+
+  dismiss-orphan-gates:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+    steps:
+      - name: Dismiss any remaining in_progress gate checks
+        uses: osac-project/osac-test-infra/.github/actions/complete-stale-e2e-gates@main
+        with:
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          after-native-success: false
+          github-token: ${{ secrets.MERGE_QUEUE_TOKEN }}

--- a/.github/workflows/e2e-cancel-on-pr-close.yml
+++ b/.github/workflows/e2e-cancel-on-pr-close.yml
@@ -12,7 +12,35 @@ on:
     branches: [main]
 
 jobs:
+  # Re-check live PR state before cleanup runs: pull_request_target's event
+  # payload reflects state at trigger time, and a queued/delayed run could
+  # fire after the PR was reopened -- cancelling e2e work or dismissing gate
+  # checks a reopened PR still needs. Cheap guard, no side effects of its own.
+  guard:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      still-closed: ${{ steps.check.outputs.still-closed }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          state=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.state')
+          if [[ "${state}" == "closed" ]]; then
+            echo "still-closed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "PR #${PR_NUMBER} is ${state}, not closed anymore; skipping cleanup."
+            echo "still-closed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   cancel-in-flight-runs:
+    needs: guard
+    if: needs.guard.outputs.still-closed == 'true'
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -34,6 +62,8 @@ jobs:
         run: bash .github/scripts/cancel-stale-e2e-runs.sh
 
   dismiss-orphan-gates:
+    needs: guard
+    if: needs.guard.outputs.still-closed == 'true'
     runs-on: ubuntu-latest
     permissions:
       checks: write


### PR DESCRIPTION
## Summary

Found while diagnosing why PR #550's e2e gate checks stayed `BLOCKED` for hours despite the real gate job succeeding: an `invalidate-e2e-gates` API placeholder (`in_progress`, unlock-time) was left permanently unresolved because nothing triggers cleanup unless a *new* push happens. `complete-stale-e2e-gates` (osac-test-infra #542, already merged) fixed the general case by running follow-up cleanup jobs right after each native gate job — but nothing handles the case where a PR closes (merged or not) while work is still in flight or an orphan is still sitting `in_progress`. That's a separate gap from #542, not a duplicate of it.

This adds a `pull_request_target: closed` handler that:
- Cancels every in-flight full-install run for the PR, via a new `CANCEL_ALL` mode on `cancel-stale-e2e-runs.sh` (the existing script explicitly skips the current head SHA by design, since it's built for the synchronize/obsolete-SHA path — this reuses it rather than duplicating it)
- Dismisses any remaining `in_progress` `e2e-*-gate` orphan checks, reusing `complete-stale-e2e-gates`'s existing `after-native-success: false` path as-is — no changes needed in `osac-test-infra`, that mode already does exactly this unconditionally

## Test plan

- [x] YAML validated, `actionlint` clean
- [x] `bash -n` on the modified script
- [x] Verified the new `CANCEL_ALL` jq filter locally against mock run data: `false` mode still only matches obsolete SHAs (unchanged behavior), `true` mode matches all SHAs
- [ ] End-to-end: close/merge a PR with e2e still in flight and confirm the runs get cancelled and no orphan checks remain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **CI:** Added closed pull request cleanup for `main`.
- **CI:** Added a live-state guard before cleanup.
- **CI:** Added `CANCEL_ALL` mode to cancel matching full-install E2E runs for the exact pull request.
- **CI:** Dismisses remaining `in_progress` E2E gate checks.
- **Security:** Uses base-repository execution and scoped write permissions.
- **Validation:** Added YAML, shell syntax, and jq-filter validation. End-to-end testing remains pending.
- **API, controllers, database, authentication, deployment, and documentation:** No changes.

## Backward compatibility

No application or public API behavior changes. The change affects CI cleanup only. A reopened pull request is protected from delayed cleanup runs.

## Risk classification

**risk:ship** — The change is limited to CI automation. It uses exact pull request matching, checks the current pull request state, and uses scoped permissions. It does not affect production runtime behavior, data, authentication, or public APIs.

The change is close to **risk:show** because it changes visible CI behavior. It does not qualify because the impact is limited to pull request cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->