### PR TITLE
NO-ISSUE: Sort gate check-runs by started_at, not nonexistent created_at

### DIFF
--- a/.github/scripts/complete-stale-e2e-gate-checks.sh
+++ b/.github/scripts/complete-stale-e2e-gate-checks.sh
@@ -71,7 +71,7 @@ native_gate_conclusion() {
       .name == $g
       and ((.details_url // "") | test("/actions/runs/[0-9]+/job/"))
     )]
-    | sort_by(.created_at)
+    | sort_by(.started_at)
     | last) as $last
     | if $last == null then "missing"
       elif $last.status != "completed" then "pending"


### PR DESCRIPTION
## Urgent -- caused an incorrect result on PR #927

Found live: \`native_gate_conclusion\` picked a real failure over a later real success for \`e2e-caas-gate\`, refusing to correct an already-mis-cancelled orphan that should have been fixed.

Root cause: check-run objects have **no \`created_at\` field at all** -- verified directly against the raw API response, only \`started_at\`/\`completed_at\` exist. \`sort_by(.created_at) | last\` was therefore sorting on a field that's always \`null\` for every entry, so "last" just picked whichever check-run happened to land last in the API's response order, not the chronologically latest attempt. In #927's case, an older failure run landed after a newer success run in the response, and the script trusted the failure.

## Fix

Switched to \`sort_by(.started_at)\`, which every check-run has regardless of whether it has completed yet (unlike \`completed_at\`, which is null for anything still \`in_progress\` and would have the exact same problem in reverse).

## Test plan

- [x] \`bash -n\` clean
- [x] Verified against a mock of #927's exact two check-runs (success at 01:21:49, failure at 20:45:51): now correctly identifies success as the latest attempt
- [ ] Re-run against #927 once merged to confirm it corrects the mis-cancelled orphan

## Also worth knowing

The identical \`sort_by(.created_at)\` pattern exists in \`osac-test-infra\`'s \`e2e-gates-lib.sh\` (used by the #542 auto-heal follow-up jobs and my #934 \`workflow_run\` handler) -- same bug, different repo. Opening a companion fix there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## CI

- `native_gate_conclusion` now sorts native gate check-runs by `started_at`.
- This selects the latest attempt by start time.
- The previous `created_at` field is not available on check-run objects.
- Tests cover selecting a later successful run over an earlier failure.
- Post-merge verification remains pending.

## API surface

- No public or exported entities changed.

## Backward compatibility

- No backward-incompatible change is expected.
- The fix changes only which existing check-run result the script selects.

## Risk classification

- `risk:ship` applies because the change is limited to CI result ordering and changes one line.
- It does not meet `risk:show` criteria because it does not affect user-visible product behavior.
- It does not meet `risk:ask` criteria because it does not affect security, persistence, deployment, or public APIs.
- No repository-specific risk-labeling guidance was found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->