### PR TITLE
NO-ISSUE: Fix complete-stale-gates checks:write 403 on fork PRs

### DIFF
--- a/.github/workflows/e2e-cancel-stale-runs-on-push.yml
+++ b/.github/workflows/e2e-cancel-stale-runs-on-push.yml
@@ -1,17 +1,28 @@
 ---
-# Cancel stale full-install runs on every synchronize. pull_request_target uses
-# default-branch workflow YAML and base-repo GITHUB_TOKEN (required to cancel
-# runs). Runs outside full-install concurrency so cleanup still runs when new
-# caller runs queue behind gh run rerun.
+# Cancel stale full-install runs on every synchronize, and clean up leftover
+# e2e-*-gate placeholder checks -- both directions. pull_request_target and
+# workflow_run both use default-branch workflow YAML and base-repo
+# GITHUB_TOKEN/secrets (required to cancel runs and patch checks): GitHub
+# always issues a read-only token for plain `pull_request` runs triggered by
+# a fork PR, and nearly every real contributor PR here is fork-originated, so
+# anything needing actions:write or checks:write has to live outside the
+# full-install workflows themselves rather than as an in-workflow job.
 name: Cancel stale e2e runs on push
 on:
   pull_request_target:
     types: [synchronize]
     branches: [main]
   workflow_call: {}
+  workflow_run:
+    workflows:
+      - "E2E VMaaS Full Install"
+      - "E2E BMaaS Full Install"
+      - "E2E CaaS Full Install"
+    types: [completed]
 
 jobs:
   cancel-stale-e2e:
+    if: github.event_name != 'workflow_run'
     runs-on: ubuntu-latest
     concurrency:
       group: cancel-stale-e2e-${{ github.event.pull_request.number }}
@@ -35,6 +46,7 @@ jobs:
         run: bash .github/scripts/cancel-stale-e2e-runs.sh
 
   dismiss-unlock-orphan-gates:
+    if: github.event_name != 'workflow_run'
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -44,4 +56,46 @@ jobs:
         with:
           head-sha: ${{ github.event.pull_request.head.sha }}
           after-native-success: false
+          github-token: ${{ secrets.MERGE_QUEUE_TOKEN }}
+
+  # The in-workflow e2e-*-complete-stale-gates jobs (inside each
+  # e2e-*-full-install.yml, added by OSAC-1735's stale-gate fix) run under
+  # plain `pull_request`, so their checks:write PATCH 403s on every fork PR
+  # (caught as non-fatal, so the job reports success while completing
+  # nothing) -- confirmed directly in a fork PR's job log:
+  #   gh: Resource not accessible by integration (HTTP 403)
+  #   Could not complete stale e2e-*-gate check ... (checks:write
+  #   unavailable; non-fatal).
+  # workflow_run runs with base-repo permissions regardless of where the
+  # triggering run came from, so this actually works for fork PRs. Safe
+  # alongside the in-workflow jobs: complete-stale-e2e-gates is idempotent
+  # (completes orphans, or finds none and no-ops), so this is a harmless
+  # no-op on same-repo PRs where the in-workflow job already succeeded.
+  complete-stale-gates-after-full-install:
+    if: >-
+      github.event_name == 'workflow_run'
+      && github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+    steps:
+      - name: Resolve gate name for this suite
+        id: gate
+        run: |
+          case "${{ github.event.workflow_run.name }}" in
+            "E2E VMaaS Full Install") echo "name=e2e-vmaas-gate" >> "$GITHUB_OUTPUT" ;;
+            "E2E BMaaS Full Install") echo "name=e2e-bmaas-gate" >> "$GITHUB_OUTPUT" ;;
+            "E2E CaaS Full Install") echo "name=e2e-caas-gate" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "::error::Unknown workflow_run name: ${{ github.event.workflow_run.name }}"
+              exit 1
+              ;;
+          esac
+      - name: Complete stale in_progress gate checks
+        uses: osac-project/osac-test-infra/.github/actions/complete-stale-e2e-gates@main
+        with:
+          head-sha: ${{ github.event.workflow_run.head_sha }}
+          gate-name: ${{ steps.gate.outputs.name }}
+          after-native-success: "true"
           github-token: ${{ secrets.MERGE_QUEUE_TOKEN }}


