### PR TITLE
OSAC-5216: add --create to buf push so the missing tests module self-heals

### DIFF
--- a/.github/workflows/publish-proto.yaml
+++ b/.github/workflows/publish-proto.yaml
@@ -42,12 +42,17 @@ jobs:
       run: |
         # Strip this component's tag prefix (see the `tags:` trigger above) so the
         # label reads as a plain version, not the full scoped git tag.
-        #
-        # --create: buf.build/osac-project/tests (proto/buf.yaml's third
-        # module) was never provisioned on the BSR, so every push has been
-        # failing with "repository ... was not found" since at least
-        # fulfillment-service/v0.0.95. --create is a no-op once a module
-        # exists, so this also self-heals any future new module the same way
-        # -- private by default (no --create-visibility) since these are
-        # internal test-fixture types, not a published API surface.
-        buf push --create --label "${GITHUB_REF_NAME#fulfillment-service/}"
+        LABEL="${GITHUB_REF_NAME#fulfillment-service/}"
+
+        # --create provisions a module on first push and is a no-op once it
+        # exists (buf.build/osac-project/tests was never provisioned, so
+        # every push has been failing with "repository ... was not found"
+        # since at least fulfillment-service/v0.0.95). A single workspace-wide
+        # `buf push --create` can't express per-module visibility though --
+        # --create-visibility is one flag applied to every module created in
+        # that call -- so push each module separately with its intended
+        # visibility rather than relying on the shared default for the
+        # externally-consumed public module.
+        buf push public --create --create-visibility public --label "${LABEL}"
+        buf push private --create --create-visibility private --label "${LABEL}"
+        buf push tests --create --create-visibility private --label "${LABEL}"

--- a/.github/workflows/publish-proto.yaml
+++ b/.github/workflows/publish-proto.yaml
@@ -42,4 +42,12 @@ jobs:
       run: |
         # Strip this component's tag prefix (see the `tags:` trigger above) so the
         # label reads as a plain version, not the full scoped git tag.
-        buf push --label "${GITHUB_REF_NAME#fulfillment-service/}"
+        #
+        # --create: buf.build/osac-project/tests (proto/buf.yaml's third
+        # module) was never provisioned on the BSR, so every push has been
+        # failing with "repository ... was not found" since at least
+        # fulfillment-service/v0.0.95. --create is a no-op once a module
+        # exists, so this also self-heals any future new module the same way
+        # -- private by default (no --create-visibility) since these are
+        # internal test-fixture types, not a published API surface.
+        buf push --create --label "${GITHUB_REF_NAME#fulfillment-service/}"


### PR DESCRIPTION
## Summary
- `buf.build/osac-project/tests` (`proto/buf.yaml`'s third module -- `public-api` and `private-api` are the other two) was never provisioned on the Buf Schema Registry
- `buf push` has failed on every `fulfillment-service/v*` release tag since at least `v0.0.95` (2026-09-01) with `Failure: not_found: repository with name "osac-project/tests" was not found`, confirmed still failing on `v0.0.98` (2026-09-12)
- `--create` provisions a module on first push if it doesn't exist yet, and is a documented no-op if it already does -- so this fixes the immediate failure and also self-heals any future new module added to `buf.yaml` the same way
- no `--create-visibility` set, so it defaults to `private` (matches `proto/tests/` being internal test-fixture types, not a published API surface)

## Test plan
- [x] Confirmed `--create` is supported by the pinned buf CLI version (1.71.0) via CHANGELOG (available since v1.19.0)
- [ ] Confirm the next `fulfillment-service/v*` tag push actually provisions the module and pushes successfully (can't be exercised without a live tag push)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## CI

- Updates `.github/workflows/publish-proto.yaml` to push the `public`, `private`, and `tests` modules separately.
- Adds `--create` with explicit visibility settings.
- Creates `buf.build/osac-project/tests` when it does not exist.
- Preserves public visibility for `public-api` and private visibility for `private` and `tests`.
- Uses Buf CLI 1.71.0 support for `--create`.

## Backward compatibility

- Existing modules are unaffected because `--create` is a no-op when a module already exists.
- The change affects CI publishing only.
- No API, runtime, authentication, database, deployment, or test behavior changes.
- Live verification with a release tag remains pending.

## Risk classification

- **risk:show** — The change is limited to CI configuration and Buf module provisioning.
- It does not qualify for **risk:ship** because live release-tag verification is pending.
- It does not qualify for **risk:ask** because it does not change application code, APIs, authentication, data storage, or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->