### PR TITLE
NO-ISSUE: Fix complete-stale-e2e-gate-checks.sh re-blocking good PRs

### DIFF
--- a/.github/scripts/complete-stale-e2e-gate-checks.sh
+++ b/.github/scripts/complete-stale-e2e-gate-checks.sh
@@ -1,7 +1,22 @@
 #!/usr/bin/env bash
-# Manual cleanup for orphaned in_progress e2e-*-gate API checks on HEAD_SHA.
-# MODE=complete: mark orphans success when native gate job already succeeded.
-# MODE=dismiss: mark unlock-time orphans cancelled (mislabeled /runs/<id> checks).
+# Manual cleanup for orphaned e2e-*-gate API checks on HEAD_SHA -- either
+# still in_progress, or already (mis-)finalized by an earlier run of this
+# same script.
+#
+# MODE=complete: mirror the orphan onto whatever the native gate job's real,
+#   terminal conclusion actually is (success or skipped). Never touches a
+#   native failure: leaving the orphan as-is or matching a real failure both
+#   correctly keep the PR blocked, and this script should never be what
+#   turns a genuinely broken PR green.
+# MODE=dismiss: cancel unlock-time orphans, but ONLY when the native gate
+#   job has not posted a terminal result yet. Cancelling an orphan whose
+#   native gate already completed can make that cancellation the *latest*
+#   check-run for the name (required-status-check evaluation uses the most
+#   recent entry per name), silently re-blocking a PR that was actually
+#   fine -- confirmed this happening in practice: an earlier run of this
+#   script in dismiss mode did exactly that after the real gate had already
+#   succeeded hours earlier. Use MODE=complete instead once a native result
+#   exists.
 
 set -euo pipefail
 
@@ -32,28 +47,34 @@ done
 check_runs=$(jq -s 'add' "${tmpdir}"/page-*.json)
 rm -rf "${tmpdir}"
 
-completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 failed=0
 
