### PR TITLE
NO-ISSUE: Fix check-labels reading stale event payload instead of live labels

### DIFF
--- a/.github/workflows/label-gate.yml
+++ b/.github/workflows/label-gate.yml
@@ -37,8 +37,27 @@ jobs:
       - name: Check required Prow labels
         if: github.event_name == 'pull_request'
         env:
-          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          # Fetch live labels rather than trusting github.event.pull_request.labels:
+          # Prow-style bots apply lgtm/approved/jira-valid-reference as separate
+          # `labeled` events in quick succession, so each event's own payload only
+          # has whatever labels existed at that exact instant -- not the final set.
+          # That's why this check would fail on the first one or two labels and
+          # only pass on the last: reading live state instead means every run sees
+          # the same (already-complete, by the time it executes) label set.
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          for i in 1 2 3; do
+            LABELS=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" --json labels --jq '[.labels[].name]') && break
+            if [ "$i" -lt 3 ]; then
+              echo "::warning::gh pr view attempt $i/3 failed, retrying in 3s..."
+              sleep 3
+            else
+              echo "::error::gh pr view failed after 3 attempts"
+              exit 1
+            fi
+          done
           missing=()
           for label in lgtm approved jira/valid-reference; do
             if ! echo "$LABELS" | jq -e "index(\"$label\")" > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary

`check-labels` reads `LABELS` from `github.event.pull_request.labels` -- a snapshot frozen at the moment that specific webhook fired. Prow-style bots apply `lgtm`, `approved`, and `jira/valid-reference` as three separate `labeled` events in quick succession, so each event's own payload only reflects whatever labels existed at that exact instant, not the final set:

- Event 1 (`approved` added): payload has `[approved]` -> missing 2 -> **FAILURE**
- Event 2 (`lgtm` added): payload has `[approved, lgtm]` -> missing 1 -> **FAILURE**
- Event 3 (`jira/valid-reference` added): payload has all 3 -> **SUCCESS**

That's the "fails once or twice, then a run seconds later succeeds" pattern observed repeatedly across many PRs. It isn't really a race so much as a guarantee: every non-final `labeled` event is checking a payload that's necessarily incomplete.

Fetches the live label list via `gh pr view` instead of trusting the event payload (`pull-requests: read` is already granted at the job level). By the time any of these runs actually executes, the real label state is already fully applied -- so every run now correctly passes on the first try instead of only the one triggered by the last label to land.

## Test plan

- [x] YAML validated, `actionlint` clean
- [ ] Confirm a PR getting `lgtm`/`approved`/`jira/valid-reference` applied in quick succession no longer produces spurious `check-labels` failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## CI

- `check-labels` now retrieves current pull request labels with `gh pr view`.
- The workflow retries retrieval up to three times.
- It waits three seconds between failed attempts.
- It exits with an error after the final failure.
- Required-label validation uses the latest successful result.
- YAML validation and `actionlint` checks passed.
- Runtime confirmation remains pending.

## Compatibility

- No API, controller, database, authentication, deployment, test, or documentation changes.
- No backward-compatibility impact is expected.
- The workflow now depends on valid `GH_TOKEN` authentication and successful GitHub CLI label retrieval.
- The change prevents validation against stale label snapshots from separate pull request events.

## Risk classification

- **risk:show** was applied because the change affects CI gate behavior and runtime confirmation is pending.
- It was close to **risk:ship**, but runtime behavior is not confirmed.
- It does not qualify for **risk:ask** because it changes only CI label retrieval and retry behavior. It does not affect production code, data, or deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->