### PR TITLE
OSAC-5215: skip re-signing a digest already signed by this workflow+ref

### DIFF
--- a/.github/actions/cosign-sign-image/action.yaml
+++ b/.github/actions/cosign-sign-image/action.yaml
@@ -18,6 +18,29 @@ runs:
   steps:
     - name: Install cosign
       uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
+    - name: Check for an existing signature from this exact workflow+ref
+      # Avoids unbounded Fulcio cert + Rekor log growth when a calling
+      # workflow (nightly-build.yaml in particular) re-publishes a
+      # byte-identical digest run after run -- re-signing an unchanged
+      # digest under the SAME identity adds nothing verifiable that isn't
+      # already there. This only skips when *this* workflow+ref already
+      # signed *this exact* digest; a different workflow/ref signing the
+      # same digest is untouched, so multiple valid identities on one
+      # digest (the documented, intentional behavior) still works. Fails
+      # open toward signing: any verify error (including "not signed yet"
+      # and transient network errors) falls through to the sign step below.
+      id: check
+      shell: bash
+      run: |
+        if cosign verify \
+            --certificate-identity "https://github.com/${{ github.workflow_ref }}" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "${{ inputs.image }}" >/dev/null 2>&1; then
+          echo "signed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "signed=false" >> "$GITHUB_OUTPUT"
+        fi
     - name: Sign image
+      if: steps.check.outputs.signed != 'true'
       shell: bash
       run: cosign sign --yes "${{ inputs.image }}"


### PR DESCRIPTION
## Summary
- `.github/actions/cosign-sign-image/action.yaml`'s `cosign sign --yes` ran unconditionally on every call -- nightly-build.yaml rebuilds and republishes every image/chart on its own schedule, and when a rebuild is byte-identical to what's already published, it still re-signed that digest, adding a new Fulcio cert + Rekor transparency-log entry every night, indefinitely, for zero new content
- adds a check step that verifies whether *this exact workflow+ref* already signed *this exact digest* (via `cosign verify --certificate-identity "https://github.com/${{ github.workflow_ref }}"`) and skips signing if so
- a different workflow/ref signing the same digest is untouched by this -- multiple valid identities on one digest (documented, intentional behavior for images/charts) still works exactly as before
- fails open toward signing: any verify error (no signature yet, transient network issue) falls through to the sign step, so this can only ever skip a redundant sign, never miss a needed one

## Test plan
- [x] Validated YAML syntax
- [ ] Confirm on the next real nightly run that a byte-identical rebuild logs a skip instead of re-signing (can't be exercised without a live run)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- **CI and deployment:** Updated `.github/actions/cosign-sign-image/action.yaml` to verify the image digest before signing.
- The verification checks the calling workflow’s certificate identity, workflow, and ref.
- The action skips signing when a matching signature exists.
- Verification errors continue to signing. Unsigned digests and transient verification failures retain existing behavior.
- Signatures from other workflows or refs do not suppress signing.
- **API surface, controllers, database, auth, documentation:** No changes.
- **Tests:** YAML syntax validation is included. Live nightly rebuild verification remains pending.

## Backward compatibility

The action preserves signing when verification fails. Existing unsigned-image workflows continue to sign. The change only prevents duplicate signatures from the same workflow and ref.

## Risk classification

**risk:ship** — The change is limited to CI signing behavior, has no production runtime or public API changes, preserves the existing fallback path, and includes YAML validation. It does not qualify as **risk:show** because it does not introduce a user-visible production behavior change. It does not qualify as **risk:ask** because it does not change security boundaries, stored data, or deployment control flow beyond avoiding duplicate signing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->