-native_gate_job_success() {
+# Prints the native gate job's real conclusion, or "pending" (not completed
+# yet) / "missing" (no native job found at all).
+native_gate_conclusion() {
   local gate="$1"
-  jq -e --arg g "${gate}" '
-    [.[] | select(
+  jq -r --arg g "${gate}" '
+    ([.[] | select(
       .name == $g
       and ((.details_url // "") | test("/actions/runs/[0-9]+/job/"))
     )]
     | sort_by(.created_at)
-    | last
-    | .status == "completed" and .conclusion == "success"
-  ' <<<"${check_runs}" >/dev/null
+    | last) as $last
+    | if $last == null then "missing"
+      elif $last.status != "completed" then "pending"
+      else $last.conclusion
+      end
+  ' <<<"${check_runs}"
 }
 
+# In_progress orphans, or already-(mis-)finalized ones from an earlier run of
+# this script -- identified structurally (external_id prefix, or an
+# API-created details_url with no /job/ segment), not by current status.
 orphan_ids_for_gate() {
   local gate="$1"
   jq -r --arg g "${gate}" --arg prefix "${INVALIDATE_EXTERNAL_ID_PREFIX}" '
     [.[] | select(
       .name == $g
-      and .status == "in_progress"
       and (
         ((.external_id // "") | startswith($prefix))
         or ((.details_url // "") | test("^https://github.com/[^/]+/[^/]+/actions/runs/[0-9]+$"))
@@ -64,15 +85,21 @@ orphan_ids_for_gate() {
 }
 
 for gate in "${GATES[@]}"; do
+  native="$(native_gate_conclusion "${gate}")"
+
   if [[ "${MODE}" == "complete" ]]; then
-    if ! native_gate_job_success "${gate}"; then
-      echo "Skipping ${gate}: no native gate job success on ${HEAD_SHA:0:7}"
+    if [[ "${native}" != "success" && "${native}" != "skipped" ]]; then
+      echo "Skipping ${gate}: native gate is '${native}' (not success/skipped) on ${HEAD_SHA:0:7}"
       continue
     fi
     title="Superseded by native e2e gate job"
-    summary="Manual cleanup; merge-required gate already success on this SHA."
-    conclusion="success"
+    summary="Manual cleanup; merge-required gate is ${native} on this SHA."
+    conclusion="${native}"
   else
+    if [[ "${native}" != "pending" && "${native}" != "missing" ]]; then
+      echo "Skipping ${gate} dismiss: native gate already '${native}' on ${HEAD_SHA:0:7} -- rerun with MODE=complete instead"
+      continue
+    fi
     title="Superseded by full-install gate job"
     summary="Manual dismiss of unlock orphan API check on this SHA."
     conclusion="cancelled"
@@ -80,10 +107,16 @@ for gate in "${GATES[@]}"; do
 
   while IFS= read -r id; do
     [[ -z "${id}" || "${id}" == "null" ]] && continue
-    if [[ "${MODE}" == "complete" ]] && ! native_gate_job_success "${gate}"; then
-      echo "Skipping stale ${gate} check ${id}: native gate no longer success"
-      continue
+    if [[ "${MODE}" == "complete" ]]; then
+      current="$(native_gate_conclusion "${gate}")"
+      if [[ "${current}" != "success" && "${current}" != "skipped" ]]; then
+        echo "Skipping stale ${gate} check ${id}: native gate now '${current}'"
+        continue
+      fi
+      conclusion="${current}"
+      summary="Manual cleanup; merge-required gate is ${current} on this SHA."
     fi
+    completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
     payload=$(jq -n \
       --arg status "completed" \
       --arg conclusion "${conclusion}" \
@@ -97,7 +130,7 @@ for gate in "${GATES[@]}"; do
         output: {title: $title, summary: $summary}
       }')
     if gh api "repos/${REPO}/check-runs/${id}" -X PATCH --input - <<<"${payload}"; then
-      echo "${MODE} stale ${gate} check ${id} on ${HEAD_SHA:0:7}"
+      echo "${MODE} stale ${gate} check ${id} on ${HEAD_SHA:0:7} -> ${conclusion}"
     else
       echo "Could not patch ${gate} check ${id}" >&2
       failed=1

--- a/.github/scripts/complete-stale-e2e-gate-checks.sh
+++ b/.github/scripts/complete-stale-e2e-gate-checks.sh
@@ -17,6 +17,14 @@
 #   script in dismiss mode did exactly that after the real gate had already
 #   succeeded hours earlier. Use MODE=complete instead once a native result
 #   exists.
+#
+# Re-fetches check-runs immediately before each per-orphan PATCH decision
+# (not just once at the top) so a gate that transitions state while this
+# script is mid-run (e.g. a still-in-flight e2e suite finishes between the
+# first gate's processing and the last) is judged on current data. This
+# narrows, but by construction of the GitHub REST API cannot fully close,
+# the gap between reading a check-run's state and PATCHing it -- a run
+# could still change state in between those two calls for a given orphan.
 
 set -euo pipefail
 
@@ -33,26 +41,31 @@ if [[ "${MODE}" != "complete" && "${MODE}" != "dismiss" ]]; then
   exit 1
 fi
 
-tmpdir=$(mktemp -d)
-page=1
-while true; do
-  resp=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100&page=${page}&filter=all")
-  jq -c '.check_runs' <<<"${resp}" > "${tmpdir}/page-${page}.json"
-  count=$(jq '.check_runs | length' <<<"${resp}")
-  if [[ "${count}" -lt 100 ]]; then
-    break
-  fi
-  page=$((page + 1))
-done
-check_runs=$(jq -s 'add' "${tmpdir}"/page-*.json)
-rm -rf "${tmpdir}"
-
 failed=0
 
+# Fetches every check-run on HEAD_SHA, fresh, paginating as needed.
+fetch_check_runs() {
+  local tmpdir page resp count
+  tmpdir=$(mktemp -d)
+  page=1
+  while true; do
+    resp=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs?per_page=100&page=${page}&filter=all")
+    jq -c '.check_runs' <<<"${resp}" > "${tmpdir}/page-${page}.json"
+    count=$(jq '.check_runs | length' <<<"${resp}")
+    if [[ "${count}" -lt 100 ]]; then
+      break
+    fi
+    page=$((page + 1))
+  done
+  jq -s 'add' "${tmpdir}"/page-*.json
+  rm -rf "${tmpdir}"
+}
+
 # Prints the native gate job's real conclusion, or "pending" (not completed
-# yet) / "missing" (no native job found at all).
+# yet) / "missing" (no native job found at all), from the given check-runs
+# snapshot.
 native_gate_conclusion() {
-  local gate="$1"
+  local gate="$1" runs="$2"
   jq -r --arg g "${gate}" '
     ([.[] | select(
       .name == $g
@@ -64,14 +77,14 @@ native_gate_conclusion() {
       elif $last.status != "completed" then "pending"
       else $last.conclusion
       end
-  ' <<<"${check_runs}"
+  ' <<<"${runs}"
 }
 
 # In_progress orphans, or already-(mis-)finalized ones from an earlier run of
 # this script -- identified structurally (external_id prefix, or an
 # API-created details_url with no /job/ segment), not by current status.
 orphan_ids_for_gate() {
-  local gate="$1"
+  local gate="$1" runs="$2"
   jq -r --arg g "${gate}" --arg prefix "${INVALIDATE_EXTERNAL_ID_PREFIX}" '
     [.[] | select(
       .name == $g
@@ -81,11 +94,12 @@ orphan_ids_for_gate() {
         or ((.details_url // "") | test("^https://github.com/[^/]+/[^/]+/runs/[0-9]+$"))
       )
     ) | .id] | .[]
-  ' <<<"${check_runs}"
+  ' <<<"${runs}"
 }
 
 for gate in "${GATES[@]}"; do
-  native="$(native_gate_conclusion "${gate}")"
+  check_runs="$(fetch_check_runs)"
+  native="$(native_gate_conclusion "${gate}" "${check_runs}")"
 
   if [[ "${MODE}" == "complete" ]]; then
     if [[ "${native}" != "success" && "${native}" != "skipped" ]]; then
@@ -93,29 +107,40 @@ for gate in "${GATES[@]}"; do
       continue
     fi
     title="Superseded by native e2e gate job"
-    summary="Manual cleanup; merge-required gate is ${native} on this SHA."
-    conclusion="${native}"
   else
     if [[ "${native}" != "pending" && "${native}" != "missing" ]]; then
       echo "Skipping ${gate} dismiss: native gate already '${native}' on ${HEAD_SHA:0:7} -- rerun with MODE=complete instead"
       continue
     fi
     title="Superseded by full-install gate job"
-    summary="Manual dismiss of unlock orphan API check on this SHA."
-    conclusion="cancelled"
   fi
 
   while IFS= read -r id; do
     [[ -z "${id}" || "${id}" == "null" ]] && continue
+
+    # Re-fetch immediately before deciding this specific orphan's fate: a
+    # gate can transition (e.g. from pending to success) while this script
+    # works through the others, and each orphan should be judged on the
+    # freshest data available right before its own PATCH, not the snapshot
+    # from when the gate-level check above ran.
+    check_runs="$(fetch_check_runs)"
+    current="$(native_gate_conclusion "${gate}" "${check_runs}")"
     if [[ "${MODE}" == "complete" ]]; then
-      current="$(native_gate_conclusion "${gate}")"
       if [[ "${current}" != "success" && "${current}" != "skipped" ]]; then
         echo "Skipping stale ${gate} check ${id}: native gate now '${current}'"
         continue
       fi
       conclusion="${current}"
       summary="Manual cleanup; merge-required gate is ${current} on this SHA."
+    else
+      if [[ "${current}" != "pending" && "${current}" != "missing" ]]; then
+        echo "Skipping ${gate} dismiss of check ${id}: native gate now '${current}' -- rerun with MODE=complete instead"
+        continue
+      fi
+      conclusion="cancelled"
+      summary="Manual dismiss of unlock orphan API check on this SHA."
     fi
+
     completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
     payload=$(jq -n \
       --arg status "completed" \
@@ -135,7 +160,7 @@ for gate in "${GATES[@]}"; do
       echo "Could not patch ${gate} check ${id}" >&2
       failed=1
     fi
-  done < <(orphan_ids_for_gate "${gate}")
+  done < <(orphan_ids_for_gate "${gate}" "${check_runs}")
 done
 
 exit "${failed}"


### PR DESCRIPTION
## Urgent -- currently re-blocking a good PR (#932)

Found live: an earlier \`MODE=dismiss\` run against #932's head SHA marked its \`e2e-*-gate\` orphan checks "cancelled" hours after the real native gate jobs had already completed "success". Since required-status-check evaluation uses the most recent check-run per name, the newly-cancelled orphan became the "latest" entry and re-blocked the PR. Confirmed via \`enqueuePullRequest\`'s own error:

\`\`\`
Pull request has failing required statuses and Pull request 3 of 26 required status checks are cancelled.
\`\`\`

Root cause: \`orphan_ids_for_gate\` only ever matched \`status=="in_progress"\`, so once dismiss mode had (wrongly) finalized an orphan as cancelled, neither mode could touch it again to fix it -- no way to undo the mistake.

## Fix

Reworks both modes around the native gate job's actual conclusion (success/skipped/pending/missing/failure) instead of a fixed target conclusion:
- \`MODE=complete\` mirrors the orphan onto the native result whenever it's \`success\` or \`skipped\` (never \`failure\` -- this script should never be what turns a genuinely broken PR green), and now matches orphans regardless of their current status, so it can correct a previously mis-cancelled one.
- \`MODE=dismiss\` only touches an orphan when the native gate has **not** posted a terminal result yet. Once a native result exists, cancelling the orphan is never safe -- that's exactly what caused this bug -- so dismiss now defers to complete instead.

## Test plan

- [x] \`bash -n\` clean
- [x] Verified the new \`native_gate_conclusion\`/\`orphan_ids_for_gate\` logic locally against a mock of #932's exact scenario (a success native result plus a later-cancelled orphan): correctly identifies the mis-cancelled orphan for correction under \`MODE=complete\`
- [ ] Run against #932 once merged to confirm it actually unblocks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- **CI:** Updated `.github/scripts/complete-stale-e2e-gate-checks.sh`.
- `MODE=complete` mirrors only `success` or `skipped` from the native gate.
- Completion mode detects orphan checks in any status, including cancelled checks.
- `MODE=dismiss` cancels an orphan only when the native gate has no terminal result.
- The script refreshes check-run data before each orphan decision.
- Pagination and conclusion handling use reusable functions.

## Compatibility and verification

- No public API, controller, database, authentication, deployment, documentation, or test interface changed.
- Valid pull requests should no longer be re-blocked after orphan checks are cancelled.
- `bash -n` passes.
- Local testing reproduces the reported scenario.
- Verification against PR `#932` after merge remains pending.
- No Jira issue is referenced.

## Risk classification

**risk:ship** — The change is limited to a CI maintenance script, preserves native gate conclusions, and has bounded scope. It does not qualify for **risk:show** because it does not introduce a user-facing feature or notable operational change. It does not qualify for **risk:ask** because it has no unresolved security, data, or deployment risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->