### PR DESCRIPTION
## Summary

Found while diagnosing PR #933 sitting `BLOCKED` with two orphaned `in_progress` `e2e-*-gate` checks despite both underlying full-installs having already succeeded.

The `e2e-*-complete-stale-gates` follow-up jobs added to `e2e-*-full-install.yml` (OSAC-1735's stale-gate fix, #542) run under plain `pull_request`. GitHub always issues a read-only `GITHUB_TOKEN` for `pull_request` runs triggered by a fork PR, regardless of the workflow's own `permissions:` block. The composite action's `checks:write` PATCH call fails with a 403, caught as non-fatal by the script, so the job reports `success` while silently completing nothing. Confirmed directly in #933's own job log:

```
gh: Resource not accessible by integration (HTTP 403)
Could not complete stale e2e-caas-gate check ... (checks:write unavailable; non-fatal).
```

Since nearly every real contributor PR here is fork-originated, this means the stale-gate auto-heal has effectively never worked for the PRs that actually need it -- only for same-repo (non-fork) branches, where `pull_request` does get a normally-scoped token.

Can't fix the in-workflow jobs directly: token permissions are tied to the whole workflow file's trigger, not per-job, and switching `e2e-*-full-install.yml` itself to `pull_request_target` isn't safe since it checks out and builds the fork PR's actual code (the classic "pwn request" vector) -- the cleanup has to live somewhere that never touches PR code.

## Fix

Adds a `workflow_run` trigger + job to the existing `e2e-cancel-stale-runs-on-push.yml`, rather than a new file (thanks for the push on this -- initial version of this PR added a separate file, this is cleaner): it already holds the `pull_request_target`-based "dismiss orphan gates before full-install" job (`after-native-success: false`) for the same underlying problem, so the "complete orphan gates after full-install succeeds" counterpart (`after-native-success: true`) belongs alongside it. `workflow_run` always runs with base-repo permissions and secrets regardless of where the triggering run came from, so `secrets.MERGE_QUEUE_TOKEN` and `checks:write` work unconditionally. Reuses `complete-stale-e2e-gates` as-is (no changes needed there, or in `osac-test-infra` at all). The existing two jobs gain an `if: github.event_name != 'workflow_run'` guard so they keep running exactly as before for their original triggers. Runs alongside the existing in-workflow jobs rather than replacing them -- the composite action is idempotent, so this is a harmless no-op on same-repo PRs where the in-workflow job already succeeded.

## Immediate relief

Also manually ran `complete-stale-e2e-gates.yml` (mode=complete) against #933's head SHA to clear its two orphaned checks right now, since this fix won't take effect until merged to `main` (`workflow_run` always uses the default-branch workflow definition).

## Test plan

- [x] YAML validated, `actionlint` clean
- [x] Manually verified the underlying fix works: PR #933's `e2e-bmaas-gate`/`e2e-caas-gate` orphans cleared after running the same cleanup this new job automates
- [ ] End-to-end: confirm a future fork PR's full-install completion triggers this job and clears its orphan without manual intervention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## CI

- Added `workflow_run` handling for the three full-install workflows.
- Added a base-repository permission path to complete stale e2e gate checks for fork pull requests.
- Reused `complete-stale-e2e-gates` without changing the action.
- Preserved existing job behavior for `pull_request` events.
- The handler is idempotent.

## Validation

- YAML validation and `actionlint` passed.
- End-to-end validation on a future fork pull request remains pending.

## Compatibility and security

- No API, controller, database, documentation, or exported-entity changes were made.
- Existing pull request jobs remain unchanged.
- Fork pull requests can update checks through the base-repository workflow permissions.
- No backward-compatibility impact is expected.

## Risk classification

- **risk:show** — The change modifies CI event handling and repository permissions, and fork-pull-request validation remains pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->